### PR TITLE
feat(hook-env): prompt for consent before auto-activating (DEV-132)

### DIFF
--- a/cli/flox/src/commands/hook_env.rs
+++ b/cli/flox/src/commands/hook_env.rs
@@ -1,5 +1,5 @@
 use std::borrow::Cow;
-use std::io::{BufWriter, Write, stdout};
+use std::io::{BufRead, BufReader, BufWriter, Write, stdout};
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
@@ -18,13 +18,14 @@ use indoc::formatdoc;
 use shell_gen::{GenerateShell, SetVar, Shell, ShellWithPath, UnsetVar};
 use tracing::debug;
 
+use super::activate::write_auto_activation_preference;
 use super::activated_environments;
 use super::deactivate::{
     emit_deactivate_script,
     flox_activate_tracelevel,
     open_deactivation_target,
 };
-use crate::config::{AutoActivationPreference, Config};
+use crate::config::{AutoActivate, AutoActivationPreference, Config};
 use crate::subcommand_metric;
 use crate::utils::message;
 
@@ -103,17 +104,6 @@ impl HookEnv {
         let ctx = gather_auto_activate_context(&config, !actions.is_empty())?;
         let plan = plan_auto_activation(&ctx);
 
-        // Only record a metric when this run actually does something;
-        // `hook-env` runs on every shell prompt, and recording the common
-        // nothing-to-do case would be noise.
-        if !actions.is_empty()
-            || !plan.deactivate.is_empty()
-            || !plan.activate.is_empty()
-            || !plan.abandoned.is_empty()
-        {
-            subcommand_metric!("hook-env");
-        }
-
         if !plan.deactivate.is_empty() {
             // Auto-activations are always in-place, so each layer recorded
             // the previous value of `_FLOX_HOOK_DIFF` in its own diff. The
@@ -183,22 +173,105 @@ impl HookEnv {
             });
         }
 
