### PR TITLE
feat(events): instrument package-group commands (dormant)

### DIFF
--- a/cli/flox-events/src/client.rs
+++ b/cli/flox-events/src/client.rs
@@ -12,9 +12,13 @@ use crate::{
     CliEnvironmentActivatePayload,
     CliEnvironmentPullPayload,
     CliEnvironmentPushPayload,
+    CliPackageInstallPayload,
+    CliPackageUninstallPayload,
+    CliPackageUpgradePayload,
     EnvDetail,
     Event,
     EventKind,
+    PackageOutcome,
     SharedMetadataTemplate,
 };
 
@@ -142,6 +146,36 @@ impl EventsClient {
             env_detail,
         );
         self.record_event(EventKind::CliEnvironmentPull(payload))
+    }
+
+    /// Record a `cli.package.install` event for one package + its outcome.
+    pub fn record_package_install(&self, package: String, outcome: PackageOutcome) -> Result<()> {
+        let payload = CliPackageInstallPayload::new(
+            self.shared_metadata.into_payload("install".to_string()),
+            package,
+            outcome,
+        );
+        self.record_event(EventKind::CliPackageInstall(payload))
+    }
+
+    /// Record a `cli.package.upgrade` event for one package + its outcome.
+    pub fn record_package_upgrade(&self, package: String, outcome: PackageOutcome) -> Result<()> {
+        let payload = CliPackageUpgradePayload::new(
+            self.shared_metadata.into_payload("upgrade".to_string()),
+            package,
+            outcome,
+        );
+        self.record_event(EventKind::CliPackageUpgrade(payload))
+    }
+
+    /// Record a `cli.package.uninstall` event for one package + its outcome.
+    pub fn record_package_uninstall(&self, package: String, outcome: PackageOutcome) -> Result<()> {
+        let payload = CliPackageUninstallPayload::new(
+            self.shared_metadata.into_payload("uninstall".to_string()),
+            package,
+            outcome,
+        );
+        self.record_event(EventKind::CliPackageUninstall(payload))
     }
 
     pub fn record_event(&self, kind: impl Into<EventKind>) -> Result<()> {

--- a/cli/flox-events/src/hub.rs
+++ b/cli/flox-events/src/hub.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use tracing::debug;
 
 use crate::client::EventsClient;
-use crate::{CliEnvironmentActivatePayload, EnvDetail, EventKind};
+use crate::{CliEnvironmentActivatePayload, EnvDetail, EventKind, PackageOutcome};
 
 static EVENTS_HUB: LazyLock<EventsHub> = LazyLock::new(EventsHub::new);
 
@@ -154,6 +154,42 @@ impl EventsHub {
                 return Ok(());
             };
             client.record_environment_pull(env_detail)
+        })
+    }
+
+    /// Record a `cli.package.install` event for one package + its outcome.
+    /// No-op when no client is installed.
+    pub fn record_package_install(&self, package: String, outcome: PackageOutcome) -> Result<()> {
+        self.with_client(|client| {
+            let Some(client) = client else {
+                debug!("No v2 events client configured, skipping package.install record");
+                return Ok(());
+            };
+            client.record_package_install(package, outcome)
+        })
+    }
+
+    /// Record a `cli.package.upgrade` event for one package + its outcome.
+    /// No-op when no client is installed.
+    pub fn record_package_upgrade(&self, package: String, outcome: PackageOutcome) -> Result<()> {
+        self.with_client(|client| {
+            let Some(client) = client else {
+                debug!("No v2 events client configured, skipping package.upgrade record");
+                return Ok(());
+            };
+            client.record_package_upgrade(package, outcome)
+        })
+    }
+
+    /// Record a `cli.package.uninstall` event for one package + its outcome.
+    /// No-op when no client is installed.
+    pub fn record_package_uninstall(&self, package: String, outcome: PackageOutcome) -> Result<()> {
+        self.with_client(|client| {
+            let Some(client) = client else {
+                debug!("No v2 events client configured, skipping package.uninstall record");
+                return Ok(());
+            };
+            client.record_package_uninstall(package, outcome)
         })
     }
 

