### PR TITLE
feat(flox-events): v2 CLI telemetry event pipeline — foundation (dormant)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1578,11 +1578,18 @@ dependencies = [
 name = "flox-events"
 version = "0.0.0"
 dependencies = [
+ "anyhow",
  "derive_more",
+ "fslock",
+ "pretty_assertions",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_with",
+ "serial_test",
+ "tempfile",
  "time",
+ "tracing",
  "uuid",
 ]
 

--- a/cli/flox-events/Cargo.toml
+++ b/cli/flox-events/Cargo.toml
@@ -4,11 +4,21 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
+anyhow.workspace = true
 derive_more.workspace = true
+fslock.workspace = true
+reqwest = { workspace = true, features = ["blocking"] }
 serde.workspace = true
+serde_json.workspace = true
 serde_with.workspace = true
 time.workspace = true
+tracing.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]
-serde_json.workspace = true
+pretty_assertions.workspace = true
+serial_test.workspace = true
+tempfile.workspace = true
+
+[features]
+tests = []

--- a/cli/flox-events/src/buffer.rs
+++ b/cli/flox-events/src/buffer.rs
@@ -1,0 +1,181 @@
+use std::collections::VecDeque;
+use std::fs::{File, OpenOptions};
+use std::io::{Read, Write};
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use fslock::LockFile;
+use time::{Duration, OffsetDateTime};
+use tracing::debug;
+
+use crate::Event;
+
+/// On-disk JSONL file used by the v2 event pipeline.
+pub const EVENTS_BUFFER_FILE_NAME: &str = "events-v2.json";
+const EVENTS_LOCK_FILE_NAME: &str = "events-v2.lock";
+const MAX_BUFFER_SIZE: usize = 1000;
+
+/// Locked on-disk event buffer.
+///
+/// An instance holds the process lock for as long as it is alive. Keep values
+/// short-lived so concurrent `flox` processes do not wait longer than needed.
+#[derive(Debug)]
+pub struct EventsBuffer {
+    storage: File,
+    _file_lock: LockFile,
+    buffer: VecDeque<Event>,
+}
+
+impl EventsBuffer {
+    /// Read the buffer from `data_dir`, creating the file if needed.
+    pub fn read(data_dir: &Path) -> Result<Self> {
+        std::fs::create_dir_all(data_dir).with_context(|| {
+            format!(
+                "Could not create v2 events buffer directory at {}",
+                data_dir.display()
+            )
+        })?;
+
+        let mut events_lock = LockFile::open(&data_dir.join(EVENTS_LOCK_FILE_NAME))
+            .context("Could not open v2 events lock file")?;
+        events_lock
+            .lock()
+            .context("Could not lock v2 events buffer")?;
+
+        let buffer_file_path = data_dir.join(EVENTS_BUFFER_FILE_NAME);
+        let mut events_buffer_file_options = OpenOptions::new();
+        events_buffer_file_options
+            .read(true)
+            .append(true)
+            .create(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            events_buffer_file_options.mode(0o600);
+        }
+        let mut events_buffer_file = events_buffer_file_options
+            .open(&buffer_file_path)
+            .with_context(|| {
+                format!(
+                    "Could not open v2 events buffer file at {}",
+                    buffer_file_path.display()
+                )
+            })?;
+
+        let mut buffer_json = String::new();
+        events_buffer_file
+            .read_to_string(&mut buffer_json)
+            .context("Could not read v2 events buffer file")?;
+
+        let buffer = serde_json::Deserializer::from_str(&buffer_json)
+            .into_iter::<Event>()
+            .filter_map(|event| match event {
+                Ok(event) => Some(event),
+                Err(err) => {
+                    debug!(error = %err, "Skipping unreadable v2 event buffer entry");
+                    None
+                },
+            })
+            .collect();
+
+        Ok(Self {
+            storage: events_buffer_file,
+            _file_lock: events_lock,
+            buffer,
+        })
+    }
+
+    pub(crate) fn is_expired(&self, expiry: Duration) -> bool {
+        let now = OffsetDateTime::now_utc();
+        self.oldest_timestamp()
+            .map(|oldest| now - oldest > expiry)
+            .unwrap_or(false)
+    }
+
+    pub(crate) fn oldest_timestamp(&self) -> Option<OffsetDateTime> {
+        self.buffer.front().map(|event| event.event_timestamp)
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.buffer.is_empty()
+    }
+
+    pub(crate) fn batch_size(&self, max_batch_size: usize) -> usize {
+        std::cmp::min(self.buffer.len(), max_batch_size)
+    }
+
+    pub(crate) fn drain_sent(&mut self, count: usize) {
+        self.buffer.drain(..count);
+    }
+
+    /// Persist the current in-memory buffer, replacing the file contents.
+    pub fn overwrite_file(&mut self) -> Result<()> {
+        self.storage
+            .set_len(0)
+            .context("Could not truncate v2 events buffer file")?;
+
+        for event in &self.buffer {
+            self.storage
+                .write_all(serde_json::to_string(event)?.as_bytes())
+                .context("Could not write v2 event to buffer file")?;
+            self.storage
+                .write_all(b"\n")
+                .context("Could not write v2 event buffer newline")?;
+        }
+
+        self.storage
+            .flush()
+            .context("Could not flush v2 events buffer file")?;
+        self.storage
+            .sync_data()
+            .context("Could not sync v2 events buffer file")?;
+        Ok(())
+    }
+
+    /// Push a new event and sync it to disk before returning.
+    pub fn push(&mut self, event: Event) -> Result<()> {
+        debug!(event_id = %event.event_id, "Pushing event to v2 events buffer");
+
+        self.buffer.push_back(event);
+
+        if self.buffer.len() >= MAX_BUFFER_SIZE {
+            self.pop_front_to_max_size();
+            self.overwrite_file()?;
+        } else {
+            self.append_new_event()?;
+        };
+
+        Ok(())
+    }
+
+    fn append_new_event(&mut self) -> Result<()> {
+        let event = self
+            .buffer
+            .back()
+            .expect("buffer has a just-pushed v2 event");
+        self.storage
+            .write_all(serde_json::to_string(event)?.as_bytes())
+            .context("Could not write new v2 event to buffer file")?;
+        self.storage
+            .write_all(b"\n")
+            .context("Could not write v2 event buffer newline")?;
+        self.storage
+            .flush()
+            .context("Could not flush v2 events buffer file")?;
+        self.storage
+            .sync_data()
+            .context("Could not sync v2 events buffer file")?;
+        Ok(())
+    }
+
+    /// Iterate over buffered events from oldest to newest.
+    pub fn iter(&self) -> impl Iterator<Item = &Event> {
+        self.buffer.iter()
+    }
+
+    fn pop_front_to_max_size(&mut self) {
+        while self.buffer.len() >= MAX_BUFFER_SIZE {
+            self.buffer.pop_front();
+        }
+    }
+}

