### PR TITLE
docs: add testing and API contract conventions to `AGENTS.md`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,6 +223,13 @@ If so, add a `## Release Notes` section to the PR description describing the cha
     identify them as tests. Name tests descriptively for what
     they verify (e.g.,
     `gather_repo_meta_no_upstream_suggests_set_upstream`).
+  - **Test behavior that can break, not plumbing:** Do not test
+    generated code, the argument parser (bpaf is declarative and
+    tested upstream), or serialization round-trips
+    (`serialize(x) == serialize(x)`). Prefer a type that makes an
+    invalid state unrepresentable (`NonZero`, domain types) over a
+    runtime guard plus a test for it. Do not add a client mock to
+    test a thin wrapper; see the provider-trait rule above.
   - **Type safety at function boundaries:** Parse strings
     at entry points (CLI arg parsing, API response
     deserialization), not deep in business logic. Before
@@ -232,6 +239,10 @@ If so, add a `## Release Notes` section to the PR description describing the cha
     `BaseCatalogUrl` for catalog URLs. Check the relevant
     provider module for existing types, e.g. when working with
     catalog information check `cli/floxhub-client/src/types.rs`.
+  - **Verify against the contract:** For generated API clients,
+    confirm behavior (paging base, defaults, error shapes) against
+    the OpenAPI spec or schema before relying on it. Do not write
+    doc comments asserting behavior you have not verified.
   - **User-visible message syntax, structure, and content:**
     - Use complete sentences. Do not use "I", "we", or "flox"
       as the subject — drop it instead


### PR DESCRIPTION
## Summary

AGENTS.md already tells contributors to reuse existing types, mocks, and patterns before adding their own, but it says nothing about which tests are worth writing or about trusting a generated client's contract. This adds two conventions under the Rust style guidance to close those gaps: test behavior that can break rather than generated code, the argument parser, or serialization, and prefer a type that makes an invalid state unrepresentable over a runtime guard and its test; and confirm a generated API client's behavior against the OpenAPI spec before relying on it or documenting it.

These were prompted by a recent factory CLI change that accumulated tests of generated and framework code, and a guard plus a doc comment for paging behavior the spec already defined; review caught most of it. Making the defaults explicit should keep the next change from repeating them.