--- a/cli/flox-events/src/lib.rs
+++ b/cli/flox-events/src/lib.rs
@@ -127,6 +127,12 @@ pub enum EventKind {
     CliEnvironmentPush(CliEnvironmentPushPayload),
     #[serde(rename = "cli.environment.pull")]
     CliEnvironmentPull(CliEnvironmentPullPayload),
+    #[serde(rename = "cli.package.install")]
+    CliPackageInstall(CliPackageInstallPayload),
+    #[serde(rename = "cli.package.upgrade")]
+    CliPackageUpgrade(CliPackageUpgradePayload),
+    #[serde(rename = "cli.package.uninstall")]
+    CliPackageUninstall(CliPackageUninstallPayload),
 }
 
 /// Shared metadata fields stamped onto every `cli.*` command event payload.
@@ -342,6 +348,88 @@ impl CliEnvironmentPullPayload {
         Self {
             command,
             env_detail,
+        }
+    }
+}
+
+/// Outcome of an individual package's install / upgrade / uninstall
+/// attempt within a single `flox <command>` invocation.
+///
+/// `Failed` is recorded on a best-effort basis from a single error-handling
+/// site (e.g. `Install::handle_error` in `cli/flox/src/commands/install.rs`).
+/// On a `?`-propagated mid-pipeline failure the consumer should not treat
+/// the absence of a `Success` event as proof of failure — only the explicit
+/// `Failed` event is authoritative.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum PackageOutcome {
+    Success,
+    Failed,
+}
+
+/// Payload for [`EventKind::CliPackageInstall`]. One event is emitted per
+/// package on the success branch (with `PackageOutcome::Success`) and per
+/// package on the failure branch (with `PackageOutcome::Failed`) — see
+/// the `cli/flox/src/commands/install.rs` call sites for the emission
+/// points.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CliPackageInstallPayload {
+    #[serde(flatten)]
+    pub command: CommandPayload,
+    /// Per-package identifier matching what
+    /// `Install::format_packages_for_tracing` joins into the legacy
+    /// `failed_packages` string (catalog `pkg_path`, flake URL, or store
+    /// path).
+    pub package: String,
+    pub outcome: PackageOutcome,
+}
+
+impl CliPackageInstallPayload {
+    pub fn new(command: CommandPayload, package: String, outcome: PackageOutcome) -> Self {
+        Self {
+            command,
+            package,
+            outcome,
+        }
+    }
+}
+
+/// Payload for [`EventKind::CliPackageUpgrade`]. One event per
+/// upgraded package on the success branch.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CliPackageUpgradePayload {
+    #[serde(flatten)]
+    pub command: CommandPayload,
+    pub package: String,
+    pub outcome: PackageOutcome,
+}
+
+impl CliPackageUpgradePayload {
+    pub fn new(command: CommandPayload, package: String, outcome: PackageOutcome) -> Self {
+        Self {
+            command,
+            package,
+            outcome,
+        }
+    }
+}
+
+/// Payload for [`EventKind::CliPackageUninstall`]. One event per
+/// removed package on the success branch.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CliPackageUninstallPayload {
+    #[serde(flatten)]
+    pub command: CommandPayload,
+    pub package: String,
+    pub outcome: PackageOutcome,
+}
+
+impl CliPackageUninstallPayload {
+    pub fn new(command: CommandPayload, package: String, outcome: PackageOutcome) -> Self {
+        Self {
+            command,
+            package,
+            outcome,
         }
     }
 }
@@ -612,6 +700,80 @@ mod tests {
             "event_type": "cli.environment.pull",
             "payload": payload_json,
         });