--- a/cli/flox-events/src/client.rs
+++ b/cli/flox-events/src/client.rs
@@ -1,0 +1,90 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use time::{Duration, OffsetDateTime};
+use uuid::Uuid;
+
+use crate::buffer::EventsBuffer;
+use crate::connection::{EventsConnection, EventsConnectionV2};
+use crate::{Event, EventKind};
+
+const DEFAULT_BUFFER_EXPIRY: Duration = Duration::minutes(2);
+pub const BATCH_SIZE: usize = 100;
+
+/// Client that stamps v2 event metadata, buffers events, and flushes
+/// them through an [`EventsConnection`].
+///
+/// The connection owns the endpoint URL and credential; the client itself
+/// holds only the per-invocation metadata stamped onto each [`Event`].
+#[derive(Debug)]
+pub struct EventsClient {
+    pub device_id: Uuid,
+    pub data_dir: PathBuf,
+    pub invocation_id: Uuid,
+    pub max_age: Duration,
+    pub connection: Box<dyn EventsConnection>,
+}
+
+impl EventsClient {
+    pub fn new(
+        device_id: Uuid,
+        data_dir: impl AsRef<Path>,
+        endpoint_url: impl Into<String>,
+        api_key: impl Into<String>,
+        invocation_id: Uuid,
+    ) -> Self {
+        let connection = EventsConnectionV2::new(endpoint_url, api_key);
+        Self::new_with_connection(device_id, data_dir, invocation_id, connection)
+    }
+
+    pub fn new_with_connection(
+        device_id: Uuid,
+        data_dir: impl AsRef<Path>,
+        invocation_id: Uuid,
+        connection: impl EventsConnection + 'static,
+    ) -> Self {
+        Self {
+            device_id,
+            data_dir: data_dir.as_ref().to_path_buf(),
+            invocation_id,
+            max_age: DEFAULT_BUFFER_EXPIRY,
+            connection: connection.boxed(),
+        }
+    }
+
+    pub fn record_event(&self, kind: impl Into<EventKind>) -> Result<()> {
+        let event = Event {
+            event_id: Uuid::new_v4(),
+            event_timestamp: OffsetDateTime::now_utc(),
+            source: "cli",
+            invocation_id: self.invocation_id,
+            device_id: self.device_id,
+            auth_subject: None,
+            kind: kind.into(),
+        };
+
+        let mut events_buffer = EventsBuffer::read(&self.data_dir)?;
+        events_buffer.push(event)?;
+        Ok(())
+    }
+
+    pub fn flush(&mut self, force: bool) -> Result<()> {
+        let mut events = EventsBuffer::read(&self.data_dir)?;
+        if !events.is_expired(self.max_age) && !force {
+            return Ok(());
+        }
+
+        while !events.is_empty() {
+            let batch_size = events.batch_size(BATCH_SIZE);
+            {
+                let batch: Vec<&Event> = events.iter().take(batch_size).collect();
+                self.connection.send(batch)?;
+            }
+
+            events.drain_sent(batch_size);
+            events.overwrite_file()?;
+        }
+
+        Ok(())
+    }
+}

