### PR TITLE
feat(events): instrument environment-group commands (dormant)

### DIFF
--- a/cli/flox-events/src/client.rs
+++ b/cli/flox-events/src/client.rs
@@ -113,6 +113,19 @@ impl EventsClient {
         )
     }
 
+    /// Convenience wrapper: build a `cli.environment.activate` payload, apply
+    /// `extras` to populate the activate-specific Optional fields (e.g.
+    /// `|p| p.with_shell(shell.to_string())`), and record the event in one
+    /// call. The call site never sees the `None`-client branch.
+    pub fn record_environment_activate_with(
+        &self,
+        env_detail: EnvDetail,
+        extras: impl FnOnce(CliEnvironmentActivatePayload) -> CliEnvironmentActivatePayload,
+    ) -> Result<()> {
+        let payload = extras(self.build_environment_activate_payload(env_detail));
+        self.record_environment_activate(payload)
+    }
+
     /// Record a `cli.environment.push` event with the supplied env detail.
     pub fn record_environment_push(&self, env_detail: EnvDetail) -> Result<()> {
         let payload = CliEnvironmentPushPayload::new(

--- a/cli/flox-events/src/client.rs
+++ b/cli/flox-events/src/client.rs
@@ -9,6 +9,10 @@ use crate::connection::{EventsConnection, EventsConnectionV2};
 use crate::{
     CliCommandCompletedPayload,
     CliCommandRunPayload,
+    CliEnvironmentActivatePayload,
+    CliEnvironmentPullPayload,
+    CliEnvironmentPushPayload,
+    EnvDetail,
     Event,
     EventKind,
     SharedMetadataTemplate,
@@ -80,6 +84,51 @@ impl EventsClient {
         let payload =
             CliCommandCompletedPayload::new(self.shared_metadata.into_payload(subcommand));
         self.record_event(EventKind::CliCommandCompleted(payload))
+    }
+
+    /// Record a `cli.environment.activate` event with the supplied env
+    /// detail. The caller is expected to populate any of the activate-
+    /// specific extras (`start_services`, `mode`, `has_includes`,
+    /// `lockfile_version`, `shell`) via the builder methods on the payload
+    /// before this is called, e.g. via [`build_environment_activate_payload`].
+    pub fn record_environment_activate(
+        &self,
+        payload: CliEnvironmentActivatePayload,
+    ) -> Result<()> {
+        self.record_event(EventKind::CliEnvironmentActivate(payload))
+    }
+
+    /// Build a `cli.environment.activate` payload using the stored shared
+    /// metadata (with `subcommand = "activate"`) and the supplied env
+    /// detail. The result has every activate extra `None`; the caller chains
+    /// `with_*` builder methods on the returned value before passing to
+    /// [`record_environment_activate`].
+    pub fn build_environment_activate_payload(
+        &self,
+        env_detail: EnvDetail,
+    ) -> CliEnvironmentActivatePayload {
+        CliEnvironmentActivatePayload::new(
+            self.shared_metadata.into_payload("activate".to_string()),
+            env_detail,
+        )
+    }
+
+    /// Record a `cli.environment.push` event with the supplied env detail.
+    pub fn record_environment_push(&self, env_detail: EnvDetail) -> Result<()> {
+        let payload = CliEnvironmentPushPayload::new(
+            self.shared_metadata.into_payload("push".to_string()),
+            env_detail,
+        );
+        self.record_event(EventKind::CliEnvironmentPush(payload))
+    }
+
+    /// Record a `cli.environment.pull` event with the supplied env detail.
+    pub fn record_environment_pull(&self, env_detail: EnvDetail) -> Result<()> {
+        let payload = CliEnvironmentPullPayload::new(
+            self.shared_metadata.into_payload("pull".to_string()),
+            env_detail,
+        );
+        self.record_event(EventKind::CliEnvironmentPull(payload))
     }
 
     pub fn record_event(&self, kind: impl Into<EventKind>) -> Result<()> {

--- a/cli/flox-events/src/hub.rs
+++ b/cli/flox-events/src/hub.rs
@@ -95,10 +95,10 @@ impl EventsHub {
         })
     }
 
-    /// Record a `cli.environment.activate` event. The caller builds the
-    /// payload via [`EventsClient::build_environment_activate_payload`]
-    /// (typically through [`EventsHub::build_environment_activate_payload`])
-    /// so the call site can populate only the activate extras it knows.
+    /// Record a `cli.environment.activate` event from an already-built
+    /// payload. Most call sites should prefer
+    /// [`EventsHub::record_environment_activate_with`], which builds the
+    /// payload and applies the activate extras in a single call.
     /// No-op when no client is installed.
     pub fn record_environment_activate(
         &self,
@@ -110,20 +110,6 @@ impl EventsHub {
                 return Ok(());
             };
             client.record_environment_activate(payload)
-        })
-    }
-
-    /// Build an empty-extras `cli.environment.activate` payload using the
-    /// installed client's shared metadata. Returns `None` when no client is
-    /// installed (production-dormant branch).
-    pub fn build_environment_activate_payload(
-        &self,
-        env_detail: EnvDetail,
-    ) -> Option<CliEnvironmentActivatePayload> {
-        self.with_client(|client| {
-            client
-                .as_ref()
-                .map(|c| c.build_environment_activate_payload(env_detail))
         })
     }
 

--- a/cli/flox-events/src/hub.rs
+++ b/cli/flox-events/src/hub.rs
@@ -4,8 +4,8 @@ use std::sync::{Arc, LazyLock, Mutex};
 use anyhow::Result;
 use tracing::debug;
 
-use crate::EventKind;
 use crate::client::EventsClient;
+use crate::{CliEnvironmentActivatePayload, EnvDetail, EventKind};
 
 static EVENTS_HUB: LazyLock<EventsHub> = LazyLock::new(EventsHub::new);
 
