### PR TITLE
fix(gen-data): Reliable unit mock regeneration (version ordering + deterministic system order)

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -157,11 +157,14 @@ gen-unit-data-no-publish force="":
         export _FLOX_UNIT_TEST_RECORD="missing"
     fi
 
-    # Use remote services for non-publish tests
-    {{cargo_test_invocation}} --filterset 'not (test(providers::build::tests) | test(providers::publish) | test(commands::publish) | test(providers::catalog::tests::creates_new_catalog))'
-
-    # Extract latest package versions from production catalog for test assertions.
-    # These versions must match what's in the recorded mock YAML files.
+    # Extract latest package versions from the production catalog BEFORE
+    # running the tests. Several tests assert the resolved version against
+    # these values (via latest_prod_versions.json), so the file must reflect
+    # current prod before the recording run. If it is written afterward (as it
+    # was previously), a force-regen run after prod has drifted records the new
+    # version but asserts it against the stale file, fails, and aborts before
+    # the file is ever refreshed -- a chicken-and-egg that makes the regen
+    # impossible to complete in a single pass.
     echo "Extracting latest package versions from production catalog..."
     python_version=$(curl -s 'https://api.flox.dev/api/v1/catalog/packages/python3' | jq -r '.items[0].version')
     go_version=$(curl -s 'https://api.flox.dev/api/v1/catalog/packages/go' | jq -r '.items[0].version')
@@ -175,6 +178,9 @@ gen-unit-data-no-publish force="":
         '{python3: $python3, go: $go, poetry: $poetry, nodejs_20: $nodejs_20}' \
         > "{{TEST_DATA}}/unit_test_generated/latest_prod_versions.json"
     echo "Wrote latest_prod_versions.json with python3=$python_version, go=$go_version, poetry=$poetry_version, nodejs_20=$nodejs_20_version"
+
+    # Use remote services for non-publish tests
+    {{cargo_test_invocation}} --filterset 'not (test(providers::build::tests) | test(providers::publish) | test(commands::publish) | test(providers::catalog::tests::creates_new_catalog))'
 
 gen-unit-data-for-publish floxhub_repo_path force="":
     #!/usr/bin/env bash

--- a/cli/flox/src/commands/install.rs
+++ b/cli/flox/src/commands/install.rs
@@ -984,7 +984,7 @@ mod tests {
         let pkg_path = if is_linux { "darwin.ps" } else { "bpftrace" };
         let install_id = if is_linux { "ps" } else { "bpftrace" };
         let installed_systems = if is_linux {
-            "x86_64-darwin, aarch64-darwin"
+            "aarch64-darwin, x86_64-darwin"
         } else {
             "aarch64-linux, x86_64-linux"
         };

--- a/cli/flox/src/utils/message.rs
+++ b/cli/flox/src/utils/message.rs
@@ -131,12 +131,15 @@ pub(crate) fn packages_successfully_installed(
 /// the requested systems.
 pub(crate) fn packages_installed_with_system_subsets(pkgs: &[PackageToInstall]) {
     for pkg in pkgs.iter() {
+        // Sort for deterministic output: `systems()` order follows the catalog
+        // response, so without sorting the message order is unstable.
+        // Only `None` for flakes, which can't reach this code path anyway.
+        let mut systems = pkg.systems().unwrap_or_default();
+        systems.sort();
         warning(format!(
             "'{}' installed only for the following systems: {}",
             pkg.id(),
-            // Only `None` for flakes, which can't reach this code
-            // path anyway.
-            pkg.systems().unwrap_or_default().join(", ")
+            systems.join(", ")
         ))
     }
 }


### PR DESCRIPTION
Two independent defects that each block `just gen-data <floxhub> -f` (regenerating the recorded catalog mocks). Found while regenerating mocks for the catalog-schema bump (#4396); neither is caused by that bump — they are pre-existing rot the regen surfaces. Each was validated live.

## 1. `gen-data` writes prod versions *after* the recording run (chicken-and-egg)
`gen-unit-data-no-publish` ran the recording tests **first** and wrote `latest_prod_versions.json` **after**. Tests assert the resolved version against that file (e.g. `go_version_from_content_returns_compatible_version_with_catalog` via `go_latest_version()`). Once the production catalog drifts (hit live: `go 1.26.2→1.26.3`, `python3→3.13.13`, `poetry→2.4.1`), the run records the new version, asserts against the stale file, fails, and `set -e` aborts before the file is refreshed — a chicken-and-egg that makes the regen impossible to complete in a single pass. Fix: extract versions **before** the test run.

## 2. Nondeterministic system order in the incomplete-availability warning
`message.rs` joined `pkg.systems()` without sorting, so the order followed the catalog response. A frozen mock hid it; re-recording flipped the order and broke the hardcoded test assertion. Fix: sort before join (deterministic user-facing output).

## Verification
With both fixes, `just gen-data <floxhub> -f` progressed from aborting at test 78 to **965/965 non-publish tests passing**. The publish phase has remaining failures that are **not** addressed here — they are pre-existing issues in the publish recording path (catalog-server returns meta-only for unconfigured catalogs vs. stale `null` mocks; a placeholder store path; a store-config-PUT 403 that is an authorization check, not an idempotency race) and are tracked in DEV-134 (with local-DB bring-up issues in DEV-133).

> An earlier revision of this PR included a third commit that tolerated the store-config-PUT 403 as an "idempotency race." That was a misdiagnosis — the 403 is `check_catalog_writable` authorization, not a set-once race — so the commit was dropped and the finding folded into DEV-134.