### PR TITLE
fix(activate): show expired-token reminder once per shell session

### DIFF
--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -467,7 +467,16 @@ impl FloxArgs {
                     self.command,
                     Some(Commands::Admin(AdminCommands::Auth(auth::Auth::Login)))
                 );
-                if !reauthenticating && !self.is_prompt_hook_flow() {
+                // The token is account-global, so the reminder only needs to
+                // appear once per shell session. The outermost activation
+                // surfaces it; any `flox` invocation already running inside an
+                // activation — a nested `flox activate`, or a command in an
+                // activated shell whose rc re-activates an environment — stays
+                // quiet. Activations export `_FLOX_ACTIVE_ENVIRONMENTS` into the
+                // shell, including in-place `eval "$(flox activate)"` ones, so
+                // it is a reliable signal even across the parent shell.
+                let nested = activated_environments().last_active().is_some();
+                if !reauthenticating && !self.is_prompt_hook_flow() && !nested {
                     message::warning(
                         "Your FloxHub token has expired. Run 'flox auth login' to re-authenticate.",
                     );

--- a/cli/tests/hook.bats
+++ b/cli/tests/hook.bats
@@ -198,6 +198,43 @@ EXPIRED_FLOXHUB_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3gu
   assert_regex "$stderr" "Your FloxHub token has expired"
 }
 
+# The expired-token reminder is account-global, so a single user action that
+# nests `flox` invocations — e.g. `flox activate` whose shell rc runs
+# `flox activate` again — should surface it only once. The outermost activation
+# warns; anything already inside an activation stays quiet.
+# bats test_tags=hook:hook-env
+@test "expired-token advisory is shown once across nested 'flox' invocations" {
+  project_setup
+
+  FLOX_FLOXHUB_TOKEN="$EXPIRED_FLOXHUB_TOKEN" \
+    run "$FLOX_BIN" activate -d "$PROJECT_DIR" -- \
+    "$FLOX_BIN" activate -d "$PROJECT_DIR" -- true
+  assert_success
+  # Once for the outer activation, and not again for the nested one.
+  run grep -c "Your FloxHub token has expired" <<< "$output"
+  assert_output "1"
+
+  project_teardown
+}
+
+# Mirrors the real-world trigger: a shell rc activates an environment in place
+# (`eval "$(flox activate)"`), then the user runs another `flox` command in the
+# same shell. The in-place activation exports `_FLOX_ACTIVE_ENVIRONMENTS`, so the
+# second command sees it is nested and does not repeat the reminder.
+# bats test_tags=hook:hook-env
+@test "expired-token advisory is not repeated after an in-place activation" {
+  project_setup
+
+  FLOX_FLOXHUB_TOKEN="$EXPIRED_FLOXHUB_TOKEN" \
+    run bash -c "eval \"\$('$FLOX_BIN' activate -d '$PROJECT_DIR')\"; '$FLOX_BIN' config"
+  assert_success
+  # Once for the in-place activation, and not again for the later command.
+  run grep -c "Your FloxHub token has expired" <<< "$output"
+  assert_output "1"
+
+  project_teardown
+}
+
 # ---------------------------------------------------------------------------- #
 # Auto-activation: cd into a project activates its environment
 # ---------------------------------------------------------------------------- #


### PR DESCRIPTION
## Problem

When the FloxHub token is expired, the preamble advisory

> ! Your FloxHub token has expired. Run 'flox auth login' to re-authenticate.

was printed by **every** `flox` invocation. In a common setup it surfaced twice for a single `flox activate`:

```
$ flox activate
! Your FloxHub token has expired. Run 'flox auth login' to re-authenticate.
ℹ 4 rebuilds available in 'park-finder'.
Use 'flox upgrade --dry-run' for details.

✔ Attached to existing activation of environment 'park-finder'
To stop using this environment, run 'flox deactivate'

! Your FloxHub token has expired. Run 'flox auth login' to re-authenticate.
```

## Reproduction

A shell rc activates a default environment in place (the common pattern), e.g. `~/.zshrc`:

```sh
eval "$(flox activate -r owner/default)"
```

A new login shell then yields two warnings from two separate, legitimate `flox` processes, each independently noticing the expired token:

1. the rc's in-place `eval "$(flox activate ...)"` at shell startup, and
2. the user's foreground `flox activate` of another environment.

The token is account-global, so repeating the reminder for every `flox` process in the same session is redundant. (DEV-128 already deduped the prompt-hook repetition by command type; nested activations from shell rc were not covered.)

An in-place activation can't be deduped with a process-inherited sentinel: `eval "$(flox activate)"` runs flox as a child of the shell and applies its output to the parent, so a variable flox sets for its own descendants never reaches the interactive shell where the next command runs.

## Fix

Suppress the advisory when the invocation is already running inside an activation, detected via `_FLOX_ACTIVE_ENVIRONMENTS`. Activations — including in-place ones — export this into the shell to track active environments and render the prompt, so it's a reliable "am I nested" signal even across the parent shell. The outermost activation in a session surfaces the reminder once; anything nested under it stays quiet.

Behavior:
- first/outermost activation or any non-nested command: warns (unchanged)
- nested `flox activate`, or a command run inside an activated shell: quiet
- trade-off: a token that expires mid-session is not re-surfaced until the next fresh shell, matching the once-per-session intent

## Tests

Adds two regression tests in `hook.bats` covering nested `flox activate` and the in-place-activation-then-command pattern. Existing expired-token assertions in `hook.bats`, `push.bats`, and `environment-remote.bats` still pass; `cargo clippy` clean.

## Release Notes

The "Your FloxHub token has expired" reminder is now shown once per shell session instead of repeating for nested `flox` invocations (e.g. a shell rc that runs `flox activate`).