@@ -92,6 +92,62 @@ impl EventsHub {
                 return Ok(());
             };
             client.record_command_completed(subcommand)
+        })
+    }
+
+    /// Record a `cli.environment.activate` event. The caller builds the
+    /// payload via [`EventsClient::build_environment_activate_payload`]
+    /// (typically through [`EventsHub::build_environment_activate_payload`])
+    /// so the call site can populate only the activate extras it knows.
+    /// No-op when no client is installed.
+    pub fn record_environment_activate(
+        &self,
+        payload: CliEnvironmentActivatePayload,
+    ) -> Result<()> {
+        self.with_client(|client| {
+            let Some(client) = client else {
+                debug!("No v2 events client configured, skipping environment.activate record");
+                return Ok(());
+            };
+            client.record_environment_activate(payload)
+        })
+    }
+
+    /// Build an empty-extras `cli.environment.activate` payload using the
+    /// installed client's shared metadata. Returns `None` when no client is
+    /// installed (production-dormant branch).
+    pub fn build_environment_activate_payload(
+        &self,
+        env_detail: EnvDetail,
+    ) -> Option<CliEnvironmentActivatePayload> {
+        self.with_client(|client| {
+            client
+                .as_ref()
+                .map(|c| c.build_environment_activate_payload(env_detail))
+        })
+    }
+
+    /// Record a `cli.environment.push` event with the supplied env detail.
+    /// No-op when no client is installed.
+    pub fn record_environment_push(&self, env_detail: EnvDetail) -> Result<()> {
+        self.with_client(|client| {
+            let Some(client) = client else {
+                debug!("No v2 events client configured, skipping environment.push record");
+                return Ok(());
+            };
+            client.record_environment_push(env_detail)
+        })
+    }
+
+    /// Record a `cli.environment.pull` event with the supplied env detail.
+    /// No-op when no client is installed.
+    pub fn record_environment_pull(&self, env_detail: EnvDetail) -> Result<()> {
+        self.with_client(|client| {
+            let Some(client) = client else {
+                debug!("No v2 events client configured, skipping environment.pull record");
+                return Ok(());
+            };
+            client.record_environment_pull(env_detail)
         })
     }
 

--- a/cli/flox-events/src/hub.rs
+++ b/cli/flox-events/src/hub.rs
@@ -127,6 +127,26 @@ impl EventsHub {
         })
     }
 
+    /// Record a `cli.environment.activate` event in one call: builds the
+    /// payload from the installed client's shared metadata, applies
+    /// `extras` to populate the activate-specific Optional fields, and
+    /// records it. When no client is installed the call short-circuits
+    /// without invoking `extras` — call sites do not need to write
+    /// `if let Some(payload) = …`.
+    pub fn record_environment_activate_with(
+        &self,
+        env_detail: EnvDetail,
+        extras: impl FnOnce(CliEnvironmentActivatePayload) -> CliEnvironmentActivatePayload,
+    ) -> Result<()> {
+        self.with_client(|client| {
+            let Some(client) = client else {
+                debug!("No v2 events client configured, skipping environment.activate record");
+                return Ok(());
+            };
+            client.record_environment_activate_with(env_detail, extras)
+        })
+    }
+
     /// Record a `cli.environment.push` event with the supplied env detail.
     /// No-op when no client is installed.
     pub fn record_environment_push(&self, env_detail: EnvDetail) -> Result<()> {

--- a/cli/flox-events/src/lib.rs
+++ b/cli/flox-events/src/lib.rs
@@ -121,6 +121,12 @@ pub enum EventKind {
     CliCommandRun(CliCommandRunPayload),
     #[serde(rename = "cli.command_completed")]
     CliCommandCompleted(CliCommandCompletedPayload),
+    #[serde(rename = "cli.environment.activate")]
+    CliEnvironmentActivate(CliEnvironmentActivatePayload),
+    #[serde(rename = "cli.environment.push")]
+    CliEnvironmentPush(CliEnvironmentPushPayload),
+    #[serde(rename = "cli.environment.pull")]
+    CliEnvironmentPull(CliEnvironmentPullPayload),
 }
 
 /// Shared metadata fields stamped onto every `cli.*` command event payload.
@@ -211,6 +217,132 @@ pub struct CliCommandCompletedPayload {
 impl CliCommandCompletedPayload {
     pub fn new(command: CommandPayload) -> Self {
         Self { command }
+    }
+}
+
+/// Environment kind a `flox activate` / `push` / `pull` invocation touched,
+/// matching the three legacy `environment_subcommand_metric!` arms
+/// (`remote_environment` / `managed_environment` / `path_environment`).
+///
+/// Carried on every `cli.environment.*` event so downstream classifiers can
+/// reconstruct the legacy `*_environment` columns without re-parsing the
+/// `event_type` tag.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EnvDetail {
+    /// One of `"remote"`, `"managed"`, `"path"` — the
+    /// [`flox_rust_sdk::models::environment::ConcreteEnvironment`] variant
+    /// the command operated on. `"managed"` is also used for `flox pull`'s
+    /// `NewAbbreviated` branch, where only the remote `RemoteRef` is known
+    /// at emission time (no materialized `ConcreteEnvironment` yet).
+    pub env_kind: String,
+    /// The environment's identifier — the result of `env_ref().to_string()`
+    /// for remote and managed environments, and `Environment::name(...)`
+    /// for path environments. Matches the value the legacy macros emit.
+    pub env_ref_or_name: String,
+}
+
+/// Payload for [`EventKind::CliEnvironmentActivate`].
+///
+/// Carries the env detail plus the extras the legacy
+/// `environment_subcommand_metric!("activate", ...)` and
+/// `subcommand_metric!("activate", ...)` call sites in
+/// `cli/flox/src/commands/activate.rs` recorded. Each call site emits one
+/// event with only the fields it knows populated; the downstream consumer
+/// correlates via `invocation_id`. `lockfile_version` lands here instead of
+/// on a (dropped) `cli.environment.activate#version` pseudo-subcommand.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CliEnvironmentActivatePayload {
+    #[serde(flatten)]
+    pub command: CommandPayload,
+    #[serde(flatten)]
+    pub env_detail: EnvDetail,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub start_services: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mode: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub has_includes: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lockfile_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub shell: Option<String>,
+}
+
+impl CliEnvironmentActivatePayload {
+    /// Construct an empty-extras payload — every Optional field defaulted
+    /// to `None`. Call sites fill in the fields they know via the builder
+    /// methods below or struct-literal field overrides.
+    pub fn new(command: CommandPayload, env_detail: EnvDetail) -> Self {
+        Self {
+            command,
+            env_detail,
+            start_services: None,
+            mode: None,
+            has_includes: None,
+            lockfile_version: None,
+            shell: None,
+        }
+    }
+
+    pub fn with_start_services(mut self, value: bool) -> Self {
+        self.start_services = Some(value);
+        self
+    }
+
+    pub fn with_mode(mut self, value: impl Into<String>) -> Self {
+        self.mode = Some(value.into());
+        self
+    }
+
+    pub fn with_has_includes(mut self, value: bool) -> Self {
+        self.has_includes = Some(value);
+        self
+    }
+
+    pub fn with_lockfile_version(mut self, value: impl Into<String>) -> Self {
+        self.lockfile_version = Some(value.into());
+        self
+    }
+
+    pub fn with_shell(mut self, value: impl Into<String>) -> Self {
+        self.shell = Some(value.into());
+        self
+    }
+}
+
+/// Payload for [`EventKind::CliEnvironmentPush`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CliEnvironmentPushPayload {
+    #[serde(flatten)]
+    pub command: CommandPayload,
+    #[serde(flatten)]
+    pub env_detail: EnvDetail,
+}
+
+impl CliEnvironmentPushPayload {
+    pub fn new(command: CommandPayload, env_detail: EnvDetail) -> Self {
+        Self {
+            command,
+            env_detail,
+        }
+    }
+}
+
+/// Payload for [`EventKind::CliEnvironmentPull`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CliEnvironmentPullPayload {
+    #[serde(flatten)]
+    pub command: CommandPayload,
+    #[serde(flatten)]
+    pub env_detail: EnvDetail,
+}
+
+impl CliEnvironmentPullPayload {
+    pub fn new(command: CommandPayload, env_detail: EnvDetail) -> Self {
+        Self {
+            command,
+            env_detail,
+        }
     }
 }
 
