### PR TITLE
feat: add hidden --beta flag to enable beta features per-invocation - CLI-105

### DIFF
--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -173,6 +173,10 @@ pub struct FloxArgs {
     #[bpaf(long, req_flag(()), many, map(vec_not_empty), hide)]
     pub debug: bool,
 
+    /// Enable beta features for this invocation
+    #[bpaf(long, hide)]
+    pub beta: bool,
+
     /// Print the version of the program
     #[allow(dead_code)] // fake arg, `--version` is checked for separately (see [Version])
     #[bpaf(long, short('V'))]
@@ -308,7 +312,13 @@ impl FloxArgs {
             floxhub_client,
             installable_locker: Default::default(),
             #[allow(deprecated, reason = "This should be the only internal use")]
-            features: config.features.unwrap_or_default(),
+            features: {
+                let mut features = config.features.unwrap_or_default();
+                // `--beta` enables beta features for this invocation only; it can
+                // only turn the flag on, never off.
+                features.beta = features.beta || self.beta;
+                features
+            },
             verbosity: self.verbosity.to_i32(),
             metrics_device_uuid,
         };

--- a/cli/tests/usage.bats
+++ b/cli/tests/usage.bats
@@ -122,3 +122,26 @@ Available options:
 Run 'man flox' for more details.
 EOF
 }
+
+@test "f3: '--beta' enables a beta subcommand for a single invocation" {
+  run "$FLOX_BIN" --beta beta-enabled
+  assert_success
+  assert_output --partial "Beta features are enabled."
+}
+
+@test "f4: '--beta' is ephemeral; a later invocation without it is gated" {
+  # Enabling beta for one call must not persist any state.
+  run "$FLOX_BIN" --beta beta-enabled
+  assert_success
+
+  # A plain invocation is gated again, proving the flag left no residue.
+  run "$FLOX_BIN" beta-enabled
+  assert_failure
+  assert_output --partial "Enable beta features to run this command"
+}
+
+@test "f5: '--beta' and beta subcommands stay hidden from 'flox --help'" {
+  run "$FLOX_BIN" --help
+  assert_success
+  refute_output --partial "beta"
+}


### PR DESCRIPTION
## Summary

Adds a global `--beta` flag to the flox CLI that enables beta features for a
single invocation, without persisting anything to config. It is the ephemeral,
in-memory equivalent of `flox config --set features.beta true` (persisted) or
`FLOX_FEATURES_BETA=true` (env, per-invocation). So `flox --beta beta-enabled`
runs a beta-gated command for that one call and leaves no residue.

## Motivation

Running a beta subcommand currently requires editing config (`features.beta`) or
exporting `FLOX_FEATURES_BETA`. A `--beta` flag is a lower-friction,
obviously-ephemeral way to opt in for a single command.

## How it works

- New hidden field on `FloxArgs`:
  ```rust
  /// Enable beta features for this invocation
  #[bpaf(long, hide)]
  pub beta: bool,
  ```
- During `Flox` construction the flag is OR-merged into the resolved `Features`,
  so it can only enable beta, never disable it:
  ```rust
  features: {
      let mut features = config.features.unwrap_or_default();
      features.beta = features.beta || self.beta;
      features
  },
  ```
- The single gate at the `Commands::Beta` dispatch arm is unchanged; no beta
  handler re-checks the flag. Flag, env, and config all converge at one point.
  Like the beta subcommands themselves, `--beta` is hidden from `flox --help`.
  No `flox-rust-sdk` changes.

## Behavior

| Command | Result |
|---|---|
| `flox beta-enabled` | gated → `Enable beta features to run this command:` (exit 1) |
| `flox --beta beta-enabled` | runs the handler (exit 0) |
| `flox beta-enabled --beta` | also runs — the flag is position-flexible |
| `FLOX_FEATURES_BETA=true flox beta-enabled` | runs (unchanged) |
| later plain `flox beta-enabled` | gated again — `--beta` persisted nothing |
| `flox --help` | `--beta` and beta subcommands do not appear |

## Test plan

- [x] `cli/tests/usage.bats` f3 — `--beta` enables a beta subcommand for a single invocation
- [x] `cli/tests/usage.bats` f4 — `--beta` is ephemeral (enable, then a later plain invocation is gated again)
- [x] `cli/tests/usage.bats` f5 — `--beta` / beta subcommands stay hidden from `flox --help`
- [x] Full `usage.bats` passes (6/6, no regressions)
- [x] `cargo build -p flox`, `cargo clippy -p flox`, `cargo fmt --check -p flox` clean

## Release Notes

`flox` now accepts a hidden global `--beta` flag that enables beta features for a
single invocation (equivalent to a one-off `features.beta = true`), without
changing your saved configuration.

## Notes for reviewer

- Minimal scope: two logical edits in `cli/flox/src/commands/mod.rs` plus three
  bats tests. No `flox-rust-sdk` changes.
- `f5` overlaps with the existing `f2`, which already pins the exact `--help`
  output; `f5` is kept as an explicit, self-documenting guard. Happy to drop it
  if preferred.