+        assert_eq!(value, expected);
+    }
+
+    fn package_envelope_json(
+        event_type: &str,
+        subcommand: &str,
+        package: &str,
+        outcome: &str,
+    ) -> serde_json::Value {
+        let mut payload_json = expected_payload_json(subcommand);
+        let payload_obj = payload_json.as_object_mut().expect("payload object");
+        payload_obj.insert("package".to_string(), json!(package));
+        payload_obj.insert("outcome".to_string(), json!(outcome));
+        json!({
+            "event_id": "00000000-0000-0000-0000-000000000000",
+            "event_timestamp": EPOCH_UNIX_MS,
+            "source": "cli",
+            "invocation_id": "00000000-0000-0000-0000-000000000000",
+            "device_id": "00000000-0000-0000-0000-000000000000",
+            "event_type": event_type,
+            "payload": payload_json,
+        })
+    }
+
+    #[test]
+    fn cli_package_install_success_envelope_golden() {
+        let payload = CliPackageInstallPayload::new(
+            command_payload("install"),
+            "hello".to_string(),
+            PackageOutcome::Success,
+        );
+        let value = serde_json::to_value(fixed_event(EventKind::CliPackageInstall(payload)))
+            .expect("event serializes");
+        let expected = package_envelope_json("cli.package.install", "install", "hello", "success");
+        assert_eq!(value, expected);
+    }
+
+    #[test]
+    fn cli_package_install_failure_envelope_golden() {
+        let payload = CliPackageInstallPayload::new(
+            command_payload("install"),
+            "nope".to_string(),
+            PackageOutcome::Failed,
+        );
+        let value = serde_json::to_value(fixed_event(EventKind::CliPackageInstall(payload)))
+            .expect("event serializes");
+        let expected = package_envelope_json("cli.package.install", "install", "nope", "failed");
+        assert_eq!(value, expected);
+    }
+
+    #[test]
+    fn cli_package_upgrade_envelope_golden() {
+        let payload = CliPackageUpgradePayload::new(
+            command_payload("upgrade"),
+            "hello".to_string(),
+            PackageOutcome::Success,
+        );
+        let value = serde_json::to_value(fixed_event(EventKind::CliPackageUpgrade(payload)))
+            .expect("event serializes");
+        let expected = package_envelope_json("cli.package.upgrade", "upgrade", "hello", "success");
+        assert_eq!(value, expected);
+    }
+
+    #[test]
+    fn cli_package_uninstall_envelope_golden() {
+        let payload = CliPackageUninstallPayload::new(
+            command_payload("uninstall"),
+            "hello".to_string(),
+            PackageOutcome::Success,
+        );
+        let value = serde_json::to_value(fixed_event(EventKind::CliPackageUninstall(payload)))
+            .expect("event serializes");
+        let expected =
+            package_envelope_json("cli.package.uninstall", "uninstall", "hello", "success");
         assert_eq!(value, expected);
     }
 }
@@ -960,5 +1122,84 @@ mod pipeline_tests {
                 .sum::<usize>(),
             1
         );
+    }
+
+    /// Mirrors the spec's "install pkgA pkgB (all succeed)" partial-
+    /// success case: one `cli.package.install` event per package with
+    /// `outcome = success`, all sharing one `invocation_id`.
+    #[test]
+    fn package_install_all_succeed_one_event_per_package() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let connection = MockEventsConnection::default();
+        let sent_batches = connection.sent_batches();
+        let hub = EventsHub::new();
+        hub.set_client(client_with_connection(&tempdir, connection));
+
+        hub.record_package_install("pkgA".to_string(), PackageOutcome::Success)
+            .expect("record pkgA");
+        hub.record_package_install("pkgB".to_string(), PackageOutcome::Success)
+            .expect("record pkgB");
+        hub.flush(true).expect("flush events");
+
+        let events: Vec<_> = sent_batches
+            .lock()
+            .unwrap()
+            .clone()
+            .into_iter()
+            .flatten()
+            .collect();
+        assert_eq!(events.len(), 2);
+        let mut packages = Vec::new();
+        for event in &events {
+            match &event.kind {
+                EventKind::CliPackageInstall(p) => {
+                    assert_eq!(p.outcome, PackageOutcome::Success);
+                    packages.push(p.package.clone());
+                },
+                other => panic!("expected CliPackageInstall, got {other:?}"),
+            }
+            assert_eq!(event.invocation_id, INVOCATION_ID);
+        }
+        packages.sort();
+        assert_eq!(packages, vec!["pkgA".to_string(), "pkgB".to_string()]);
+    }
+
+    /// Mirrors the spec's "install pkgA nope" partial-failure case: the
+    /// new pipeline's failure-path emit records every attempted package
+    /// (the `?`-propagated equivalent the spec calls out), not just the
+    /// one that failed.
+    #[test]
+    fn package_install_failure_path_records_every_attempted_package() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let connection = MockEventsConnection::default();
+        let sent_batches = connection.sent_batches();
+        let hub = EventsHub::new();
+        hub.set_client(client_with_connection(&tempdir, connection));
+
+        // Simulating `Install::handle_error` calling
+        // `record_package_install` for every attempted package on a
+        // mid-pipeline failure.
+        for package in ["pkgA", "nope"] {
+            hub.record_package_install(package.to_string(), PackageOutcome::Failed)
+                .expect("record failure");
+        }
+        hub.flush(true).expect("flush events");
+
+        let events: Vec<_> = sent_batches
+            .lock()
+            .unwrap()
+            .clone()
+            .into_iter()
+            .flatten()
+            .collect();
+        assert_eq!(events.len(), 2);
+        for event in &events {
+            match &event.kind {
+                EventKind::CliPackageInstall(p) => {
+                    assert_eq!(p.outcome, PackageOutcome::Failed);
+                },
+                other => panic!("expected CliPackageInstall, got {other:?}"),
+            }
+        }
     }
 }

