### PR TITLE
feat: nef input lockfile generation from nix source files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2971,6 +2971,7 @@ dependencies = [
  "rowan",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
  "tokio",
  "toml",
  "tracing",

--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -7,6 +7,8 @@ use floxhub_client::{
     ApiResponseValue,
     BaseCatalogInfo,
     BaseCatalogUrl,
+    BuildInputsLookupRequest,
+    BuildInputsLookupResponse,
     CatalogClientTrait,
     CatalogStoreConfig,
     CheckBuildResponse,
@@ -378,6 +380,16 @@ impl CatalogClientTrait for MockClient {
         _catalog_name: impl AsRef<str> + Send + Sync,
     ) -> Result<ResultsPage<LockedSourceItem>, FloxhubClientError> {
         unimplemented!("get_catalog_locked_sources not implemented for MockClient")
+    }
+
+    async fn build_inputs_lookup(
+        &self,
+        _request: BuildInputsLookupRequest,
+    ) -> Result<BuildInputsLookupResponse, FloxhubClientError> {
+        // Intentionally unsupported: the lockless lookup path is tested via the
+        // record/replay client and pure nef-lock-catalog unit tests, not the
+        // MockClient response queue.
+        unimplemented!("build_inputs_lookup is not supported in MockClient")
     }
 
     async fn check_build_already_recorded(

--- a/cli/flox/src/commands/build.rs
+++ b/cli/flox/src/commands/build.rs
@@ -27,7 +27,7 @@ use flox_rust_sdk::utils::{CommandExt, FLOX_INTERPRETER};
 use floxhub_client::{BaseCatalogUrl, CatalogClientTrait};
 use indoc::formatdoc;
 use itertools::Itertools;
-use nef_lock_catalog::{NixFlakeref, lock_config, read_config, write_lock};
+use nef_lock_catalog::NixFlakeref;
 use thiserror::Error;
 use tracing::{debug, instrument, trace};
 use url::Url;
@@ -482,43 +482,19 @@ impl Build {
         Ok(())
     }
 
-    async fn update_catalogs(flox: &Flox, env: ConcreteEnvironment) -> Result<()> {
-        match &env {
-            ConcreteEnvironment::Path(_) => (),
-            ConcreteEnvironment::Managed(_) => {
-                bail!("Cannot update catalogs in a managed environment on FloxHub.")
-            },
-            ConcreteEnvironment::Remote(_) => {
-                unreachable!("Cannot update catalogs in a remote environment")
-            },
-        };
+    async fn update_catalogs(_flox: &Flox, _env: ConcreteEnvironment) -> Result<()> {
+        // The standalone `nix-builds.toml` catalog-declaration + nix-prefetch
+        // locking path has been retired (ECO-93/D4). Catalog inputs are now
+        // resolved and locked through the lockless lookup flow as part of the
+        // build itself, so there is no separate lockfile to update here.
+        // Full removal of this subcommand follows in ECO-94/95.
+        bail!(formatdoc! {"
+            `flox build update-catalogs` is no longer supported.
 
-        let config_path = env.dot_flox_path().join("nix-builds.toml");
-
-        if !config_path.exists() {
-            message::warning(formatdoc! {"
-                No catalog inputs defined in this project.
-
-                Create and edit catalog inputs in your .flox/nix-builds.toml:
-
-                    {}
-            ", config_path.display()});
-            return Ok(());
-        };
-
-        let config = read_config(&config_path)?;
-        let catalog = &flox.floxhub_client;
-        let lockfile = lock_config(&config, catalog).await?;
-
-        let lockfile_path = config_path.with_extension("lock");
-        write_lock(&lockfile, &lockfile_path)?;
-
-        message::updated(format!(
-            "Updated catalog lockfile at {}",
-            lockfile_path.display()
-        ));
-
-        Ok(())
+            Catalog inputs are now locked automatically during the build via the
+            lockless resolution flow; the standalone nix-builds.toml locking step
+            has been retired.
+        "});
     }
 
     /// If so, shorten symlink for a package it if in the current directory.

--- a/cli/floxhub-client/src/client.rs
+++ b/cli/floxhub-client/src/client.rs
@@ -203,6 +203,13 @@ pub trait CatalogClientTrait {
         catalog_name: impl AsRef<str> + Send + Sync,
     ) -> Result<ResultsPage<LockedSourceItem>, FloxhubClientError>;
 
+    /// Look up and lock build inputs for one or more grouped reference sets in
+    /// a single batched request (POST /build-inputs/lookup).
+    async fn build_inputs_lookup(
+        &self,
+        request: BuildInputsLookupRequest,
+    ) -> Result<BuildInputsLookupResponse, FloxhubClientError>;
+
     /// Create a package within a user catalog.
     async fn create_package(
         &self,
@@ -424,6 +431,27 @@ impl CatalogClientTrait for FloxhubClient {
         let (count, results) = collect_all_results(stream).await?;
 
         Ok(ResultsPage { results, count })
+    }
+
+    async fn build_inputs_lookup(
+        &self,
+        request: BuildInputsLookupRequest,
+    ) -> Result<BuildInputsLookupResponse, FloxhubClientError> {
+        tracing::debug!(n_groups = request.groups.len(), "looking up build inputs");
+
+        // NOTE: unlike sibling catalog endpoints, the generated lookup endpoint
+        // is typed with `HttpValidationError` (the default 422 envelope) rather
+        // than the shared `ErrorResponse`, so the `map_api_error` machinery does
+        // not apply. Map to a string error for now; richer token/4xx handling
+        // lands with the lock binary in ECO-94. (Likely wants a backend schema
+        // fix to declare `ErrorResponse` like the other endpoints.)
+        let response = self
+            .catalog
+            .lookup_api_v1_catalog_build_inputs_lookup_post(&request)
+            .await
+            .map_err(|err| FloxhubClientError::Other(err.to_string()))?;
+
+        Ok(response.into_inner())
     }
 
     async fn publish_info(

--- a/cli/floxhub-client/src/types.rs
+++ b/cli/floxhub-client/src/types.rs
@@ -40,6 +40,7 @@ pub use api_types::{
     BuildInputsLookupRequest,
     BuildInputsLookupResponse,
     GroupResult,
+    LockedGitSource,
     LockedInputEntry,
     LookupGroup,
     ReferencePoint,

--- a/cli/floxhub-client/src/types.rs
+++ b/cli/floxhub-client/src/types.rs
@@ -34,10 +34,22 @@ pub type SearchResults = ResultsPage<SearchResult>;
 pub use api_types::{PackageOutput, PackageOutputs, PackageResolutionInfo as PackageBuild};
 pub type PackageDetails = ResultsPage<PackageBuild>;
 
+// Build-inputs lookup (lockless catalog locking, ECO-93). Re-exported so
+// consumers (e.g. nef-lock-catalog) depend only on floxhub-client.
+pub use api_types::{
+    BuildInputsLookupRequest,
+    BuildInputsLookupResponse,
+    GroupResult,
+    LockedInputEntry,
+    LookupGroup,
+    ReferencePoint,
+    Stability,
+    UnresolvableEntry,
+    UnresolvableLeaf,
+};
 // ---------------------------------------------------------------------------
 // Package descriptors
 // ---------------------------------------------------------------------------
-
 /// Just an alias until the auto-generated PackageDescriptor diverges from what
 /// we need.
 pub use api_types::{

--- a/cli/nef-lock-catalog/Cargo.toml
+++ b/cli/nef-lock-catalog/Cargo.toml
@@ -10,6 +10,7 @@ url.workspace = true
 serde_json.workspace = true
 toml.workspace = true
 serde.workspace = true
+thiserror.workspace = true
 indexmap.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/cli/nef-lock-catalog/src/lib.rs
+++ b/cli/nef-lock-catalog/src/lib.rs
@@ -27,5 +27,6 @@ impl Display for CatalogId {
 
 pub use lock::build_lock::{BuildLock, write_lock};
 pub use lock::flakeref::NixFlakeref;
+pub use lock::lookup::{LockError, lock_references};
 pub use nix_build_config::{LockOptions, lock_config, lock_config_with_options, read_config};
 pub use scan::{CatalogRef, scan_package, scan_package_with_roots};

--- a/cli/nef-lock-catalog/src/lock/flakeref.rs
+++ b/cli/nef-lock-catalog/src/lock/flakeref.rs
@@ -116,6 +116,35 @@ impl NixFlakeref {
     }
 }
 
+/// The raw attribute-set form of a locked nix flakeref (a "source ref"),
+/// carried verbatim as JSON.
+///
+/// Unlike [NixFlakeref], this performs no nix-based parsing or validation: the
+/// catalog `/build-inputs/lookup` endpoint returns sources already locked
+/// server-side, and this type carries that JSON through unchanged into the
+/// build lock, where the NEF feeds it to `builtins.fetchTree`. It is a marker
+/// for the "assumed-locked, stored-verbatim" invariant — the source is not
+/// re-validated client-side.
+///
+/// Serialized transparently, so the lockfile shape is just the inner object.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct RawNixFlakerefAttrs(Value);
+
+impl RawNixFlakerefAttrs {
+    /// Wrap an already-locked source value (e.g. a catalog lookup result)
+    /// without validating it — the caller asserts it is a locked flakeref.
+    pub fn new_unchecked(value: Value) -> Self {
+        Self(value)
+    }
+}
+
+impl From<floxhub_client::LockedGitSource> for RawNixFlakerefAttrs {
+    fn from(value: floxhub_client::LockedGitSource) -> Self {
+        Self::new_unchecked(serde_json::to_value(value).expect("deserialized from json body"))
+    }
+}
+
 /// Lock a flakeref url
 pub fn lock_url_with_options(
     flakeref: &NixFlakeref,

--- a/cli/nef-lock-catalog/src/lock/lookup.rs
+++ b/cli/nef-lock-catalog/src/lock/lookup.rs
@@ -1,0 +1,197 @@
+//! Batched lockless lookup engine.
+//!
+//! Turns a flat list of scanned catalog references into a single
+//! `/build-inputs/lookup` request, then maps the response into a [BuildLock].
+//!
+//! The CLI only ever locks one logical set at a time — either a single NEF
+//! package's references, or the union of the NEF dependencies of a manifest
+//! build — so the public surface takes a plain list of references. The wire
+//! protocol's per-group keying is an internal detail (one synthetic group).
+
+use std::collections::BTreeSet;
+
+use floxhub_client::{
+    BuildInputsLookupRequest,
+    BuildInputsLookupResponse,
+    CatalogClientTrait,
+    FloxhubClientError,
+    LookupGroup,
+    Stability,
+    UnresolvableEntry,
+};
+use tracing::debug;
+
+use crate::CatalogRef;
+use crate::lock::build_lock::BuildLock;
+use crate::lock::transform::build_lock_from_locked_inputs;
+
+/// Synthetic key for the single wire group the CLI ever sends.
+const LOOKUP_GROUP_KEY: &str = "default";
+
+/// Failure modes of [lock_references].
+#[derive(Debug, thiserror::Error)]
+pub enum LockError {
+    /// The lookup reported unresolvable references. The lock fails as a whole
+    /// and no partial lock is produced; each [UnresolvableEntry] carries its
+    /// own `reference` and `chain`. Rendering is the caller's responsibility
+    /// (ECO-94/A5).
+    #[error("{} catalog reference(s) were unresolvable", .0.len())]
+    Unresolvable(Vec<UnresolvableEntry>),
+
+    /// The requested stability is not a valid catalog stability string.
+    #[error("invalid stability: {0:?}")]
+    InvalidStability(String),
+
+    /// The catalog lookup request itself failed.
+    #[error(transparent)]
+    Client(#[from] FloxhubClientError),
+
+    /// Assembling the [BuildLock] from a successful response failed.
+    #[error(transparent)]
+    Transform(#[from] anyhow::Error),
+}
+
+/// Lock a flat list of catalog references in a single batched request.
+///
+/// Builds the wire request internally (one synthetic group), performs one
+/// `/build-inputs/lookup` call, and maps the response to a [BuildLock].
+/// Returns [LockError::Unresolvable] if any reference is unresolvable.
+///
+/// `stability` is the higher-level string input; it is parsed into the typed
+/// [Stability] required by the request contract, failing with
+/// [LockError::InvalidStability] if empty/invalid.
+pub async fn lock_references(
+    client: &(impl CatalogClientTrait + Send + Sync),
+    references: BTreeSet<CatalogRef>,
+    stability: &str,
+) -> Result<BuildLock, LockError> {
+    let stability: Stability = stability
+        .parse()
+        .map_err(|_| LockError::InvalidStability(stability.to_string()))?;
+    let response = client
+        .build_inputs_lookup(build_request(references, stability))
+        .await?;
+    lock_from_response(response)
+}
+
+/// Convert the reference list into the generated wire request.
+///
+/// Wraps all references in a single [`floxhub_client::LookupGroup`].
+/// `reference_point` is defaulted to `None` for now; `system` is filled with a
+/// placeholder to satisfy the (soon-to-be-removed) required wire field.
+fn build_request(
+    references: BTreeSet<CatalogRef>,
+    stability: Stability,
+) -> BuildInputsLookupRequest {
+    let group = LookupGroup {
+        key: LOOKUP_GROUP_KEY.to_string(),
+        // Move each reference's inner string out — no per-string reallocation.
+        references: references.into_iter().map(String::from).collect(),
+    };
+
+    BuildInputsLookupRequest {
+        groups: vec![group],
+        reference_point: None,
+        stability,
+    }
+}
+
+/// Map a lookup response into a [BuildLock], or fail with the unresolvable
+/// references.
+///
+/// The CLI always sends exactly one group, keyed by [LOOKUP_GROUP_KEY], so
+/// exactly one group in the response is ours. Extract that group rather than
+/// merging across groups; locking multiple groups at once is not supported yet.
+///
+/// Boundary: if the group reports any unresolvable references, fail the whole
+/// lock. Otherwise hand the resolved `lock` map off to the A2 transform.
+fn lock_from_response(mut response: BuildInputsLookupResponse) -> Result<BuildLock, LockError> {
+    let Some(group) = response.groups.remove(LOOKUP_GROUP_KEY) else {
+        return Err(LockError::Transform(anyhow::anyhow!(
+            "The server returned no group for our request; nothing to lock."
+        )));
+    };
+
+    // Any unresolvable references fail the whole lock with no partial output.
+    if !group.unresolvable.is_empty() {
+        debug!(
+            unresolvable = group.unresolvable.len(),
+            "lookup reported unresolvable references"
+        );
+        return Err(LockError::Unresolvable(group.unresolvable));
+    }
+
+    Ok(build_lock_from_locked_inputs(group.lock)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn build_request_maps_references_and_stability() {
+        let references = BTreeSet::from([
+            CatalogRef::from("catalogs.myorg.hello"),
+            CatalogRef::from("catalogs.myorg.world"),
+        ]);
+
+        let wire = build_request(references, "stable".parse().unwrap());
+
+        // All references collapse into a single wire group.
+        assert_eq!(wire.groups.len(), 1);
+        assert_eq!(
+            serde_json::to_value(&wire.groups[0].references).unwrap(),
+            json!(["catalogs.myorg.hello", "catalogs.myorg.world"])
+        );
+        assert_eq!(
+            serde_json::to_value(&wire.stability).unwrap(),
+            json!("stable")
+        );
+        assert!(wire.reference_point.is_none());
+    }
+
+    #[test]
+    fn r11_success_fixture_locks() {
+        let response: BuildInputsLookupResponse = serde_json::from_str(include_str!(
+            "../../test_data/build_inputs_lookup/success.json"
+        ))
+        .expect("success fixture deserializes");
+
+        let lock = lock_from_response(response).expect("success fixture locks");
+        let value = serde_json::to_value(&lock).unwrap();
+
+        assert_eq!(value["version"], json!(1));
+        assert_eq!(
+            value["catalogs"]["myorg"]["packages"]["entries"]["hello"]["build_type"],
+            json!("nef")
+        );
+        assert_eq!(
+            value["catalogs"]["myorg"]["packages"]["entries"]["hello"]["source"],
+            json!({ "type": "git", "url": "https://example.com/repo", "rev": "abc123" })
+        );
+    }
+
+    #[test]
+    fn r11_partial_fixture_is_unresolvable() {
+        let response: BuildInputsLookupResponse = serde_json::from_str(include_str!(
+            "../../test_data/build_inputs_lookup/partial.json"
+        ))
+        .expect("partial fixture deserializes");
+
+        let err = lock_from_response(response).expect_err("partial fixture fails the lock");
+
+        match err {
+            LockError::Unresolvable(entries) => {
+                assert_eq!(entries.len(), 1);
+                assert_eq!(entries[0].reference, "catalogs.myorg.missing-dep");
+                assert_eq!(entries[0].chain, vec![
+                    "catalogs.myorg.hello".to_string(),
+                    "catalogs.myorg.missing-dep".to_string(),
+                ]);
+            },
+            other => panic!("expected LockError::Unresolvable, got {other:?}"),
+        }
+    }
+}

--- a/cli/nef-lock-catalog/src/lock/lookup.rs
+++ b/cli/nef-lock-catalog/src/lock/lookup.rs
@@ -77,8 +77,9 @@ pub async fn lock_references(
 /// Convert the reference list into the generated wire request.
 ///
 /// Wraps all references in a single [`floxhub_client::LookupGroup`].
-/// `reference_point` is defaulted to `None` for now; `system` is filled with a
-/// placeholder to satisfy the (soon-to-be-removed) required wire field.
+/// `reference_point` is defaulted to `None` for now. The endpoint is
+/// system-independent: the response carries source revs + DAG edges, which
+/// carry no system, so the request has no system field.
 fn build_request(
     references: BTreeSet<CatalogRef>,
     stability: Stability,
@@ -169,7 +170,13 @@ mod tests {
         );
         assert_eq!(
             value["catalogs"]["myorg"]["packages"]["entries"]["hello"]["source"],
-            json!({ "type": "git", "url": "https://example.com/repo", "rev": "abc123" })
+            json!({
+                "type": "git",
+                "url": "https://example.com/repo",
+                "rev": "abc123",
+                "ref": "refs/heads/main",
+                "dir": "."
+            })
         );
     }
 

--- a/cli/nef-lock-catalog/src/lock/mod.rs
+++ b/cli/nef-lock-catalog/src/lock/mod.rs
@@ -8,4 +8,5 @@
 
 pub(crate) mod build_lock;
 pub(crate) mod flakeref;
+pub(crate) mod transform;
 pub(crate) mod tree;

--- a/cli/nef-lock-catalog/src/lock/mod.rs
+++ b/cli/nef-lock-catalog/src/lock/mod.rs
@@ -8,5 +8,6 @@
 
 pub(crate) mod build_lock;
 pub(crate) mod flakeref;
+pub(crate) mod lookup;
 pub(crate) mod transform;
 pub(crate) mod tree;

--- a/cli/nef-lock-catalog/src/lock/transform.rs
+++ b/cli/nef-lock-catalog/src/lock/transform.rs
@@ -1,0 +1,193 @@
+//! Transform the flat locked-input map returned by the catalog
+//! `/build-inputs/lookup` endpoint into the hierarchical [BuildLock] consumed
+//! by the NEF.
+
+use std::collections::{BTreeMap, HashMap};
+
+use anyhow::Result;
+use floxhub_client::LockedInputEntry;
+
+use crate::CatalogId;
+use crate::lock::build_lock::{BuildLock, CatalogLock};
+use crate::lock::tree::PackageTreeBuilder;
+
+/// Build a hierarchical [BuildLock] from the flat locked-input map (the merged
+/// `lock` maps of one or more `/build-inputs/lookup` groups).
+///
+/// Entries are grouped by their [`LockedInputEntry::catalog`]; each catalog's
+/// packages are assembled into a [`crate::lock::tree::PackageTreeNode`] via
+/// [`crate::lock::tree::PackageTreeBuilder`], keyed by
+/// [`LockedInputEntry::attr_path`]. The wire `source` is stored **verbatim** —
+/// no nix invocation.
+pub(crate) fn build_lock_from_locked_inputs(
+    locked: HashMap<String, LockedInputEntry>,
+) -> Result<BuildLock> {
+    let mut builders: BTreeMap<CatalogId, PackageTreeBuilder> = BTreeMap::new();
+
+    for entry in locked.into_values() {
+        let LockedInputEntry {
+            attr_path,
+            build_type,
+            catalog,
+            inputs: _,
+            locked_inputs_hash: _,
+            source,
+        } = entry;
+
+        builders
+            .entry(CatalogId(catalog))
+            .or_insert_with(PackageTreeBuilder::new)
+            .add_package_source(attr_path, build_type, serde_json::to_value(source)?)?;
+    }
+
+    let catalogs = builders
+        .into_iter()
+        .map(|(id, builder)| {
+            (id, CatalogLock::FloxHub {
+                packages: builder.into_root(),
+            })
+        })
+        .collect();
+
+    Ok(BuildLock {
+        catalogs,
+        ..Default::default()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use floxhub_client::BuildType;
+    use serde_json::json;
+
+    use super::*;
+
+    fn entry(
+        catalog: &str,
+        attr_path: &[&str],
+        build_type: BuildType,
+        source: serde_json::Value,
+    ) -> LockedInputEntry {
+        LockedInputEntry {
+            attr_path: attr_path.iter().map(|s| s.to_string()).collect(),
+            build_type,
+            catalog: catalog.to_string(),
+            inputs: None,
+            source: serde_json::from_value(source).expect("mocked values is not a valid source"),
+            locked_inputs_hash: "sha256-test".to_string(),
+        }
+    }
+
+    #[test]
+    fn single_package_single_catalog() {
+        let source = json!({ "type": "git", "url": "https://example.com/repo", "rev": "abc" });
+        let locked = HashMap::from([(
+            "myorg.hello".to_string(),
+            entry("myorg", &["hello"], BuildType::Nef, source.clone()),
+        )]);
+
+        let lock = build_lock_from_locked_inputs(locked).expect("transform succeeds");
+
+        assert_eq!(
+            serde_json::to_value(&lock).unwrap(),
+            json!({
+                "version": 1,
+                "catalogs": {
+                    "myorg": {
+                        "type": "floxhub",
+                        "packages": {
+                            "type": "package_set",
+                            "entries": {
+                                "hello": {
+                                    "type": "package",
+                                    "build_type": "nef",
+                                    "source": source,
+                                }
+                            }
+                        }
+                    }
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn nested_attr_path_builds_package_set() {
+        let source = json!({ "type": "git", "url": "https://example.com/repo" });
+        let locked = HashMap::from([(
+            "myorg.python3Packages.boolex".to_string(),
+            entry(
+                "myorg",
+                &["python3Packages", "boolex"],
+                BuildType::Manifest,
+                source.clone(),
+            ),
+        )]);
+
+        let lock = build_lock_from_locked_inputs(locked).expect("transform succeeds");
+
+        assert_eq!(
+            serde_json::to_value(&lock).unwrap(),
+            json!({
+                "version": 1,
+                "catalogs": {
+                    "myorg": {
+                        "type": "floxhub",
+                        "packages": {
+                            "type": "package_set",
+                            "entries": {
+                                "python3Packages": {
+                                    "type": "package_set",
+                                    "entries": {
+                                        "boolex": {
+                                            "type": "package",
+                                            "build_type": "manifest",
+                                            "source": source,
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn groups_by_catalog_and_preserves_source_verbatim() {
+        let src_a = json!({
+            "type": "git",
+            "url": "https://a.example/x",
+            "rev": "deadbeef",
+            "extra": { "nested": [1, 2, 3] },
+        });
+        let src_b = json!({ "type": "path", "path": "/store/b" });
+        let locked = HashMap::from([
+            (
+                "a.foo".to_string(),
+                entry("alpha", &["foo"], BuildType::Nef, src_a.clone()),
+            ),
+            (
+                "b.bar".to_string(),
+                entry("beta", &["bar"], BuildType::Nef, src_b.clone()),
+            ),
+        ]);
+
+        let value = serde_json::to_value(
+            build_lock_from_locked_inputs(locked).expect("transform succeeds"),
+        )
+        .unwrap();
+
+        // Each catalog gets its own tree, and the locked source is stored
+        // byte-for-byte (no nix normalization).
+        assert_eq!(
+            value["catalogs"]["alpha"]["packages"]["entries"]["foo"]["source"],
+            src_a
+        );
+        assert_eq!(
+            value["catalogs"]["beta"]["packages"]["entries"]["bar"]["source"],
+            src_b
+        );
+    }
+}

--- a/cli/nef-lock-catalog/src/lock/transform.rs
+++ b/cli/nef-lock-catalog/src/lock/transform.rs
@@ -37,7 +37,7 @@ pub(crate) fn build_lock_from_locked_inputs(
         builders
             .entry(CatalogId(catalog))
             .or_insert_with(PackageTreeBuilder::new)
-            .add_package_source(attr_path, build_type, serde_json::to_value(source)?)?;
+            .add_package_source(attr_path, build_type, source.into())?;
     }
 
     let catalogs = builders

--- a/cli/nef-lock-catalog/src/lock/transform.rs
+++ b/cli/nef-lock-catalog/src/lock/transform.rs
@@ -57,33 +57,46 @@ pub(crate) fn build_lock_from_locked_inputs(
 
 #[cfg(test)]
 mod tests {
-    use floxhub_client::BuildType;
+    use floxhub_client::{BuildType, LockedGitSource};
     use serde_json::json;
 
     use super::*;
+
+    /// A locked git source. Locked inputs are only ever tracked as git
+    /// flakerefs, so the typed wire model carries exactly these fields.
+    fn git_source(url: &str, rev: &str) -> LockedGitSource {
+        LockedGitSource {
+            dir: ".".to_string(),
+            ref_: "refs/heads/main".to_string(),
+            rev: rev.to_string(),
+            type_: "git".to_string(),
+            url: url.to_string(),
+        }
+    }
 
     fn entry(
         catalog: &str,
         attr_path: &[&str],
         build_type: BuildType,
-        source: serde_json::Value,
+        source: LockedGitSource,
     ) -> LockedInputEntry {
         LockedInputEntry {
             attr_path: attr_path.iter().map(|s| s.to_string()).collect(),
             build_type,
             catalog: catalog.to_string(),
             inputs: None,
-            source: serde_json::from_value(source).expect("mocked values is not a valid source"),
             locked_inputs_hash: "sha256-test".to_string(),
+            source,
         }
     }
 
     #[test]
     fn single_package_single_catalog() {
-        let source = json!({ "type": "git", "url": "https://example.com/repo", "rev": "abc" });
+        let source = git_source("https://example.com/repo", "abc");
+        let expected_source = serde_json::to_value(&source).unwrap();
         let locked = HashMap::from([(
             "myorg.hello".to_string(),
-            entry("myorg", &["hello"], BuildType::Nef, source.clone()),
+            entry("myorg", &["hello"], BuildType::Nef, source),
         )]);
 
         let lock = build_lock_from_locked_inputs(locked).expect("transform succeeds");
@@ -101,7 +114,7 @@ mod tests {
                                 "hello": {
                                     "type": "package",
                                     "build_type": "nef",
-                                    "source": source,
+                                    "source": expected_source,
                                 }
                             }
                         }
@@ -113,14 +126,15 @@ mod tests {
 
     #[test]
     fn nested_attr_path_builds_package_set() {
-        let source = json!({ "type": "git", "url": "https://example.com/repo" });
+        let source = git_source("https://example.com/repo", "abc");
+        let expected_source = serde_json::to_value(&source).unwrap();
         let locked = HashMap::from([(
             "myorg.python3Packages.boolex".to_string(),
             entry(
                 "myorg",
                 &["python3Packages", "boolex"],
                 BuildType::Manifest,
-                source.clone(),
+                source,
             ),
         )]);
 
@@ -142,7 +156,7 @@ mod tests {
                                         "boolex": {
                                             "type": "package",
                                             "build_type": "manifest",
-                                            "source": source,
+                                            "source": expected_source,
                                         }
                                     }
                                 }
@@ -156,21 +170,18 @@ mod tests {
 
     #[test]
     fn groups_by_catalog_and_preserves_source_verbatim() {
-        let src_a = json!({
-            "type": "git",
-            "url": "https://a.example/x",
-            "rev": "deadbeef",
-            "extra": { "nested": [1, 2, 3] },
-        });
-        let src_b = json!({ "type": "path", "path": "/store/b" });
+        let src_a = git_source("https://a.example/x", "deadbeef");
+        let src_b = git_source("https://b.example/y", "cafebabe");
+        let expected_a = serde_json::to_value(&src_a).unwrap();
+        let expected_b = serde_json::to_value(&src_b).unwrap();
         let locked = HashMap::from([
             (
                 "a.foo".to_string(),
-                entry("alpha", &["foo"], BuildType::Nef, src_a.clone()),
+                entry("alpha", &["foo"], BuildType::Nef, src_a),
             ),
             (
                 "b.bar".to_string(),
-                entry("beta", &["bar"], BuildType::Nef, src_b.clone()),
+                entry("beta", &["bar"], BuildType::Nef, src_b),
             ),
         ]);
 
@@ -180,14 +191,14 @@ mod tests {
         .unwrap();
 
         // Each catalog gets its own tree, and the locked source is stored
-        // byte-for-byte (no nix normalization).
+        // verbatim (no nix normalization).
         assert_eq!(
             value["catalogs"]["alpha"]["packages"]["entries"]["foo"]["source"],
-            src_a
+            expected_a
         );
         assert_eq!(
             value["catalogs"]["beta"]["packages"]["entries"]["bar"]["source"],
-            src_b
+            expected_b
         );
     }
 }

--- a/cli/nef-lock-catalog/src/lock/tree.rs
+++ b/cli/nef-lock-catalog/src/lock/tree.rs
@@ -6,10 +6,9 @@ use std::collections::BTreeMap;
 use anyhow::Result;
 use floxhub_client::BuildType;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 use tracing::warn;
 
-use super::flakeref::NixFlakeref;
+use super::flakeref::{NixFlakeref, RawNixFlakerefAttrs};
 
 /// Represents a node in the package tree - either a package set or an individual package
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
@@ -22,15 +21,9 @@ pub enum PackageTreeNode {
     /// An individual package (leaf node)
     Package {
         build_type: BuildType,
-        /// The package's locked nix source ref, as a raw JSON value.
-        ///
-        /// Stored verbatim. For catalog `/build-inputs/lookup` results
-        /// ([PackageTreeBuilder::add_package_source]) the source is already
-        /// locked server-side and is carried through without a nix call.
-        /// [PackageTreeBuilder::add_package] instead supplies the parsed value
-        /// of a [NixFlakeref] (which is not [serde::Serialize], hence a [Value]
-        /// here rather than the typed ref).
-        source: Value,
+        /// The package's locked source ref, stored verbatim. See
+        /// [RawNixFlakerefAttrs] for the invariant it carries.
+        source: RawNixFlakerefAttrs,
     },
 }
 
@@ -61,7 +54,7 @@ impl PackageTreeBuilder {
         &mut self,
         attr_path: Vec<String>,
         build_type: BuildType,
-        source: Value,
+        source: RawNixFlakerefAttrs,
     ) -> Result<()> {
         let Some((final_attribute, parent_attributes)) = attr_path.split_last() else {
             anyhow::bail!("Empty attribute path");
@@ -153,7 +146,11 @@ impl PackageTreeBuilder {
         source: NixFlakeref,
     ) -> Result<()> {
         // The parsed flake reference is the source value stored at the leaf.
-        self.add_package_source(attr_path, build_type, source.as_parsed().clone())
+        self.add_package_source(
+            attr_path,
+            build_type,
+            RawNixFlakerefAttrs::new_unchecked(source.as_parsed().clone()),
+        )
     }
 }
 
@@ -161,7 +158,7 @@ impl PackageTreeBuilder {
 mod tests {
 
     use floxhub_client::BuildType;
-    use serde_json::json;
+    use serde_json::{Value, json};
 
     use super::*;
 
@@ -429,28 +426,22 @@ mod tests {
 
         assert_eq!(tree, expected_tree);
 
-        // Verify the source is preserved correctly by checking the expected tree
-        if let PackageTreeNode::PackageSet { entries: children } = &expected_tree {
-            if let Some(PackageTreeNode::Package { source, .. }) = children.get("test") {
-                // Verify the source is a proper Value
-                assert!(source.is_object());
-
-                // Verify it contains expected fields
-                let source_obj = source.as_object().unwrap();
-                assert!(source_obj.contains_key("type"));
-                assert!(source_obj.contains_key("url"));
-                assert!(source_obj.contains_key("rev"));
-                assert_eq!(source_obj.get("url").unwrap(), "https://example.com");
-                assert_eq!(
-                    source_obj.get("rev").unwrap(),
-                    "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
-                );
-            } else {
-                panic!("Expected package node");
-            }
-        } else {
-            panic!("Expected package set node");
-        }
+        // The source is stored verbatim as the locked flakeref attrs.
+        let PackageTreeNode::PackageSet { entries: children } = &tree else {
+            panic!("expected package set node");
+        };
+        let Some(PackageTreeNode::Package { source, .. }) = children.get("test") else {
+            panic!("expected package node");
+        };
+        assert_eq!(
+            source,
+            &RawNixFlakerefAttrs::new_unchecked(json!({
+                "type": "git",
+                "url": "https://example.com",
+                "rev": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+                "dir": "foo/bar/.flox"
+            }))
+        );
     }
 
     #[test]

--- a/cli/nef-lock-catalog/src/lock/tree.rs
+++ b/cli/nef-lock-catalog/src/lock/tree.rs
@@ -22,10 +22,14 @@ pub enum PackageTreeNode {
     /// An individual package (leaf node)
     Package {
         build_type: BuildType,
-        /// A validated nix source ref
-        /// Note: validation (parsing) is done during construction using [NixFlakeref::from_value].
-        /// The [NixFlakeref] type is then unwrapped to a [Value] for serialization as
-        /// [NixFlakeref] does not implement [serde::Serialize].
+        /// The package's locked nix source ref, as a raw JSON value.
+        ///
+        /// Stored verbatim. For catalog `/build-inputs/lookup` results
+        /// ([PackageTreeBuilder::add_package_source]) the source is already
+        /// locked server-side and is carried through without a nix call.
+        /// [PackageTreeBuilder::add_package] instead supplies the parsed value
+        /// of a [NixFlakeref] (which is not [serde::Serialize], hence a [Value]
+        /// here rather than the typed ref).
         source: Value,
     },
 }
@@ -48,17 +52,16 @@ impl PackageTreeBuilder {
         self.root
     }
 
-    /// Add a package to the tree using optimized split_last() approach
+    /// Add a package to the tree from a raw, already-locked source value.
     ///
-    /// # Parameters
-    /// - `attr_path`: Path components (e.g., ["pkgs", "hello"])
-    /// - `build_type`: Type of build
-    /// - `source`: Validated source reference
-    pub fn add_package(
+    /// Unlike [Self::add_package], this stores `source` verbatim and performs
+    /// no nix invocation — used for catalog `/build-inputs/lookup` results,
+    /// whose `source` is already locked server-side.
+    pub fn add_package_source(
         &mut self,
         attr_path: Vec<String>,
         build_type: BuildType,
-        source: NixFlakeref,
+        source: Value,
     ) -> Result<()> {
         let Some((final_attribute, parent_attributes)) = attr_path.split_last() else {
             anyhow::bail!("Empty attribute path");
@@ -101,16 +104,9 @@ impl PackageTreeBuilder {
                     });
         }
 
-        // Insert final package using final component as key
-        let package = {
-            // Use the parsed flake reference data directly
-            let source_value = source.as_parsed().clone();
-
-            PackageTreeNode::Package {
-                build_type,
-                source: source_value,
-            }
-        };
+        // Insert final package using final component as key. The source is
+        // stored verbatim — it is already locked server-side.
+        let package = PackageTreeNode::Package { build_type, source };
         match current_node {
             PackageTreeNode::PackageSet { entries } => {
                 // Check if there's already a package set at this location
@@ -142,6 +138,22 @@ impl PackageTreeBuilder {
         }
 
         Ok(())
+    }
+
+    /// Add a package to the tree using optimized split_last() approach
+    ///
+    /// # Parameters
+    /// - `attr_path`: Path components (e.g., ["pkgs", "hello"])
+    /// - `build_type`: Type of build
+    /// - `source`: Validated source reference
+    pub fn add_package(
+        &mut self,
+        attr_path: Vec<String>,
+        build_type: BuildType,
+        source: NixFlakeref,
+    ) -> Result<()> {
+        // The parsed flake reference is the source value stored at the leaf.
+        self.add_package_source(attr_path, build_type, source.as_parsed().clone())
     }
 }
 

--- a/cli/nef-lock-catalog/test_data/build_inputs_lookup/partial.json
+++ b/cli/nef-lock-catalog/test_data/build_inputs_lookup/partial.json
@@ -1,0 +1,16 @@
+{
+  "groups": {
+    "default": {
+      "lock": {},
+      "matched": {},
+      "unresolvable": [
+        {
+          "chain": ["catalogs.myorg.hello", "catalogs.myorg.missing-dep"],
+          "leaf": { "unresolvable": {} },
+          "reference": "catalogs.myorg.missing-dep"
+        }
+      ]
+    }
+  },
+  "version": 1
+}

--- a/cli/nef-lock-catalog/test_data/build_inputs_lookup/success.json
+++ b/cli/nef-lock-catalog/test_data/build_inputs_lookup/success.json
@@ -1,0 +1,23 @@
+{
+  "groups": {
+    "default": {
+      "lock": {
+        "myorg.hello": {
+          "attr_path": ["hello"],
+          "build_type": "nef",
+          "catalog": "myorg",
+          "source": {
+            "type": "git",
+            "url": "https://example.com/repo",
+            "rev": "abc123"
+          }
+        }
+      },
+      "matched": {
+        "myorg.hello": ["catalogs.myorg.hello"]
+      },
+      "unresolvable": []
+    }
+  },
+  "version": 1
+}

--- a/cli/nef-lock-catalog/test_data/build_inputs_lookup/success.json
+++ b/cli/nef-lock-catalog/test_data/build_inputs_lookup/success.json
@@ -6,10 +6,13 @@
           "attr_path": ["hello"],
           "build_type": "nef",
           "catalog": "myorg",
+          "locked_inputs_hash": "sha256-success-fixture",
           "source": {
             "type": "git",
             "url": "https://example.com/repo",
-            "rev": "abc123"
+            "rev": "abc123",
+            "ref": "refs/heads/main",
+            "dir": "."
           }
         }
       },


### PR DESCRIPTION
## Proposed Changes

Implements [ECO-93](https://linear.app/floxdotdev/issue/ECO-93) — completes the `nef-lock-catalog` locking library (Increment 1 of the lockless CLI flow). Catalog inputs are locked via a single server-side `POST /build-inputs/lookup` rather than local closure assembly.

- **P2** — `build_inputs_lookup` on `CatalogClientTrait` (+ wire-type re-exports through `floxhub-client`; `MockClient` stub — the record/replay client is the path forward for client-level tests).
- **A1** — batched lookup engine `lock_references(references, stability)`: domain refs → one `/build-inputs/lookup` request → `BuildLock`. Any group-scoped `unresolvable` fails the whole lock (`LockError::Unresolvable`, no partial output); chain rendering is deferred to ECO-94.
- **A2** — `build_lock_from_locked_inputs`: flat locked inputs → hierarchical `BuildLock` via `PackageTreeBuilder`, storing the wire `source` **verbatim** (no nix invocation — the server returns already-locked sources).
- **A3** — `flox build update-catalogs` now defers to the lockless flow; the `nix-builds.toml` catalog-declaration / nix-prefetch path is retired (kept as a compile shim for the lock binary, removed in ECO-94).
- Supporting types: `CatalogRef` (scanner output) and `RawNixFlakerefAttrs` (raw, assumed-locked source ref) newtypes; removed unused `NixPrefetchResult` accessors.
- Also folds in a fix for a **pre-existing** broken test (`check_build_metadata` was missing the `nef_targets` arg, introduced alongside the per-pname make-args change).

### Follow-ups that fell out of this work

- [ECO-94](https://linear.app/floxdotdev/issue/ECO-94) — lock-binary CLI (`--rel-path`/`--out`/`--system`/`--stability`), REQ-013 unresolvable-chain rendering, and removal of the retained toml/nix-prefetch shim. `update-catalogs` bails pending this.
- [CLI-92](https://linear.app/floxdotdev/issue/CLI-92) — relocate `NixFlakeref` out of `nef-lock-catalog`; it's a general nix source-ref utility, no longer core now that locking carries `RawNixFlakerefAttrs`.
- Spec-dependent stopgaps to revisit once the catalog OpenAPI settles:
  - the lookup request's `system` field is sent as a `PackageSystem::Invalid` placeholder (the field is being removed from this endpoint upstream);
  - the lookup endpoint is generated with `HttpValidationError` instead of the shared `ErrorResponse`, so it bypasses `map_api_error` (mapped to `FloxhubClientError::Other` for now);
  - stability validity is the server's authority — the client only does the non-empty check the generated `Stability` newtype forces.

## Release Notes

`flox build update-catalogs` no longer locks catalog inputs from `.flox/nix-builds.toml`; it reports that catalog inputs are now locked automatically as part of the lockless build flow.