--- a/cli/flox-events/src/connection.rs
+++ b/cli/flox-events/src/connection.rs
@@ -1,0 +1,203 @@
+use std::fmt::{Debug, Formatter};
+use std::time::Duration as TimeoutDuration;
+
+use anyhow::{Context, Result};
+use tracing::debug;
+
+use crate::Event;
+
+/// Timeout used for network operations that run after the main command has
+/// completed.
+pub const TRAILING_NETWORK_CALL_TIMEOUT: TimeoutDuration = TimeoutDuration::from_secs(2);
+
+/// A connection to a v2 events backend.
+pub trait EventsConnection: Debug + Send + Sync {
+    /// Send events to the backend defined by this connection.
+    fn send(&mut self, events: Vec<&Event>) -> Result<()>;
+
+    /// Box this connection as a trait object.
+    fn boxed(self) -> Box<dyn EventsConnection>
+    where
+        Self: Sized + 'static,
+    {
+        Box::new(self)
+    }
+}
+
+/// Blocking HTTP connection for v2 CLI events.
+#[derive(Clone)]
+pub struct EventsConnectionV2 {
+    pub timeout: TimeoutDuration,
+    pub(crate) endpoint_url: String,
+    pub(crate) api_key: String,
+}
+
+impl Debug for EventsConnectionV2 {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EventsConnectionV2")
+            .field("timeout", &self.timeout)
+            .field("endpoint_url", &self.endpoint_url)
+            .field("api_key", &"<redacted>")
+            .finish()
+    }
+}
+
+impl EventsConnectionV2 {
+    pub fn new(endpoint_url: impl Into<String>, api_key: impl Into<String>) -> Self {
+        Self {
+            timeout: TRAILING_NETWORK_CALL_TIMEOUT,
+            endpoint_url: endpoint_url.into(),
+            api_key: api_key.into(),
+        }
+    }
+
+    /// Serialize a batch of events as the request body for the ingest
+    /// endpoint. The wire contract is **NDJSON** — one JSON object per line.
+    ///
+    /// The ingest is API Gateway -> Firehose -> S3 -> ClickHouse
+    /// `JSONEachRow`: the API Gateway request-mapping template (see
+    /// `flox-analytics/terraform/units/ingest/api_gateway.tf`) takes the raw
+    /// `$input.body`, appends a single trailing newline, and writes the whole
+    /// thing as one Firehose Record. So:
+    ///
+    /// - 1 event  -> body `{...}`              -> S3 line `{...}\n`        (1 NDJSON line)
+    /// - N events -> body `{...}\n{...}\n...`  -> S3 record has N NDJSON lines
+    ///
+    /// An array body (e.g. `[{...},{...}]`) is the poison shape that stalls
+    /// the entire S3Queue behind it — ClickHouse cannot parse a body starting
+    /// with `[`. This is the parallel fix to the same bug on the FloxHub side
+    /// (floxhub@128dce329).
+    pub fn serialize_events(events: &[&Event]) -> Result<String> {
+        let mut lines = Vec::with_capacity(events.len());
+        for event in events {
+            lines.push(serde_json::to_string(event).context("Could not serialize event")?);
+        }
+        Ok(lines.join("\n"))
+    }
+}
+
+impl EventsConnection for EventsConnectionV2 {
+    fn send(&mut self, events: Vec<&Event>) -> Result<()> {
+        let event_count = events.len();
+        let body = Self::serialize_events(&events)?;
+        debug!(
+            event_count,
+            endpoint_url = %self.endpoint_url,
+            "Sending v2 events"
+        );
+
+        let thread_timeout = self.timeout;
+        let thread_endpoint_url = self.endpoint_url.clone();
+        let thread_api_key = self.api_key.clone();
+
+        // Run the blocking request on a separate thread so the channel
+        // `recv_timeout` below — not the reqwest client — bounds how long the
+        // send can take. reqwest's own timeout does not cover the `getaddrinfo`
+        // call in the system libc, which can block far past the configured
+        // timeout when DNS does not respond (for example a local resolver
+        // forwarding to the internet while Wi-Fi is disabled). See
+        // https://github.com/flox/flox/pull/1769#issuecomment-2260675622. On
+        // timeout the thread is left to finish on its own; a short-lived CLI
+        // invocation exits and the OS reaps it.
+        let (sender, receiver) = std::sync::mpsc::sync_channel(1);
+        std::thread::spawn(move || {
+            let result = (|| {
+                let client = reqwest::blocking::ClientBuilder::new()
+                    .timeout(thread_timeout)
+                    .build()
+                    .context("Could not build v2 events HTTP client")?;
+                client
+                    .put(thread_endpoint_url)
+                    .header("content-type", "application/json")
+                    .header("x-api-key", thread_api_key)
+                    .header("user-agent", "flox-cli")
+                    .body(body)
+                    .send()
+                    .context("Could not send v2 events")
+            })();
+            let _ = sender.send(result);
+        });
+
+        let response = match receiver.recv_timeout(self.timeout) {
+            Ok(Ok(response)) => response,
+            Ok(Err(err)) => {
+                debug!(error = %err, "V2 events request failed");
+                return Err(err);
+            },
+            Err(err) => {
+                let err = anyhow::anyhow!(err).context("v2 events api request");
+                debug!(error = %err, "V2 events request timed out");
+                return Err(err);
+            },
+        };
+
+        let status = response.status();
+        match response.error_for_status() {
+            Ok(_) => {
+                debug!(status = %status, event_count, "V2 events sent");
+                Ok(())
+            },
+            // Non-2xx: the endpoint rejected the request (e.g. a malformed body
+            // or a 4xx/5xx from the ingest gateway). Surface it as an error so
+            // the caller leaves the events buffered for a later retry, instead
+            // of treating the rejection as a successful send and dropping them.
+            Err(err) => {
+                debug!(error = %err, %status, "V2 events rejected by endpoint");
+                Err(anyhow::Error::new(err)
+                    .context("v2 events endpoint returned a non-success status"))
+            },
+        }
+    }
+}
+
+#[cfg(any(test, feature = "tests"))]
+mod mock {
+    use std::sync::{Arc, Mutex};
+
+    use anyhow::{Result, bail};
+
+    use super::{Debug, Event, EventsConnection};
+
+    #[derive(Debug, Clone, Default)]
+    pub struct MockEventsConnection {
+        sent_batches: Arc<Mutex<Vec<Vec<Event>>>>,
+        failures_remaining: Arc<Mutex<usize>>,
+    }
+
+    impl MockEventsConnection {
+        pub fn sent_batches(&self) -> Arc<Mutex<Vec<Vec<Event>>>> {
+            self.sent_batches.clone()
+        }
+
+        pub fn fail_next_send(&self) {
+            let mut failures = self
+                .failures_remaining
+                .lock()
+                .expect("mock failures lock poisoned");
+            *failures += 1;
+        }
+    }
+
+    impl EventsConnection for MockEventsConnection {
+        fn send(&mut self, events: Vec<&Event>) -> Result<()> {
+            let mut failures = self
+                .failures_remaining
+                .lock()
+                .expect("mock failures lock poisoned");
+            if *failures > 0 {
+                *failures -= 1;
+                bail!("mock events send failed");
+            }
+            drop(failures);
+
+            self.sent_batches
+                .lock()
+                .expect("mock sent batches lock poisoned")
+                .push(events.into_iter().cloned().collect());
+            Ok(())
+        }
+    }
+}
+
+#[cfg(any(test, feature = "tests"))]
+pub use mock::MockEventsConnection;