--- a/cli/flox-events/src/lib.rs
+++ b/cli/flox-events/src/lib.rs
@@ -355,21 +355,30 @@ impl CliEnvironmentPullPayload {
 /// Outcome of an individual package's install / upgrade / uninstall
 /// attempt within a single `flox <command>` invocation.
 ///
-/// `Failed` is recorded on a best-effort basis from a single error-handling
-/// site (e.g. `Install::handle_error` in `cli/flox/src/commands/install.rs`).
-/// On a `?`-propagated mid-pipeline failure the consumer should not treat
-/// the absence of a `Success` event as proof of failure — only the explicit
-/// `Failed` event is authoritative.
+/// Recorded best-effort from a single error-handling site (e.g.
+/// `Install::handle_error` in `cli/flox/src/commands/install.rs`); the
+/// outcome value is ambiguous in two directions and consumers must
+/// account for both:
+///
+/// - **Absence of `Success` is not proof of failure.** A `?`-propagated
+///   early exit from inside the install pipeline skips the success-branch
+///   emit; no per-package record is written for any package the
+///   invocation attempted.
+/// - **Presence of `Failure` is not proof that *that specific package*
+///   failed.** On a partial-failure invocation the failure-branch emit
+///   marks every attempted package `Failure` because the partition of
+///   succeeded vs failed packages has not been computed at that site —
+///   matching the legacy packed `failed_packages` string's semantics.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum PackageOutcome {
     Success,
-    Failed,
+    Failure,
 }
 
 /// Payload for [`EventKind::CliPackageInstall`]. One event is emitted per
 /// package on the success branch (with `PackageOutcome::Success`) and per
-/// package on the failure branch (with `PackageOutcome::Failed`) — see
+/// package on the failure branch (with `PackageOutcome::Failure`) — see
 /// the `cli/flox/src/commands/install.rs` call sites for the emission
 /// points.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -742,11 +751,11 @@ mod tests {
         let payload = CliPackageInstallPayload::new(
             command_payload("install"),
             "nope".to_string(),
-            PackageOutcome::Failed,
+            PackageOutcome::Failure,
         );
         let value = serde_json::to_value(fixed_event(EventKind::CliPackageInstall(payload)))
             .expect("event serializes");
-        let expected = package_envelope_json("cli.package.install", "install", "nope", "failed");
+        let expected = package_envelope_json("cli.package.install", "install", "nope", "failure");
         assert_eq!(value, expected);
     }
 
