### PR TITLE
feat(hook-env): respect allow/deny config for auto-activation (DEV-120)

### DIFF
--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -38,6 +38,7 @@ use flox_rust_sdk::providers::services::process_compose::{PROCESS_COMPOSE_BIN, P
 use flox_rust_sdk::providers::upgrade_checks::UpgradeInformationGuard;
 use flox_rust_sdk::utils::FLOX_INTERPRETER;
 use indoc::{formatdoc, indoc};
+use toml_edit::Key;
 use tracing::{debug, trace, warn};
 
 use super::{
@@ -48,7 +49,7 @@ use super::{
     environment_select,
 };
 use crate::commands::check_for_upgrades::spawn_detached_check_for_upgrades_process;
-use crate::commands::general::update_config;
+use crate::commands::general::update_config_with_query;
 use crate::commands::services::ServicesCommandsError;
 use crate::commands::{
     EnvironmentSelectError,
@@ -111,11 +112,11 @@ pub enum ActivateSubcommandOrOptions {
 #[derive(Bpaf, Debug, Clone, Copy)]
 pub enum AutoActivate {
     /// Allow auto-activation for an environment
-    #[bpaf(command, hide)]
+    #[bpaf(command)]
     Allow,
 
     /// Deny auto-activation for an environment
-    #[bpaf(command, hide)]
+    #[bpaf(command)]
     Deny,
 }
 
@@ -870,47 +871,59 @@ fn notify_environment_upgrades(
 
 /// Allow auto-activation for an environment by updating the config.
 ///
-/// Writes the allow preference to the config file for the environment's parent path.
+/// Writes the allow preference to the config file for the environment's parent
+/// path.
 pub fn allow(config: &Config, concrete_environment: &ConcreteEnvironment) -> Result<()> {
-    let env_path = concrete_environment.parent_path()?;
-    let path_str = env_path.display().to_string();
-    let key = format!("auto_activate_environments.{}", path_str);
-    update_config(
-        &config.flox.config_dir,
-        key,
-        Some(AutoActivationPreference::Allow),
-    )?;
-    Ok(())
+    set_auto_activation_preference(
+        config,
+        concrete_environment,
+        AutoActivationPreference::Allow,
+    )
 }
 
 /// Deny auto-activation for an environment by updating the config.
 ///
-/// Writes the deny preference to the config file for the environment's parent path.
+/// Writes the deny preference to the config file for the environment's parent
+/// path.
 pub fn deny(config: &Config, concrete_environment: &ConcreteEnvironment) -> Result<()> {
-    let env_path = concrete_environment.parent_path()?;
-    let path_str = env_path.display().to_string();
-    let key = format!("auto_activate_environments.{}", path_str);
-    update_config(
-        &config.flox.config_dir,
-        key,
-        Some(AutoActivationPreference::Deny),
-    )?;
-    Ok(())
+    set_auto_activation_preference(config, concrete_environment, AutoActivationPreference::Deny)
 }
 
-/// Check if auto-activation is allowed for an environment.
-///
-/// Returns true if the environment is explicitly allowed or has no preference set.
-/// Returns false if the environment is explicitly denied.
-#[allow(dead_code)]
-pub fn is_allowed(config: &Config, concrete_environment: &ConcreteEnvironment) -> Result<bool> {
+/// Record the user's per-directory auto-activation preference under
+/// `auto_activate_environments` in the config.
+fn set_auto_activation_preference(
+    config: &Config,
+    concrete_environment: &ConcreteEnvironment,
+    preference: AutoActivationPreference,
+) -> Result<()> {
     let env_path = concrete_environment.parent_path()?;
-    let preference = config.flox.auto_activate_environments.get(&env_path);
+    write_auto_activation_preference(&config.flox.config_dir, &env_path, preference)
+}
 
-    match preference {
-        Some(AutoActivationPreference::Deny) => Ok(false),
-        Some(AutoActivationPreference::Allow) | None => Ok(true),
-    }
+/// Write an auto-activation preference for a project directory (the directory
+/// containing `.flox`) to the config under `auto_activate_environments`.
+///
+/// The directory is written as a single literal TOML key rather than spliced
+/// into a dot-separated key string: a path can contain `.` (macOS temp dirs
+/// live under paths like `/var/folders/...`, and project directories may have
+/// names like `my.app`), which dotted-key parsing would shatter into several
+/// nested tables.
+///
+/// `env_path` must be canonical so it matches the directories the prompt hook
+/// discovers. Subcommand callers get this from
+/// [`Environment::parent_path`] (a popped `CanonicalPath`); the prompt hook
+/// passes the already-canonical discovered directory.
+pub fn write_auto_activation_preference(
+    config_dir: &Path,
+    env_path: &Path,
+    preference: AutoActivationPreference,
+) -> Result<()> {
+    let query = [
+        Key::new("auto_activate_environments"),
+        Key::new(env_path.to_string_lossy().into_owned()),
+    ];
+    update_config_with_query(config_dir, &query, Some(preference))?;
+    Ok(())
 }
 
 #[cfg(test)]

--- a/cli/flox/src/commands/general.rs
+++ b/cli/flox/src/commands/general.rs
@@ -150,10 +150,23 @@ pub(super) fn update_config<V: Serialize>(
     value: Option<V>,
 ) -> Result<()> {
     let query = parse_toml_key(key.as_ref()).context("Could not parse key")?;
+    update_config_with_query(config_dir, &query, value)
+}
 
+/// Like [`update_config`], but takes an already-parsed TOML key path instead of
+/// a dot-separated string.
+///
+/// Use this when a key segment can itself contain `.` — e.g. a filesystem path
+/// — which [`parse_toml_key`]'s dot-splitting would otherwise shatter into
+/// several nested-table segments.
+pub(super) fn update_config_with_query<V: Serialize>(
+    config_dir: &Path,
+    query: &[Key],
+    value: Option<V>,
+) -> Result<()> {
     let config_file_path = config_dir.join(FLOX_CONFIG_FILE);
 
-    match Config::write_to_in(config_file_path, &query, value) {
+    match Config::write_to_in(config_file_path, query, value) {
                 err @ Err(ReadWriteError::ReadConfig(_)) => err.context("Could not read current config file.\nPlease verify the format or reset using `flox config --reset`")?,
                 err @ Err(_) => err?,
                 Ok(()) => ()

--- a/cli/flox/src/commands/hook_env.rs
+++ b/cli/flox/src/commands/hook_env.rs
@@ -24,6 +24,7 @@ use super::deactivate::{
     flox_activate_tracelevel,
     open_deactivation_target,
 };
+use crate::config::{AutoActivationPreference, Config};
 use crate::subcommand_metric;
 use crate::utils::message;
 
@@ -53,7 +54,7 @@ pub struct HookEnv {
 }
 
 impl HookEnv {
-    pub fn handle(self, flox: Flox) -> Result<()> {
+    pub fn handle(self, config: Config, flox: Flox) -> Result<()> {
         let mut writer = BufWriter::new(stdout());
 
         // Consume any actions another flox command (e.g. `flox deactivate`) left
@@ -99,7 +100,7 @@ impl HookEnv {
             return Ok(());
         }
 
-        let ctx = gather_auto_activate_context(!actions.is_empty())?;
+        let ctx = gather_auto_activate_context(&config, !actions.is_empty())?;
         let plan = plan_auto_activation(&ctx);
 
         // Only record a metric when this run actually does something;
@@ -223,6 +224,12 @@ struct AutoActivateContext {
     auto_activated: Vec<PathBuf>,
     /// Project directories suppressed from auto-activation in this shell.
     suppressed: Vec<PathBuf>,
+    /// Project directories the user has allowed auto-activation for via
+    /// `flox activate allow` (config `auto_activate_environments`).
+    allowed: Vec<PathBuf>,
+    /// Project directories the user has denied auto-activation for via
+    /// `flox activate deny` (config `auto_activate_environments`).
+    denied: Vec<PathBuf>,
     /// Whether this run consumed pending prompt-hook deactivation actions.
     pending_deactivations: bool,
 }
@@ -231,7 +238,8 @@ struct AutoActivateContext {
 /// auto-activation state variables.
 #[derive(Clone, Debug, PartialEq)]
 struct AutoActivatePlan {
-    /// Project directories to activate, outermost-first.
+    /// Project directories to activate, outermost-first. These are discovered
+    /// environments that have not been denied.
     activate: Vec<PathBuf>,
     /// Project directories to deactivate, front of stack first.
     deactivate: Vec<PathBuf>,
@@ -258,9 +266,17 @@ struct AutoActivatePlan {
 /// can pop. While any tracked layer the shell has left remains active, newly
 /// discovered environments are not activated yet — they would bury the
 /// still-unwinding layers.
+///
+/// A discovered environment is auto-activated unless the user has denied it
+/// with `flox activate deny`.
+///
+/// Deny governs future auto-activation only: an environment that is already
+/// active (whether activated manually or before being denied) is left running,
+/// and is auto-deactivated as usual once the shell leaves its directory.
 fn plan_auto_activation(ctx: &AutoActivateContext) -> AutoActivatePlan {
     let inside = |path: &Path| ctx.cwd.starts_with(path);
     let is_active = |path: &PathBuf| ctx.active.iter().flatten().any(|active| active == path);
+    let is_denied = |path: &PathBuf| ctx.denied.contains(path);
 
     // Reconcile tracked state with the actual activation stack. A suppressed
     // environment stays suppressed only while the shell remains inside its
@@ -336,16 +352,23 @@ fn plan_auto_activation(ctx: &AutoActivateContext) -> AutoActivatePlan {
         }
     }
 
-    // Activate discovered environments that aren't already active or
-    // suppressed, outermost-first so the innermost ends up on top. Defer
-    // while tracked environments the shell has left are still unwinding:
-    // activating now would stack the new environment on top of them, and a
-    // buried environment can't be popped (it would be abandoned instead).
+    // Walk discovered environments outermost-first so the innermost ends up on
+    // top. A discovered environment activates unless it has been denied; deny
+    // is per-directory, so a denied directory in the middle of a stack does not
+    // block its ancestors or descendants.
+    //
+    // Defer all of this while tracked environments the shell has left are still
+    // unwinding: activating now would stack the new environment on top of them,
+    // and a buried environment can't be popped (it would be abandoned instead).
     let unwinding = auto_activated.iter().any(|path| !inside(path));
     let mut activate = Vec::new();
     if !unwinding {
         for path in &ctx.discovered {
-            if is_active(path) || suppressed.contains(path) || activate.contains(path) {
+            if is_active(path)
+                || suppressed.contains(path)
+                || is_denied(path)
+                || activate.contains(path)
+            {
                 continue;
             }
             activate.push(path.clone());
@@ -364,8 +387,12 @@ fn plan_auto_activation(ctx: &AutoActivateContext) -> AutoActivatePlan {
 
 /// Gather the runtime inputs for [`plan_auto_activation`]: the shell's
 /// working directory, the environments discoverable from it, the activation
-/// stack, and the hook's tracked state variables.
-fn gather_auto_activate_context(pending_deactivations: bool) -> Result<AutoActivateContext> {
+/// stack, the hook's tracked state variables, and the user's per-directory
+/// auto-activation preferences.
+fn gather_auto_activate_context(
+    config: &Config,
+    pending_deactivations: bool,
+) -> Result<AutoActivateContext> {
     let cwd = std::env::current_dir().context("failed to read current directory")?;
     let discovered = find_all_dot_flox(&cwd)
         .context("failed to discover environments for auto-activation")?
@@ -386,12 +413,29 @@ fn gather_auto_activate_context(pending_deactivations: bool) -> Result<AutoActiv
         .iter()
         .map(|env| env.path().and_then(Path::parent).map(Path::to_path_buf))
         .collect();
+    // `flox activate allow`/`deny` key the config by the environment's parent
+    // path, which they derive by popping `.flox` off a `CanonicalPath`. Those
+    // keys are therefore already canonical and comparable to `discovered`
+    // without re-canonicalizing here.
+    let preference = |want: AutoActivationPreference| {
+        config
+            .flox
+            .auto_activate_environments
+            .iter()
+            .filter(move |(_, pref)| **pref == want)
+            .map(|(path, _)| path.clone())
+            .collect::<Vec<_>>()
+    };
+    let allowed = preference(AutoActivationPreference::Allow);
+    let denied = preference(AutoActivationPreference::Deny);
     Ok(AutoActivateContext {
         cwd,
         discovered,
         active,
         auto_activated: read_path_list_var(FLOX_AUTO_ACTIVATED_ENVIRONMENTS_VAR),
         suppressed: read_path_list_var(FLOX_SUPPRESSED_ENVIRONMENTS_VAR),
+        allowed,
+        denied,
         pending_deactivations,
     })
 }
@@ -484,6 +528,8 @@ mod tests {
             active: Vec::new(),
             auto_activated: Vec::new(),
             suppressed: Vec::new(),
+            allowed: Vec::new(),
+            denied: Vec::new(),
             pending_deactivations: false,
         }
     }
@@ -512,6 +558,7 @@ mod tests {
     fn activates_discovered_env() {
         let ctx = AutoActivateContext {
             discovered: paths(&["/home/user/proj"]),
+            allowed: paths(&["/home/user/proj"]),
             ..empty_ctx("/home/user/proj")
         };
         assert_eq!(plan_auto_activation(&ctx), AutoActivatePlan {
@@ -525,6 +572,7 @@ mod tests {
     fn activates_stack_outermost_first() {
         let ctx = AutoActivateContext {
             discovered: paths(&["/home/user/outer", "/home/user/outer/inner"]),
+            allowed: paths(&["/home/user/outer", "/home/user/outer/inner"]),
             ..empty_ctx("/home/user/outer/inner")
         };
         assert_eq!(plan_auto_activation(&ctx), AutoActivatePlan {
@@ -554,6 +602,7 @@ mod tests {
             discovered: paths(&["/home/user/outer", "/home/user/outer/inner"]),
             active: vec![Some(PathBuf::from("/home/user/outer"))],
             auto_activated: paths(&["/home/user/outer"]),
+            allowed: paths(&["/home/user/outer", "/home/user/outer/inner"]),
             ..empty_ctx("/home/user/outer/inner")
         };
         assert_eq!(plan_auto_activation(&ctx), AutoActivatePlan {
@@ -600,6 +649,7 @@ mod tests {
             discovered: paths(&["/home/user/proj_b"]),
             active: vec![Some(PathBuf::from("/home/user/proj_a"))],
             auto_activated: paths(&["/home/user/proj_a"]),
+            allowed: paths(&["/home/user/proj_b"]),
             ..empty_ctx("/home/user/proj_b")
         };
         assert_eq!(plan_auto_activation(&ctx), AutoActivatePlan {
@@ -622,6 +672,7 @@ mod tests {
                 Some(PathBuf::from("/tmp/a")),
             ],
             auto_activated: paths(&["/tmp/a", "/tmp/a/b"]),
+            allowed: paths(&["/tmp/z"]),
             ..empty_ctx("/tmp/z")
         };
         assert_eq!(plan_auto_activation(&ctx), AutoActivatePlan {
@@ -668,6 +719,7 @@ mod tests {
                 Some(PathBuf::from("/tmp/a")),
             ],
             auto_activated: paths(&["/tmp/a"]),
+            allowed: paths(&["/tmp/z"]),
             ..empty_ctx("/tmp/z")
         };
         assert_eq!(plan_auto_activation(&ctx), AutoActivatePlan {
@@ -824,11 +876,92 @@ mod tests {
         // directory); coming back in looks like a fresh discovery.
         let ctx = AutoActivateContext {
             discovered: paths(&["/home/user/proj"]),
+            allowed: paths(&["/home/user/proj"]),
             ..empty_ctx("/home/user/proj")
         };
         assert_eq!(plan_auto_activation(&ctx), AutoActivatePlan {
             activate: paths(&["/home/user/proj"]),
             auto_activated: paths(&["/home/user/proj"]),
+            ..noop_plan()
+        });
+    }
+
+    #[test]
+    fn does_not_activate_denied_env() {
+        // The user denied auto-activation for this directory, so discovering
+        // it must not activate it.
+        let ctx = AutoActivateContext {
+            discovered: paths(&["/home/user/proj"]),
+            denied: paths(&["/home/user/proj"]),
+            ..empty_ctx("/home/user/proj")
+        };
+        assert_eq!(plan_auto_activation(&ctx), noop_plan());
+    }
+
+    #[test]
+    fn denied_inner_env_does_not_block_allowed_outer() {
+        // Denying the innermost environment leaves its allowed ancestor free
+        // to auto-activate.
+        let ctx = AutoActivateContext {
+            discovered: paths(&["/home/user/outer", "/home/user/outer/inner"]),
+            allowed: paths(&["/home/user/outer"]),
+            denied: paths(&["/home/user/outer/inner"]),
+            ..empty_ctx("/home/user/outer/inner")
+        };
+        assert_eq!(plan_auto_activation(&ctx), AutoActivatePlan {
+            activate: paths(&["/home/user/outer"]),
+            auto_activated: paths(&["/home/user/outer"]),
+            ..noop_plan()
+        });
+    }
+
+    #[test]
+    fn denied_outer_env_does_not_block_allowed_inner() {
+        // Denying an ancestor leaves an allowed descendant free to
+        // auto-activate; the deny applies per-directory, not to the subtree.
+        let ctx = AutoActivateContext {
+            discovered: paths(&["/home/user/outer", "/home/user/outer/inner"]),
+            allowed: paths(&["/home/user/outer/inner"]),
+            denied: paths(&["/home/user/outer"]),
+            ..empty_ctx("/home/user/outer/inner")
+        };
+        assert_eq!(plan_auto_activation(&ctx), AutoActivatePlan {
+            activate: paths(&["/home/user/outer/inner"]),
+            auto_activated: paths(&["/home/user/outer/inner"]),
+            ..noop_plan()
+        });
+    }
+
+    #[test]
+    fn deny_while_inside_does_not_deactivate_active_env() {
+        // Denying an environment that was already auto-activated does not tear
+        // it down; deny only governs future auto-activation. It stays tracked
+        // and active until the shell leaves its directory.
+        let ctx = AutoActivateContext {
+            discovered: paths(&["/home/user/proj"]),
+            active: vec![Some(PathBuf::from("/home/user/proj"))],
+            auto_activated: paths(&["/home/user/proj"]),
+            denied: paths(&["/home/user/proj"]),
+            ..empty_ctx("/home/user/proj")
+        };
+        assert_eq!(plan_auto_activation(&ctx), AutoActivatePlan {
+            auto_activated: paths(&["/home/user/proj"]),
+            ..noop_plan()
+        });
+    }
+
+    #[test]
+    fn denied_env_still_pops_after_leaving() {
+        // An environment denied while it was active is auto-deactivated as
+        // usual once the shell leaves its directory.
+        let ctx = AutoActivateContext {
+            active: vec![Some(PathBuf::from("/home/user/proj"))],
+            auto_activated: paths(&["/home/user/proj"]),
+            denied: paths(&["/home/user/proj"]),
+            ..empty_ctx("/home/user/elsewhere")
+        };
+        assert_eq!(plan_auto_activation(&ctx), AutoActivatePlan {
+            deactivate: paths(&["/home/user/proj"]),
             ..noop_plan()
         });
     }

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -863,7 +863,7 @@ enum InternalCommands {
 }
 
 impl InternalCommands {
-    async fn handle(self, _config: Config, flox: Flox) -> Result<()> {
+    async fn handle(self, config: Config, flox: Flox) -> Result<()> {
         match self {
             InternalCommands::ResetMetrics(args) => args.handle(flox).await?,
             InternalCommands::Upload(args) => args.handle(flox).await?,
@@ -871,7 +871,7 @@ impl InternalCommands {
             InternalCommands::CheckForUpgrades(args) => args.handle(flox).await?,
             InternalCommands::ActivationState(args) => args.handle(flox).await?,
             InternalCommands::ServicesSocket(args) => args.handle(flox).await?,
-            InternalCommands::HookEnv(args) => args.handle(flox)?,
+            InternalCommands::HookEnv(args) => args.handle(config, flox)?,
         }
         Ok(())
     }

--- a/cli/flox/src/config/mod.rs
+++ b/cli/flox/src/config/mod.rs
@@ -758,6 +758,29 @@ mod tests {
     }
 
     #[test]
+    fn writing_auto_activate_preference_for_path_with_dot() {
+        // Regression: an auto-activation preference is keyed by a filesystem
+        // path, which can contain `.` (macOS temp dirs live under paths like
+        // `/var/folders/...`, and project directories may be named `my.app`).
+        // The path must be written as a single literal TOML key rather than a
+        // dot-separated key string, which would shatter it into nested tables
+        // and fail validation with "unknown variant". `write_to` validates the
+        // result by deserializing it, so a successful call already proves the
+        // path round-trips back into the typed config.
+        let path = "/var/folders/ab/cd.ef/my.project";
+        let query = [
+            Key::new("auto_activate_environments"),
+            Key::new(path.to_string()),
+        ];
+        let rendered =
+            Config::write_to(None, &query, Some(AutoActivationPreference::Deny)).unwrap();
+        assert_eq!(rendered, indoc! {r#"
+            [auto_activate_environments]
+            "/var/folders/ab/cd.ef/my.project" = "deny"
+        "#});
+    }
+
+    #[test]
     fn test_remove() {
         let config_before = indoc! {"
         # my git base url is friendly, see:

--- a/cli/tests/hook.bats
+++ b/cli/tests/hook.bats
@@ -416,6 +416,34 @@ EXPIRED_FLOXHUB_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3gu
 }
 
 # ---------------------------------------------------------------------------- #
+# Config: 'flox activate deny' suppresses auto-activation for a directory
+# ---------------------------------------------------------------------------- #
+
+# bats test_tags=hook:deny:bash
+@test "bash: hook does not auto-activate an environment denied via 'flox activate deny'" {
+  project_setup
+  project2_setup
+  export FLOX_FEATURES_AUTO_ACTIVATE=true
+
+  # Record the deny preference for the second project before entering it.
+  "$FLOX_BIN" activate deny -d "$PROJECT2_DIR"
+
+  run --separate-stderr bash -c "
+    export FLOX_FEATURES_AUTO_ACTIVATE=true
+    export FLOX_SHELL=\$(which bash)
+    eval \"\$($FLOX_BIN activate -d $PROJECT_DIR)\"
+    cd $PROJECT2_DIR
+    _flox_hook
+    echo \"var2:\${TEST_VAR2:-unset}\"
+    echo \"tracked:\${_FLOX_AUTO_ACTIVATED_ENVIRONMENTS:-unset}\"
+  "
+  assert_success
+  # The denied environment is neither activated nor tracked.
+  assert_output --partial "var2:unset"
+  assert_output --partial "tracked:unset"
+}
+
+# ---------------------------------------------------------------------------- #
 # Hook auto-fires: verify the prompt hook triggers without manual invocation
 # ---------------------------------------------------------------------------- #
 


### PR DESCRIPTION
## What

Implements **DEV-120 ("Respect the config")** — wires up the per-directory `flox activate allow` / `flox activate deny` preferences, makes the prompt hook **respect `deny`**, fixes a bug that prevented those preferences from being stored, and makes the subcommands discoverable.

Auto-activation stays **opt-out** in this PR: a discovered environment auto-activates unless the user has denied it. Flipping the default to opt-in (only allowed environments activate) and adding the interactive consent prompt is the follow-up **DEV-132** ([#4405](https://github.com/flox/flox/pull/4405), stacked on this branch).

- **Respect `deny`:** the prompt-hook planner skips a discovered environment the user has denied (`flox activate deny`). Everything else discovered still auto-activates.
- **`allow` is recorded but not yet a gate:** `flox activate allow` persists the preference (and the config-write fix below makes that actually work), but the opt-out planner doesn't consult it yet — it becomes the opt-in gate in DEV-132.
- Deny governs *future* auto-activation only: an already-active environment is left running and auto-deactivates as usual on leave. A denied directory in the middle of a stack doesn't block its ancestors/descendants (deny is per-directory).
- **Discoverability:** `flox activate allow` / `flox activate deny` are unhidden — they now appear in `flox activate --help`.
- `Config` is threaded into `flox hook-env`; the allowed/denied directories are gathered into the pure, unit-testable planner.

## Embedded bug fix: `flox activate allow/deny` could not store paths

`allow`/`deny` (DEV-48) were **broken**: the config key was built as `auto_activate_environments.` and run through dot-splitting key parsing, so any path containing `.` (every macOS temp dir; project dirs like `my.app`) was shattered into nested tables and the write failed with `unknown variant ...`. Preferences are now written as a single literal TOML key via a new `update_config_with_query` helper. Without this fix the allow/deny lists could never be stored.

## Testing
- **Unit** (hook-env planner): denied env is skipped; deny doesn't block a non-denied ancestor/descendant in a stack; plus the existing stacking/deactivation tests. Config-write regression test for dotted paths. (31 planner tests pass locally; 282 in the full `flox` unit suite.)
- **Integration** (`hook.bats`): deny test; the auto-activate tests no longer pre-`allow` their targets (opt-out). Spot-checked across bash/zsh/fish/tcsh.
- clippy + rustfmt clean.

## Follow-ups
- **[DEV-132](https://linear.app/floxdotdev/issue/DEV-132)** ([#4405](https://github.com/flox/flox/pull/4405)) — opt-in default (`auto_activate = "prompt"`) + interactive consent prompt; carries the opt-in planner gate (stacked on this branch).
- **[DEV-131](https://linear.app/floxdotdev/issue/DEV-131)** — re-allowing a mid-stack environment activates it on top instead of in ancestor order.

Linear: [DEV-120](https://linear.app/floxdotdev/issue/DEV-120/respect-the-config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)