@@ -333,6 +465,154 @@ mod tests {
         };
         let payload = template.into_payload("activate".to_string());
         assert_eq!(payload, command_payload("activate"));
+    }
+
+    fn env_detail(kind: &str, ref_or_name: &str) -> EnvDetail {
+        EnvDetail {
+            env_kind: kind.to_string(),
+            env_ref_or_name: ref_or_name.to_string(),
+        }
+    }
+
+    fn activate_envelope_json(payload_extras: serde_json::Value) -> serde_json::Value {
+        let mut payload = expected_payload_json("activate");
+        let payload_obj = payload.as_object_mut().expect("payload object");
+        for (key, value) in payload_extras.as_object().expect("extras object") {
+            payload_obj.insert(key.clone(), value.clone());
+        }
+        json!({
+            "event_id": "00000000-0000-0000-0000-000000000000",
+            "event_timestamp": EPOCH_UNIX_MS,
+            "source": "cli",
+            "invocation_id": "00000000-0000-0000-0000-000000000000",
+            "device_id": "00000000-0000-0000-0000-000000000000",
+            "event_type": "cli.environment.activate",
+            "payload": payload,
+        })
+    }
+
+    #[test]
+    fn cli_environment_activate_remote_envelope_golden() {
+        let payload = CliEnvironmentActivatePayload::new(
+            command_payload("activate"),
+            env_detail("remote", "alice/myenv"),
+        )
+        .with_start_services(false)
+        .with_mode("dev");
+        let value = serde_json::to_value(fixed_event(EventKind::CliEnvironmentActivate(payload)))
+            .expect("event serializes");
+        let expected = activate_envelope_json(json!({
+            "env_kind": "remote",
+            "env_ref_or_name": "alice/myenv",
+            "start_services": false,
+            "mode": "dev",
+        }));
+        assert_eq!(value, expected);
+    }
+
+    #[test]
+    fn cli_environment_activate_managed_envelope_golden() {
+        let payload = CliEnvironmentActivatePayload::new(
+            command_payload("activate"),
+            env_detail("managed", "alice/myenv"),
+        )
+        .with_has_includes(true);
+        let value = serde_json::to_value(fixed_event(EventKind::CliEnvironmentActivate(payload)))
+            .expect("event serializes");
+        let expected = activate_envelope_json(json!({
+            "env_kind": "managed",
+            "env_ref_or_name": "alice/myenv",
+            "has_includes": true,
+        }));
+        assert_eq!(value, expected);
+    }
+
+    #[test]
+    fn cli_environment_activate_path_envelope_golden() {
+        let payload = CliEnvironmentActivatePayload::new(
+            command_payload("activate"),
+            env_detail("path", "myenv"),
+        )
+        .with_lockfile_version("1")
+        .with_shell("bash");
+        let value = serde_json::to_value(fixed_event(EventKind::CliEnvironmentActivate(payload)))
+            .expect("event serializes");
+        let expected = activate_envelope_json(json!({
+            "env_kind": "path",
+            "env_ref_or_name": "myenv",
+            "lockfile_version": "1",
+            "shell": "bash",
+        }));
+        assert_eq!(value, expected);
+    }
+
+    #[test]
+    fn cli_environment_activate_omits_unset_extras() {
+        // No extras populated: every Optional field is `None` and the
+        // wire shape omits them entirely (skip_serializing_if).
+        let payload = CliEnvironmentActivatePayload::new(
+            command_payload("activate"),
+            env_detail("path", "myenv"),
+        );
+        let value = serde_json::to_value(fixed_event(EventKind::CliEnvironmentActivate(payload)))
+            .expect("event serializes");
+        let expected = activate_envelope_json(json!({
+            "env_kind": "path",
+            "env_ref_or_name": "myenv",
+        }));
+        assert_eq!(value, expected);
+    }
+
+    #[test]
+    fn cli_environment_push_envelope_golden() {
+        let payload = CliEnvironmentPushPayload::new(
+            command_payload("push"),
+            env_detail("managed", "alice/myenv"),
+        );
+        let value = serde_json::to_value(fixed_event(EventKind::CliEnvironmentPush(payload)))
+            .expect("event serializes");
+        let mut payload_json = expected_payload_json("push");
+        let payload_obj = payload_json.as_object_mut().expect("payload object");
+        payload_obj.insert("env_kind".to_string(), json!("managed"));
+        payload_obj.insert("env_ref_or_name".to_string(), json!("alice/myenv"));
+        let expected = json!({
+            "event_id": "00000000-0000-0000-0000-000000000000",
+            "event_timestamp": EPOCH_UNIX_MS,
+            "source": "cli",
+            "invocation_id": "00000000-0000-0000-0000-000000000000",
+            "device_id": "00000000-0000-0000-0000-000000000000",
+            "event_type": "cli.environment.push",
+            "payload": payload_json,
+        });
+        assert_eq!(value, expected);
+    }
+
+    #[test]
+    fn cli_environment_pull_envelope_golden() {
+        // The `NewAbbreviated` branch in `pull.rs:103` constructs the
+        // detail directly with `env_kind = "managed"`; assert that
+        // shape on the wire so a future drift in the wrapper trips
+        // this test.
+        let payload = CliEnvironmentPullPayload::new(
+            command_payload("pull"),
+            env_detail("managed", "alice/myenv"),
+        );
+        let value = serde_json::to_value(fixed_event(EventKind::CliEnvironmentPull(payload)))
+            .expect("event serializes");
+        let mut payload_json = expected_payload_json("pull");
+        let payload_obj = payload_json.as_object_mut().expect("payload object");
+        payload_obj.insert("env_kind".to_string(), json!("managed"));
+        payload_obj.insert("env_ref_or_name".to_string(), json!("alice/myenv"));
+        let expected = json!({
+            "event_id": "00000000-0000-0000-0000-000000000000",
+            "event_timestamp": EPOCH_UNIX_MS,
+            "source": "cli",
+            "invocation_id": "00000000-0000-0000-0000-000000000000",
+            "device_id": "00000000-0000-0000-0000-000000000000",
+            "event_type": "cli.environment.pull",
+            "payload": payload_json,
+        });
+        assert_eq!(value, expected);
     }
 }
 

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -210,6 +210,13 @@ impl Activate {
         // Both telemetry stacks emit in parallel through the dormant
         // phase; the new-pipeline mirrors below are no-ops in production
         // until the cutover PR installs an `EventsHub` client.
+        //
+        // This v2 emit sits at the same dispatch point as the legacy
+        // `environment_subcommand_metric!` above — before the remote-trust
+        // check below — to mirror it 1:1 (parity contract). The activation
+        // *outcome* is carried on `cli.command_completed` (exit_code), not by
+        // the presence of this dispatch-time event, so emitting before a
+        // possible trust decline is intentional, not a logged false success.
         let v2_env_detail = env_detail_from_concrete(&concrete_environment);
         let v2_mode = options
             .mode

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -19,6 +19,7 @@ use flox_core::activations::activation_state_dir_path;
 use flox_core::data::System;
 use flox_core::data::environment_ref::DEFAULT_NAME;
 use flox_core::traceable_path;
+use flox_events::EventsHub;
 use flox_manifest::interfaces::{AsLatestSchema, AsWritableManifest, WriteManifest};
 use flox_manifest::parsed::Inner;
 use flox_manifest::parsed::common::IncludeDescriptor;
@@ -62,6 +63,7 @@ use crate::commands::{
 use crate::config::{AutoActivationPreference, Config, EnvironmentPromptConfig};
 use crate::utils::detect_shell::{detect_shell_for_in_place, detect_shell_for_subshell};
 use crate::utils::errors::format_diverged_metadata;
+use crate::utils::events::env_detail_from_concrete;
 use crate::utils::message;
 use crate::utils::upgrade_output::{count_upgrade_categories, format_upgrade_summary};
 use crate::{Exit, environment_subcommand_metric, subcommand_metric, utils};
@@ -205,31 +207,20 @@ impl Activate {
                 .to_string()
         );
 
-        // Mirror the legacy emit above on the new pipeline as a typed
-        // `cli.environment.activate` event. The legacy stays in place
-        // (it feeds the dormant-from-the-other-side `Hub`); this emit
-        // feeds the dormant-until-cutover `EventsHub`. See PR 6 for the
-        // flip.
-        {
-            let env_detail = crate::utils::events::env_detail_from_concrete(&concrete_environment);
-            let hub = flox_events::EventsHub::global();
-            if let Some(payload) = hub.build_environment_activate_payload(env_detail) {
-                let payload = payload
-                    .with_start_services(options.start_services)
-                    .with_mode(
-                        options
-                            .mode
-                            .clone()
-                            .unwrap_or(ActivateMode::Dev)
-                            .to_string(),
-                    );
-                if let Err(err) = hub.record_environment_activate(payload) {
-                    debug!(
-                        error = %err,
-                        "Failed to record v2 cli.environment.activate (start_services + mode) event"
-                    );
-                }
-            }
+        // Both telemetry stacks emit in parallel through the dormant
+        // phase; the new-pipeline mirrors below are no-ops in production
+        // until the cutover PR installs an `EventsHub` client.
+        let v2_env_detail = env_detail_from_concrete(&concrete_environment);
+        let v2_mode = options
+            .mode
+            .clone()
+            .unwrap_or(ActivateMode::Dev)
+            .to_string();
+        if let Err(err) = EventsHub::global().record_environment_activate_with(v2_env_detail, |p| {
+            p.with_start_services(options.start_services)
+                .with_mode(v2_mode)
+        }) {
+            debug!(error = %err, "Failed to record v2 event");
         }
 
         if let ConcreteEnvironment::Remote(ref env) = concrete_environment
@@ -399,19 +390,11 @@ impl ActivateOptions {
         let has_includes = lockfile.compose.is_some();
         subcommand_metric!("activate", "has_includes" = has_includes);
 
-        // Same breadcrumb on the new pipeline as a typed event.
-        {
-            let env_detail = crate::utils::events::env_detail_from_concrete(&concrete_environment);
-            let hub = flox_events::EventsHub::global();
-            if let Some(payload) = hub.build_environment_activate_payload(env_detail) {
-                let payload = payload.with_has_includes(has_includes);
-                if let Err(err) = hub.record_environment_activate(payload) {
-                    debug!(
-                        error = %err,
-                        "Failed to record v2 cli.environment.activate (has_includes) event"
-                    );
-                }
-            }
+        if let Err(err) = EventsHub::global().record_environment_activate_with(
+            env_detail_from_concrete(&concrete_environment),
+            |p| p.with_has_includes(has_includes),
+        ) {
+            debug!(error = %err, "Failed to record v2 event");
         }
 
         let rendered_env_path_result = concrete_environment.rendered_env_links(&flox);
@@ -440,22 +423,14 @@ impl ActivateOptions {
         let lockfile_version = lockfile.version();
         subcommand_metric!("activate#version", lockfile_version = lockfile_version);
 
-        // The legacy emit above uses the `activate#version` pseudo-
-        // subcommand to carry `lockfile_version`. The new pipeline drops
-        // that pseudo-sub entirely (per spec AC #4) and rides the value
-        // on a real `cli.environment.activate` event instead.
-        {
-            let env_detail = crate::utils::events::env_detail_from_concrete(&concrete_environment);
-            let hub = flox_events::EventsHub::global();
-            if let Some(payload) = hub.build_environment_activate_payload(env_detail) {
-                let payload = payload.with_lockfile_version(lockfile_version.to_string());
-                if let Err(err) = hub.record_environment_activate(payload) {
-                    debug!(
-                        error = %err,
-                        "Failed to record v2 cli.environment.activate (lockfile_version) event"
-                    );
-                }
-            }
+        // The new pipeline drops the legacy `activate#version` pseudo-
+        // subcommand (per spec AC #4) and rides `lockfile_version` on a
+        // real `cli.environment.activate` event instead.
+        if let Err(err) = EventsHub::global().record_environment_activate_with(
+            env_detail_from_concrete(&concrete_environment),
+            |p| p.with_lockfile_version(lockfile_version.to_string()),
+        ) {
+            debug!(error = %err, "Failed to record v2 event");
         }
 
         let mode = self.mode.clone().unwrap_or(
@@ -570,22 +545,14 @@ impl ActivateOptions {
         };
         subcommand_metric!("activate", "shell" = shell.to_string());
 
-        // Same shell breadcrumb on the new pipeline. Runs before the
-        // `command.exec()` site below, so the buffered event is flushed
-        // synchronously by the PR 2b pre-exec emit + flush block (spec AC
-        // #5).
-        {
-            let env_detail = crate::utils::events::env_detail_from_concrete(&concrete_environment);
-            let hub = flox_events::EventsHub::global();
-            if let Some(payload) = hub.build_environment_activate_payload(env_detail) {
-                let payload = payload.with_shell(shell.to_string());
-                if let Err(err) = hub.record_environment_activate(payload) {
-                    debug!(
-                        error = %err,
-                        "Failed to record v2 cli.environment.activate (shell) event"
-                    );
-                }
-            }
+        // Runs before `command.exec()`, so the buffered event is flushed
+        // synchronously by the pre-exec emit + flush block below
+        // (spec AC #5).
+        if let Err(err) = EventsHub::global().record_environment_activate_with(
+            env_detail_from_concrete(&concrete_environment),
+            |p| p.with_shell(shell.to_string()),
+        ) {
+            debug!(error = %err, "Failed to record v2 event");
         }
 
         let core = AttachCtx {

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -205,6 +205,33 @@ impl Activate {
                 .to_string()
         );
 
+        // Mirror the legacy emit above on the new pipeline as a typed
+        // `cli.environment.activate` event. The legacy stays in place
+        // (it feeds the dormant-from-the-other-side `Hub`); this emit
+        // feeds the dormant-until-cutover `EventsHub`. See PR 6 for the
+        // flip.
+        {
+            let env_detail = crate::utils::events::env_detail_from_concrete(&concrete_environment);
+            let hub = flox_events::EventsHub::global();
+            if let Some(payload) = hub.build_environment_activate_payload(env_detail) {
+                let payload = payload
+                    .with_start_services(options.start_services)
+                    .with_mode(
+                        options
+                            .mode
+                            .clone()
+                            .unwrap_or(ActivateMode::Dev)
+                            .to_string(),
+                    );
+                if let Err(err) = hub.record_environment_activate(payload) {
+                    debug!(
+                        error = %err,
+                        "Failed to record v2 cli.environment.activate (start_services + mode) event"
+                    );
+                }
+            }
+        }
+
         if let ConcreteEnvironment::Remote(ref env) = concrete_environment
             && !options.trust
         {
@@ -372,6 +399,21 @@ impl ActivateOptions {
         let has_includes = lockfile.compose.is_some();
         subcommand_metric!("activate", "has_includes" = has_includes);
 
+        // Same breadcrumb on the new pipeline as a typed event.
+        {
+            let env_detail = crate::utils::events::env_detail_from_concrete(&concrete_environment);
+            let hub = flox_events::EventsHub::global();
+            if let Some(payload) = hub.build_environment_activate_payload(env_detail) {
+                let payload = payload.with_has_includes(has_includes);
+                if let Err(err) = hub.record_environment_activate(payload) {
+                    debug!(
+                        error = %err,
+                        "Failed to record v2 cli.environment.activate (has_includes) event"
+                    );
+                }
+            }
+        }
+
         let rendered_env_path_result = concrete_environment.rendered_env_links(&flox);
         let rendered_env_path = match rendered_env_path_result {
             Err(EnvironmentError::Core(err)) if err.is_incompatible_system_error() => {
@@ -397,6 +439,24 @@ impl ActivateOptions {
         // for reasons unknown.
         let lockfile_version = lockfile.version();
         subcommand_metric!("activate#version", lockfile_version = lockfile_version);
+
+        // The legacy emit above uses the `activate#version` pseudo-
+        // subcommand to carry `lockfile_version`. The new pipeline drops
+        // that pseudo-sub entirely (per spec AC #4) and rides the value
+        // on a real `cli.environment.activate` event instead.
+        {
+            let env_detail = crate::utils::events::env_detail_from_concrete(&concrete_environment);
+            let hub = flox_events::EventsHub::global();
+            if let Some(payload) = hub.build_environment_activate_payload(env_detail) {
+                let payload = payload.with_lockfile_version(lockfile_version.to_string());
+                if let Err(err) = hub.record_environment_activate(payload) {
+                    debug!(
+                        error = %err,
+                        "Failed to record v2 cli.environment.activate (lockfile_version) event"
+                    );
+                }
+            }
+        }
 
         let mode = self.mode.clone().unwrap_or(
             manifest
@@ -509,6 +569,24 @@ impl ActivateOptions {
             detect_shell_for_subshell()
         };
         subcommand_metric!("activate", "shell" = shell.to_string());
+
+        // Same shell breadcrumb on the new pipeline. Runs before the
+        // `command.exec()` site below, so the buffered event is flushed
+        // synchronously by the PR 2b pre-exec emit + flush block (spec AC
+        // #5).
+        {
+            let env_detail = crate::utils::events::env_detail_from_concrete(&concrete_environment);
+            let hub = flox_events::EventsHub::global();
+            if let Some(payload) = hub.build_environment_activate_payload(env_detail) {
+                let payload = payload.with_shell(shell.to_string());
+                if let Err(err) = hub.record_environment_activate(payload) {
+                    debug!(
+                        error = %err,
+                        "Failed to record v2 cli.environment.activate (shell) event"
+                    );
+                }
+            }
+        }
 
         let core = AttachCtx {
             // Don't rely on FLOX_ENV in the environment when we explicitly know

--- a/cli/flox/src/commands/pull.rs
+++ b/cli/flox/src/commands/pull.rs
@@ -102,6 +102,28 @@ impl Pull {
                 // `ManagedEnvironment`, but we want to keep the remote name.
                 subcommand_metric!("pull", managed_environment = remote.to_string());
 
+                // Same env detail on the new pipeline. This branch runs
+                // **before** any `ConcreteEnvironment` is materialized, so
+                // the shared `env_detail_from_concrete` helper does not
+                // apply — construct the `EnvDetail` directly from the
+                // `RemoteRef` available here, matching the legacy
+                // `managed_environment = remote.to_string()` extra above
+                // for parity (spec AC #2).
+                {
+                    let env_detail = flox_events::EnvDetail {
+                        env_kind: "managed".to_string(),
+                        env_ref_or_name: remote.to_string(),
+                    };
+                    if let Err(err) =
+                        flox_events::EventsHub::global().record_environment_pull(env_detail)
+                    {
+                        debug!(
+                            error = %err,
+                            "Failed to record v2 cli.environment.pull (NewAbbreviated) event"
+                        );
+                    }
+                }
+
                 let (dir_message, dir) = match dir {
                     Some(dir) => (format!("{}", dir.display()), dir),
                     None => (
@@ -136,6 +158,22 @@ impl Pull {
                     .detect_concrete_environment(&mut flox, "Pull")
                     .await?;
                 environment_subcommand_metric!("pull", environment);
+
+                // Mirror the legacy emit above on the new pipeline as a
+                // typed `cli.environment.pull` event. Standard shared
+                // helper applies here — `environment` is a
+                // `ConcreteEnvironment`.
+                {
+                    let env_detail = crate::utils::events::env_detail_from_concrete(&environment);
+                    if let Err(err) =
+                        flox_events::EventsHub::global().record_environment_pull(env_detail)
+                    {
+                        debug!(
+                            error = %err,
+                            "Failed to record v2 cli.environment.pull (RemoteUpdate) event"
+                        );
+                    }
+                }
 
                 if let ConcreteEnvironment::Path(environment) = environment {
                     bail!(

--- a/cli/flox/src/commands/pull.rs
+++ b/cli/flox/src/commands/pull.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use anyhow::{Context, Result, anyhow, bail};
 use bpaf::Bpaf;
 use flox_core::data::environment_ref::RemoteEnvironmentRef;
+use flox_events::{EnvDetail, EventsHub};
 use flox_manifest::interfaces::{AsLatestSchema, AsWritableManifest, WriteManifest};
 use flox_manifest::raw::SyncTypedToRaw;
 use flox_manifest::{Manifest, Migrated};
@@ -35,6 +36,7 @@ use super::{ConcreteEnvironment, open_path};
 use crate::commands::{EnvironmentSelect, environment_description, environment_select};
 use crate::utils::dialog::{Dialog, Select};
 use crate::utils::errors::{display_chain, format_core_error};
+use crate::utils::events::env_detail_from_concrete;
 use crate::utils::message;
 use crate::{environment_subcommand_metric, subcommand_metric};
 
@@ -102,26 +104,17 @@ impl Pull {
                 // `ManagedEnvironment`, but we want to keep the remote name.
                 subcommand_metric!("pull", managed_environment = remote.to_string());
 
-                // Same env detail on the new pipeline. This branch runs
-                // **before** any `ConcreteEnvironment` is materialized, so
-                // the shared `env_detail_from_concrete` helper does not
-                // apply — construct the `EnvDetail` directly from the
-                // `RemoteRef` available here, matching the legacy
-                // `managed_environment = remote.to_string()` extra above
-                // for parity (spec AC #2).
-                {
-                    let env_detail = flox_events::EnvDetail {
-                        env_kind: "managed".to_string(),
-                        env_ref_or_name: remote.to_string(),
-                    };
-                    if let Err(err) =
-                        flox_events::EventsHub::global().record_environment_pull(env_detail)
-                    {
-                        debug!(
-                            error = %err,
-                            "Failed to record v2 cli.environment.pull (NewAbbreviated) event"
-                        );
-                    }
+                // No `ConcreteEnvironment` is materialized here yet, so
+                // the shared helper does not apply — construct the env
+                // detail directly from the `RemoteRef` to match the
+                // legacy `managed_environment = remote.to_string()`
+                // extra above (spec AC #2).
+                let env_detail = EnvDetail {
+                    env_kind: "managed".to_string(),
+                    env_ref_or_name: remote.to_string(),
+                };
+                if let Err(err) = EventsHub::global().record_environment_pull(env_detail) {
+                    debug!(error = %err, "Failed to record v2 event");
                 }
 
                 let (dir_message, dir) = match dir {
@@ -159,20 +152,10 @@ impl Pull {
                     .await?;
                 environment_subcommand_metric!("pull", environment);
 
-                // Mirror the legacy emit above on the new pipeline as a
-                // typed `cli.environment.pull` event. Standard shared
-                // helper applies here — `environment` is a
-                // `ConcreteEnvironment`.
+                if let Err(err) = EventsHub::global()
+                    .record_environment_pull(env_detail_from_concrete(&environment))
                 {
-                    let env_detail = crate::utils::events::env_detail_from_concrete(&environment);
-                    if let Err(err) =
-                        flox_events::EventsHub::global().record_environment_pull(env_detail)
-                    {
-                        debug!(
-                            error = %err,
-                            "Failed to record v2 cli.environment.pull (RemoteUpdate) event"
-                        );
-                    }
+                    debug!(error = %err, "Failed to record v2 event");
                 }
 
                 if let ConcreteEnvironment::Path(environment) = environment {

--- a/cli/flox/src/commands/pull.rs
+++ b/cli/flox/src/commands/pull.rs
@@ -152,6 +152,11 @@ impl Pull {
                     .await?;
                 environment_subcommand_metric!("pull", environment);
 
+                // Dispatch-time emit at the same point as the legacy
+                // `environment_subcommand_metric!` above — before the
+                // path-environment bail below — mirroring it 1:1 (parity
+                // contract). Outcome rides on `cli.command_completed`
+                // (exit_code), so emitting before the bail is intentional.
                 if let Err(err) = EventsHub::global()
                     .record_environment_pull(env_detail_from_concrete(&environment))
                 {

--- a/cli/flox/src/commands/push.rs
+++ b/cli/flox/src/commands/push.rs
@@ -83,6 +83,19 @@ impl Push {
 
         environment_subcommand_metric!("push", env);
 
+        // Mirror the legacy emit above on the new pipeline as a typed
+        // `cli.environment.push` event. Dormant until the PR 6 cutover
+        // installs a real client.
+        {
+            let env_detail = crate::utils::events::env_detail_from_concrete(&env);
+            if let Err(err) = flox_events::EventsHub::global().record_environment_push(env_detail) {
+                debug!(
+                    error = %err,
+                    "Failed to record v2 cli.environment.push event"
+                );
+            }
+        }
+
         match (env, self.owner) {
             (ConcreteEnvironment::Managed(managed_environment), Some(owner)) => {
                 cant_change_owner_error(managed_environment.pointer(), owner)?

--- a/cli/flox/src/commands/push.rs
+++ b/cli/flox/src/commands/push.rs
@@ -3,6 +3,7 @@ use std::str::FromStr;
 use anyhow::{Context, Result, bail};
 use bpaf::Bpaf;
 use flox_core::data::environment_ref::EnvironmentOwner;
+use flox_events::EventsHub;
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::managed_environment::{
     ManagedEnvironment,
@@ -23,6 +24,7 @@ use tracing::{debug, instrument};
 use crate::commands::{EnvironmentSelect, ensure_auth, environment_select};
 use crate::environment_subcommand_metric;
 use crate::utils::errors::format_core_error;
+use crate::utils::events::env_detail_from_concrete;
 use crate::utils::message;
 
 // Send environment to FloxHub
@@ -83,17 +85,10 @@ impl Push {
 
         environment_subcommand_metric!("push", env);
 
-        // Mirror the legacy emit above on the new pipeline as a typed
-        // `cli.environment.push` event. Dormant until the PR 6 cutover
-        // installs a real client.
+        if let Err(err) =
+            EventsHub::global().record_environment_push(env_detail_from_concrete(&env))
         {
-            let env_detail = crate::utils::events::env_detail_from_concrete(&env);
-            if let Err(err) = flox_events::EventsHub::global().record_environment_push(env_detail) {
-                debug!(
-                    error = %err,
-                    "Failed to record v2 cli.environment.push event"
-                );
-            }
+            debug!(error = %err, "Failed to record v2 event");
         }
 
         match (env, self.owner) {

--- a/cli/flox/src/utils/events.rs
+++ b/cli/flox/src/utils/events.rs
@@ -16,8 +16,9 @@ use std::env;
 use std::str::FromStr;
 use std::sync::OnceLock;
 
-use flox_events::{EventsClient, EventsGuard, EventsHub, SharedMetadataTemplate};
+use flox_events::{EnvDetail, EventsClient, EventsGuard, EventsHub, SharedMetadataTemplate};
 use flox_rust_sdk::flox::FLOX_VERSION;
+use flox_rust_sdk::models::environment::{ConcreteEnvironment, Environment};
 use flox_rust_sdk::utils::INVOCATION_SOURCES;
 use tracing::debug;
 use uuid::Uuid;
@@ -176,6 +177,34 @@ pub fn install_events_client_for_main(config: &Config, invocation_id: Uuid) -> E
         EventsHub::global().set_client(client);
     }
     EventsGuard::new()
+}
+
+/// Build an [`EnvDetail`] for the supplied [`ConcreteEnvironment`], using
+/// the same env-kind / env-ref mapping the legacy
+/// `environment_subcommand_metric!` macro at
+/// `cli/flox/src/utils/metrics.rs:57-71` applies.
+///
+/// This is the **single shared helper** the spec mandates for the new path
+/// — the per-kind match must not be duplicated across `activate`, `push`,
+/// and `pull` call sites. (PR 2's `pull.rs:103` `NewAbbreviated` branch is
+/// the lone exception: it runs before a `ConcreteEnvironment` is
+/// materialized, so it constructs the `EnvDetail` directly from the
+/// `RemoteRef` available there — see the call-site comment.)
+pub fn env_detail_from_concrete(env: &ConcreteEnvironment) -> EnvDetail {
+    match env {
+        ConcreteEnvironment::Remote(environment) => EnvDetail {
+            env_kind: "remote".to_string(),
+            env_ref_or_name: environment.env_ref().to_string(),
+        },
+        ConcreteEnvironment::Managed(environment) => EnvDetail {
+            env_kind: "managed".to_string(),
+            env_ref_or_name: environment.env_ref().to_string(),
+        },
+        ConcreteEnvironment::Path(environment) => EnvDetail {
+            env_kind: "path".to_string(),
+            env_ref_or_name: Environment::name(environment).to_string(),
+        },
+    }
 }
 
 /// Resolve the endpoint URL for the v2 events client.


### PR DESCRIPTION
**Part 3 of 5 — CLI producer telemetry cutover.** Reshapes the environment-related signal onto the v2 pipeline for `flox activate` / `push` / `pull`. Still **dormant**.

## What this PR does

Attaches the **environment detail** the legacy `environment_subcommand_metric!` macro captures today (env kind + ref/name) onto new typed v2 events for `activate`, `push`, and `pull`, so the cutover preserves the env-related `cli.telemetry` columns. This is **existing data reshaped** onto the new pipeline — not a new metric. The legacy macros stay at every call site; both pipelines emit in parallel through the dormant phase, and the cutover PR flips production traffic.

## New event variants

Three `EventKind` variants land on `flox-events`: `cli.environment.activate`, `cli.environment.push`, `cli.environment.pull`. Each payload carries the shared `CommandPayload` (stamped by PR&nbsp;2) plus a flattened `EnvDetail { env_kind, env_ref_or_name }` that normalizes the legacy three-way `remote_environment` / `managed_environment` / `path_environment` split into one uniform pair of columns.

`CliEnvironmentActivatePayload` additionally carries the activate-specific extras — `start_services`, `mode`, `has_includes`, `lockfile_version`, `shell` — each `Option` with `skip_serializing_if = "Option::is_none"`, so a call site that knows only one extra emits only that field on the wire.

## The one place env-detail is derived

The env-kind / env-ref derivation lives in **exactly one** function — `env_detail_from_concrete(&ConcreteEnvironment)` in `cli/flox/src/utils/events.rs`. It mirrors the legacy macro's match (`Remote`/`Managed` → `env_ref()`, `Path` → `Environment::name(..)`) so the parity baseline is auditable in one place and never duplicated across call sites.

## Per-site dispositions (what maps to what)

- **`activate`** — the start-services/mode site → `cli.environment.activate` with `start_services` + `mode`; the `has_includes` site → same event with `has_includes`; the `shell` site → same event with `shell`.
- **`activate#version` pseudo-subcommand is dropped** on the new path; `lockfile_version` rides on a real `cli.environment.activate` event instead.
- **`push`** → `cli.environment.push`.
- **`pull`** — the `RemoteUpdate` branch → `cli.environment.pull` via the shared helper; the `NewAbbreviated` branch runs *before* a `ConcreteEnvironment` is materialized, so it constructs the `EnvDetail` directly from the `RemoteRef` with `env_kind = "managed"`, matching the legacy `managed_environment = remote.to_string()` extra.

## Lifecycle

Every `cli.environment.activate` event is emitted at its call site *before* `command.exec()` in `activate`. PR&nbsp;2's pre-exec `command_completed` + flush block flushes the buffered env-detail events synchronously, so the user shell never inherits an unsent buffer.

## Behavior & testing

Behavior-neutral (dormant); errors from the dormant path are logged at `debug!` and swallowed, never affecting exit codes. Wire-shape golden fixtures cover each env kind for `cli.environment.activate` (remote / managed / path) plus a no-extras case asserting every Optional field is omitted, and goldens for `push` and `pull`. Compiles + `rustfmt`-clean under the pinned toolchain; `flox-events` suite passes.

---
### Stack — review bottom-up
1. #4414 — pipeline foundation
2. #4415 — wire the pipeline
3. **#4416 — environment-group commands (this PR)** → #4415
4. #4417 — instrument package-group commands
5. #4418 — instrument remaining subcommands

🤖 Generated with [Claude Code](https://claude.com/claude-code)
