### PR TITLE
feat(run): implement flox run phase 1 (explicit package)

### DIFF
--- a/cli/flox-rust-sdk/src/providers/buildenv.rs
+++ b/cli/flox-rust-sdk/src/providers/buildenv.rs
@@ -236,26 +236,143 @@ pub struct BuildEnvNix<A> {
     auth: A,
 }
 
+/// Build the base `nix build` command shared by all store-path operations.
+///
+/// Enables impure language features, applies the store URL override from
+/// `_FLOX_NIX_STORE_URL`, and requests build logs.
+fn base_command() -> Command {
+    let mut nix_build_command = nix_base_command();
+    // allow impure language features such as `builtins.storePath`,
+    // and use the auto store (which is used by the preceding `realise` command)
+    // TODO: formalize this in a config file,
+    // and potentially disable other user configs (allowing specific overrides)
+    nix_build_command.args(["--option", "pure-eval", "false"]);
+    apply_nix_store_url(&mut nix_build_command);
+    // we generally want to see more logs (we can always filter them out)
+    nix_build_command.arg("--print-build-logs");
+
+    nix_build_command
+}
+
+/// Fetch the given store paths via `nix build`, downloading from configured
+/// substituters or building from source if needed.
+///
+/// When `out_link` is `Some(prefix)`, passes `--out-link <prefix>` so the
+/// downloaded paths are registered as GC roots under that prefix.
+/// When `out_link` is `None`, passes `--no-link` instead.
+///
+/// Returns `true` if all paths were fetched successfully, `false` otherwise.
+pub fn substitute_store_paths(
+    paths: impl IntoIterator<Item = impl AsRef<OsStr>>,
+    out_link: Option<&Path>,
+) -> Result<bool, BuildEnvError> {
+    let paths: Vec<_> = paths.into_iter().collect();
+
+    let mut cmd = base_command();
+    cmd.arg("build");
+    match out_link {
+        Some(prefix) => {
+            cmd.arg("--out-link").arg(prefix);
+        },
+        None => {
+            cmd.arg("--no-link");
+        },
+    }
+    cmd.args(paths);
+
+    debug!(cmd=%cmd.display(), "trying to fetch store paths");
+
+    let output = cmd.output().map_err(BuildEnvError::CallNixBuild)?;
+    let success = output.status.success();
+    if !success {
+        debug!(
+            stderr = %String::from_utf8_lossy(&output.stderr),
+            "store path fetch failed"
+        );
+    }
+    Ok(success)
+}
+
+/// Build a catalog package from source when the binary cache does not have it.
+///
+/// Constructs the `flox-nixpkgs` flake installable from `locked_url` and
+/// `attr_path`, then invokes `nix build` with the Nix plugins that allow
+/// unfree and broken packages.
+///
+/// When `gc_root_prefix` is `Some(p)`, passes `--out-link <p>` so the build
+/// output is registered as a GC root. When `None`, passes `--no-link`.
+///
+/// Returns `Err(BuildEnvError::Realise2)` if the build fails.
+pub fn build_catalog_pkg_from_source(
+    locked_url: &str,
+    attr_path: &str,
+    system: &str,
+    unfree: Option<bool>,
+    broken: Option<bool>,
+    gc_root_prefix: Option<&Path>,
+) -> Result<(), BuildEnvError> {
+    // Transform the locked URL: strip the nixpkgs GitHub prefix and replace
+    // it with the flox-nixpkgs fetcher reference so that evaluation checks
+    // (allowUnfree, allowBroken) are controlled by manifest options rather
+    // than Nix's built-in guards.
+    let flake_ref = if let Some(rev) = locked_url.strip_prefix(NIXPKGS_CATALOG_URL_PREFIX) {
+        format!("{FLOX_NIXPKGS_PROXY_FLAKE_REF_BASE}/{rev}")
+    } else {
+        return Err(BuildEnvError::LockfileContents(format!(
+            "Locked package '{}' is a base catalog package, but the locked url '{}' does not start with the expected prefix '{}'",
+            attr_path, locked_url, NIXPKGS_CATALOG_URL_PREFIX
+        )));
+    };
+
+    // Build all outputs (^*) from legacyPackages.<system>.<attr_path>.
+    let installable = format!("{flake_ref}#legacyPackages.{system}.{attr_path}^*");
+
+    let reason = match (unfree, broken) {
+        (Some(true), _) => " (unfree license)",
+        (_, Some(true)) => " (upstream build marked as broken)",
+        _ => "",
+    };
+
+    let _span = info_span!(
+        "build_catalog_pkg_from_source",
+        progress = format!("Building '{attr_path}' from source{reason}")
+    )
+    .entered();
+
+    let mut cmd = base_command();
+    cmd.args(["--option", "extra-plugin-files", &*NIX_PLUGINS]);
+    cmd.arg("build");
+    cmd.arg("--no-write-lock-file");
+    cmd.arg("--no-update-lock-file");
+    cmd.args(["--option", "pure-eval", "true"]);
+    match gc_root_prefix {
+        Some(prefix) => {
+            cmd.arg("--out-link").arg(prefix);
+        },
+        None => {
+            cmd.arg("--no-link");
+        },
+    }
+    cmd.arg(&installable);
+
+    debug!(%installable, cmd=%cmd.display(), "building catalog package from source");
+
+    let output = cmd.output().map_err(BuildEnvError::CallNixBuild)?;
+    if output.status.success() {
+        return Ok(());
+    }
+    Err(BuildEnvError::Realise2 {
+        install_id: attr_path.to_string(),
+        message: String::from_utf8_lossy(&output.stderr).to_string(),
+    })
+}
+
 impl<A> BuildEnvNix<A>
 where
     A: AuthProvider,
 {
     pub fn new(auth: A) -> BuildEnvNix<A> {
         BuildEnvNix { auth }
-    }
-
-    fn base_command() -> Command {
-        let mut nix_build_command = nix_base_command();
-        // allow impure language features such as `builtins.storePath`,
-        // and use the auto store (which is used by the preceding `realise` command)
-        // TODO: formalize this in a config file,
-        // and potentially disable other user configs (allowing specific overrides)
-        nix_build_command.args(["--option", "pure-eval", "false"]);
-        apply_nix_store_url(&mut nix_build_command);
-        // we generally want to see more logs (we can always filter them out)
-        nix_build_command.arg("--print-build-logs");
-
-        nix_build_command
     }
 
     /// Realise all store paths of packages that are installed to the environment,
@@ -582,7 +699,7 @@ where
 
         debug!(count = missing.len(), "substituting store paths in batch");
 
-        let mut cmd = Self::base_command();
+        let mut cmd = base_command();
         cmd.arg("build")
             .arg("--no-link")
             .arg("--keep-going")
@@ -676,73 +793,15 @@ where
         }
 
         // If we get here it means we need to build a package from source.
-
-        let installable = {
-            // We swap out the locked URL of the package (which points at our nixpkgs
-            // fork) for a flake reference that uses our custom `flox-nixpkgs` URL
-            // scheme. This disables certain built-in evaluation checks (allowUnfree, etc).
-            // That's important because we move those checks into manifest options, and
-            // don't want conflicts or duplicates.
-            let mut locked_url = locked_pkg.locked_url.to_string();
-            if let Some(revision_suffix) = locked_url.strip_prefix(NIXPKGS_CATALOG_URL_PREFIX) {
-                locked_url = format!("{FLOX_NIXPKGS_PROXY_FLAKE_REF_BASE}/{revision_suffix}");
-            } else {
-                return Err(BuildEnvError::LockfileContents(format!(
-                    "Locked package '{}' is a base catalog package, but the locked url '{}' does not start with the expected prefix '{}'",
-                    locked_pkg.install_id, locked_pkg.locked_url, NIXPKGS_CATALOG_URL_PREFIX
-                )));
-            }
-
-            // For the attribute path we construct a real installable's attribute path
-            // by prepending `legacyPackages.<system>` to the `pkg-path`/`attr_path`.
-            //
-            // The `^*` bit builds all outputs.
-            let attrpath = format!(
-                "legacyPackages.{}.{}^*",
-                locked_pkg.system, locked_pkg.attr_path
-            );
-
-            format!("{}#{}", locked_url, attrpath)
-        };
-
-        let reason = match (locked_pkg.unfree, locked_pkg.broken) {
-            (Some(true), _) => " (unfree license)",
-            (_, Some(true)) => " (upstream build marked as broken)",
-            _ => "",
-        };
-
-        let _span = info_span!(
-            parent: span.clone(),
-            "build from catalog",
-            progress = format!("Building '{}' from source{reason}", locked_pkg.attr_path)
+        // Delegate to the shared function so buildenv and `flox run` stay in sync.
+        build_catalog_pkg_from_source(
+            &locked_pkg.locked_url,
+            &locked_pkg.attr_path,
+            &locked_pkg.system,
+            locked_pkg.unfree,
+            locked_pkg.broken,
+            None, // buildenv manages its own GC roots; use --no-link here
         )
-        .entered();
-
-        let mut nix_build_command = Self::base_command();
-
-        nix_build_command.args(["--option", "extra-plugin-files", &*NIX_PLUGINS]);
-
-        nix_build_command.arg("build");
-        nix_build_command.arg("--no-write-lock-file");
-        nix_build_command.arg("--no-update-lock-file");
-        nix_build_command.args(["--option", "pure-eval", "true"]);
-        nix_build_command.arg("--no-link");
-        nix_build_command.arg(&installable);
-
-        debug!(%installable, cmd=%nix_build_command.display(), "building catalog package");
-
-        let output = nix_build_command
-            .output()
-            .map_err(BuildEnvError::CallNixBuild)?;
-
-        if !output.status.success() {
-            return Err(BuildEnvError::Realise2 {
-                install_id: locked_pkg.install_id.clone(),
-                message: String::from_utf8_lossy(&output.stderr).to_string(),
-            });
-        }
-
-        Ok(())
     }
 
     /// Realise a package from a flake.
@@ -771,7 +830,7 @@ where
             return Ok(());
         }
 