--- a/cli/flox-events/src/guard.rs
+++ b/cli/flox-events/src/guard.rs
@@ -1,0 +1,31 @@
+use tracing::debug;
+
+use crate::hub::EventsHub;
+
+/// Flushes the configured events client when dropped.
+#[derive(Debug)]
+pub struct EventsGuard {
+    hub: EventsHub,
+}
+
+impl EventsGuard {
+    pub fn new() -> Self {
+        Self {
+            hub: EventsHub::global().clone(),
+        }
+    }
+}
+
+impl Default for EventsGuard {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Drop for EventsGuard {
+    fn drop(&mut self) {
+        if let Err(err) = self.hub.flush(true) {
+            debug!(error = %err, "Failed to flush v2 events on guard drop");
+        }
+    }
+}

--- a/cli/flox-events/src/hub.rs
+++ b/cli/flox-events/src/hub.rs
@@ -1,0 +1,71 @@
+use std::sync::{Arc, LazyLock, Mutex};
+
+use anyhow::Result;
+use tracing::debug;
+
+use crate::EventKind;
+use crate::client::EventsClient;
+
+static EVENTS_HUB: LazyLock<EventsHub> = LazyLock::new(EventsHub::new);
+
+/// Shared event client holder used by CLI call sites.
+#[derive(Debug, Clone)]
+pub struct EventsHub {
+    client: Arc<Mutex<Option<EventsClient>>>,
+}
+
+impl EventsHub {
+    pub fn global() -> &'static Self {
+        &EVENTS_HUB
+    }
+
+    pub fn new() -> Self {
+        Self {
+            client: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    pub fn set_client(&self, new_client: EventsClient) -> Option<EventsClient> {
+        self.with_client(|client| client.replace(new_client))
+    }
+
+    pub fn clear_client(&self) -> Option<EventsClient> {
+        self.with_client(Option::take)
+    }
+
+    pub fn flush(&self, force: bool) -> Result<()> {
+        self.with_client(|client| {
+            if let Some(client) = client {
+                client.flush(force)
+            } else {
+                debug!("No v2 events client configured, skipping flush");
+                Ok(())
+            }
+        })
+    }
+
+    pub fn record_event(&self, kind: EventKind) -> Result<()> {
+        self.with_client(|client| {
+            let Some(client) = client else {
+                debug!("No v2 events client configured, skipping record");
+                return Ok(());
+            };
+
+            client.record_event(kind)
+        })
+    }
+
+    fn with_client<T>(&self, f: impl FnOnce(&mut Option<EventsClient>) -> T) -> T {
+        let mut client = self
+            .client
+            .lock()
+            .expect("v2 events client mutex panicked on another thread");
+        f(&mut client)
+    }
+}
+
+impl Default for EventsHub {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/cli/flox-events/src/lib.rs
+++ b/cli/flox-events/src/lib.rs
@@ -1,23 +1,43 @@
-//! Canonical telemetry event types emitted by the flox CLI.
+//! V2 telemetry events emitted by the Flox CLI.
 //!
-//! Types only. There is no sink, no context, and no emission machinery
-//! in this crate.
+//! This crate contains the v2 event envelope and the self-contained
+//! pipeline for buffering and sending `cli.*` events. The global hub is dormant
+//! until a client is installed by the CLI.
 
-use serde::Serialize;
+mod buffer;
+mod client;
+mod connection;
+mod guard;
+mod hub;
+
+pub use buffer::{EVENTS_BUFFER_FILE_NAME, EventsBuffer};
+pub use client::{BATCH_SIZE, EventsClient};
+pub use connection::{EventsConnection, EventsConnectionV2, TRAILING_NETWORK_CALL_TIMEOUT};
+pub use guard::EventsGuard;
+pub use hub::EventsHub;
+use serde::{Deserialize, Serialize, de};
 use serde_with::{TimestampMilliSeconds, serde_as};
 use time::OffsetDateTime;
 use uuid::Uuid;
 
-/// A single telemetry event in the canonical envelope shape.
+#[cfg(any(test, feature = "tests"))]
+pub mod test_helpers {
+    pub use crate::connection::MockEventsConnection;
+}
+
+const CLI_SOURCE: &str = "cli";
+
+/// A single telemetry event in the v2 envelope shape.
 ///
 /// `source` is always `"cli"`. `kind` carries the variant tag and its
 /// typed payload and is flattened into the envelope, so the wire shape
 /// is `{event_id, event_timestamp, source, invocation_id, device_id,
 /// auth_subject?, event_type, payload}`.
 ///
-/// Serialize-only: the CLI produces events, it never reads them back.
+/// The CLI serializes events for transport and deserializes the same shape to
+/// reload its local buffer.
 #[serde_as]
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct Event {
     /// Unique id for this event (used downstream for de-duplication).
     pub event_id: Uuid,
@@ -49,13 +69,52 @@ pub struct Event {
     pub kind: EventKind,
 }
 
+#[serde_as]
+#[derive(Debug, Deserialize)]
+struct EventWire {
+    event_id: Uuid,
+    #[serde_as(as = "TimestampMilliSeconds<i64>")]
+    event_timestamp: OffsetDateTime,
+    source: String,
+    invocation_id: Uuid,
+    device_id: Uuid,
+    auth_subject: Option<String>,
+    #[serde(flatten)]
+    kind: EventKind,
+}
+
+impl<'de> Deserialize<'de> for Event {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let wire = EventWire::deserialize(deserializer)?;
+        if wire.source != CLI_SOURCE {
+            return Err(de::Error::custom(format!(
+                "expected v2 event source {CLI_SOURCE:?}, got {:?}",
+                wire.source
+            )));
+        }
+
+        Ok(Self {
+            event_id: wire.event_id,
+            event_timestamp: wire.event_timestamp,
+            source: CLI_SOURCE,
+            invocation_id: wire.invocation_id,
+            device_id: wire.device_id,
+            auth_subject: wire.auth_subject,
+            kind: wire.kind,
+        })
+    }
+}
+
 /// The set of event variants the CLI emits.
 ///
 /// The dotted wire name on `#[serde(rename)]` is the single source of
 /// truth for each variant; call sites use the enum, never a string
 /// literal. `derive_more::From` is derived so a call site can pass a
 /// payload value directly to anything accepting `impl Into<EventKind>`.
-#[derive(Debug, Clone, Serialize, derive_more::From)]
+#[derive(Debug, Clone, Serialize, Deserialize, derive_more::From, PartialEq, Eq)]
 #[serde(tag = "event_type", content = "payload")]
 pub enum EventKind {
     #[serde(rename = "cli.command_run")]
@@ -65,11 +124,11 @@ pub enum EventKind {
 }
 
 /// Payload for [`EventKind::CliCommandRun`]. Serializes to `{}`.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CliCommandRunPayload {}
 
 /// Payload for [`EventKind::CliCommandCompleted`]. Serializes to `{}`.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CliCommandCompletedPayload {}
 
 #[cfg(test)]
@@ -97,7 +156,7 @@ mod tests {
     }
 
     #[test]
-    fn command_run_serializes_to_canonical_envelope() {
+    fn command_run_serializes_to_v2_envelope() {
         let value = serde_json::to_value(fixed_event(EventKind::CliCommandRun(
             CliCommandRunPayload {},
         )))
@@ -115,7 +174,7 @@ mod tests {
     }
 
     #[test]
-    fn command_completed_serializes_to_canonical_envelope() {
+    fn command_completed_serializes_to_v2_envelope() {
         let value = serde_json::to_value(fixed_event(EventKind::CliCommandCompleted(
             CliCommandCompletedPayload {},
         )))
@@ -148,5 +207,244 @@ mod tests {
             "payload": {},
         });
         assert_eq!(value, expected);
+    }
+}
+
+#[cfg(test)]
+mod pipeline_tests {
+    use pretty_assertions::assert_eq;
+    use serial_test::serial;
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::test_helpers::MockEventsConnection;
+
+    const DEVICE_ID: Uuid = Uuid::from_u128(0xaaaaaaaa_aaaa_aaaa_aaaa_aaaaaaaaaaaa);
+    const INVOCATION_ID: Uuid = Uuid::from_u128(0xbbbbbbbb_bbbb_bbbb_bbbb_bbbbbbbbbbbb);
+
+    fn fixed_event(kind: EventKind) -> Event {
+        Event {
+            event_id: Uuid::from_u128(0x11111111_1111_1111_1111_111111111111),
+            event_timestamp: OffsetDateTime::from_unix_timestamp(1_700_000_000)
+                .expect("fixture timestamp is valid"),
+            source: "cli",
+            invocation_id: INVOCATION_ID,
+            device_id: DEVICE_ID,
+            auth_subject: None,
+            kind,
+        }
+    }
+
+    fn command_run_kind() -> EventKind {
+        EventKind::CliCommandRun(CliCommandRunPayload {})
+    }
+
+    fn command_completed_kind() -> EventKind {
+        EventKind::CliCommandCompleted(CliCommandCompletedPayload {})
+    }
+
+    fn unix_timestamp_millis(time: OffsetDateTime) -> i128 {
+        time.unix_timestamp_nanos() / 1_000_000
+    }
+
+    fn client_with_connection(tempdir: &TempDir, connection: MockEventsConnection) -> EventsClient {
+        EventsClient::new_with_connection(DEVICE_ID, tempdir.path(), INVOCATION_ID, connection)
+    }
+
+    #[test]
+    fn events_buffer_round_trips_entries_from_disk() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let first = fixed_event(command_run_kind());
+        let second = fixed_event(command_completed_kind());
+
+        let mut buffer = EventsBuffer::read(tempdir.path()).expect("read empty buffer");
+        buffer.push(first.clone()).expect("push first event");
+        buffer.push(second.clone()).expect("push second event");
+        drop(buffer);
+
+        let buffer = EventsBuffer::read(tempdir.path()).expect("read persisted buffer");
+
+        assert_eq!(buffer.iter().cloned().collect::<Vec<_>>(), vec![
+            first, second
+        ]);
+    }
+
+    #[test]
+    fn events_hub_without_client_skips_recording() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let hub = EventsHub::new();
+
+        hub.record_event(command_run_kind())
+            .expect("record with no client");
+
+        assert!(!tempdir.path().join(EVENTS_BUFFER_FILE_NAME).exists());
+    }
+
+    #[test]
+    fn events_hub_records_and_flushes_when_client_is_set() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let connection = MockEventsConnection::default();
+        let sent_batches = connection.sent_batches();
+        let hub = EventsHub::new();
+        hub.set_client(client_with_connection(&tempdir, connection));
+
+        hub.record_event(command_run_kind()).expect("record event");
+        assert!(tempdir.path().join(EVENTS_BUFFER_FILE_NAME).exists());
+
+        hub.flush(true).expect("flush events");
+
+        let sent_batches = sent_batches.lock().expect("sent batches lock").clone();
+        assert_eq!(sent_batches.len(), 1);
+        assert_eq!(sent_batches[0].len(), 1);
+        assert_eq!(sent_batches[0][0].kind, command_run_kind());
+    }
+
+    #[test]
+    fn events_client_record_stamps_event_metadata() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let client = client_with_connection(&tempdir, MockEventsConnection::default());
+        let before = OffsetDateTime::now_utc();
+
+        client
+            .record_event(command_completed_kind())
+            .expect("record event");
+
+        let after = OffsetDateTime::now_utc();
+        let buffer = EventsBuffer::read(tempdir.path()).expect("read buffer");
+        let event = buffer.iter().next().expect("one buffered event");
+
+        assert_ne!(event.event_id, Uuid::nil());
+        assert!(unix_timestamp_millis(event.event_timestamp) >= unix_timestamp_millis(before));
+        assert!(unix_timestamp_millis(event.event_timestamp) <= unix_timestamp_millis(after));
+        assert_eq!(event.source, "cli");
+        assert_eq!(event.invocation_id, INVOCATION_ID);
+        assert_eq!(event.device_id, DEVICE_ID);
+        assert_eq!(event.auth_subject, None);
+        assert_eq!(event.kind, command_completed_kind());
+    }
+
+    #[test]
+    fn events_client_flush_batches_and_overwrites_buffer_file() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let connection = MockEventsConnection::default();
+        let sent_batches = connection.sent_batches();
+        let mut client = client_with_connection(&tempdir, connection);
+
+        for _ in 0..(BATCH_SIZE + 1) {
+            client
+                .record_event(command_run_kind())
+                .expect("record event");
+        }
+
+        client.flush(true).expect("flush events");
+
+        let sent_batches = sent_batches.lock().expect("sent batches lock").clone();
+        assert_eq!(sent_batches.iter().map(Vec::len).collect::<Vec<_>>(), vec![
+            BATCH_SIZE, 1
+        ]);
+
+        let buffer = EventsBuffer::read(tempdir.path()).expect("read buffer");
+        assert_eq!(buffer.iter().count(), 0);
+        assert_eq!(
+            std::fs::read_to_string(tempdir.path().join(EVENTS_BUFFER_FILE_NAME))
+                .expect("read buffer file"),
+            ""
+        );
+    }
+
+    #[test]
+    fn events_client_flush_retains_buffer_when_connection_errors() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let connection = MockEventsConnection::default();
+        connection.fail_next_send();
+        let mut client = client_with_connection(&tempdir, connection);
+
+        client
+            .record_event(command_run_kind())
+            .expect("record event");
+
+        let err = client.flush(true).expect_err("flush should fail");
+        assert!(err.to_string().contains("mock events send failed"));
+
+        let buffer = EventsBuffer::read(tempdir.path()).expect("read buffer");
+        let buffered = buffer.iter().cloned().collect::<Vec<_>>();
+        assert_eq!(buffered.len(), 1);
+        assert_eq!(buffered[0].kind, command_run_kind());
+    }
+
+    /// Wire-contract test: the body for one event is exactly one JSON object
+    /// (one NDJSON line), NOT a `[{...}]` array. An array body is the poison
+    /// shape that stalls the S3Queue downstream — see
+    /// `EventsConnectionV2::serialize_events` for the full rationale. Parallel
+    /// fix to the same bug on the FloxHub side (floxhub@128dce329).
+    #[test]
+    fn v2_events_serializes_single_event_as_one_ndjson_object() {
+        let event = fixed_event(command_run_kind());
+        let body = EventsConnectionV2::serialize_events(&[&event]).expect("serialize events");
+
+        // Wire contract: not an array.
+        assert!(
+            !body.starts_with('['),
+            "body must not be a JSON array (would poison the S3Queue); got prefix: {:?}",
+            &body[..body.len().min(48)]
+        );
+        // Exactly one JSON object on one line.
+        assert!(body.starts_with('{') && body.ends_with('}'));
+        assert!(
+            !body.contains('\n'),
+            "single-event body must be one line, no embedded \\n"
+        );
+        // This test pins the wire *shape*; the exact envelope bytes are
+        // covered by the envelope serialization tests, and the payload grows
+        // across PR 2b+, so it stays decoupled from payload contents.
+        let parsed: serde_json::Value =
+            serde_json::from_str(&body).expect("single-event body parses as a JSON object");
+        assert!(parsed.is_object());
+        assert_eq!(parsed["event_type"], "cli.command_run");
+    }
+
+    /// A multi-event batch becomes one JSON object per line (`\n`-separated),
+    /// so the API Gateway template's trailing-newline-appended Firehose Record
+    /// lands as exactly N NDJSON lines in S3.
+    #[test]
+    fn v2_events_serializes_batch_as_ndjson_lines() {
+        let e1 = fixed_event(command_run_kind());
+        let e2 = fixed_event(command_run_kind());
+        let body = EventsConnectionV2::serialize_events(&[&e1, &e2]).expect("serialize events");
+
+        assert!(
+            !body.starts_with('['),
+            "batch body must not be a JSON array"
+        );
+        let lines: Vec<&str> = body.split('\n').collect();
+        assert_eq!(lines.len(), 2, "two events must produce two NDJSON lines");
+        for line in &lines {
+            let parsed: serde_json::Value = serde_json::from_str(line).expect("parse line");
+            assert!(parsed.is_object(), "each line must be a JSON object");
+        }
+    }
+
+    #[test]
+    #[serial(global_events_client)]
+    fn events_guard_drop_flushes_global_hub() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let connection = MockEventsConnection::default();
+        let sent_batches = connection.sent_batches();
+        let previous_client =
+            EventsHub::global().set_client(client_with_connection(&tempdir, connection));
+
+        EventsHub::global()
+            .record_event(command_run_kind())
+            .expect("record event");
+        drop(EventsGuard::new());
+
+        EventsHub::global().clear_client();
+        if let Some(previous_client) = previous_client {
+            EventsHub::global().set_client(previous_client);
+        }
+
+        let sent_batches = sent_batches.lock().expect("sent batches lock").clone();
+        assert_eq!(sent_batches.len(), 1);
+        assert_eq!(sent_batches[0].len(), 1);
     }
 }


