### PR TITLE
test(hook): serialize hook.bats to fix flaky auto-activate timeout

### DIFF
--- a/cli/tests/hook.bats
+++ b/cli/tests/hook.bats
@@ -75,6 +75,20 @@ projectz_teardown() {
   unset PROJECTZ_DIR
 }
 
+setup_file() {
+  common_file_setup
+  # Many of these tests drive real, interactive `flox activate` runs through
+  # `expect`, and several build and activate two or three environments in a
+  # single test. Run in parallel within the file, they contend on the shared
+  # Nix store and pile up concurrent executive (activation daemon) processes,
+  # which can starve an activation long enough to blow past the `expect`
+  # timeout — a ~60s window with no terminal output that surfaces as a flaky
+  # timeout on whichever consent/activation test loses the race. Serialize the
+  # file so these interactive tests stay deterministic. Mirrors
+  # containerize.bats, which serializes for the same reason.
+  export BATS_NO_PARALLELIZE_WITHIN_FILE=true
+}
+
 setup() {
   common_test_setup
   setup_isolated_flox


### PR DESCRIPTION
## What

Fixes a flaky timeout in `hook.bats`'s interactive auto-activation tests — most visibly `bash: a single consent prompt activates a whole nested hierarchy`, which intermittently times out at ~61s (seen on the CI for an unrelated PR, [#4290](https://github.com/flox/flox/pull/4290)).

## Root cause

Not a logic bug in the consent/batching code — environment discovery (`find_all_dot_flox` walking up from the nested dir) and batching are deterministic. It's a **test-infrastructure concurrency flake**:

- The suite runs `bats --jobs 4 --no-parallelize-across-files`, so **multiple `hook.bats` tests activate environments concurrently**.
- `setup_isolated_flox` isolates config/data/state/cache per test, but the **Nix store, pkgdb caches, and `XDG_RUNTIME_DIR` stay shared**, and each `flox activate` spawns a long-lived `executive` (activation daemon).
- Under that contention an activation occasionally **stalls with zero terminal output past the 60s `expect` timeout**. The expect scripts reset their timeout on every line of output (`expect_after { "*\n" { exp_continue } }`), so the 60s is *total silence* — a ~40× stall, not gradual slowness. It surfaces on whichever consent/activation test loses the race (test #132 in CI, test #17 in local repro — same class).

The captured failure showed the interactive shell going silent *immediately after the first activation* — it never even echoed the next `cd`.

## Fix

Add a `setup_file()` to `hook.bats` exporting `BATS_NO_PARALLELIZE_WITHIN_FILE=true`, serializing the file so its interactive activation tests don't contend. This mirrors `containerize.bats`, which serializes for the same reason; `services.bats` documents the same parallel-executive interference.

A real user — one shell, one `cd` — never creates the pathological concurrency this needs, so a test-level fix is correct.

## Verification

Reproduced and verified under heavy load (`FLOX_TEST_JOBS=24` + 10 CPU hogs on a 14-core machine), running the full `hook.bats` file in a loop:

| Condition | Slowest test | Flakes |
|---|---|---|
| Before (parallel + load) | **62073 ms** (= 60s `expect` timeout, the CI symptom) | 1 / 14 |
| After (serialized + same load) | ~1900 ms | **0 / 40** |

## Optional follow-ups (not in this PR)

Two latent robustness gaps in the activation daemon path noticed while tracing — only bite under pathological concurrency, but worth a separate look:

1. `flox-activations/src/start.rs` spawns the `executive` with only stdio set to null; it doesn't `close_fds…cloexecfrom(3)` at spawn like the correct daemon spawn in `check_for_upgrades.rs`, so it inherits fds ≥3.
2. `wait_for_executive` has no timeout (its own comment: *"this will loop forever"*) — a lost/coalesced `SIGUSR1`/`SIGCHLD` under load could hang an activation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