-        let mut nix_build_command = Self::base_command();
+        let mut nix_build_command = base_command();
 
         // naïve url construction
         let installable = {
@@ -853,24 +912,7 @@ where
     fn try_substitute_store_paths(
         paths: impl IntoIterator<Item = impl AsRef<OsStr>>,
     ) -> Result<bool, BuildEnvError> {
-        let paths: Vec<_> = paths.into_iter().collect();
-
-        let mut cmd = Self::base_command();
-        cmd.arg("build");
-        cmd.arg("--no-link");
-        cmd.args(paths);
-
-        debug!(cmd=%cmd.display(), "trying to fetch store paths");
-
-        let output = cmd.output().map_err(BuildEnvError::CallNixBuild)?;
-        let success = output.status.success();
-        if !success {
-            debug!(
-                stderr = %String::from_utf8_lossy(&output.stderr),
-                "store path fetch failed"
-            );
-        }
-        Ok(success)
+        substitute_store_paths(paths, None)
     }
 
     /// Build the environment by evaluating and building
@@ -892,7 +934,7 @@ where
         service_config_path: Option<PathBuf>,
         out_link_prefix: Option<&Path>,
     ) -> Result<BuildEnvOutputs, BuildEnvError> {
-        let mut nix_build_command = Self::base_command();
+        let mut nix_build_command = base_command();
         nix_build_command.args(["build", "--offline", "--json"]);
         if let Some(prefix) = out_link_prefix {
             nix_build_command.arg("--out-link").arg(prefix);
@@ -1033,7 +1075,7 @@ fn remove_build_output_symlinks_by_scan(out_link_prefix: Option<&Path>) {
 }
 
 /// Apply the `_FLOX_NIX_STORE_URL` store override to `cmd` if set, so that
-/// Nix commands spawned outside of `BuildEnvNix::base_command` (e.g. the
+/// Nix commands spawned outside of `base_command` (e.g. the
 /// daemon-check and force-registration commands) target the same store as the
 /// rest of environment construction.
 fn apply_nix_store_url(cmd: &mut Command) {
@@ -1133,12 +1175,12 @@ fn is_deterministic_buildenv_conflict(err: &BuildEnvError) -> bool {
 /// `expected_paths` returns the full list of store paths the environment
 /// depends on. It is called once per attempt for diagnostic logging and
 /// for the `nix path-info` store-database check on failure.
-fn materialise_with_retry(
+pub fn materialise_with_retry<T>(
     mut realise: impl FnMut() -> Result<(), BuildEnvError>,
     mut missing_paths: impl FnMut() -> Vec<String>,
     expected_paths: impl Fn() -> Vec<String>,
-    mut build_env: impl FnMut() -> Result<BuildEnvOutputs, BuildEnvError>,
-) -> Result<BuildEnvOutputs, BuildEnvError> {
+    mut build_env: impl FnMut() -> Result<T, BuildEnvError>,
+) -> Result<T, BuildEnvError> {
     const MAX_RETRIES: usize = 3;
     for attempt in 1..=MAX_RETRIES {
         realise()?;
@@ -2926,7 +2968,7 @@ mod materialise_retry_tests {
         init_tracing();
         // Paths always disappear after build_env fails — exhausts all retries.
         let missing_call = Cell::new(0usize);
-        let result = materialise_with_retry(
+        let result: Result<BuildEnvOutputs, _> = materialise_with_retry(
             || Ok(()),
             || {
                 missing_call.set(missing_call.get() + 1);
@@ -2959,7 +3001,7 @@ mod materialise_retry_tests {
         // before propagating the error.
         let realise_calls = Cell::new(0usize);
         let build_calls = Cell::new(0usize);
-        let result = materialise_with_retry(
+        let result: Result<BuildEnvOutputs, _> = materialise_with_retry(
             || {
                 realise_calls.set(realise_calls.get() + 1);
                 Ok(())
@@ -3001,7 +3043,7 @@ mod materialise_retry_tests {
                                packages or setting the priority of the \
                                preferred package to a value lower than '5'"
             .to_string();
-        let result = materialise_with_retry(
+        let result: Result<(), _> = materialise_with_retry(
             || {
                 realise_calls.set(realise_calls.get() + 1);
                 Ok(())

--- a/cli/flox/doc/flox-run.md
+++ b/cli/flox/doc/flox-run.md
@@ -1,0 +1,177 @@
+---
+title: FLOX-RUN
+section: 1
+header: "Flox User Manuals"
+...
+
+# NAME
+
+flox-run - run a command from a Flox Catalog package
+
+# SYNOPSIS
+
+```
+flox [<general-options>] run
+     -p <package>
+     -- <command> [<arguments>]
+```
+
+# DESCRIPTION
+
+Run a command from a Flox Catalog package without creating an environment.
+
+`flox run` is designed for one-off invocations.
+It resolves the requested package from the Flox Catalog,
+downloads its store paths,
+and executes the command directly —
+no `flox init`, `flox install`, or environment cleanup needed.
+
+## Specifying the Package
+
+The `-p`/`--package` flag is required and names the package explicitly.
+For example:
+
+```
+$ flox run -p gnugrep -- grep "pattern" file.txt
+```
+
+The package name is a plain Flox Catalog attribute path
+(e.g. `curl`, `python3Packages.requests`).
+
+## Flags Before and After the Command
+
+`flox run` uses POSIX stop-at-first-positional parsing:
+flags before `--` belong to `flox run`;
+everything after `--` is passed to the command verbatim.
+
+Always use `--` to separate the flox flags from the command:
+
+```
+flox run -p curl -- curl http://example.com
+```
+
+Without `--`, flags that look like options could be claimed by the
+wrong side of the boundary — for example, `flox run -p curl curl
+-sL http://example.com` passes `-sL` to `curl`, but
+`flox run curl -p curl -- curl ...` would fail because `-p` is
+consumed by `curl`, leaving flox without a package.
+
+**`--version` caveat:**
+Flox intercepts `--version` from the full argument list before parsing.
+Always use `--` so `--version` reaches the command:
+
+```
+$ flox run -p hello -- hello --version   # ✅ shows hello's version
+$ flox run -p hello hello --version      # ❌ shows flox's version instead
+```
+
+## Command Lookup
+
+`flox run` looks up the command strictly inside the resolved package's
+output directories: `bin/` first, then `sbin/`
+(`bin/` wins if both contain the command).
+The file must be a regular file with an executable bit set.
+
+There is no fallback to the caller's `PATH`.
+If the command is not found in the package,
+`flox run` exits with an error.
+
+## Exec Semantics
+
+`flox run` replaces the flox process with the invoked command via `exec`.
+The caller's PID becomes the command,
+signals go directly to it,
+and the shell sees the command's exit code.
+Stdin, stdout, and stderr are inherited unmodified.
+
+## Caching
+
+Downloaded store paths are registered as GC roots under
+`$FLOX_CACHE_DIR/run-gc-roots/`.
+Repeated invocations of the same package skip the download step.
+
+# OPTIONS
+
+## Run Options
+
+`-p <package>`, `--package <package>`
+:   Required. The Flox Catalog package that provides the command.
+    Accepts plain package names only (e.g. `curl`, `ripgrep`).
+    Version constraints (`@`), output selectors (`^`), and custom
+    catalogs (`/`) are not supported in this release.
+
+`-- <command> [<arguments>]`
+:   The command to run and any arguments to pass to it.
+    Use `--` to separate flox flags from the command and its arguments.
+
+```{.include}
+./include/general-options.md
+```
+
+# EXAMPLES
+
+Run a command:
+
+```
+$ flox run -p cowsay -- cowsay "Hello, Flox!"
+```
+
+Run a command whose name differs from the package name:
+
+```
+$ flox run -p binutils -- readelf -a /bin/ls
+```
+
+Pass option-style arguments to the command:
+
+```
+$ flox run -p curl -- curl -sL http://example.com
+```
+
+Pipe input to a command:
+
+```
+$ echo '{"name":"Flox"}' | flox run -p jq -- jq '.name'
+```
+
+Show the command's own help or version:
+
+```
+$ flox run -p hello -- hello --help
+$ flox run -p hello -- hello --version
+```
+
+# LIMITATIONS
+
+This release (phase 1) requires the `-p`/`--package` flag.
+The following features are not yet supported and will be available
+in a future release:
+
+- Defaulting the package to the command name (`flox run readelf`)
+- Version constraints: `flox run -p curl@8.0 -- curl …`
+- Output selectors: `flox run -p foo^dev …`
+- Custom catalogs: `flox run -p mycatalog/vim -- vim …`
+- Executable-to-package lookup and disambiguation
+
+## Binary cache requirement
+
+`flox run` fetches packages by store path using substitution only.
+It does not evaluate Nix expressions or build packages from source
+unless the binary cache does not have the package.
+A package must have a pre-built binary available in the Nix binary
+cache, or be buildable from source.
+
+Packages that require building from source — including those with
+unfree licenses that are not pre-cached — cannot be substituted
+directly. `flox run` will build such packages from source automatically,
+displaying a progress indicator while the build runs.
+Press Ctrl-C to cancel if you do not want to wait.
+Built packages are stored in a temporary GC root that is removed when
+the command exits.
+Use `flox install` to add a package to a persistent environment instead.
+
+# SEE ALSO
+
+[`flox-activate(1)`](./flox-activate.md),
+[`flox-install(1)`](./flox-install.md),
+[`flox-search(1)`](./flox-search.md)

--- a/cli/flox/doc/flox.md
+++ b/cli/flox/doc/flox.md
@@ -56,6 +56,9 @@ sharing environments, and administration.
 `deactivate`
 :   Deactivate the current environment.
 
+`run`
+:   Run a command from a Flox Catalog package without installing it.
+
 `search`
 :   Search for system or library packages to install.
 
@@ -127,6 +130,7 @@ sharing environments, and administration.
 
 [`flox-init(1)`](./flox-init.md),
 [`flox-activate(1)`](./flox-activate.md),
+[`flox-run(1)`](./flox-run.md),
 [`flox-install(1)`](./flox-install.md),
 [`flox-uninstall(1)`](./flox-uninstall.md),
 [`flox-upgrade(1)`](./flox-upgrade.md),

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -22,6 +22,7 @@ mod lock_manifest;
 mod publish;
 mod pull;
 mod push;
+mod run;
 mod search;
 mod services;
 mod services_socket;
@@ -630,6 +631,15 @@ struct Help {
 
 /// Force `--help` output for `flox` with a given command
 pub fn display_help(cmd: Option<String>) {
+    // `flox run` uses an unconditional catchall that consumes `--help`, so
+    // running `flox_cli().run_inner(["run", "--help"])` would parse OK and
+    // hit the `unreachable!()` arm below — a panic. Route to the hand-written
+    // synopsis instead.
+    if cmd.as_deref() == Some("run") {
+        run::print_help();
+        return;
+    }
+
     let mut args = Vec::from_iter(cmd.as_deref());
     args.push("--help");
 
@@ -710,6 +720,10 @@ enum UseCommands {
     #[bpaf(command, long("exit"))]
     Deactivate(#[bpaf(external(deactivate::deactivate))] deactivate::Deactivate),
 
+    /// Run a command from a Flox Catalog package
+    #[bpaf(command, footer("Run 'man flox-run' for more details."))]
+    Run(#[bpaf(external(run::run))] run::Run),
+
     /// Manage services in an environment
     #[bpaf(command)]
     Services(
@@ -726,6 +740,7 @@ impl UseCommands {
         match self {
             UseCommands::Activate(args) => args.handle(config, flox).await,
             UseCommands::Deactivate(args) => args.handle(config, flox),
+            UseCommands::Run(args) => args.handle(flox).await,
             UseCommands::Services(args) => args.handle(config, flox).await,
         }
     }
@@ -734,6 +749,7 @@ impl UseCommands {
         match self {
             UseCommands::Activate(args) => args.subcommand_name(),
             UseCommands::Deactivate(_) => "deactivate",
+            UseCommands::Run(_) => "run",
             UseCommands::Services(sub) => sub.subcommand_name(),
         }
     }

--- a/cli/flox/src/commands/run.rs
+++ b/cli/flox/src/commands/run.rs
@@ -1,0 +1,1224 @@
+//! `flox run` — resolve a catalog package and exec an executable from it.
+//!
+//! bpaf cannot implement POSIX stop-at-first-positional parsing (validated
+//! against bpaf 0.9.24 vendored source, `args.rs:372-392`):
+//!
+//! 1. bpaf consumes the first `--` before `any()` catchalls see it, losing
+//!    a distinction `flox run` needs.
+//! 2. bpaf's flag recognition is order-independent, so in
+//!    `flox run curl -p curl` it would wrongly claim `-p curl` for flox —
+//!    POSIX rules say it belongs to `curl`.
+//!
+//! So `flox` splits argv itself; bpaf only dispatches the `run` subcommand.
+//! `Run._raw_args` is an unconditional catchall so bpaf never intercepts
+//! flags that belong to the invoked command. `handle()` re-reads raw process
+//! arguments with `std::env::args_os()`.
+
+use std::ffi::{OsStr, OsString};
+use std::os::unix::ffi::OsStringExt as _;
+use std::os::unix::fs::PermissionsExt;
+use std::os::unix::process::CommandExt;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+
+use anyhow::Result;
+use bpaf::Bpaf;
+use flox_manifest::raw::{CatalogPackage, RawManifestError};
+use flox_rust_sdk::flox::Flox;
+use flox_rust_sdk::providers::buildenv::{
+    BuildEnvError,
+    build_catalog_pkg_from_source,
+    materialise_with_retry,
+    substitute_store_paths,
+};
+use floxhub_client::{
+    CatalogClientTrait,
+    MessageLevel,
+    PackageDescriptor,
+    PackageGroup,
+    PackageSystem,
+    ResolutionMessage,
+};
+use indoc::indoc;
+use thiserror::Error;
+use tracing::{debug, info_span};
+
+use crate::subcommand_metric;
+
+// ---------------------------------------------------------------------------
+// Error types
+// ---------------------------------------------------------------------------
+
+/// Errors specific to `flox run`.
+#[derive(Debug, Error)]
+pub enum RunError {
+    /// No command was given after parsing all flags.
+    #[error(
+        "No command specified.\n\
+         Run 'flox run --package <PACKAGE> <COMMAND> [ARGS...]'."
+    )]
+    NoExecutable,
+
+    /// `-p`/`--package` was absent (reported before `NoExecutable`).
+    #[error(
+        "No package specified.\n\
+         Use '--package <PACKAGE>' to specify the package that provides the command."
+    )]
+    MissingPackage,
+
+    /// `-p`/`--package` flag appeared without a value.
+    #[error(
+        "Missing value for '{0}'.\n\
+         Use '--package <PACKAGE>' to specify the package that provides the command."
+    )]
+    MissingPackageValue(String),
+
+    /// The value passed to `-p`/`--package` was not valid UTF-8.
+    #[error("Package specs must be valid UTF-8.")]
+    PackageSpecNotUtf8,
+
+    /// `CatalogPackage::from_str` failed.
+    #[error(
+        "Invalid package '{0}'.\n\
+         Use 'flox search' to find available packages."
+    )]
+    InvalidPackageSpec(String, #[source] RawManifestError),
+
+    /// Package spec uses syntax not supported in phase 1 (`@`, `^`, `/`).
+    #[error(
+        "Unsupported package '{0}'.\n\
+         'flox run' accepts a plain package name; version constraints ('@'), \
+         output selectors ('^'), and custom catalogs ('/') are not supported."
+    )]
+    UnsupportedPackageSpec(String),
+
+    /// An unrecognised flag appeared before the command name.
+    #[error(
+        "Unknown option '{0}'.\n\
+         Use '--' before the command name if it starts with '-'."
+    )]
+    UnknownFlag(String),
+
+    /// Package was not found in the Flox Catalog.
+    #[error(
+        "Package '{0}' was not found in the Flox Catalog.\n\
+         Use 'flox search {0}' to find available packages."
+    )]
+    PackageNotFound(String),
+
+    /// Package exists but is not available for the current system.
+    #[error("Package '{0}' is not available for system '{1}'.")]
+    PackageUnavailableOnSystem(String, String),
+
+    /// The catalog returned an error-level resolution message not otherwise classified.
+    #[error(
+        "Failed to resolve package '{0}'.\n\
+         {1}"
+    )]
+    ResolutionMessage(String, String),
+
+    /// Transport/network failure during catalog resolve.
+    #[error(
+        "Failed to resolve package '{0}'.\n\
+         Check your network connection and try again."
+    )]
+    CatalogError(String),
+
+    /// The resolved package has no store paths for this system.
+    #[error("Package '{0}' has no store paths to download for this system.")]
+    NoStorePaths(String),
+
+    /// Creating the GC-root cache directory failed.
+    #[error("Failed to prepare the cache directory for '{0}'.")]
+    CreateGcRootDir(String, #[source] std::io::Error),
+
+    /// The `nix build` invocation for building from source failed.
+    #[error(
+        "Failed to build '{0}' from source.\n\
+         Use 'flox install {0}' to add it to a persistent environment."
+    )]
+    BuildFailed(String, #[source] BuildEnvError),
+
+    /// The requested executable was not found in `bin/` or `sbin/` of any output.
+    #[error(
+        "Command '{executable}' was not found in package '{package}'.\n\
+         The package may provide the command under a different name."
+    )]
+    ExecutableNotFound { executable: String, package: String },
+
+    /// The final `exec` syscall returned (rare — permissions or missing binary).
+    #[error("Failed to run '{0}'.")]
+    ExecFailed(String, #[source] std::io::Error),
+}
+
+// ---------------------------------------------------------------------------
+// Parsed argument types
+// ---------------------------------------------------------------------------
+
+/// Outcome of the `parse_run_args` state machine.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ParsedArgs {
+    /// `-h`/`--help` was seen before the first positional or `--`.
+    Help,
+    /// A fully-specified run invocation.
+    Run(RunArgs),
+}
+
+/// Validated arguments produced by the POSIX state machine.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RunArgs {
+    /// Package spec from `-p`/`--package` (required, plain form only).
+    pub package: String,
+    /// Command name (first positional argument).
+    pub executable: OsString,
+    /// Remaining arguments forwarded verbatim to the command.
+    pub args: Vec<OsString>,
+}
+
+// ---------------------------------------------------------------------------
+// bpaf registration struct
+// ---------------------------------------------------------------------------
+
+/// Run a command from a Flox Catalog package.
+#[derive(Bpaf, Clone, Debug)]
+pub struct Run {
+    // Unconditional catchall: bpaf dispatches the subcommand but never
+    // intercepts any flag, including -h/--help. handle() re-reads argv via
+    // args_os() and delegates to parse_run_args().
+    #[bpaf(any("ARGS", Some), many)]
+    _raw_args: Vec<String>,
+}
+
+impl Run {
+    /// Entry point: parse args with POSIX stop-at-first-positional semantics,
+    /// then resolve, download, and exec.
+    pub async fn handle(self, flox: Flox) -> Result<()> {
+        subcommand_metric!("run");
+
+        // Re-read raw OS args. bpaf has already consumed the first `--`, so
+        // we cannot rely on self._raw_args for correct passthrough semantics.
+        // Locating the first "run" token is safe: the only options before a
+        // subcommand are boolean flags (-v, --debug), so the first "run" token
+        // is always the subcommand keyword.
+        let all_args: Vec<OsString> = std::env::args_os().collect();
+        let run_idx = all_args
+            .iter()
+            .position(|a| a == "run")
+            .unwrap_or(all_args.len());
+        let after_run: Vec<OsString> = all_args[run_idx + 1..].to_vec();
+
+        let parsed = parse_run_args(after_run).map_err(anyhow::Error::from)?;
+
+        match parsed {
+            ParsedArgs::Help => {
+                print_help();
+                Ok(())
+            },
+            ParsedArgs::Run(run_args) => exec_run(run_args, &flox).await,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Arg pre-processor (POSIX stop-at-first-positional state machine)
+// ---------------------------------------------------------------------------
+
+/// Parse the arguments that follow `flox run` using POSIX stop-at-first-positional
+/// semantics.
+///
+/// Flag rules (before the first positional or `--`):
+/// - `-h` / `--help` → `ParsedArgs::Help`
+/// - `-p` / `--package` (space form only) → consume next arg as package spec
+/// - `-p=…` / `--package=…` / bundled forms → `UnknownFlag`
+/// - `--` → force positional mode; next arg is the command even if it starts with `-`
+/// - any other `"-…"` → `UnknownFlag`
+///
+/// After the first positional (or after `--`), everything is forwarded
+/// verbatim including any literal `--`.
+///
+/// After the loop: missing `-p` is reported before missing command.
+pub fn parse_run_args(args: Vec<OsString>) -> Result<ParsedArgs, RunError> {
+    let mut package: Option<String> = None;
+    let mut executable: Option<OsString> = None;
+    let mut passthrough: Vec<OsString> = Vec::new();
+
+    let mut iter = args.into_iter();
+
+    // Phase 1: scan flags until we see `--` or the first positional.
+    'flags: loop {
+        let Some(arg) = iter.next() else {
+            break 'flags;
+        };
+
+        match arg.to_str() {
+            Some("--") => {
+                // Force positional mode: the next arg is the command even if
+                // it starts with `-`. Everything after it is passthrough.
+                if let Some(cmd) = iter.next() {
+                    executable = Some(cmd);
+                }
+                passthrough.extend(iter);
+                break 'flags;
+            },
+            Some("-h") | Some("--help") => {
+                return Ok(ParsedArgs::Help);
+            },
+            Some("-p") | Some("--package") => {
+                let value_os = iter.next().ok_or_else(|| {
+                    RunError::MissingPackageValue(arg.to_string_lossy().into_owned())
+                })?;
+                let value = value_os
+                    .into_string()
+                    .map_err(|_| RunError::PackageSpecNotUtf8)?;
+                package = Some(value);
+            },
+            Some(s) if s.starts_with('-') => {
+                return Err(RunError::UnknownFlag(s.to_owned()));
+            },
+            _ => {
+                // First non-flag positional is the command name; everything
+                // after it is passthrough verbatim (including any literal `--`).
+                executable = Some(arg);
+                passthrough.extend(iter);
+                break 'flags;
+            },
+        }
+    }
+
+    // Report missing package before missing command.
+    let package = package.ok_or(RunError::MissingPackage)?;
+    let executable = executable.ok_or(RunError::NoExecutable)?;
+
+    Ok(ParsedArgs::Run(RunArgs {
+        package,
+        executable,
+        args: passthrough,
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// Package spec validation
+// ---------------------------------------------------------------------------
+
+/// Reject package specs that use syntax unsupported in phase 1.
+///
+/// Accepts only a plain attr-path (e.g. `cowsay`, `python3Packages.requests`).
+/// Version constraints (`@`), output selectors (`^`), and custom catalogs
+/// (`/`) are not supported and cause `UnsupportedPackageSpec`.
+///
+/// Custom catalog rejection also makes the substituter-only download path
+/// below sufficient: private catalogs require the buildenv realise path
+/// (`nix copy --from` + catalog auth) rather than the substituter path.
+pub fn validate_plain_package(pkg: &CatalogPackage, raw: &str) -> Result<(), RunError> {
+    if pkg.version.is_some() || pkg.outputs.is_some() || pkg.is_custom_catalog() {
+        return Err(RunError::UnsupportedPackageSpec(raw.to_string()));
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Core pipeline
+// ---------------------------------------------------------------------------
+
+/// Resolve, download, and exec the requested command.
+async fn exec_run(run_args: RunArgs, flox: &Flox) -> Result<()> {
+    let pkg_spec = run_args.package.clone();
+
+    // 1. Parse the package spec and reject unsupported syntax.
+    let catalog_pkg = CatalogPackage::from_str(&pkg_spec)
+        .map_err(|e| RunError::InvalidPackageSpec(pkg_spec.clone(), e))?;
+
+    validate_plain_package(&catalog_pkg, &pkg_spec)?;
+
+    let attr_path = catalog_pkg.pkg_path.clone();
+    let version = catalog_pkg.version.clone();
+
+    debug!(
+        install_id = %catalog_pkg.id,
+        attr_path = %attr_path,
+        version = ?version,
+        "resolved package spec"
+    );
+
+    // 2. Parse the system.
+    let system: PackageSystem = flox
+        .system
+        .parse()
+        .map_err(|_| RunError::PackageUnavailableOnSystem(pkg_spec.clone(), flox.system.clone()))?;
+
+    // 3. Build a PackageGroup and call the catalog resolver.
+    let descriptor = PackageDescriptor {
+        install_id: catalog_pkg.id.clone(),
+        attr_path: attr_path.clone(),
+        systems: vec![system],
+        version,
+        allow_broken: None,
+        allow_insecure: None,
+        allow_missing_builds: None,
+        allow_pre_releases: None,
+        allow_unfree: None,
+        allowed_licenses: None,
+        derivation: None,
+    };
+
+    let package_group = PackageGroup {
+        name: "toplevel".to_string(),
+        descriptors: vec![descriptor],
+    };
+
+    let mut resolved_groups = flox
+        .floxhub_client
+        .resolve(vec![package_group])
+        .await
+        .map_err(|_| RunError::CatalogError(pkg_spec.clone()))?;
+
+    // 4. Extract and classify the resolution result.
+    let group = resolved_groups
+        .drain(..)
+        .next()
+        .ok_or_else(|| RunError::CatalogError(pkg_spec.clone()))?;
+
+    // Check for error-level resolution messages before looking at the page.
+    for msg in &group.msgs {
+        if msg.level() != MessageLevel::Error {
+            continue;
+        }
+        return Err(classify_resolution_message(msg, &pkg_spec, &flox.system).into());
+    }
+
+    let page = group
+        .page
+        .ok_or_else(|| RunError::PackageNotFound(pkg_spec.clone()))?;
+
+    let packages = page.packages.unwrap_or_default();
+    if packages.is_empty() {
+        return Err(RunError::PackageNotFound(pkg_spec.clone()).into());
+    }
+
+    let resolved_pkg = &packages[0];
+
+    debug!(
+        pname = %resolved_pkg.pname,
+        version = %resolved_pkg.version,
+        "package resolved"
+    );
+
+    // 5. Collect store paths.
+    let outputs_to_install: Vec<String> = resolved_pkg
+        .outputs_to_install
+        .clone()
+        .unwrap_or_else(|| vec!["out".to_string()]);
+
+    let store_paths: Vec<String> = resolved_pkg
+        .outputs
+        .iter()
+        .filter(|o| outputs_to_install.contains(&o.name))
+        .map(|o| o.store_path.clone())
+        .collect();
+
+    if store_paths.is_empty() {
+        return Err(RunError::NoStorePaths(pkg_spec.clone()).into());
+    }
+
+    debug!(store_paths = ?store_paths, "store paths to download");
+
+    // 6. Download via the SDK's substitution path with a stable GC root.
+    //
+    // The GC root is keyed on system + attr_path so repeated invocations of
+    // the same package skip the download. `flox.cache_dir/run` is already
+    // reserved as a runtime-dir fallback, hence the `run-gc-roots` name.
+    let gc_root_dir = flox.cache_dir.join("run-gc-roots");
+    std::fs::create_dir_all(&gc_root_dir)
+        .map_err(|e| RunError::CreateGcRootDir(pkg_spec.clone(), e))?;
+
+    let gc_root_prefix = gc_root_dir.join(format!("{}.{}", flox.system, attr_path));
+
+    // Skip if store paths are present AND our GC root symlink already exists.
+    // Checking both avoids the case where the store was populated by another
+    // process (e.g., an earlier test): we must still register the GC root so
+    // `nix store gc` cannot collect the paths out from under us.
+    let gc_root_exists = gc_root_prefix.exists();
+    let all_present = store_paths.iter().all(|p| Path::new(p).exists());
+    if !all_present || !gc_root_exists {
+        // Per-run GC root for source builds; keyed on PID so concurrent
+        // runs don't clobber each other's outputs.
+        let pid = std::process::id();
+        let build_gc_root =
+            gc_root_dir.join(format!("build-{}.{}-{}", flox.system, attr_path, pid));
+
+        // Substitution and source-build are both inside the realise closure so
+        // materialise_with_retry can retry the whole sequence on a GC race.
+        materialise_with_retry(
+            || {
+                let ok = {
+                    let _dl = info_span!(
+                        "run_download",
+                        progress = format!("Downloading '{pkg_spec}'...")
+                    )
+                    .entered();
+                    substitute_store_paths(&store_paths, Some(&gc_root_prefix))?
+                };
+                if !ok {
+                    // Cache miss; build from source.
+                    build_catalog_pkg_from_source(
+                        &resolved_pkg.locked_url,
+                        &attr_path,
+                        &flox.system,
+                        resolved_pkg.unfree,
+                        resolved_pkg.broken,
+                        Some(&build_gc_root),
+                    )
+                } else {
+                    Ok(())
+                }
+            },
+            || {
+                // Source-built paths (different hash from catalog) are tracked
+                // via GC root symlinks, not store_paths. If build_gc_root has
+                // symlinks, the source-build path was taken — check those real
+                // output paths. Otherwise, substitution was used — check the
+                // catalog store_paths directly.
+                let gc_paths = collect_store_paths_from_gc_root(&build_gc_root);
+                if gc_paths.is_empty() {
+                    store_paths
+                        .iter()
+                        .filter(|p| std::fs::metadata(p).is_err())
+                        .cloned()
+                        .collect()
+                } else {
+                    gc_paths
+                        .into_iter()
+                        .filter(|p| std::fs::metadata(p).is_err())
+                        .collect()
+                }
+            },
+            || {
+                let gc_paths = collect_store_paths_from_gc_root(&build_gc_root);
+                if gc_paths.is_empty() {
+                    store_paths.clone()
+                } else {
+                    gc_paths
+                }
+            },
+            || Ok::<(), BuildEnvError>(()),
+        )
+        .map_err(|e| RunError::BuildFailed(pkg_spec.clone(), e))?;
+
+        // Source build was used if the GC root has symlinks; exec via its PATH.
+        // Substitution leaves build_gc_root empty — fall through to store_paths exec.
+        let build_paths = collect_store_paths_from_gc_root(&build_gc_root);
+        if !build_paths.is_empty() {
+            // Fork a background watcher that removes the GC root when the
+            // exec'd command exits.
+            fork_gc_root_watcher(&build_gc_root)
+                .map_err(|e| RunError::ExecFailed("fork gc watcher".into(), e))?;
+
+            let bin_dirs = collect_bin_dirs_from_gc_root(&build_gc_root);
+            let new_path = prepend_path_dirs(&bin_dirs);
+
+            debug!(path = ?new_path, "exec via build output PATH");
+
+            let err = std::process::Command::new(&run_args.executable)
+                .args(&run_args.args)
+                .env("PATH", &new_path)
+                .exec();
+
+            return Err(RunError::ExecFailed(
+                run_args.executable.to_string_lossy().into_owned(),
+                err,
+            )
+            .into());
+        }
+    }
+
+    // 7. Locate the executable in bin/ then sbin/ of all outputs.
+    let executable_path = find_executable(&store_paths, &run_args.executable, &pkg_spec)?;
+
+    debug!(path = %executable_path.display(), "found executable");
+
+    // 8. Exec (replace the flox process).
+    let err = std::process::Command::new(&executable_path)
+        .args(&run_args.args)
+        .exec();
+
+    // exec only returns on error.
+    Err(RunError::ExecFailed(executable_path.display().to_string(), err).into())
+}
+
+// ---------------------------------------------------------------------------
+// Resolution error classification
+// ---------------------------------------------------------------------------
+
+/// Map a typed `ResolutionMessage` to the appropriate `RunError`.
+fn classify_resolution_message(msg: &ResolutionMessage, pkg_spec: &str, system: &str) -> RunError {
+    match msg {
+        ResolutionMessage::AttrPathNotFoundNotInCatalog(_) => {
+            RunError::PackageNotFound(pkg_spec.to_string())
+        },
+        ResolutionMessage::AttrPathNotFoundNotFoundForAllSystems(_) => {
+            RunError::PackageUnavailableOnSystem(pkg_spec.to_string(), system.to_string())
+        },
+        other => RunError::ResolutionMessage(pkg_spec.to_string(), other.msg().to_string()),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Executable discovery
+// ---------------------------------------------------------------------------
+
+/// Search `bin/` across all outputs, then `sbin/` across all outputs.
+///
+/// `bin/` wins overall before `sbin/` is consulted, so the result is
+/// deterministic. A candidate must be a regular file with at least one
+/// executable bit (`mode & 0o111 != 0`). No fallback to the caller's PATH.
+pub fn find_executable(
+    store_paths: &[String],
+    executable: &OsString,
+    pkg_spec: &str,
+) -> Result<PathBuf, RunError> {
+    // Reject names containing path separators to prevent traversal outside
+    // the package's store prefix (e.g. "../../etc/shadow").
+    if executable.to_string_lossy().contains('/') {
+        return Err(RunError::ExecutableNotFound {
+            executable: executable.to_string_lossy().into_owned(),
+            package: pkg_spec.to_string(),
+        });
+    }
+
+    for dir in &["bin", "sbin"] {
+        for store_path in store_paths {
+            let candidate = Path::new(store_path).join(dir).join(executable);
+            if let Ok(meta) = std::fs::metadata(&candidate)
+                && meta.is_file()
+                && meta.permissions().mode() & 0o111 != 0
+            {
+                return Ok(candidate);
+            }
+        }
+    }
+
+    Err(RunError::ExecutableNotFound {
+        executable: executable.to_string_lossy().into_owned(),
+        package: pkg_spec.to_string(),
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Build-from-source helpers
+// ---------------------------------------------------------------------------
+
+/// Collect `bin/` directories from build output symlinks rooted at `prefix`.
+///
+/// `nix build --out-link <prefix>` creates `<prefix>`, `<prefix>-doc`,
+/// `<prefix>-dev`, etc. This function scans the parent directory for any
+/// entry whose name starts with the file_name component of `prefix`, follows
+/// each symlink to its store-path target, and collects any `bin/` subdirs
+/// that exist there.
+pub fn collect_bin_dirs_from_gc_root(prefix: &Path) -> Vec<PathBuf> {
+    let parent = match prefix.parent() {
+        Some(p) => p,
+        None => return vec![],
+    };
+    let file_name = match prefix.file_name().and_then(OsStr::to_str) {
+        Some(n) => n.to_string(),
+        None => return vec![],
+    };
+
+    let Ok(entries) = std::fs::read_dir(parent) else {
+        return vec![];
+    };
+
+    let mut bin_dirs = Vec::new();
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+        if !name_str.starts_with(&file_name) {
+            continue;
+        }
+        // Follow the symlink (nix build creates symlinks into the store).
+        let target = match std::fs::read_link(entry.path())
+            .or_else(|_| std::fs::canonicalize(entry.path()))
+        {
+            Ok(t) => t,
+            Err(_) => continue,
+        };
+        let bin = target.join("bin");
+        if bin.is_dir() {
+            bin_dirs.push(bin);
+        }
+    }
+    bin_dirs
+}
+
+/// Collect the Nix store-path targets of build output symlinks rooted at `prefix`.
+///
+/// After `nix build --out-link <prefix>`, symlinks like `<prefix>`,
+/// `<prefix>-doc`, `<prefix>-dev` point into the Nix store.  This function
+/// returns those store-path strings so callers can check whether they are
+/// present on disk (used as the `missing_paths` / `expected_paths` closures
+/// passed to `materialise_with_retry`).
+pub fn collect_store_paths_from_gc_root(prefix: &Path) -> Vec<String> {
+    let parent = match prefix.parent() {
+        Some(p) => p,
+        None => return vec![],
+    };
+    let file_name = match prefix.file_name().and_then(OsStr::to_str) {
+        Some(n) => n.to_string(),
+        None => return vec![],
+    };
+    let Ok(entries) = std::fs::read_dir(parent) else {
+        return vec![];
+    };
+    entries
+        .flatten()
+        .filter(|e| {
+            let n = e.file_name();
+            let s = n.to_string_lossy();
+            s == file_name || s.starts_with(&format!("{file_name}-"))
+        })
+        .filter(|e| e.path().is_symlink())
+        .filter_map(|e| std::fs::read_link(e.path()).ok())
+        .filter_map(|t| t.to_str().map(|s| s.to_string()))
+        .collect()
+}
+
+/// Prepend `dirs` to the current `PATH`, returning the combined value.
+///
+/// Each directory is joined with `:` and the current `PATH` is appended.
+pub fn prepend_path_dirs(dirs: &[PathBuf]) -> OsString {
+    let current_path = std::env::var_os("PATH").unwrap_or_default();
+    let mut parts: Vec<u8> = Vec::new();
+    for dir in dirs {
+        if !parts.is_empty() {
+            parts.push(b':');
+        }
+        parts.extend_from_slice(dir.as_os_str().as_encoded_bytes());
+    }
+    if !parts.is_empty() && !current_path.is_empty() {
+        parts.push(b':');
+    }
+    parts.extend_from_slice(current_path.as_encoded_bytes());
+    OsString::from_vec(parts)
+}
+
+/// Fork a background watcher child that removes `prefix`* symlinks when the
+/// parent (exec'd command) exits.
+///
+/// `exec` preserves the PID, so the command the user invoked keeps this
+/// process's PID. The watcher polls `getppid()`: while it still reports that
+/// PID the parent is alive, and once the parent exits the watcher is reparented
+/// (to init or a subreaper) and `getppid()` changes. The watcher then removes
+/// all symlinks whose name starts with `prefix.file_name()` in the same
+/// directory, and exits.
+///
+/// Polling `getppid()` is a cheap syscall and, unlike a recorded PID compared
+/// with `kill(pid, 0)`, cannot be fooled by PID reuse: the reparent is what is
+/// observed, not the liveness of an arbitrary PID.
+///
+/// This ensures temporary GC-root symlinks created by `nix build --out-link`
+/// are cleaned up even though we `exec` into the target command and can no
+/// longer run cleanup code ourselves.
+pub fn fork_gc_root_watcher(gc_root_prefix: &Path) -> Result<(), std::io::Error> {
+    use std::thread::sleep;
+    use std::time::Duration;
+
+    use nix::unistd::{ForkResult, fork, getppid};
+
+    // The exec'd command keeps this process's PID, so capture it before the
+    // fork as the parent the watcher should wait on.
+    let expected_parent = std::process::id() as i32;
+
+    match unsafe { fork() }.map_err(std::io::Error::from)? {
+        ForkResult::Child => {
+            // Poll until the parent (exec'd command) exits. `getppid()` stops
+            // reporting `expected_parent` once the parent dies and the watcher
+            // is reparented. If the parent already exited (e.g. exec failed),
+            // the condition is false on the first check and cleanup runs
+            // immediately.
+            while getppid().as_raw() == expected_parent {
+                sleep(Duration::from_millis(500));
+            }
+
+            // Parent exited. Remove GC root symlinks.
+            if let (Some(parent), Some(file_name)) =
+                (gc_root_prefix.parent(), gc_root_prefix.file_name())
+            {
+                let scan_prefix = file_name.to_string_lossy().into_owned();
+                if let Ok(entries) = std::fs::read_dir(parent) {
+                    for entry in entries.flatten() {
+                        let name = entry.file_name();
+                        let name_str = name.to_string_lossy();
+                        if name_str.starts_with(&scan_prefix) && entry.path().is_symlink() {
+                            let _ = std::fs::remove_file(entry.path());
+                        }
+                    }
+                }
+            }
+
+            // Use _exit, not exit: after fork() the child must not run
+            // atexit handlers or flush stdio buffers shared with the parent.
+            unsafe { nix::libc::_exit(0) };
+        },
+        ForkResult::Parent { .. } => Ok(()),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Help
+// ---------------------------------------------------------------------------
+
+/// Print a hand-written synopsis for `flox run`.
+///
+/// bpaf's built-in help is suppressed because the catchall struct consumes
+/// `--help` before bpaf can render it. This function matches bpaf's stdout
+/// convention so callers cannot tell the difference.
+pub fn print_help() {
+    print!(indoc! {"
+        Run a command from a Flox Catalog package
+
+        Usage: flox run -p <PACKAGE> -- <COMMAND> [ARGS...]
+
+        Options:
+          -p, --package <PACKAGE>   Package that provides the command (required)
+          -h, --help                Print this help
+
+        Always use '--' to separate flox flags from the command and its arguments.
+        This matches 'flox activate -- <command>' and ensures flags like '--version'
+        reach the command rather than flox.
+
+        Examples:
+          flox run -p curl -- curl http://example.com
+          flox run -p binutils -- readelf -a /bin/ls
+          flox run -p hello -- hello --help
+          flox run -p hello -- hello --version
+
+        Limitations (phase 1):
+          Version constraints (@), output selectors (^), and custom catalogs (/) are
+          not supported. The -p flag is always required.
+
+        Caching:
+          Downloaded store paths are registered as GC roots under
+          $FLOX_CACHE_DIR/run-gc-roots/. Repeated invocations of the same package
+          skip the download step.
+
+        Run 'man flox-run' for more details.
+    "});
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsString;
+    #[cfg(unix)]
+    use std::os::unix::ffi::OsStringExt;
+
+    use super::*;
+
+    fn os(s: &str) -> OsString {
+        OsString::from(s)
+    }
+
+    fn os_vec(v: &[&str]) -> Vec<OsString> {
+        v.iter().map(OsString::from).collect()
+    }
+
+    // -----------------------------------------------------------------------
+    // parse_run_args tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn package_flag_short() {
+        let result =
+            parse_run_args(os_vec(&["-p", "binutils", "readelf", "-a", "/bin/ls"])).unwrap();
+        assert_eq!(
+            result,
+            ParsedArgs::Run(RunArgs {
+                package: "binutils".to_string(),
+                executable: os("readelf"),
+                args: os_vec(&["-a", "/bin/ls"]),
+            })
+        );
+    }
+
+    #[test]
+    fn package_flag_long() {
+        let result = parse_run_args(os_vec(&["--package", "binutils", "readelf"])).unwrap();
+        assert_eq!(
+            result,
+            ParsedArgs::Run(RunArgs {
+                package: "binutils".to_string(),
+                executable: os("readelf"),
+                args: vec![],
+            })
+        );
+    }
+
+    #[test]
+    fn double_dash_before_executable() {
+        let result = parse_run_args(os_vec(&["-p", "somepkg", "--", "-weirdname"])).unwrap();
+        assert_eq!(
+            result,
+            ParsedArgs::Run(RunArgs {
+                package: "somepkg".to_string(),
+                executable: os("-weirdname"),
+                args: vec![],
+            })
+        );
+    }
+
+    #[test]
+    fn double_dash_after_command_stays_in_passthrough() {
+        // A literal `--` after the command stays in passthrough.
+        let result = parse_run_args(os_vec(&["-p", "x", "cmd", "--", "-z"])).unwrap();
+        assert_eq!(
+            result,
+            ParsedArgs::Run(RunArgs {
+                package: "x".to_string(),
+                executable: os("cmd"),
+                args: os_vec(&["--", "-z"]),
+            })
+        );
+    }
+
+    #[test]
+    fn no_args_returns_missing_package_error() {
+        let result = parse_run_args(vec![]);
+        assert!(matches!(result, Err(RunError::MissingPackage)));
+    }
+
+    #[test]
+    fn no_package_flag_returns_missing_package() {
+        // A bare command with no -p/--package must report MissingPackage.
+        let result = parse_run_args(os_vec(&["curl", "http://example.com"]));
+        assert!(matches!(result, Err(RunError::MissingPackage)));
+    }
+
+    #[test]
+    fn posix_order_dependence_curl_minus_p_curl() {
+        // After the first positional `curl`, -p belongs to curl (not flox).
+        // The absence of a flox -p flag should yield MissingPackage.
+        let result = parse_run_args(os_vec(&["curl", "-p", "curl"]));
+        assert!(matches!(result, Err(RunError::MissingPackage)));
+    }
+
+    #[test]
+    fn unknown_flag_returns_error() {
+        let result = parse_run_args(os_vec(&["--unknown", "curl"]));
+        assert!(matches!(result, Err(RunError::UnknownFlag(_))));
+    }
+
+    #[test]
+    fn equals_form_long_rejected() {
+        let result = parse_run_args(os_vec(&["--package=binutils", "readelf"]));
+        assert!(matches!(result, Err(RunError::UnknownFlag(_))));
+    }
+
+    #[test]
+    fn equals_form_short_rejected() {
+        let result = parse_run_args(os_vec(&["-p=binutils", "readelf"]));
+        assert!(matches!(result, Err(RunError::UnknownFlag(_))));
+    }
+
+    #[test]
+    fn bundled_short_form_rejected() {
+        let result = parse_run_args(os_vec(&["-pbinutils", "readelf"]));
+        assert!(matches!(result, Err(RunError::UnknownFlag(_))));
+    }
+
+    #[test]
+    fn help_short_before_positional() {
+        let result = parse_run_args(os_vec(&["-h"])).unwrap();
+        assert_eq!(result, ParsedArgs::Help);
+    }
+
+    #[test]
+    fn help_long_before_positional() {
+        let result = parse_run_args(os_vec(&["--help"])).unwrap();
+        assert_eq!(result, ParsedArgs::Help);
+    }
+
+    #[test]
+    fn help_after_package_before_command_is_intercepted() {
+        // `flox run -p curl --help` — help is before the command.
+        let result = parse_run_args(os_vec(&["-p", "curl", "--help"])).unwrap();
+        assert_eq!(result, ParsedArgs::Help);
+    }
+
+    #[test]
+    fn help_after_command_stays_in_passthrough() {
+        // `flox run -p curl curl --help` — help is after the command name (curl).
+        let result = parse_run_args(os_vec(&["-p", "curl", "curl", "--help"])).unwrap();
+        assert_eq!(
+            result,
+            ParsedArgs::Run(RunArgs {
+                package: "curl".to_string(),
+                executable: os("curl"),
+                args: os_vec(&["--help"]),
+            })
+        );
+    }
+
+    #[test]
+    fn help_after_double_dash_stays_in_passthrough() {
+        // `--` forces positional mode, so `--help` after it goes to command.
+        let result = parse_run_args(os_vec(&["-p", "hello", "--", "hello", "--help"])).unwrap();
+        assert_eq!(
+            result,
+            ParsedArgs::Run(RunArgs {
+                package: "hello".to_string(),
+                executable: os("hello"),
+                args: os_vec(&["--help"]),
+            })
+        );
+    }
+
+    #[test]
+    fn missing_package_value_short() {
+        let result = parse_run_args(os_vec(&["-p"]));
+        assert!(matches!(result, Err(RunError::MissingPackageValue(_))));
+    }
+
+    #[test]
+    fn missing_package_value_long() {
+        let result = parse_run_args(os_vec(&["--package"]));
+        assert!(matches!(result, Err(RunError::MissingPackageValue(_))));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn non_utf8_package_value() {
+        let bad = OsString::from_vec(vec![0xff]);
+        let args = vec![os("-p"), bad, os("cmd")];
+        let result = parse_run_args(args);
+        assert!(matches!(result, Err(RunError::PackageSpecNotUtf8)));
+    }
+
+    // -----------------------------------------------------------------------
+    // validate_plain_package tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn validate_plain_package_accepts_simple() {
+        let pkg: CatalogPackage = "cowsay".parse().unwrap();
+        assert!(validate_plain_package(&pkg, "cowsay").is_ok());
+    }
+
+    #[test]
+    fn validate_plain_package_accepts_dotted() {
+        let pkg: CatalogPackage = "python3Packages.requests".parse().unwrap();
+        assert!(validate_plain_package(&pkg, "python3Packages.requests").is_ok());
+    }
+
+    #[test]
+    fn validate_plain_package_rejects_version() {
+        let pkg: CatalogPackage = "curl@8.0".parse().unwrap();
+        assert!(matches!(
+            validate_plain_package(&pkg, "curl@8.0"),
+            Err(RunError::UnsupportedPackageSpec(_))
+        ));
+    }
+
+    #[test]
+    fn validate_plain_package_rejects_outputs() {
+        let pkg: CatalogPackage = "foo^bin".parse().unwrap();
+        assert!(matches!(
+            validate_plain_package(&pkg, "foo^bin"),
+            Err(RunError::UnsupportedPackageSpec(_))
+        ));
+    }
+
+    #[test]
+    fn validate_plain_package_rejects_custom_catalog() {
+        let pkg: CatalogPackage = "mycatalog/vim".parse().unwrap();
+        assert!(matches!(
+            validate_plain_package(&pkg, "mycatalog/vim"),
+            Err(RunError::UnsupportedPackageSpec(_))
+        ));
+    }
+
+    // -----------------------------------------------------------------------
+    // find_executable tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn find_executable_in_bin_dir() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let bin_dir = tmp.path().join("bin");
+        std::fs::create_dir(&bin_dir).unwrap();
+        let exe_path = bin_dir.join("hello");
+        std::fs::write(&exe_path, "#!/bin/sh\necho hello").unwrap();
+        // Set executable bit.
+        let mut perms = std::fs::metadata(&exe_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&exe_path, perms).unwrap();
+
+        let store_path = tmp.path().to_string_lossy().to_string();
+        let result = find_executable(&[store_path], &os("hello"), "hello").unwrap();
+        assert_eq!(result, exe_path);
+    }
+
+    #[test]
+    fn find_executable_skips_non_executable_file() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let bin_dir = tmp.path().join("bin");
+        std::fs::create_dir(&bin_dir).unwrap();
+        let path = bin_dir.join("hello");
+        std::fs::write(&path, "#!/bin/sh").unwrap();
+        // No executable bit.
+        let mut perms = std::fs::metadata(&path).unwrap().permissions();
+        perms.set_mode(0o644);
+        std::fs::set_permissions(&path, perms).unwrap();
+
+        let store_path = tmp.path().to_string_lossy().to_string();
+        let result = find_executable(&[store_path], &os("hello"), "hello");
+        assert!(matches!(result, Err(RunError::ExecutableNotFound { .. })));
+    }
+
+    #[test]
+    fn find_executable_sbin_fallback() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let sbin_dir = tmp.path().join("sbin");
+        std::fs::create_dir(&sbin_dir).unwrap();
+        let exe_path = sbin_dir.join("arp");
+        std::fs::write(&exe_path, "#!/bin/sh").unwrap();
+        let mut perms = std::fs::metadata(&exe_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&exe_path, perms).unwrap();
+
+        let store_path = tmp.path().to_string_lossy().to_string();
+        let result = find_executable(&[store_path], &os("arp"), "net-tools").unwrap();
+        assert_eq!(result, exe_path);
+    }
+
+    #[test]
+    fn find_executable_bin_wins_over_sbin() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let bin_dir = tmp.path().join("bin");
+        let sbin_dir = tmp.path().join("sbin");
+        std::fs::create_dir_all(&bin_dir).unwrap();
+        std::fs::create_dir_all(&sbin_dir).unwrap();
+
+        let bin_path = bin_dir.join("tool");
+        let sbin_path = sbin_dir.join("tool");
+        for p in &[&bin_path, &sbin_path] {
+            std::fs::write(p, "#!/bin/sh").unwrap();
+            let mut perms = std::fs::metadata(p).unwrap().permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(p, perms).unwrap();
+        }
+
+        let store_path = tmp.path().to_string_lossy().to_string();
+        let result = find_executable(&[store_path], &os("tool"), "somepkg").unwrap();
+        assert_eq!(result, bin_path);
+    }
+
+    #[test]
+    fn find_executable_not_found() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let store_path = tmp.path().to_string_lossy().to_string();
+        let result = find_executable(&[store_path], &os("missing"), "mypkg");
+        assert!(matches!(result, Err(RunError::ExecutableNotFound { .. })));
+    }
+
+    #[test]
+    fn find_executable_second_output() {
+        let tmp1 = tempfile::TempDir::new().unwrap();
+        let tmp2 = tempfile::TempDir::new().unwrap();
+        let sp1 = tmp1.path().to_string_lossy().to_string();
+        let sp2 = tmp2.path().to_string_lossy().to_string();
+
+        let bin_dir2 = tmp2.path().join("bin");
+        std::fs::create_dir(&bin_dir2).unwrap();
+        let exe_path = bin_dir2.join("readelf");
+        std::fs::write(&exe_path, "#!/bin/sh").unwrap();
+        let mut perms = std::fs::metadata(&exe_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&exe_path, perms).unwrap();
+
+        let result = find_executable(&[sp1, sp2], &os("readelf"), "binutils").unwrap();
+        assert_eq!(result, exe_path);
+    }
+
+    // -----------------------------------------------------------------------
+    // collect_bin_dirs_from_gc_root tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn collect_bin_dirs_finds_bin_under_symlink() {
+        let tmp = tempfile::TempDir::new().unwrap();
+
+        // Simulate a nix store output: a real directory with a bin/ subdir.
+        let store_out = tmp.path().join("store-out");
+        let bin_dir = store_out.join("bin");
+        std::fs::create_dir_all(&bin_dir).unwrap();
+
+        // Create a symlink that looks like nix build --out-link output.
+        let prefix = tmp.path().join("build-aarch64-darwin.hello-42");
+        std::os::unix::fs::symlink(&store_out, &prefix).unwrap();
+
+        let result = collect_bin_dirs_from_gc_root(&prefix);
+        assert_eq!(result, vec![bin_dir]);
+    }
+
+    #[test]
+    fn collect_bin_dirs_collects_suffix_symlinks() {
+        let tmp = tempfile::TempDir::new().unwrap();
+
+        // Simulate nix build creating multiple output symlinks with the same
+        // prefix: <prefix>, <prefix>-doc, <prefix>-dev.
+        let prefix = tmp.path().join("build-aarch64-darwin.pkg-99");
+
+        for suffix in &["", "-doc", "-dev"] {
+            let store_out = tmp.path().join(format!("store-out{suffix}"));
+            let bin = store_out.join("bin");
+            std::fs::create_dir_all(&bin).unwrap();
+            let link = tmp
+                .path()
+                .join(format!("build-aarch64-darwin.pkg-99{suffix}"));
+            std::os::unix::fs::symlink(&store_out, &link).unwrap();
+        }
+
+        let mut result = collect_bin_dirs_from_gc_root(&prefix);
+        result.sort();
+        assert_eq!(result.len(), 3);
+    }
+
+    #[test]
+    fn collect_bin_dirs_skips_outputs_without_bin() {
+        let tmp = tempfile::TempDir::new().unwrap();
+
+        let store_out = tmp.path().join("store-out-no-bin");
+        // No bin/ subdir.
+        std::fs::create_dir_all(&store_out).unwrap();
+
+        let prefix = tmp.path().join("build-aarch64-darwin.no-bin-42");
+        std::os::unix::fs::symlink(&store_out, &prefix).unwrap();
+
+        let result = collect_bin_dirs_from_gc_root(&prefix);
+        assert!(result.is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // prepend_path_dirs tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn prepend_path_dirs_prepends_to_existing_path() {
+        // We cannot rely on the process-level PATH in tests; check structure.
+        let dirs = vec![PathBuf::from("/my/bin"), PathBuf::from("/other/bin")];
+        let result = prepend_path_dirs(&dirs);
+        let result_str = result.to_string_lossy();
+        assert!(result_str.starts_with("/my/bin:/other/bin"));
+    }
+
+    #[test]
+    fn prepend_path_dirs_empty_dirs_returns_existing_path() {
+        let result = prepend_path_dirs(&[]);
+        // When no dirs are passed, the result should equal the current PATH.
+        let current = std::env::var_os("PATH").unwrap_or_default();
+        assert_eq!(result, current);
+    }
+}

--- a/cli/tests/run.bats
+++ b/cli/tests/run.bats
@@ -1,0 +1,253 @@
+#! /usr/bin/env bats
+# -*- mode: bats; -*-
+# ============================================================================ #
+#
+# Integration tests for `flox run`
+#
+# Tests that require a real Nix store download are tagged `run:store`
+# and can be run with:
+#   just integ-tests run.bats -- --filter-tags run:store
+#
+# All other tests use the catalog mock mechanism and run without network.
+#
+# ---------------------------------------------------------------------------- #
+
+load test_support.bash
+# bats file_tags=run
+
+# ---------------------------------------------------------------------------- #
+
+setup() {
+  common_test_setup
+  setup_isolated_flox
+}
+
+teardown() {
+  common_test_teardown
+}
+
+# ---------------------------------------------------------------------------- #
+# Help
+# ---------------------------------------------------------------------------- #
+
+@test "'flox run --help' shows synopsis" {
+  run "$FLOX_BIN" run --help
+  assert_success
+  assert_output --partial "flox run"
+  assert_output --partial "-p"
+}
+
+@test "'flox help run' shows synopsis without panic" {
+  run "$FLOX_BIN" help run
+  assert_success
+  assert_output --partial "flox run"
+  assert_output --partial "-p"
+}
+
+# ---------------------------------------------------------------------------- #
+# Required-flag errors (no network or store required)
+# ---------------------------------------------------------------------------- #
+
+@test "'flox run' with no args reports missing package" {
+  run "$FLOX_BIN" run
+  assert_failure
+  assert_output --partial "No package specified"
+}
+
+@test "'flox run <command>' without -p reports missing package" {
+  run "$FLOX_BIN" run cowsay
+  assert_failure
+  assert_output --partial "No package specified"
+}
+
+@test "'flox run -p' without a value reports missing package value" {
+  run "$FLOX_BIN" run -p
+  assert_failure
+  assert_output --partial "Missing value"
+}
+
+# ---------------------------------------------------------------------------- #
+# Unknown-flag handling
+# ---------------------------------------------------------------------------- #
+
+@test "'flox run --unknown-flag <cmd>' before command reports unknown option" {
+  run "$FLOX_BIN" run --unknown-flag curl
+  assert_failure
+  assert_output --partial "Unknown option"
+  assert_output --partial "'--'"
+}
+
+# ---------------------------------------------------------------------------- #
+# Unsupported package spec rejection (no network required)
+# ---------------------------------------------------------------------------- #
+
+@test "'flox run' rejects version constraint (@) in package spec" {
+  run "$FLOX_BIN" run -p "hello@2.12" hello
+  assert_failure
+  assert_output --partial "Unsupported package"
+}
+
+@test "'flox run' rejects output selector (^) in package spec" {
+  run "$FLOX_BIN" run -p "foo^bin" foo
+  assert_failure
+  assert_output --partial "Unsupported package"
+}
+
+@test "'flox run' rejects custom catalog (/) in package spec" {
+  run "$FLOX_BIN" run -p "mycat/vim" vi
+  assert_failure
+  assert_output --partial "Unsupported package"
+}
+
+# ---------------------------------------------------------------------------- #
+# Resolution errors (mock catalog, no store required)
+# ---------------------------------------------------------------------------- #
+
+@test "'flox run' reports package not found with search hint" {
+  export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/run/failed_resolution.yaml"
+  run "$FLOX_BIN" run -p nonexistent-xyz-package nonexistent-xyz-package
+  assert_failure
+  assert_output --partial "not found"
+  assert_output --partial "flox search"
+}
+
+# ---------------------------------------------------------------------------- #
+# Help passthrough regression (regression for prototype defect 1)
+#
+# With the original prototype, `flox run -p curl --help` would incorrectly
+# show flox's help because --help was intercepted anywhere in argv.
+# With the OsString state machine, --help after the command stays in
+# passthrough.  The cheap version of this test exercises resolution failure
+# (which happens before exec, so we can assert without a store), while the
+# store variant actually execs the command.
+# ---------------------------------------------------------------------------- #
+
+@test "help-passthrough: '--help' after command is NOT shown as flox help (cheap)" {
+  # Using a mock that returns not-found: if --help were intercepted by flox,
+  # this would exit 0 (flox help) instead of failing with "not found".
+  export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/run/failed_resolution.yaml"
+  run "$FLOX_BIN" run -p nonexistent-xyz-package nonexistent-xyz-package --help
+  assert_failure
+  assert_output --partial "not found"
+  # Must NOT show flox run's own help text
+  refute_output --partial "flox run -p"
+}
+
+# ---------------------------------------------------------------------------- #
+# Store tests (require Nix binary cache access)
+#
+# Run with:  just integ-tests run.bats -- --filter-tags run:store
+# Skip with: just integ-tests run.bats -- --filter-tags '!run:store'
+# ---------------------------------------------------------------------------- #
+
+# bats test_tags=run:store
+@test "flox run -p hello hello executes and succeeds [run:store]" {
+  export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/run/hello.yaml"
+  run "$FLOX_BIN" run -p hello hello
+  assert_success
+  assert_output --partial "Hello"
+}
+
+# bats test_tags=run:store
+@test "flox run -p hello hello -g 'hi flox' passes args verbatim [run:store]" {
+  export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/run/hello.yaml"
+  run "$FLOX_BIN" run -p hello hello -g "hi flox"
+  assert_success
+  assert_output --partial "hi flox"
+}
+
+# bats test_tags=run:store
+@test "flox run exit code is forwarded: hello --bogus-flag fails [run:store]" {
+  export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/run/hello.yaml"
+  run "$FLOX_BIN" run -p hello hello --bogus-flag
+  assert_failure
+}
+
+# bats test_tags=run:store
+@test "flox run -- hello --version passes --version to command [run:store]" {
+  # Without `--`, flox intercepts --version (Version::check scans all args).
+  # With `--`, --version reaches the command.
+  export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/run/hello.yaml"
+  run "$FLOX_BIN" run -p hello -- hello --version
+  assert_success
+  # GNU hello prints its version to stdout
+  assert_output --partial "hello"
+}
+
+# bats test_tags=run:store
+@test "flox run -p hello -- hello --help shows hello's help [run:store]" {
+  export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/run/hello.yaml"
+  run "$FLOX_BIN" run -p hello -- hello --help
+  assert_success
+  # GNU Hello's help mentions its own name
+  assert_output --partial "hello"
+  # Must NOT show flox run's own synopsis
+  refute_output --partial "flox run -p"
+}
+
+# ---------------------------------------------------------------------------- #
+# Source-build fallback (require Nix access to attempt the build)
+# ---------------------------------------------------------------------------- #
+
+# bats test_tags=run:store
+@test "flox run falls back to source build when binary not in cache [run:store]" {
+  # terraform is unfree; the mock returns a store path that won't exist in
+  # the local Nix store, so substitution fails and the source-build path is
+  # taken. Since stderr is not a TTY in bats, no prompt is shown and the
+  # build proceeds automatically.
+  export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/run/terraform.yaml"
+  run "$FLOX_BIN" run -p terraform -- terraform --version
+  assert_success
+  assert_output --partial "Terraform"
+}
+
+# bats test_tags=run:store
+@test "stable GC root: second run -p hello hello skips download [run:store]" {
+  export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/run/hello.yaml"
+  # First run: populates the GC root.
+  run "$FLOX_BIN" run -p hello hello
+  assert_success
+
+  # GC root should exist under $FLOX_CACHE_DIR/run-gc-roots/
+  local gc_dir="${FLOX_CACHE_DIR:-$HOME/.cache/flox}/run-gc-roots"
+  run ls "$gc_dir"
+  assert_success
+  # At least one entry containing "hello" in its name
+  assert_output --partial "hello"
+
+  # Second run: still succeeds (store path already present / cached).
+  run "$FLOX_BIN" run -p hello hello
+  assert_success
+}
+
+# bats test_tags=run:store
+@test "source-build GC root is removed after the command exits [run:store]" {
+  # terraform is unfree and not in the local cache, so 'flox run' builds it
+  # from source and forks a watcher that removes the per-PID 'build-*' GC root
+  # once the exec'd command exits. The "Terraform" output confirms the
+  # source-built binary actually ran, so the cleanup assertion below applies
+  # to a real source build rather than passing vacuously.
+  export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/run/terraform.yaml"
+  run "$FLOX_BIN" run -p terraform -- terraform --version
+  assert_success
+  assert_output --partial "Terraform"
+
+  local gc_dir="${FLOX_CACHE_DIR:-$HOME/.cache/flox}/run-gc-roots"
+
+  # The watcher polls getppid() every 500ms, so the build GC root may linger
+  # briefly after the command exits. Poll for its removal (up to ~10s).
+  local tries=0
+  while true; do
+    shopt -s nullglob
+    local leftovers=("$gc_dir"/build-*)
+    shopt -u nullglob
+    [[ ${#leftovers[@]} -eq 0 ]] && break
+
+    tries=$((tries + 1))
+    if [[ $tries -gt 100 ]]; then
+      echo "ERROR: build GC root not cleaned up after ~10s: ${leftovers[*]}" >&3
+      return 1
+    fi
+    sleep 0.1
+  done
+}

--- a/cli/tests/usage.bats
+++ b/cli/tests/usage.bats
@@ -85,6 +85,7 @@ Manage environments
 Use environments
     activate       Enter the environment, run 'flox deactivate' to leave
     deactivate     Deactivate the current environment
+    run            Run a command from a Flox Catalog package
     services       Manage services in an environment
 
 Discover packages

--- a/test_data/generated/resolve/run/failed_resolution.yaml
+++ b/test_data/generated/resolve/run/failed_resolution.yaml
@@ -1,0 +1,59 @@
+when:
+  path: /api/v1/catalog/resolve
+  method: POST
+  body: '{"items":[{"descriptors":[{"allow_broken":null,"allow_insecure":null,"allow_pre_releases":null,"allow_unfree":null,"attr_path":"nonexistent-xyz-package","install_id":"nonexistent-xyz-package","systems":["aarch64-darwin"]}],"name":"toplevel"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  - name: content-length
+    value: '1401'
+  - name: server
+    value: uvicorn
+  body: '{"items":[{"name":"toplevel","page":null,"candidate_pages":null,"messages":[{"level":"error","type":"attr_path_not_found.not_in_catalog","message":"The package ''nonexistent-xyz-package'' is not found in the catalog.","context":{"attr_path":"nonexistent-xyz-package","install_id":"nonexistent-xyz-package"}},{"level":"trace","type":"resolution_logic","message":"TRACE (GROUP): Group ''toplevel'' could not be resolved with strategy: Stage 1: Only allow missing builds for packages without current locked derivations.","context":{"install_id":"GROUP","message":"Group ''toplevel'' could not be resolved with strategy: Stage 1: Only allow missing builds for packages without current locked derivations."}},{"level":"trace","type":"resolution_logic","message":"TRACE (GROUP): Group ''toplevel'' could not be resolved with strategy: Stage 2: Unlock existing derivations but require known builds.","context":{"install_id":"GROUP","message":"Group ''toplevel'' could not be resolved with strategy: Stage 2: Unlock existing derivations but require known builds."}},{"level":"trace","type":"resolution_logic","message":"TRACE (GROUP): Group ''toplevel'' could not be resolved with strategy: Stage 3: Unlock existing derivations and allow missing builds.","context":{"install_id":"GROUP","message":"Group ''toplevel'' could not be resolved with strategy: Stage 3: Unlock existing derivations and allow missing builds."}}]}]}'
+---
+when:
+  path: /api/v1/catalog/resolve
+  method: POST
+  body: '{"items":[{"descriptors":[{"allow_broken":null,"allow_insecure":null,"allow_pre_releases":null,"allow_unfree":null,"attr_path":"nonexistent-xyz-package","install_id":"nonexistent-xyz-package","systems":["aarch64-linux"]}],"name":"toplevel"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  - name: content-length
+    value: '1401'
+  - name: server
+    value: uvicorn
+  body: '{"items":[{"name":"toplevel","page":null,"candidate_pages":null,"messages":[{"level":"error","type":"attr_path_not_found.not_in_catalog","message":"The package ''nonexistent-xyz-package'' is not found in the catalog.","context":{"attr_path":"nonexistent-xyz-package","install_id":"nonexistent-xyz-package"}},{"level":"trace","type":"resolution_logic","message":"TRACE (GROUP): Group ''toplevel'' could not be resolved with strategy: Stage 1: Only allow missing builds for packages without current locked derivations.","context":{"install_id":"GROUP","message":"Group ''toplevel'' could not be resolved with strategy: Stage 1: Only allow missing builds for packages without current locked derivations."}},{"level":"trace","type":"resolution_logic","message":"TRACE (GROUP): Group ''toplevel'' could not be resolved with strategy: Stage 2: Unlock existing derivations but require known builds.","context":{"install_id":"GROUP","message":"Group ''toplevel'' could not be resolved with strategy: Stage 2: Unlock existing derivations but require known builds."}},{"level":"trace","type":"resolution_logic","message":"TRACE (GROUP): Group ''toplevel'' could not be resolved with strategy: Stage 3: Unlock existing derivations and allow missing builds.","context":{"install_id":"GROUP","message":"Group ''toplevel'' could not be resolved with strategy: Stage 3: Unlock existing derivations and allow missing builds."}}]}]}'
+---
+when:
+  path: /api/v1/catalog/resolve
+  method: POST
+  body: '{"items":[{"descriptors":[{"allow_broken":null,"allow_insecure":null,"allow_pre_releases":null,"allow_unfree":null,"attr_path":"nonexistent-xyz-package","install_id":"nonexistent-xyz-package","systems":["x86_64-darwin"]}],"name":"toplevel"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  - name: content-length
+    value: '1401'
+  - name: server
+    value: uvicorn
+  body: '{"items":[{"name":"toplevel","page":null,"candidate_pages":null,"messages":[{"level":"error","type":"attr_path_not_found.not_in_catalog","message":"The package ''nonexistent-xyz-package'' is not found in the catalog.","context":{"attr_path":"nonexistent-xyz-package","install_id":"nonexistent-xyz-package"}},{"level":"trace","type":"resolution_logic","message":"TRACE (GROUP): Group ''toplevel'' could not be resolved with strategy: Stage 1: Only allow missing builds for packages without current locked derivations.","context":{"install_id":"GROUP","message":"Group ''toplevel'' could not be resolved with strategy: Stage 1: Only allow missing builds for packages without current locked derivations."}},{"level":"trace","type":"resolution_logic","message":"TRACE (GROUP): Group ''toplevel'' could not be resolved with strategy: Stage 2: Unlock existing derivations but require known builds.","context":{"install_id":"GROUP","message":"Group ''toplevel'' could not be resolved with strategy: Stage 2: Unlock existing derivations but require known builds."}},{"level":"trace","type":"resolution_logic","message":"TRACE (GROUP): Group ''toplevel'' could not be resolved with strategy: Stage 3: Unlock existing derivations and allow missing builds.","context":{"install_id":"GROUP","message":"Group ''toplevel'' could not be resolved with strategy: Stage 3: Unlock existing derivations and allow missing builds."}}]}]}'
+---
+when:
+  path: /api/v1/catalog/resolve
+  method: POST
+  body: '{"items":[{"descriptors":[{"allow_broken":null,"allow_insecure":null,"allow_pre_releases":null,"allow_unfree":null,"attr_path":"nonexistent-xyz-package","install_id":"nonexistent-xyz-package","systems":["x86_64-linux"]}],"name":"toplevel"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  - name: content-length
+    value: '1401'
+  - name: server
+    value: uvicorn
+  body: '{"items":[{"name":"toplevel","page":null,"candidate_pages":null,"messages":[{"level":"error","type":"attr_path_not_found.not_in_catalog","message":"The package ''nonexistent-xyz-package'' is not found in the catalog.","context":{"attr_path":"nonexistent-xyz-package","install_id":"nonexistent-xyz-package"}},{"level":"trace","type":"resolution_logic","message":"TRACE (GROUP): Group ''toplevel'' could not be resolved with strategy: Stage 1: Only allow missing builds for packages without current locked derivations.","context":{"install_id":"GROUP","message":"Group ''toplevel'' could not be resolved with strategy: Stage 1: Only allow missing builds for packages without current locked derivations."}},{"level":"trace","type":"resolution_logic","message":"TRACE (GROUP): Group ''toplevel'' could not be resolved with strategy: Stage 2: Unlock existing derivations but require known builds.","context":{"install_id":"GROUP","message":"Group ''toplevel'' could not be resolved with strategy: Stage 2: Unlock existing derivations but require known builds."}},{"level":"trace","type":"resolution_logic","message":"TRACE (GROUP): Group ''toplevel'' could not be resolved with strategy: Stage 3: Unlock existing derivations and allow missing builds.","context":{"install_id":"GROUP","message":"Group ''toplevel'' could not be resolved with strategy: Stage 3: Unlock existing derivations and allow missing builds."}}]}]}'

--- a/test_data/generated/resolve/run/hello.yaml
+++ b/test_data/generated/resolve/run/hello.yaml
@@ -1,0 +1,59 @@
+when:
+  path: /api/v1/catalog/resolve
+  method: POST
+  body: '{"items":[{"descriptors":[{"allow_broken":null,"allow_insecure":null,"allow_pre_releases":null,"allow_unfree":null,"attr_path":"hello","install_id":"hello","systems":["aarch64-darwin"]}],"name":"toplevel"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  - name: content-length
+    value: '961'
+  - name: server
+    value: uvicorn
+  body: '{"items":[{"name":"toplevel","page":{"page":982522,"url":"","packages":[{"catalog":"nixpkgs","attr_path":"hello","pkg_path":"hello","derivation":"/nix/store/w0axphsdrbdjylhf1rp6wrh4xb7q8cf8-hello-2.12.3.drv","name":"hello-2.12.3","pname":"hello","version":"2.12.3","system":"aarch64-darwin","outputs":[{"name":"out","store_path":"/nix/store/5cg54ha6i85582akxl6vpp5421lyr4pb-hello-2.12.3"}],"outputs_to_install":["out"],"description":"Program that produces a familiar, friendly greeting","license":"GPL-3.0-or-later","locked_url":"https://github.com/flox/nixpkgs?rev=b12141ef619e0a9c1c84dc8c684040326f27cdcc","rev":"b12141ef619e0a9c1c84dc8c684040326f27cdcc","rev_count":982522,"rev_date":"2026-04-18T21:33:21Z","broken":false,"insecure":false,"unfree":false,"missing_builds":false,"stabilities":["unstable"],"scrape_date":"2026-04-21T06:03:34.910020Z","cache_uri":null,"install_id":"hello"}],"messages":[],"complete":true},"candidate_pages":null,"messages":[]}]}'
+---
+when:
+  path: /api/v1/catalog/resolve
+  method: POST
+  body: '{"items":[{"descriptors":[{"allow_broken":null,"allow_insecure":null,"allow_pre_releases":null,"allow_unfree":null,"attr_path":"hello","install_id":"hello","systems":["aarch64-linux"]}],"name":"toplevel"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  - name: content-length
+    value: '960'
+  - name: server
+    value: uvicorn
+  body: '{"items":[{"name":"toplevel","page":{"page":982522,"url":"","packages":[{"catalog":"nixpkgs","attr_path":"hello","pkg_path":"hello","derivation":"/nix/store/6cccmgw49dd50vgh6p0cz4g9ja772l6j-hello-2.12.3.drv","name":"hello-2.12.3","pname":"hello","version":"2.12.3","system":"aarch64-linux","outputs":[{"name":"out","store_path":"/nix/store/g383j16f2lxz4zzs967i9hjgvivy6q7h-hello-2.12.3"}],"outputs_to_install":["out"],"description":"Program that produces a familiar, friendly greeting","license":"GPL-3.0-or-later","locked_url":"https://github.com/flox/nixpkgs?rev=b12141ef619e0a9c1c84dc8c684040326f27cdcc","rev":"b12141ef619e0a9c1c84dc8c684040326f27cdcc","rev_count":982522,"rev_date":"2026-04-18T21:33:21Z","broken":false,"insecure":false,"unfree":false,"missing_builds":false,"stabilities":["unstable"],"scrape_date":"2026-04-21T06:36:56.359081Z","cache_uri":null,"install_id":"hello"}],"messages":[],"complete":true},"candidate_pages":null,"messages":[]}]}'
+---
+when:
+  path: /api/v1/catalog/resolve
+  method: POST
+  body: '{"items":[{"descriptors":[{"allow_broken":null,"allow_insecure":null,"allow_pre_releases":null,"allow_unfree":null,"attr_path":"hello","install_id":"hello","systems":["x86_64-darwin"]}],"name":"toplevel"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  - name: content-length
+    value: '960'
+  - name: server
+    value: uvicorn
+  body: '{"items":[{"name":"toplevel","page":{"page":982522,"url":"","packages":[{"catalog":"nixpkgs","attr_path":"hello","pkg_path":"hello","derivation":"/nix/store/m0ccxjpn61yr7zngqra0ahg8aqarpvca-hello-2.12.3.drv","name":"hello-2.12.3","pname":"hello","version":"2.12.3","system":"x86_64-darwin","outputs":[{"name":"out","store_path":"/nix/store/kqbjfx3hp125sg0fkv1141m4s02z9w0r-hello-2.12.3"}],"outputs_to_install":["out"],"description":"Program that produces a familiar, friendly greeting","license":"GPL-3.0-or-later","locked_url":"https://github.com/flox/nixpkgs?rev=b12141ef619e0a9c1c84dc8c684040326f27cdcc","rev":"b12141ef619e0a9c1c84dc8c684040326f27cdcc","rev_count":982522,"rev_date":"2026-04-18T21:33:21Z","broken":false,"insecure":false,"unfree":false,"missing_builds":false,"stabilities":["unstable"],"scrape_date":"2026-04-21T07:08:27.302720Z","cache_uri":null,"install_id":"hello"}],"messages":[],"complete":true},"candidate_pages":null,"messages":[]}]}'
+---
+when:
+  path: /api/v1/catalog/resolve
+  method: POST
+  body: '{"items":[{"descriptors":[{"allow_broken":null,"allow_insecure":null,"allow_pre_releases":null,"allow_unfree":null,"attr_path":"hello","install_id":"hello","systems":["x86_64-linux"]}],"name":"toplevel"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  - name: content-length
+    value: '959'
+  - name: server
+    value: uvicorn
+  body: '{"items":[{"name":"toplevel","page":{"page":982522,"url":"","packages":[{"catalog":"nixpkgs","attr_path":"hello","pkg_path":"hello","derivation":"/nix/store/7mdg60drrnh0wq1j8hmmbhll47czm107-hello-2.12.3.drv","name":"hello-2.12.3","pname":"hello","version":"2.12.3","system":"x86_64-linux","outputs":[{"name":"out","store_path":"/nix/store/10s5j3mfdg22k1597x580qrhprnzcjwb-hello-2.12.3"}],"outputs_to_install":["out"],"description":"Program that produces a familiar, friendly greeting","license":"GPL-3.0-or-later","locked_url":"https://github.com/flox/nixpkgs?rev=b12141ef619e0a9c1c84dc8c684040326f27cdcc","rev":"b12141ef619e0a9c1c84dc8c684040326f27cdcc","rev_count":982522,"rev_date":"2026-04-18T21:33:21Z","broken":false,"insecure":false,"unfree":false,"missing_builds":false,"stabilities":["unstable"],"scrape_date":"2026-04-21T07:44:59.797392Z","cache_uri":null,"install_id":"hello"}],"messages":[],"complete":true},"candidate_pages":null,"messages":[]}]}'

--- a/test_data/generated/resolve/run/terraform.yaml
+++ b/test_data/generated/resolve/run/terraform.yaml
@@ -1,0 +1,59 @@
+when:
+  path: /api/v1/catalog/resolve
+  method: POST
+  body: '{"items":[{"descriptors":[{"allow_broken":null,"allow_insecure":null,"allow_pre_releases":null,"allow_unfree":null,"attr_path":"terraform","install_id":"terraform","systems":["aarch64-darwin"]}],"name":"toplevel"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  - name: content-length
+    value: '976'
+  - name: server
+    value: uvicorn
+  body: '{"items":[{"name":"toplevel","page":{"page":982522,"url":"","packages":[{"catalog":"nixpkgs","attr_path":"terraform","pkg_path":"terraform","derivation":"/nix/store/placeholder-terraform-1.9.8-aarch64-darwin.drv","name":"terraform-1.9.8","pname":"terraform","version":"1.9.8","system":"aarch64-darwin","outputs":[{"name":"out","store_path":"/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0-terraform-1.9.8"}],"outputs_to_install":["out"],"description":"Tool for building, changing, and versioning infrastructure","license":"BSL-1.1","locked_url":"https://github.com/flox/nixpkgs?rev=b12141ef619e0a9c1c84dc8c684040326f27cdcc","rev":"b12141ef619e0a9c1c84dc8c684040326f27cdcc","rev_count":982522,"rev_date":"2026-04-18T21:33:21Z","broken":false,"insecure":false,"unfree":true,"missing_builds":false,"stabilities":["unstable"],"scrape_date":"2026-04-21T06:03:34.910020Z","cache_uri":null,"install_id":"terraform"}],"messages":[],"complete":true},"candidate_pages":null,"messages":[]}]}'
+---
+when:
+  path: /api/v1/catalog/resolve
+  method: POST
+  body: '{"items":[{"descriptors":[{"allow_broken":null,"allow_insecure":null,"allow_pre_releases":null,"allow_unfree":null,"attr_path":"terraform","install_id":"terraform","systems":["aarch64-linux"]}],"name":"toplevel"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  - name: content-length
+    value: '973'
+  - name: server
+    value: uvicorn
+  body: '{"items":[{"name":"toplevel","page":{"page":982522,"url":"","packages":[{"catalog":"nixpkgs","attr_path":"terraform","pkg_path":"terraform","derivation":"/nix/store/placeholder-terraform-1.9.8-aarch64-linux.drv","name":"terraform-1.9.8","pname":"terraform","version":"1.9.8","system":"aarch64-linux","outputs":[{"name":"out","store_path":"/nix/store/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb0-terraform-1.9.8"}],"outputs_to_install":["out"],"description":"Tool for building, changing, and versioning infrastructure","license":"BSL-1.1","locked_url":"https://github.com/flox/nixpkgs?rev=b12141ef619e0a9c1c84dc8c684040326f27cdcc","rev":"b12141ef619e0a9c1c84dc8c684040326f27cdcc","rev_count":982522,"rev_date":"2026-04-18T21:33:21Z","broken":false,"insecure":false,"unfree":true,"missing_builds":false,"stabilities":["unstable"],"scrape_date":"2026-04-21T06:03:34.910020Z","cache_uri":null,"install_id":"terraform"}],"messages":[],"complete":true},"candidate_pages":null,"messages":[]}]}'
+---
+when:
+  path: /api/v1/catalog/resolve
+  method: POST
+  body: '{"items":[{"descriptors":[{"allow_broken":null,"allow_insecure":null,"allow_pre_releases":null,"allow_unfree":null,"attr_path":"terraform","install_id":"terraform","systems":["x86_64-darwin"]}],"name":"toplevel"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  - name: content-length
+    value: '973'
+  - name: server
+    value: uvicorn
+  body: '{"items":[{"name":"toplevel","page":{"page":982522,"url":"","packages":[{"catalog":"nixpkgs","attr_path":"terraform","pkg_path":"terraform","derivation":"/nix/store/placeholder-terraform-1.9.8-x86_64-darwin.drv","name":"terraform-1.9.8","pname":"terraform","version":"1.9.8","system":"x86_64-darwin","outputs":[{"name":"out","store_path":"/nix/store/cccccccccccccccccccccccccccccc0-terraform-1.9.8"}],"outputs_to_install":["out"],"description":"Tool for building, changing, and versioning infrastructure","license":"BSL-1.1","locked_url":"https://github.com/flox/nixpkgs?rev=b12141ef619e0a9c1c84dc8c684040326f27cdcc","rev":"b12141ef619e0a9c1c84dc8c684040326f27cdcc","rev_count":982522,"rev_date":"2026-04-18T21:33:21Z","broken":false,"insecure":false,"unfree":true,"missing_builds":false,"stabilities":["unstable"],"scrape_date":"2026-04-21T07:08:27.302720Z","cache_uri":null,"install_id":"terraform"}],"messages":[],"complete":true},"candidate_pages":null,"messages":[]}]}'
+---
+when:
+  path: /api/v1/catalog/resolve
+  method: POST
+  body: '{"items":[{"descriptors":[{"allow_broken":null,"allow_insecure":null,"allow_pre_releases":null,"allow_unfree":null,"attr_path":"terraform","install_id":"terraform","systems":["x86_64-linux"]}],"name":"toplevel"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  - name: content-length
+    value: '971'
+  - name: server
+    value: uvicorn
+  body: '{"items":[{"name":"toplevel","page":{"page":982522,"url":"","packages":[{"catalog":"nixpkgs","attr_path":"terraform","pkg_path":"terraform","derivation":"/nix/store/placeholder-terraform-1.9.8-x86_64-linux.drv","name":"terraform-1.9.8","pname":"terraform","version":"1.9.8","system":"x86_64-linux","outputs":[{"name":"out","store_path":"/nix/store/dddddddddddddddddddddddddddddd0-terraform-1.9.8"}],"outputs_to_install":["out"],"description":"Tool for building, changing, and versioning infrastructure","license":"BSL-1.1","locked_url":"https://github.com/flox/nixpkgs?rev=b12141ef619e0a9c1c84dc8c684040326f27cdcc","rev":"b12141ef619e0a9c1c84dc8c684040326f27cdcc","rev_count":982522,"rev_date":"2026-04-18T21:33:21Z","broken":false,"insecure":false,"unfree":true,"missing_builds":false,"stabilities":["unstable"],"scrape_date":"2026-04-21T07:44:59.797392Z","cache_uri":null,"install_id":"terraform"}],"messages":[],"complete":true},"candidate_pages":null,"messages":[]}]}'


### PR DESCRIPTION
`flox run -p <package> [--] <command> [args...]` runs a command from a Flox Catalog package without creating a persistent environment.

## What this adds

- **`flox run`** new subcommand: resolve a catalog package, download its store paths via the existing SDK substitution path, find the executable in `bin/` then `sbin/`, and `exec` it.
- **Source-build fallback** (DEV-139): when substitution misses (e.g. unfree packages like `terraform`), `flox run` falls back to `nix build` via the `flox-nixpkgs` proxy flake ref. Both paths run inside `materialise_with_retry` so GC races at any step trigger a clean retry.
- **POSIX stop-at-first-positional** arg parsing via a hand-rolled `OsString` state machine. bpaf cannot express this (order-dependent flag ownership, `--` passthrough) — the rationale is documented in `run.rs` module docs.
- **Stable GC root** at `cache_dir/run-gc-roots/<system>.<attr_path>` for substitution-downloaded paths — repeated invocations skip the download. Source-built paths use a per-PID GC root cleaned up by a `getppid()`-polling fork watcher.
- **Classified resolution errors**: package not found, unavailable on system, and network/catalog errors each produce distinct messages.

## Changes

- `cli/flox/src/commands/run.rs` — new `run` subcommand
- `cli/flox-rust-sdk/src/providers/buildenv.rs` — `substitute_store_paths` and `build_catalog_pkg_from_source` lifted to pub free functions; `materialise_with_retry` made generic
- `cli/flox/doc/flox-run.md` — man page
- `cli/tests/run.bats` + fixtures — integration tests for happy path, source build, and error cases

## Limitations (Phase 1)

- `-p` is required; implicit resolution (package = command name) is Phase 2.
- No `@version` constraints, output selectors (`^`), or custom catalogs.
- Source-built packages rebuild on every invocation (no durable per-key GC root for source builds); follow-up work.

Fixes DEV-74. Source-build fallback fixes DEV-139.

## Release Notes

`flox run -p <package> [--] <command>` runs a command directly from a Flox Catalog package without creating an environment — the package is resolved, downloaded, and exec'd in one step. Packages not available in the binary cache (e.g. unfree packages) are built from source automatically.

---
*Via Forge (interactive) • 85052ded*