### PR DESCRIPTION
**Part 1 of 5 — CLI producer telemetry cutover.** Foundation PR: a new, fully **dormant** v2 event pipeline. Nothing emits through it yet, so production behavior is unchanged.

## What this PR adds

Promotes the `flox-events` crate from bare envelope types into a self-contained event pipeline that mirrors the shape of the existing metrics path:

- **`EventsHub`** — a global hub that is dormant by default; with no client installed every `record_*` call short-circuits (the production state until the cutover PR).
- **`EventsBuffer`** — an on-disk, file-locked JSONL buffer that persists events before delivery.
- **`EventsClient`** — stamps shared event metadata and buffers events.
- **`EventsConnectionV2`** — a blocking HTTP connection wrapped in a timeout-bounded thread.
- **`EventsGuard`** — flushes any buffered events on drop.

The pipeline lives in its own crate (matching the workspace pattern of `flox-core`, `flox-rust-sdk`, `flox-catalog`, `flox-activations`) so the typed envelope and its delivery mechanics can be reviewed as one library surface before any CLI wiring lands.

## Why it stays a leaf crate

`EventsClient::new` takes the device id, data dir, endpoint URL, API key, and invocation id as plain parameters; `EventsConnectionV2::new` takes the URL and API key. No `Config`, no `env!`, and no edge to `flox-rust-sdk` or the binary crate — `cargo tree -p flox-events --edges normal` shows only leaf workspace deps. Callers pass typed `EventKind` values directly.