-        for path in &plan.activate {
-            write_activate_command(self.shell, path, &mut writer)?;
+        // Ask for consent once for all unregistered environments discovered
+        // this run, rather than once per environment: walking into a deep tree
+        // can surface several at once, and a prompt per layer is tedious. The
+        // single answer applies to the whole batch (`plan.prompt`).
+        let consent = if plan.prompt.is_empty() {
+            AutoActivateConsent::NoTerminal
+        } else {
+            prompt_for_auto_activation(&plan.prompt)?
+        };
+
+        // Only record a metric when this run actually does something;
+        // `hook-env` runs on every shell prompt, and recording the common
+        // nothing-to-do case would be noise. Gate the prompt case on the
+        // consent answer, not `plan.prompt`: a non-interactive shell has no
+        // controlling terminal, so it yields `NoTerminal` and does nothing —
+        // counting it would fire the metric on every prompt.
+        if !actions.is_empty()
+            || !plan.deactivate.is_empty()
+            || !plan.activate.is_empty()
+            || matches!(
+                consent,
+                AutoActivateConsent::Allow | AutoActivateConsent::Decline
+            )
+            || !plan.abandoned.is_empty()
+        {
+            subcommand_metric!("hook-env");
+        }
+
+        // Walk discovered directories outermost-first so activations stack in
+        // the right order. Allowed environments activate directly; unregistered
+        // ones (only present in `prompt` mode) activate or are suppressed
+        // according to the consent answer. Prompt outcomes adjust the
+        // tracked-state lists the planner produced.
+        let mut auto_activated = plan.auto_activated.clone();
+        let mut suppressed = plan.suppressed.clone();
+        for path in &ctx.discovered {
+            if plan.activate.contains(path) {
+                write_activate_command(self.shell, path, &mut writer)?;
+            } else if plan.prompt.contains(path) {
+                match consent {
+                    AutoActivateConsent::Allow => {
+                        write_auto_activation_preference(
+                            &config.flox.config_dir,
+                            path,
+                            AutoActivationPreference::Allow,
+                        )?;
+                        write_activate_command(self.shell, path, &mut writer)?;
+                        if !auto_activated.contains(path) {
+                            auto_activated.push(path.clone());
+                        }
+                    },
+                    // Decline: suppress for this shell so the hook stops asking
+                    // while the shell stays within the directory. Leaving clears
+                    // the suppression (re-entering asks again); `flox activate
+                    // deny` makes the refusal permanent. The user-facing note is
+                    // emitted once after the loop, not per environment.
+                    AutoActivateConsent::Decline => {
+                        if !suppressed.contains(path) {
+                            suppressed.push(path.clone());
+                        }
+                    },
+                    // No terminal to prompt on (non-interactive shell): leave
+                    // the environment unregistered so a later interactive prompt
+                    // can still ask. Take no action and record nothing.
+                    AutoActivateConsent::NoTerminal => {},
+                }
+            }
+        }
+
+        // One note for the whole batch: the prompt already listed the
+        // environments, so declining repeats neither the list nor a per
+        // environment explanation. Reached only on the first decline;
+        // afterwards the planner drops the suppressed environments from the
+        // prompt, so `plan.prompt` is empty.
+        if matches!(consent, AutoActivateConsent::Decline) && !plan.prompt.is_empty() {
+            let environments = if plan.prompt.len() == 1 {
+                "the environment"
+            } else {
+                "these environments"
+            };
+            message::info(formatdoc! {"
+                Did not auto-activate {environments}.
+                You will be asked again in a new shell or when you re-enter the directory.
+                Run 'flox activate deny --dir <PATH>' to stop being asked."
+            });
         }
 
         write_path_list_update(
             self.shell,
             FLOX_AUTO_ACTIVATED_ENVIRONMENTS_VAR,
             &ctx.auto_activated,
-            &plan.auto_activated,
+            &auto_activated,
             &mut writer,
         )?;
         write_path_list_update(
             self.shell,
             FLOX_SUPPRESSED_ENVIRONMENTS_VAR,
             &ctx.suppressed,
-            &plan.suppressed,
+            &suppressed,
             &mut writer,
         )?;
 
@@ -224,12 +297,18 @@ struct AutoActivateContext {
     auto_activated: Vec<PathBuf>,
     /// Project directories suppressed from auto-activation in this shell.
     suppressed: Vec<PathBuf>,
-    /// Project directories the user has allowed auto-activation for via
-    /// `flox activate allow` (config `auto_activate_environments`).
+    /// Project directories the user has allowed auto-activation for via the
+    /// consent prompt or `flox activate allow` (config
+    /// `auto_activate_environments`).
     allowed: Vec<PathBuf>,
     /// Project directories the user has denied auto-activation for via
     /// `flox activate deny` (config `auto_activate_environments`).
     denied: Vec<PathBuf>,
+    /// Whether to prompt before auto-activating an environment that is neither
+    /// allowed nor denied (config `auto_activate = "prompt"`). When false
+    /// (`auto_activate = "allowed"`), unregistered environments are skipped
+    /// silently.
+    prompt_unregistered: bool,
     /// Whether this run consumed pending prompt-hook deactivation actions.
     pending_deactivations: bool,
 }
@@ -238,9 +317,12 @@ struct AutoActivateContext {
 /// auto-activation state variables.
 #[derive(Clone, Debug, PartialEq)]
 struct AutoActivatePlan {
-    /// Project directories to activate, outermost-first. These are discovered
-    /// environments that have not been denied.
+    /// Project directories to activate, outermost-first. These are environments
+    /// the user has already allowed.
     activate: Vec<PathBuf>,
+    /// Unregistered project directories to prompt the user about before
+    /// activating, outermost-first. Empty unless `auto_activate = "prompt"`.
+    prompt: Vec<PathBuf>,
     /// Project directories to deactivate, front of stack first.
     deactivate: Vec<PathBuf>,
     /// Auto-activated environments that should be deactivated but are buried
@@ -267,15 +349,21 @@ struct AutoActivatePlan {
 /// discovered environments are not activated yet — they would bury the
 /// still-unwinding layers.
 ///
-/// A discovered environment is auto-activated unless the user has denied it
-/// with `flox activate deny`.
+/// Auto-activation is opt-in. A discovered environment activates only if the
+/// user has allowed it (via the consent prompt or `flox activate allow`).
+/// An environment that is neither allowed nor denied is "unregistered": in
+/// `prompt` mode it is added to the plan's `prompt` list so the hook can ask
+/// for consent; in `allowed` mode it is skipped silently. Denied environments
+/// are never activated and never prompted.
 ///
-/// Deny governs future auto-activation only: an environment that is already
-/// active (whether activated manually or before being denied) is left running,
-/// and is auto-deactivated as usual once the shell leaves its directory.
+/// Allow/deny govern future auto-activation only: an environment that is
+/// already active (whether activated manually or before being denied) is left
+/// running, and is auto-deactivated as usual once the shell leaves its
+/// directory.
 fn plan_auto_activation(ctx: &AutoActivateContext) -> AutoActivatePlan {
     let inside = |path: &Path| ctx.cwd.starts_with(path);
     let is_active = |path: &PathBuf| ctx.active.iter().flatten().any(|active| active == path);
+    let is_allowed = |path: &PathBuf| ctx.allowed.contains(path);
     let is_denied = |path: &PathBuf| ctx.denied.contains(path);
 
     // Reconcile tracked state with the actual activation stack. A suppressed
@@ -317,6 +405,7 @@ fn plan_auto_activation(ctx: &AutoActivateContext) -> AutoActivatePlan {
         }
         return AutoActivatePlan {
             activate: Vec::new(),
+            prompt: Vec::new(),
             deactivate: Vec::new(),
             abandoned: Vec::new(),
             auto_activated,
@@ -353,31 +442,44 @@ fn plan_auto_activation(ctx: &AutoActivateContext) -> AutoActivatePlan {
     }
 
     // Walk discovered environments outermost-first so the innermost ends up on
-    // top. A discovered environment activates unless it has been denied; deny
-    // is per-directory, so a denied directory in the middle of a stack does not
-    // block its ancestors or descendants.
+    // top. Auto-activation is opt-in: only allowed environments activate.
+    // Unregistered ones (neither allowed nor denied) are queued for a consent
+    // prompt in `prompt` mode, or skipped in `allowed` mode; denied ones are
+    // always skipped. A registered preference is per-directory, so a denied or
+    // unregistered directory in the middle of a stack does not block its
+    // allowed ancestors or descendants.
     //
     // Defer all of this while tracked environments the shell has left are still
     // unwinding: activating now would stack the new environment on top of them,
     // and a buried environment can't be popped (it would be abandoned instead).
     let unwinding = auto_activated.iter().any(|path| !inside(path));
     let mut activate = Vec::new();
+    let mut prompt = Vec::new();
     if !unwinding {
         for path in &ctx.discovered {
             if is_active(path)
                 || suppressed.contains(path)
                 || is_denied(path)
                 || activate.contains(path)
+                || prompt.contains(path)
             {
                 continue;
             }
-            activate.push(path.clone());
-            auto_activated.push(path.clone());
+            if is_allowed(path) {
+                activate.push(path.clone());
+                auto_activated.push(path.clone());
+            } else if ctx.prompt_unregistered {
+                // Unregistered: ask before activating. Not tracked as
+                // auto-activated yet — the hook adds it only if the user
+                // consents.
+                prompt.push(path.clone());
+            }
         }
     }
 
     AutoActivatePlan {
         activate,
+        prompt,
         deactivate,
         abandoned,
         auto_activated,
@@ -428,6 +530,10 @@ fn gather_auto_activate_context(
     };
     let allowed = preference(AutoActivationPreference::Allow);
     let denied = preference(AutoActivationPreference::Deny);
+    let prompt_unregistered = matches!(
+        config.flox.auto_activate.clone().unwrap_or_default(),
+        AutoActivate::Prompt
+    );
     Ok(AutoActivateContext {
         cwd,
         discovered,
@@ -436,6 +542,7 @@ fn gather_auto_activate_context(
         suppressed: read_path_list_var(FLOX_SUPPRESSED_ENVIRONMENTS_VAR),
         allowed,
         denied,
+        prompt_unregistered,
         pending_deactivations,
     })
 }
@@ -456,6 +563,76 @@ fn read_path_list_var(var: &str) -> Vec<PathBuf> {
             debug!(%err, var, "ignoring unparseable auto-activation state variable");
             Vec::new()
         },
+    }
+}
+
+/// The user's answer to the auto-activation consent prompt.
+#[derive(Clone, Copy)]
+enum AutoActivateConsent {
+    /// Activate the environments and remember the choice (persist `Allow`).
+    Allow,
+    /// Don't activate; suppress re-prompting for this shell session.
+    Decline,
+    /// No controlling terminal to prompt on; make no decision this run.
+    NoTerminal,
+}
+
+/// Ask the user, on the controlling terminal, whether to auto-activate the
+/// unregistered environments discovered this run.
+///
+/// One prompt covers the whole batch: a single `cd` into a deep tree can
+/// surface several environments at once, and asking per environment is tedious.
+/// The answer applies to all of `project_dirs`.
+///
+/// The prompt hook's stdout is captured and evaluated by the shell, so the
+/// question and the answer go through `/dev/tty` directly rather than
+/// stdout/stdin. When there is no controlling terminal (a non-interactive
+/// shell), returns [`AutoActivateConsent::NoTerminal`] so the caller leaves the
+/// environments unregistered instead of blocking. A bare Enter (or EOF)
+/// defaults to declining.
+fn prompt_for_auto_activation(project_dirs: &[PathBuf]) -> Result<AutoActivateConsent> {
+    let Ok(tty) = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open("/dev/tty")
+    else {
+        return Ok(AutoActivateConsent::NoTerminal);
+    };
+
+    let question = match project_dirs {
+        [dir] => format!(
+            "Auto-activate the environment in '{}'? [y/N] ",
+            dir.display()
+        ),
+        dirs => {
+            let mut question = format!("Auto-activate these {} environments?\n", dirs.len());
+            for dir in dirs {
+                question.push_str(&format!("  {}\n", dir.display()));
+            }
+            question.push_str("[y/N] ");
+            question
+        },
+    };
+
+    // `File` implements `Read`/`Write` through shared references, so one open
+    // handle drives both the question and the answer.
+    let mut tty_writer = &tty;
+    tty_writer
+        .write_all(question.as_bytes())
+        .context("failed to write the auto-activation prompt")?;
+    tty_writer
+        .flush()
+        .context("failed to flush the auto-activation prompt")?;
+
+    let mut answer = String::new();
+    BufReader::new(&tty)
+        .read_line(&mut answer)
+        .context("failed to read the auto-activation response")?;
+    let answer = answer.trim();
+    if answer.eq_ignore_ascii_case("y") || answer.eq_ignore_ascii_case("yes") {
+        Ok(AutoActivateConsent::Allow)
+    } else {
+        Ok(AutoActivateConsent::Decline)
     }
 }
 
@@ -521,6 +698,9 @@ mod tests {
     use super::*;
 
     /// A context with nothing discovered, nothing active, and no state.
+    ///
+    /// Defaults to `allowed` mode (`prompt_unregistered: false`); tests that
+    /// exercise the consent prompt set it to true explicitly.
     fn empty_ctx(cwd: &str) -> AutoActivateContext {
         AutoActivateContext {
             cwd: PathBuf::from(cwd),
@@ -530,6 +710,7 @@ mod tests {
             suppressed: Vec::new(),
             allowed: Vec::new(),
             denied: Vec::new(),
+            prompt_unregistered: false,
             pending_deactivations: false,
         }
     }
@@ -541,6 +722,7 @@ mod tests {
     fn noop_plan() -> AutoActivatePlan {
         AutoActivatePlan {
             activate: Vec::new(),
+            prompt: Vec::new(),
             deactivate: Vec::new(),
             abandoned: Vec::new(),
             auto_activated: Vec::new(),
@@ -975,6 +1157,65 @@ mod tests {
             ..empty_ctx("/home/user/elsewhere")
         };
         assert_eq!(plan_auto_activation(&ctx), noop_plan());
+    }
+
+    #[test]
+    fn unregistered_env_is_prompted_in_prompt_mode() {
+        // Auto-activation is opt-in: an environment with no recorded preference
+        // is queued for a consent prompt rather than activated, and is not
+        // tracked until the user consents.
+        let ctx = AutoActivateContext {
+            discovered: paths(&["/home/user/proj"]),
+            prompt_unregistered: true,
+            ..empty_ctx("/home/user/proj")
+        };
+        assert_eq!(plan_auto_activation(&ctx), AutoActivatePlan {
+            prompt: paths(&["/home/user/proj"]),
+            ..noop_plan()
+        });
+    }
+
+    #[test]
+    fn unregistered_env_is_skipped_in_allowed_mode() {
+        // In `allowed` mode an unregistered environment is skipped silently —
+        // no activation, no prompt.
+        let ctx = AutoActivateContext {
+            discovered: paths(&["/home/user/proj"]),
+            prompt_unregistered: false,
+            ..empty_ctx("/home/user/proj")
+        };
+        assert_eq!(plan_auto_activation(&ctx), noop_plan());
+    }
+
+    #[test]
+    fn denied_env_is_never_prompted() {
+        // A denied environment is skipped even in prompt mode.
+        let ctx = AutoActivateContext {
+            discovered: paths(&["/home/user/proj"]),
+            denied: paths(&["/home/user/proj"]),
+            prompt_unregistered: true,
+            ..empty_ctx("/home/user/proj")
+        };
+        assert_eq!(plan_auto_activation(&ctx), noop_plan());
+    }
+
+    #[test]
+    fn allowed_activates_while_unregistered_prompts_in_one_stack() {
+        // In a stack, an allowed ancestor activates directly while an
+        // unregistered descendant is queued for a prompt — both in
+        // outermost-first order.
+        let ctx = AutoActivateContext {
+            discovered: paths(&["/home/user/outer", "/home/user/outer/inner"]),
+            allowed: paths(&["/home/user/outer"]),
+            prompt_unregistered: true,
+            ..empty_ctx("/home/user/outer/inner")
+        };
+        assert_eq!(plan_auto_activation(&ctx), AutoActivatePlan {
+            activate: paths(&["/home/user/outer"]),
+            prompt: paths(&["/home/user/outer/inner"]),
+            auto_activated: paths(&["/home/user/outer"]),
+            ..noop_plan()
+        });
     }
 
     #[test]

--- a/cli/flox/src/config/mod.rs
+++ b/cli/flox/src/config/mod.rs
@@ -121,7 +121,7 @@ pub struct FloxConfig {
     pub keep_tempdir: Option<bool>,
 
     /// Whether to automatically activate environments.
-    /// Possible values: `allowed` (default), `prompt`.
+    /// Possible values: `prompt` (default), `allowed`.
     pub auto_activate: Option<AutoActivate>,
 
     /// Controls how the fish shell hook responds to directory changes.
@@ -179,8 +179,13 @@ pub enum InstallerChannel {
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum AutoActivate {
-    #[default]
+    /// Only auto-activate environments the user has already allowed (via the
+    /// prompt or `flox activate allow`). Walking past an unregistered `.flox`
+    /// does nothing — no prompt.
     Allowed,
+    /// Auto-activate allowed environments, and prompt before activating an
+    /// environment that has not yet been allowed or denied.
+    #[default]
     Prompt,
 }
 

--- a/cli/tests/activate/hook-consent.exp
+++ b/cli/tests/activate/hook-consent.exp
@@ -1,0 +1,38 @@
+# Activate a project environment using --dir, then cd into a second,
+# unregistered directory and answer the auto-activation consent prompt the hook
+# raises (default `auto_activate = "prompt"`). The fourth argument is a command
+# run afterwards to observe whether the environment activated.
+
+set dir [lindex $argv 0]
+set target [lindex $argv 1]
+set answer [lindex $argv 2]
+set command [lindex $argv 3]
+set flox $env(FLOX_BIN)
+# Auto-activation may lock and build an environment on first use, which can
+# exceed 30s under parallel load. Match hook-nested-cd.exp, which builds the
+# same way.
+set timeout 60
+set env(NO_COLOR) 1
+set env(TERM) xterm-mono
+set stty_init "cols 1000"
+
+spawn $flox activate --dir $dir
+expect_after {
+  timeout { exit 1 }
+  eof { exit 2 }
+  "*\n" { exp_continue }
+  "*\r" { exp_continue }
+}
+
+expect "You are now using the environment"
+expect $env(KNOWN_PROMPT)
+
+send "cd $target\n"
+# The prompt hook runs before the next prompt and asks for consent on the tty.
+# Matches both the single-environment and the batched "[y/N]" prompts.
+expect "y/N"
+send "$answer\n"
+expect $env(KNOWN_PROMPT)
+
+send "$command && exit\n"
+expect eof

--- a/cli/tests/hook.bats
+++ b/cli/tests/hook.bats
@@ -200,6 +200,8 @@ EXPIRED_FLOXHUB_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3gu
   project_setup
   project2_setup
   export FLOX_FEATURES_AUTO_ACTIVATE=true
+  # Auto-activation is opt-in; allow the target before entering it.
+  "$FLOX_BIN" activate allow -d "$PROJECT2_DIR"
 
   run --separate-stderr bash -c "
     export FLOX_FEATURES_AUTO_ACTIVATE=true
@@ -220,6 +222,8 @@ EXPIRED_FLOXHUB_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3gu
   project_setup
   project2_setup
   export FLOX_FEATURES_AUTO_ACTIVATE=true
+  # Auto-activation is opt-in; allow the target before entering it.
+  "$FLOX_BIN" activate allow -d "$PROJECT2_DIR"
 
   run --separate-stderr zsh -c "
     export FLOX_FEATURES_AUTO_ACTIVATE=true
@@ -240,6 +244,8 @@ EXPIRED_FLOXHUB_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3gu
   project_setup
   project2_setup
   export FLOX_FEATURES_AUTO_ACTIVATE=true
+  # Auto-activation is opt-in; allow the target before entering it.
+  "$FLOX_BIN" activate allow -d "$PROJECT2_DIR"
 
   run --separate-stderr fish -c "
     set -gx FLOX_FEATURES_AUTO_ACTIVATE true
@@ -259,6 +265,8 @@ EXPIRED_FLOXHUB_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3gu
   project_setup
   project2_setup
   export FLOX_FEATURES_AUTO_ACTIVATE=true
+  # Auto-activation is opt-in; allow the target before entering it.
+  "$FLOX_BIN" activate allow -d "$PROJECT2_DIR"
 
   run --separate-stderr tcsh -c "
     setenv FLOX_FEATURES_AUTO_ACTIVATE true
@@ -282,6 +290,8 @@ EXPIRED_FLOXHUB_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3gu
   project_setup
   project2_setup
   export FLOX_FEATURES_AUTO_ACTIVATE=true
+  # Auto-activation is opt-in; allow the target before entering it.
+  "$FLOX_BIN" activate allow -d "$PROJECT2_DIR"
 
   run --separate-stderr bash -c "
     export FLOX_FEATURES_AUTO_ACTIVATE=true
@@ -324,6 +334,8 @@ EXPIRED_FLOXHUB_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3gu
   project_setup
   project2_setup
   export FLOX_FEATURES_AUTO_ACTIVATE=true
+  # Auto-activation is opt-in; allow the target before entering it.
+  "$FLOX_BIN" activate allow -d "$PROJECT2_DIR"
 
   run --separate-stderr bash -c "
     export FLOX_FEATURES_AUTO_ACTIVATE=true
@@ -354,6 +366,9 @@ EXPIRED_FLOXHUB_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3gu
   project2_setup
   project3_setup
   export FLOX_FEATURES_AUTO_ACTIVATE=true
+  # Auto-activation is opt-in; allow both layers of the nested stack.
+  "$FLOX_BIN" activate allow -d "$PROJECT2_DIR"
+  "$FLOX_BIN" activate allow -d "$PROJECT3_DIR"
 
   run --separate-stderr bash -c "
     export FLOX_FEATURES_AUTO_ACTIVATE=true
@@ -384,6 +399,8 @@ EXPIRED_FLOXHUB_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3gu
   project_setup
   project2_setup
   export FLOX_FEATURES_AUTO_ACTIVATE=true
+  # Auto-activation is opt-in; allow the target before entering it.
+  "$FLOX_BIN" activate allow -d "$PROJECT2_DIR"
 
   run --separate-stderr bash -c "
     export FLOX_FEATURES_AUTO_ACTIVATE=true
@@ -444,6 +461,120 @@ EXPIRED_FLOXHUB_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3gu
 }
 
 # ---------------------------------------------------------------------------- #
+# Config: 'prompt' mode (the default) asks for consent before auto-activating
+# ---------------------------------------------------------------------------- #
+
+# bats test_tags=hook:prompt:default
+@test "bash: unregistered environment is not auto-activated without consent" {
+  project_setup
+  project2_setup
+  export FLOX_FEATURES_AUTO_ACTIVATE=true
+  # No allow/deny recorded, so the default 'prompt' mode applies. This run is
+  # non-interactive (no controlling terminal), so the hook cannot prompt and
+  # must leave the environment unregistered rather than auto-activating it.
+
+  run --separate-stderr bash -c "
+    export FLOX_FEATURES_AUTO_ACTIVATE=true
+    export FLOX_SHELL=\$(which bash)
+    eval \"\$($FLOX_BIN activate -d $PROJECT_DIR)\"
+    cd $PROJECT2_DIR
+    _flox_hook
+    echo \"var2:\${TEST_VAR2:-unset}\"
+    echo \"tracked:\${_FLOX_AUTO_ACTIVATED_ENVIRONMENTS:-unset}\"
+  "
+  assert_success
+  assert_output --partial "var2:unset"
+  assert_output --partial "tracked:unset"
+}
+
+# bats test_tags=hook:prompt:yes
+@test "bash: answering the consent prompt with 'y' auto-activates the environment" {
+  project_setup
+  project2_setup
+  export FLOX_FEATURES_AUTO_ACTIVATE=true
+
+  # Set up a .bashrc so the interactive shell has a known prompt
+  export KNOWN_PROMPT="hooktest> "
+  cat >"$HOME/.bashrc" <<EOF
+export PS1="$KNOWN_PROMPT"
+EOF
+  cat >"$HOME/.inputrc" <<EOF
+set enable-bracketed-paste off
+EOF
+
+  FLOX_SHELL="bash" run -0 expect "$TESTS_DIR/activate/hook-consent.exp" "$PROJECT_DIR" "$PROJECT2_DIR" "y" 'echo TEST_VAR2="$TEST_VAR2"'
+  assert_output --partial 'TEST_VAR2=auto2'
+}
+
+# bats test_tags=hook:prompt:no
+@test "bash: declining the consent prompt does not auto-activate the environment" {
+  project_setup
+  project2_setup
+  export FLOX_FEATURES_AUTO_ACTIVATE=true
+
+  # Set up a .bashrc so the interactive shell has a known prompt
+  export KNOWN_PROMPT="hooktest> "
+  cat >"$HOME/.bashrc" <<EOF
+export PS1="$KNOWN_PROMPT"
+EOF
+  cat >"$HOME/.inputrc" <<EOF
+set enable-bracketed-paste off
+EOF
+
+  FLOX_SHELL="bash" run -0 expect "$TESTS_DIR/activate/hook-consent.exp" "$PROJECT_DIR" "$PROJECT2_DIR" "n" 'echo TEST_VAR2="$TEST_VAR2"'
+  refute_output --partial 'TEST_VAR2=auto2'
+}
+
+# bats test_tags=hook:prompt:batched
+@test "bash: a single consent prompt activates a whole nested hierarchy" {
+  project_setup
+  project2_setup
+  project3_setup
+  export FLOX_FEATURES_AUTO_ACTIVATE=true
+
+  # Set up a .bashrc so the interactive shell has a known prompt
+  export KNOWN_PROMPT="hooktest> "
+  cat >"$HOME/.bashrc" <<EOF
+export PS1="$KNOWN_PROMPT"
+EOF
+  cat >"$HOME/.inputrc" <<EOF
+set enable-bracketed-paste off
+EOF
+
+  # Entering the nested project discovers two unregistered environments
+  # (PROJECT2 and the nested PROJECT3). A single 'y' must activate both.
+  FLOX_SHELL="bash" run -0 expect "$TESTS_DIR/activate/hook-consent.exp" "$PROJECT_DIR" "$PROJECT3_DIR" "y" 'echo "v2:$TEST_VAR2 v3:$TEST_VAR3"'
+  assert_output --partial 'v2:auto2 v3:auto3'
+  # A single batched prompt covered both environments.
+  assert_output --partial 'Auto-activate these 2 environments'
+}
+
+# bats test_tags=hook:prompt:batched:no
+@test "bash: declining a batched consent prompt shows a single note" {
+  project_setup
+  project2_setup
+  project3_setup
+  export FLOX_FEATURES_AUTO_ACTIVATE=true
+
+  # Set up a .bashrc so the interactive shell has a known prompt
+  export KNOWN_PROMPT="hooktest> "
+  cat >"$HOME/.bashrc" <<EOF
+export PS1="$KNOWN_PROMPT"
+EOF
+  cat >"$HOME/.inputrc" <<EOF
+set enable-bracketed-paste off
+EOF
+
+  # Declining the batched prompt activates neither environment and prints a
+  # single consolidated note, not one per environment.
+  FLOX_SHELL="bash" run -0 expect "$TESTS_DIR/activate/hook-consent.exp" "$PROJECT_DIR" "$PROJECT3_DIR" "n" 'echo "v2:$TEST_VAR2 v3:$TEST_VAR3"'
+  refute_output --partial 'v2:auto2'
+  refute_output --partial 'v3:auto3'
+  assert_output --partial 'Did not auto-activate these environments'
+  assert_equal "$(grep -c 'Did not auto-activate' <<< "$output")" 1
+}
+
+# ---------------------------------------------------------------------------- #
 # Hook auto-fires: verify the prompt hook triggers without manual invocation
 # ---------------------------------------------------------------------------- #
 
@@ -452,6 +583,9 @@ EXPIRED_FLOXHUB_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3gu
   project_setup
   project2_setup
   export FLOX_FEATURES_AUTO_ACTIVATE=true
+  # Auto-activation is opt-in; allow the target so the hook activates it
+  # without prompting.
+  "$FLOX_BIN" activate allow -d "$PROJECT2_DIR"
 
   # Set up a .bashrc so the interactive shell has a known prompt
   export KNOWN_PROMPT="hooktest> "
@@ -473,6 +607,11 @@ EOF
   project3_setup
   projectz_setup
   export FLOX_FEATURES_AUTO_ACTIVATE=true
+  # Auto-activation is opt-in; allow every environment the run activates so the
+  # hook does not prompt.
+  "$FLOX_BIN" activate allow -d "$PROJECT2_DIR"
+  "$FLOX_BIN" activate allow -d "$PROJECT3_DIR"
+  "$FLOX_BIN" activate allow -d "$PROJECTZ_DIR"
 
   # Set up a .bashrc so the interactive shell has a known prompt
   export KNOWN_PROMPT="hooktest> "


### PR DESCRIPTION
## What

Makes auto-activation **opt-in** and adds the interactive **consent prompt** for unregistered environments, on top of the allow/deny config wiring from #4402.

> **Stacked on #4402** (`daniel/dev-120-respect-the-config`). Review/merge that first. #4402 wires up the allow/deny config and respects **deny** (auto-activation stays opt-out there); this PR adds the **opt-in gate** (only allowed environments activate), the consent prompt, and flips the default to `prompt`.

- **Default `auto_activate = "prompt"`** (flipped from `allowed`). The feature is behind the `auto_activate` feature flag, so anyone enabling the flag wants to *try* auto-activation; requiring an explicit `flox activate allow` first would be needless friction.
- When the hook discovers environments that are neither allowed nor denied, it asks for consent on the controlling terminal before activating:

```
flox: auto-activate these 2 environments?
  /private/tmp/a/b
  /private/tmp/a/b/c/d
[y/N]
```

- **One prompt covers the whole batch** discovered in a single `cd` (a deep tree can surface several at once); the answer applies to all of them.
- **y** → persist an `allow` (won't ask again) and activate now.
- **Enter / n** → suppress re-prompting for this shell session; leaving the directory clears it (re-asks on return, keeping the feature discoverable); `flox activate deny` makes the refusal permanent. Declining does **not** persist a deny.
- **No controlling terminal** (non-interactive shell) → leave unregistered; don't block, don't activate.

Already-allowed environments in the same hierarchy activate silently; denied ones are skipped silently.

## Implementation note

`hook-env`'s stdout is captured and `eval`'d by the shell, so the question and answer go through `/dev/tty`, not stdin/stdout. The planner stays pure: it emits a `prompt` list of unregistered dirs; the hook does the tty I/O and resolves activate / suppress / skip.

## Testing
- **Unit:** the opt-in gate (only allowed environments activate); the planner emits a `prompt` list for unregistered envs in `prompt` mode, skips them silently in `allowed` mode; allowed activates alongside; denied never prompts.
- **Integration** (`hook.bats`, via a new `hook-consent.exp`): prompt-mode default (no consent → no activation), `y` activates, `n` doesn't, and a single batched prompt activates a whole nested hierarchy. Auto-activate tests `allow` their targets up front so they activate without prompting under the `prompt` default.
- Full `flox` unit suite and `hook.bats` (across bash/zsh/fish/tcsh) pass; clippy/rustfmt/treefmt clean.

Linear: [DEV-132](https://linear.app/floxdotdev/issue/DEV-132)

🤖 Generated with [Claude Code](https://claude.com/claude-code)