@@ -1180,7 +1189,7 @@ mod pipeline_tests {
         // `record_package_install` for every attempted package on a
         // mid-pipeline failure.
         for package in ["pkgA", "nope"] {
-            hub.record_package_install(package.to_string(), PackageOutcome::Failed)
+            hub.record_package_install(package.to_string(), PackageOutcome::Failure)
                 .expect("record failure");
         }
         hub.flush(true).expect("flush events");
@@ -1196,7 +1205,7 @@ mod pipeline_tests {
         for event in &events {
             match &event.kind {
                 EventKind::CliPackageInstall(p) => {
-                    assert_eq!(p.outcome, PackageOutcome::Failed);
+                    assert_eq!(p.outcome, PackageOutcome::Failure);
                 },
                 other => panic!("expected CliPackageInstall, got {other:?}"),
             }

--- a/cli/flox/src/commands/install.rs
+++ b/cli/flox/src/commands/install.rs
@@ -293,13 +293,11 @@ impl Install {
             warn_manifest_changes_for_services(&flox, &concrete_environment);
         }
 
-        // Per-package success events on the new pipeline. The legacy path
-        // emits nothing per-package on success; this is the intended
-        // net-new signal called out in PR 6 Merge gate #2's enumerated
-        // correction list. Dispatched before the dispatcher's
-        // `command_completed` (cli_worker emits that after this `handle`
-        // returns), so the per-package events correlate with the same
-        // invocation downstream.
+        // Both telemetry stacks emit in parallel through the dormant
+        // phase; the new-pipeline per-package mirrors in this PR are
+        // no-ops in production until the cutover installs an
+        // `EventsHub` client. Net-new on this branch: legacy emits
+        // nothing per-package on success.
         let hub = EventsHub::global();
         for package in &packages_to_install {
             if let Err(err) = hub.record_package_install(
@@ -314,10 +312,7 @@ impl Install {
     }
 
     fn format_packages_for_tracing(packages: &[PackageToInstall]) -> String {
-        packages
-            .iter()
-            .map(|p| Install::package_identifier(p))
-            .join(",")
+        packages.iter().map(Install::package_identifier).join(",")
     }
 
     /// Per-package identifier emitted on `cli.package.install` events.
@@ -496,16 +491,11 @@ impl Install {
             "failed_packages" = Install::format_packages_for_tracing(packages)
         );
 
-        // Per-package failure events on the new pipeline. Mirrors the legacy
-        // packed `failed_packages` string above, unpacked into one event
-        // per attempted package so the consumer can count failures by
-        // package rather than parse a comma-joined string (intended
-        // correction per PR 6 Merge gate #2).
         let hub = EventsHub::global();
         for package in packages {
             if let Err(err) = hub.record_package_install(
                 Install::package_identifier(package),
-                PackageOutcome::Failed,
+                PackageOutcome::Failure,
             ) {
                 debug!(error = %err, "Failed to record v2 event");
             }

--- a/cli/flox/src/commands/install.rs
+++ b/cli/flox/src/commands/install.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result, anyhow, bail};
 use bpaf::Bpaf;
 use flox_core::data::environment_ref::DEFAULT_NAME;
+use flox_events::{EventsHub, PackageOutcome};
 use flox_manifest::compose::{
     COMPOSER_MANIFEST_ID,
     new_package_overrides,
@@ -292,18 +293,42 @@ impl Install {
             warn_manifest_changes_for_services(&flox, &concrete_environment);
         }
 
+        // Per-package success events on the new pipeline. The legacy path
+        // emits nothing per-package on success; this is the intended
+        // net-new signal called out in PR 6 Merge gate #2's enumerated
+        // correction list. Dispatched before the dispatcher's
+        // `command_completed` (cli_worker emits that after this `handle`
+        // returns), so the per-package events correlate with the same
+        // invocation downstream.
+        let hub = EventsHub::global();
+        for package in &packages_to_install {
+            if let Err(err) = hub.record_package_install(
+                Install::package_identifier(package),
+                PackageOutcome::Success,
+            ) {
+                debug!(error = %err, "Failed to record v2 event");
+            }
+        }
+
         Ok(())
     }
 
     fn format_packages_for_tracing(packages: &[PackageToInstall]) -> String {
         packages
             .iter()
-            .map(|p| match p {
-                PackageToInstall::Catalog(pkg) => pkg.pkg_path.clone(),
-                PackageToInstall::Flake(pkg) => pkg.url.to_string(),
-                PackageToInstall::StorePath(pkg) => pkg.store_path.display().to_string(),
-            })
+            .map(|p| Install::package_identifier(p))
             .join(",")
+    }
+
+    /// Per-package identifier emitted on `cli.package.install` events.
+    /// Same source values as [`Install::format_packages_for_tracing`]
+    /// joins into the legacy `failed_packages` string.
+    fn package_identifier(p: &PackageToInstall) -> String {
+        match p {
+            PackageToInstall::Catalog(pkg) => pkg.pkg_path.clone(),
+            PackageToInstall::Flake(pkg) => pkg.url.to_string(),
+            PackageToInstall::StorePath(pkg) => pkg.store_path.display().to_string(),
+        }
     }
 
     fn partition_installed_packages(
@@ -470,6 +495,21 @@ impl Install {
             "install",
             "failed_packages" = Install::format_packages_for_tracing(packages)
         );
+
+        // Per-package failure events on the new pipeline. Mirrors the legacy
+        // packed `failed_packages` string above, unpacked into one event
+        // per attempted package so the consumer can count failures by
+        // package rather than parse a comma-joined string (intended
+        // correction per PR 6 Merge gate #2).
+        let hub = EventsHub::global();
+        for package in packages {
+            if let Err(err) = hub.record_package_install(
+                Install::package_identifier(package),
+                PackageOutcome::Failed,
+            ) {
+                debug!(error = %err, "Failed to record v2 event");
+            }
+        }
 
         match err {
             // Try to make suggestions when a package isn't found

--- a/cli/flox/src/commands/uninstall.rs
+++ b/cli/flox/src/commands/uninstall.rs
@@ -1,5 +1,6 @@
 use anyhow::{Result, bail};
 use bpaf::Bpaf;
+use flox_events::{EventsHub, PackageOutcome};
 use flox_manifest::parsed::latest::SelectedOutputs;
 use flox_manifest::raw::PackageModification;
 use flox_rust_sdk::flox::Flox;
@@ -123,6 +124,19 @@ impl Uninstall {
         }
 
         warn_manifest_changes_for_services(&flox, &concrete_environment);
+
+        // Per-package success events on the new pipeline. One event per
+        // package the uninstall actually touched (the iteration above
+        // already gates on the same `attempt.modifications` set). Net-
+        // new signal per PR 6 Merge gate #2.
+        let hub = EventsHub::global();
+        for modification in attempt.modifications.iter() {
+            if let Err(err) = hub
+                .record_package_uninstall(modification.install_id.clone(), PackageOutcome::Success)
+            {
+                debug!(error = %err, "Failed to record v2 event");
+            }
+        }
 
         Ok(())
     }

--- a/cli/flox/src/commands/uninstall.rs
+++ b/cli/flox/src/commands/uninstall.rs
@@ -125,10 +125,6 @@ impl Uninstall {
 
         warn_manifest_changes_for_services(&flox, &concrete_environment);
 
-        // Per-package success events on the new pipeline. One event per
-        // package the uninstall actually touched (the iteration above
-        // already gates on the same `attempt.modifications` set). Net-
-        // new signal per PR 6 Merge gate #2.
         let hub = EventsHub::global();
         for modification in attempt.modifications.iter() {
             if let Err(err) = hub

--- a/cli/flox/src/commands/uninstall.rs
+++ b/cli/flox/src/commands/uninstall.rs
@@ -127,6 +127,13 @@ impl Uninstall {
 
         let hub = EventsHub::global();
         for modification in attempt.modifications.iter() {
+            // Only a genuine removal is an uninstall. `UpdateOutputs` trims
+            // some of a package's outputs without removing the package (the
+            // display layer above shows it as "Updated outputs", not
+            // "uninstalled"), so it must not emit a `cli.package.uninstall`.
+            if !matches!(modification.modification, PackageModification::Remove) {
+                continue;
+            }
             if let Err(err) = hub
                 .record_package_uninstall(modification.install_id.clone(), PackageOutcome::Success)
             {

--- a/cli/flox/src/commands/upgrade.rs
+++ b/cli/flox/src/commands/upgrade.rs
@@ -1,12 +1,13 @@
 use anyhow::Result;
 use bpaf::Bpaf;
 use crossterm::style::Stylize;
+use flox_events::{EventsHub, PackageOutcome};
 use flox_manifest::lockfile::LockedPackage;
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::{Environment, SingleSystemUpgradeDiff};
 use indoc::formatdoc;
 use itertools::Itertools;
-use tracing::{info_span, instrument};
+use tracing::{debug, info_span, instrument};
 
 use super::services::warn_manifest_changes_for_services;
 use super::{EnvironmentSelect, environment_select};
@@ -148,6 +149,20 @@ impl Upgrade {
         }
 
         warn_manifest_changes_for_services(&flox, &concrete_environment);
+
+        // Per-package success events on the new pipeline. One event per
+        // package that was actually upgraded on the current system —
+        // dry-run paths and "no upgrades available" returns earlier never
+        // reach here, so they never emit. Net-new signal per PR 6 Merge
+        // gate #2.
+        let hub = EventsHub::global();
+        for (_, (before, _after)) in diff_for_system.iter() {
+            if let Err(err) =
+                hub.record_package_upgrade(before.install_id().to_string(), PackageOutcome::Success)
+            {
+                debug!(error = %err, "Failed to record v2 event");
+            }
+        }
 
         Ok(())
     }

--- a/cli/flox/src/commands/upgrade.rs
+++ b/cli/flox/src/commands/upgrade.rs
@@ -150,13 +150,8 @@ impl Upgrade {
 
         warn_manifest_changes_for_services(&flox, &concrete_environment);
 
-        // Per-package success events on the new pipeline. One event per
-        // package that was actually upgraded on the current system —
-        // dry-run paths and "no upgrades available" returns earlier never
-        // reach here, so they never emit. Net-new signal per PR 6 Merge
-        // gate #2.
         let hub = EventsHub::global();
-        for (_, (before, _after)) in diff_for_system.iter() {
+        for (_, (before, _)) in diff_for_system.iter() {
             if let Err(err) =
                 hub.record_package_upgrade(before.install_id().to_string(), PackageOutcome::Success)
             {


### PR DESCRIPTION
**Part 4 of 5 — CLI producer telemetry cutover.** Reshapes the package-command signal into a per-package form for `flox install` / `upgrade` / `uninstall`. Still **dormant**.

## What this PR does

Restructures the package-command signals into a **counted-objects** form: one event per package rather than the legacy packed comma-string. Note this is partly a deliberate **signal change**, not a pure reshape:

- **Success branch — net-new signal.** The legacy path emits nothing per-package on success; this PR emits one event per package with its outcome.
- **Failure branch — reshape.** The legacy packed `failed_packages` extra (one emit) becomes one event per attempted package.

Both are intended corrections that the cutover PR's sign-off list enumerates. The new pipeline stays dormant; legacy macros are untouched at every call site.

## New event variants

Three `EventKind` variants land on `flox-events`: `cli.package.install`, `cli.package.upgrade`, `cli.package.uninstall`. Each payload carries the shared `CommandPayload` (from PR&nbsp;2) plus a per-package `package: String` and an `outcome: PackageOutcome` enum (`success` / `failure`, serialized lowercase). No env detail here — the corresponding env-bearing sites get env detail on the new path in PR&nbsp;5, alongside the other env-bearing subcommands.

## Per-site dispositions

- **`install` success** — emit `cli.package.install` per package to install with `outcome = success`, just before the dispatcher's `command_completed`.
- **`install` failure** — emit `cli.package.install` per attempted package with `outcome = failure`, at the same site as the legacy `failed_packages` extra, so a `?`-propagated mid-pipeline failure still records outcomes. On a partial failure (e.g. `install pkgA nope`) every attempted package is marked failed, because at that point the pipeline has not yet partitioned successes from failures — same semantics as the legacy packed-string emit.
- **`upgrade` success** — emit `cli.package.upgrade` per upgraded entry with `outcome = success`. Dry-run and "no upgrades available" early returns never reach this site, so they emit nothing.
- **`uninstall` success** — emit `cli.package.uninstall` per removed entry with `outcome = success`.

A small `Install::package_identifier(&PackageToInstall) -> String` helper extracts the **same** per-package identifier the legacy code joins into its packed string, so the new event's `package` field carries the same byte sequence a comma-split of the legacy string would.

## Behavior & testing

Behavior-neutral (dormant); dormant-path errors are logged at `debug!` and swallowed. Wire-shape golden fixtures cover all three variants (install success / install failure / upgrade / uninstall), plus pipeline-level tests through `MockEventsConnection` mirroring the all-succeed (`install pkgA pkgB`) and partial-failure (`install pkgA nope`) cases. Compiles + `rustfmt`-clean under the pinned toolchain; `flox-events` suite passes.

---
### Stack — review bottom-up
1. #4414 — pipeline foundation
2. #4415 — wire the pipeline
3. #4416 — environment-group commands
4. **#4417 — package-group commands (this PR)** → #4416
5. #4418 — instrument remaining subcommands

🤖 Generated with [Claude Code](https://claude.com/claude-code)