## Two deliberate improvements over the legacy template (worth a closer look)

- **Crash durability:** the buffer calls `File::sync_data()` after `append_new_event` / `overwrite_file`, where the legacy buffer uses only `File::flush()`. A SIGKILL/OOM between recording an event and the HTTP send preserves it for the next invocation by construction.
- **Credential hygiene:** the connection's `api_key` field is `pub(crate)` (not `pub`), the manual `Debug` impl prints `api_key: "<redacted>"`, and on unix the buffer file is opened `mode(0o600)` so on-disk events are owner-readable only.

## Review notes

- The test-only mock connection is exposed behind the crate's `tests` feature, so downstream integration tests can opt in without shipping helpers in the default build.
- Every exported type keeps an `Events*` prefix (no un-prefixed aliases) so a single grep finds every new-stack reference while the legacy and new stacks coexist.

## Behavior & testing

Behavior-neutral — library only, no callers. The `flox-events` test suite (buffer/connection mechanics + envelope golden fixtures) passes under the repo's pinned toolchain; compiles clean and `rustfmt`-clean; `git grep env! cli/flox-events/src/` returns zero hits.

---
### Stack — review bottom-up
1. **#4414 — pipeline foundation (this PR)** → `main`
2. #4415 — wire the pipeline into the CLI
3. #4416 — instrument environment-group commands
4. #4417 — instrument package-group commands
5. #4418 — instrument remaining subcommands

🤖 Generated with [Claude Code](https://claude.com/claude-code)
