### PR TITLE
fix(flox-activations): downgrade process-compose shutdown log from error to warn (DEV-137)

### DIFF
--- a/cli/flox-activations/src/cli/executive/mod.rs
+++ b/cli/flox-activations/src/cli/executive/mod.rs
@@ -15,7 +15,7 @@ use nix::sys::signal::kill;
 use nix::unistd::{Pid, getpgid, getpid, setsid};
 use reaper::reap_orphaned_children;
 use serde::{Deserialize, Serialize};
-use tracing::{debug, debug_span, error, info, instrument};
+use tracing::{debug, debug_span, error, info, instrument, warn};
 use uuid::Uuid;
 use watcher::LockedActivationState;
 
@@ -456,7 +456,7 @@ fn cleanup_all(
     let socket_path = socket_path.as_ref();
     if socket_path.exists() {
         if let Err(err) = process_compose_down(process_compose_bin, socket_path) {
-            error!(%err, "failed to run process-compose shutdown command");
+            warn!(%err, "failed to run process-compose shutdown command");
         }
         info!("shut down process-compose");
     } else {


### PR DESCRIPTION
## Summary

- `cleanup_all` logged at `error!` when `process_compose_down` fails, but this is an expected, recoverable condition — process-compose may already be gone by the time cleanup runs
- Downgraded to `warn!` so the Sentry tracing layer no longer captures it as an event
- Fixes Sentry signature `CLI-FLOX-W` — 18,431 occurrences / 130 users

## Changes

`cli/flox-activations/src/cli/executive/mod.rs`: `error!` → `warn!` on the shutdown failure log line; added `warn` to the `tracing` import.

## Test plan

- [x] `cargo test -p flox-activations` passes (97 tests)
- [ ] After rollout: confirm `CLI-FLOX-W` no longer appears as a Sentry event

Closes DEV-137

---
> [!NOTE]
> Generated by [Forge](https://github.com/flox/forge) · forge@33dafa1a