### PR TITLE
feat(events): instrument remaining subcommands (dormant)

### DIFF
--- a/cli/flox-events/src/client.rs
+++ b/cli/flox-events/src/client.rs
@@ -18,7 +18,7 @@ use crate::{
     CliEnvironmentGenerationsListPayload,
     CliEnvironmentGenerationsRollbackPayload,
     CliEnvironmentGenerationsSwitchPayload,
-    CliEnvironmentIncludePayload,
+    CliEnvironmentIncludeUpgradePayload,
     CliEnvironmentInstallPayload,
     CliEnvironmentListPayload,
     CliEnvironmentPublishPayload,
@@ -199,8 +199,6 @@ impl EventsClient {
         self.record_event(EventKind::CliPackageUninstall(payload))
     }
 
-    // -------- PR 5: env-detail-only commands --------
-
     /// Record a `cli.environment.containerize` event with env detail.
     pub fn record_environment_containerize(&self, env_detail: EnvDetail) -> Result<()> {
         let payload = CliEnvironmentContainerizePayload::new(
@@ -220,18 +218,19 @@ impl EventsClient {
         self.record_event(EventKind::CliEnvironmentDelete(payload))
     }
 
-    /// Record a `cli.environment.include` event with env detail.
-    pub fn record_environment_include(&self, env_detail: EnvDetail) -> Result<()> {
-        let payload = CliEnvironmentIncludePayload::new(
+    /// Record a `cli.environment.include.upgrade` event with env
+    /// detail.
+    pub fn record_environment_include_upgrade(&self, env_detail: EnvDetail) -> Result<()> {
+        let payload = CliEnvironmentIncludeUpgradePayload::new(
             self.shared_metadata
                 .into_payload("include::upgrade".to_string()),
             env_detail,
         );
-        self.record_event(EventKind::CliEnvironmentInclude(payload))
+        self.record_event(EventKind::CliEnvironmentIncludeUpgrade(payload))
     }
 
     /// Record a `cli.environment.install` event with env detail.
-    /// The per-package detail rides on `cli.package.install` (PR 4).
+    /// The per-package detail rides on `cli.package.install`.
     pub fn record_environment_install(&self, env_detail: EnvDetail) -> Result<()> {
         let payload = CliEnvironmentInstallPayload::new(
             self.shared_metadata.into_payload("install".to_string()),
@@ -250,7 +249,7 @@ impl EventsClient {
     }
 
     /// Record a `cli.environment.uninstall` event with env detail.
-    /// The per-package detail rides on `cli.package.uninstall` (PR 4).
+    /// The per-package detail rides on `cli.package.uninstall`.
     pub fn record_environment_uninstall(&self, env_detail: EnvDetail) -> Result<()> {
         let payload = CliEnvironmentUninstallPayload::new(
             self.shared_metadata.into_payload("uninstall".to_string()),
@@ -260,7 +259,7 @@ impl EventsClient {
     }
 
     /// Record a `cli.environment.upgrade` event with env detail.
-    /// The per-package detail rides on `cli.package.upgrade` (PR 4).
+    /// The per-package detail rides on `cli.package.upgrade`.
     pub fn record_environment_upgrade(&self, env_detail: EnvDetail) -> Result<()> {
         let payload = CliEnvironmentUpgradePayload::new(
             self.shared_metadata.into_payload("upgrade".to_string()),
@@ -359,8 +358,6 @@ impl EventsClient {
         self.record_event(EventKind::CliEnvironmentGenerationsSwitch(payload))
     }
 
-    // -------- PR 5: env-detail + Optional extras commands --------
-
     /// Record a `cli.environment.edit` event with just env detail.
     /// Used at the eager call site (before the edit operation runs);
     /// the `edited_includes` field is left unpopulated and the
@@ -428,8 +425,6 @@ impl EventsClient {
         );
         self.record_event(EventKind::CliEnvironmentGenerationsList(extras(payload)))
     }
-
-    // -------- PR 5: no-env extras commands --------
 
     /// Record a `cli.build` event carrying build-kind detection flags.
     pub fn record_build(&self, has_expression_build: bool, has_manifest_build: bool) -> Result<()> {

--- a/cli/flox-events/src/client.rs
+++ b/cli/flox-events/src/client.rs
@@ -7,14 +7,35 @@ use uuid::Uuid;
 use crate::buffer::EventsBuffer;
 use crate::connection::{EventsConnection, EventsConnectionV2};
 use crate::{
+    CliBuildPayload,
     CliCommandCompletedPayload,
     CliCommandRunPayload,
     CliEnvironmentActivatePayload,
+    CliEnvironmentContainerizePayload,
+    CliEnvironmentDeletePayload,
+    CliEnvironmentEditPayload,
+    CliEnvironmentGenerationsHistoryPayload,
+    CliEnvironmentGenerationsListPayload,
+    CliEnvironmentGenerationsRollbackPayload,
+    CliEnvironmentGenerationsSwitchPayload,
+    CliEnvironmentIncludePayload,
+    CliEnvironmentInstallPayload,
+    CliEnvironmentListPayload,
+    CliEnvironmentPublishPayload,
     CliEnvironmentPullPayload,
     CliEnvironmentPushPayload,
+    CliEnvironmentServicesLogsPayload,
+    CliEnvironmentServicesPersistPayload,
+    CliEnvironmentServicesRestartPayload,
+    CliEnvironmentServicesStartPayload,
+    CliEnvironmentServicesStatusPayload,
+    CliEnvironmentServicesStopPayload,
+    CliEnvironmentUninstallPayload,
+    CliEnvironmentUpgradePayload,
     CliPackageInstallPayload,
     CliPackageUninstallPayload,
     CliPackageUpgradePayload,
+    CliSearchPayload,
     EnvDetail,
     Event,
     EventKind,
@@ -176,6 +197,258 @@ impl EventsClient {
             outcome,
         );
         self.record_event(EventKind::CliPackageUninstall(payload))
+    }
+
+    // -------- PR 5: env-detail-only commands --------
+
+    /// Record a `cli.environment.containerize` event with env detail.
+    pub fn record_environment_containerize(&self, env_detail: EnvDetail) -> Result<()> {
+        let payload = CliEnvironmentContainerizePayload::new(
+            self.shared_metadata
+                .into_payload("containerize".to_string()),
+            env_detail,
+        );
+        self.record_event(EventKind::CliEnvironmentContainerize(payload))
+    }
+
+    /// Record a `cli.environment.delete` event with env detail.
+    pub fn record_environment_delete(&self, env_detail: EnvDetail) -> Result<()> {
+        let payload = CliEnvironmentDeletePayload::new(
+            self.shared_metadata.into_payload("delete".to_string()),
+            env_detail,
+        );
+        self.record_event(EventKind::CliEnvironmentDelete(payload))
+    }
+
+    /// Record a `cli.environment.include` event with env detail.
+    pub fn record_environment_include(&self, env_detail: EnvDetail) -> Result<()> {
+        let payload = CliEnvironmentIncludePayload::new(
+            self.shared_metadata
+                .into_payload("include::upgrade".to_string()),
+            env_detail,
+        );
+        self.record_event(EventKind::CliEnvironmentInclude(payload))
+    }
+
+    /// Record a `cli.environment.install` event with env detail.
+    /// The per-package detail rides on `cli.package.install` (PR 4).
+    pub fn record_environment_install(&self, env_detail: EnvDetail) -> Result<()> {
+        let payload = CliEnvironmentInstallPayload::new(
+            self.shared_metadata.into_payload("install".to_string()),
+            env_detail,
+        );
+        self.record_event(EventKind::CliEnvironmentInstall(payload))
+    }
+
+    /// Record a `cli.environment.list` event with env detail.
+    pub fn record_environment_list(&self, env_detail: EnvDetail) -> Result<()> {
+        let payload = CliEnvironmentListPayload::new(
+            self.shared_metadata.into_payload("list".to_string()),
+            env_detail,
+        );
+        self.record_event(EventKind::CliEnvironmentList(payload))
+    }
+
+    /// Record a `cli.environment.uninstall` event with env detail.
+    /// The per-package detail rides on `cli.package.uninstall` (PR 4).
+    pub fn record_environment_uninstall(&self, env_detail: EnvDetail) -> Result<()> {
+        let payload = CliEnvironmentUninstallPayload::new(
+            self.shared_metadata.into_payload("uninstall".to_string()),
+            env_detail,
+        );
+        self.record_event(EventKind::CliEnvironmentUninstall(payload))
+    }
+
+    /// Record a `cli.environment.upgrade` event with env detail.
+    /// The per-package detail rides on `cli.package.upgrade` (PR 4).
+    pub fn record_environment_upgrade(&self, env_detail: EnvDetail) -> Result<()> {
+        let payload = CliEnvironmentUpgradePayload::new(
+            self.shared_metadata.into_payload("upgrade".to_string()),
+            env_detail,
+        );
+        self.record_event(EventKind::CliEnvironmentUpgrade(payload))
+    }
+
+    /// Record a `cli.environment.services.start` event with env detail.
+    pub fn record_environment_services_start(&self, env_detail: EnvDetail) -> Result<()> {
+        let payload = CliEnvironmentServicesStartPayload::new(
+            self.shared_metadata
+                .into_payload("services::start".to_string()),
+            env_detail,
+        );
+        self.record_event(EventKind::CliEnvironmentServicesStart(payload))
+    }
+
+    /// Record a `cli.environment.services.stop` event with env detail.
+    pub fn record_environment_services_stop(&self, env_detail: EnvDetail) -> Result<()> {
+        let payload = CliEnvironmentServicesStopPayload::new(
+            self.shared_metadata
+                .into_payload("services::stop".to_string()),
+            env_detail,
+        );
+        self.record_event(EventKind::CliEnvironmentServicesStop(payload))
+    }
+
+    /// Record a `cli.environment.services.restart` event with env detail.
+    pub fn record_environment_services_restart(&self, env_detail: EnvDetail) -> Result<()> {
+        let payload = CliEnvironmentServicesRestartPayload::new(
+            self.shared_metadata
+                .into_payload("services::restart".to_string()),
+            env_detail,
+        );
+        self.record_event(EventKind::CliEnvironmentServicesRestart(payload))
+    }
+
+    /// Record a `cli.environment.services.status` event with env detail.
+    pub fn record_environment_services_status(&self, env_detail: EnvDetail) -> Result<()> {
+        let payload = CliEnvironmentServicesStatusPayload::new(
+            self.shared_metadata
+                .into_payload("services::status".to_string()),
+            env_detail,
+        );
+        self.record_event(EventKind::CliEnvironmentServicesStatus(payload))
+    }
+
+    /// Record a `cli.environment.services.logs` event with env detail.
+    pub fn record_environment_services_logs(&self, env_detail: EnvDetail) -> Result<()> {
+        let payload = CliEnvironmentServicesLogsPayload::new(
+            self.shared_metadata
+                .into_payload("services::logs".to_string()),
+            env_detail,
+        );
+        self.record_event(EventKind::CliEnvironmentServicesLogs(payload))
+    }
+
+    /// Record a `cli.environment.services.persist` event with env detail.
+    pub fn record_environment_services_persist(&self, env_detail: EnvDetail) -> Result<()> {
+        let payload = CliEnvironmentServicesPersistPayload::new(
+            self.shared_metadata
+                .into_payload("services::persist".to_string()),
+            env_detail,
+        );
+        self.record_event(EventKind::CliEnvironmentServicesPersist(payload))
+    }
+
+    /// Record a `cli.environment.generations.history` event with env detail.
+    pub fn record_environment_generations_history(&self, env_detail: EnvDetail) -> Result<()> {
+        let payload = CliEnvironmentGenerationsHistoryPayload::new(
+            self.shared_metadata
+                .into_payload("generations::history".to_string()),
+            env_detail,
+        );
+        self.record_event(EventKind::CliEnvironmentGenerationsHistory(payload))
+    }
+
+    /// Record a `cli.environment.generations.rollback` event with env detail.
+    pub fn record_environment_generations_rollback(&self, env_detail: EnvDetail) -> Result<()> {
+        let payload = CliEnvironmentGenerationsRollbackPayload::new(
+            self.shared_metadata
+                .into_payload("generations::rollback".to_string()),
+            env_detail,
+        );
+        self.record_event(EventKind::CliEnvironmentGenerationsRollback(payload))
+    }
+
+    /// Record a `cli.environment.generations.switch` event with env detail.
+    pub fn record_environment_generations_switch(&self, env_detail: EnvDetail) -> Result<()> {
+        let payload = CliEnvironmentGenerationsSwitchPayload::new(
+            self.shared_metadata
+                .into_payload("generations::switch".to_string()),
+            env_detail,
+        );
+        self.record_event(EventKind::CliEnvironmentGenerationsSwitch(payload))
+    }
+
+    // -------- PR 5: env-detail + Optional extras commands --------
+
+    /// Record a `cli.environment.edit` event with just env detail.
+    /// Used at the eager call site (before the edit operation runs);
+    /// the `edited_includes` field is left unpopulated and the
+    /// result-known site emits a second event via
+    /// [`Self::record_environment_edit_with`].
+    pub fn record_environment_edit(&self, env_detail: EnvDetail) -> Result<()> {
+        let payload = CliEnvironmentEditPayload::new(
+            self.shared_metadata.into_payload("edit".to_string()),
+            env_detail,
+        );
+        self.record_event(EventKind::CliEnvironmentEdit(payload))
+    }
+
+    /// Record a `cli.environment.edit` event populated by `extras`.
+    /// Builds the payload from the installed shared metadata + env
+    /// detail and lets the call site set `edited_includes` via the
+    /// builder closure.
+    pub fn record_environment_edit_with(
+        &self,
+        env_detail: EnvDetail,
+        extras: impl FnOnce(CliEnvironmentEditPayload) -> CliEnvironmentEditPayload,
+    ) -> Result<()> {
+        let payload = CliEnvironmentEditPayload::new(
+            self.shared_metadata.into_payload("edit".to_string()),
+            env_detail,
+        );
+        self.record_event(EventKind::CliEnvironmentEdit(extras(payload)))
+    }
+
+    /// Record a `cli.environment.publish` event with just env detail.
+    pub fn record_environment_publish(&self, env_detail: EnvDetail) -> Result<()> {
+        let payload = CliEnvironmentPublishPayload::new(
+            self.shared_metadata.into_payload("publish".to_string()),
+            env_detail,
+        );
+        self.record_event(EventKind::CliEnvironmentPublish(payload))
+    }
+
+    /// Record a `cli.environment.publish` event populated by `extras`.
+    pub fn record_environment_publish_with(
+        &self,
+        env_detail: EnvDetail,
+        extras: impl FnOnce(CliEnvironmentPublishPayload) -> CliEnvironmentPublishPayload,
+    ) -> Result<()> {
+        let payload = CliEnvironmentPublishPayload::new(
+            self.shared_metadata.into_payload("publish".to_string()),
+            env_detail,
+        );
+        self.record_event(EventKind::CliEnvironmentPublish(extras(payload)))
+    }
+
+    /// Record a `cli.environment.generations.list` event populated by
+    /// `extras`. Single call site (no separate eager-emit form).
+    pub fn record_environment_generations_list_with(
+        &self,
+        env_detail: EnvDetail,
+        extras: impl FnOnce(
+            CliEnvironmentGenerationsListPayload,
+        ) -> CliEnvironmentGenerationsListPayload,
+    ) -> Result<()> {
+        let payload = CliEnvironmentGenerationsListPayload::new(
+            self.shared_metadata
+                .into_payload("generations::list".to_string()),
+            env_detail,
+        );
+        self.record_event(EventKind::CliEnvironmentGenerationsList(extras(payload)))
+    }
+
+    // -------- PR 5: no-env extras commands --------
+
+    /// Record a `cli.build` event carrying build-kind detection flags.
+    pub fn record_build(&self, has_expression_build: bool, has_manifest_build: bool) -> Result<()> {
+        let payload = CliBuildPayload::new(
+            self.shared_metadata.into_payload("build".to_string()),
+            has_expression_build,
+            has_manifest_build,
+        );
+        self.record_event(EventKind::CliBuild(payload))
+    }
+
+    /// Record a `cli.search` event carrying the user-supplied search
+    /// term verbatim (D3, 2026-05-30).
+    pub fn record_search(&self, search_term: String) -> Result<()> {
+        let payload = CliSearchPayload::new(
+            self.shared_metadata.into_payload("search".to_string()),
+            search_term,
+        );
+        self.record_event(EventKind::CliSearch(payload))
     }
 
     pub fn record_event(&self, kind: impl Into<EventKind>) -> Result<()> {

--- a/cli/flox-events/src/hub.rs
+++ b/cli/flox-events/src/hub.rs
@@ -2,7 +2,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, LazyLock, Mutex};
 
 use anyhow::Result;
-use tracing::debug;
+use tracing::{debug, trace};
 
 use crate::client::EventsClient;
 use crate::{
@@ -56,7 +56,7 @@ impl EventsHub {
             if let Some(client) = client {
                 client.flush(force)
             } else {
-                debug!("No v2 events client configured, skipping flush");
+                trace!("No v2 events client configured, skipping flush");
                 Ok(())
             }
         })
@@ -65,7 +65,7 @@ impl EventsHub {
     pub fn record_event(&self, kind: EventKind) -> Result<()> {
         self.with_client(|client| {
             let Some(client) = client else {
-                debug!("No v2 events client configured, skipping record");
+                trace!("No v2 events client configured, skipping record");
                 return Ok(());
             };
 
@@ -78,7 +78,7 @@ impl EventsHub {
     pub fn record_command_run(&self, subcommand: String) -> Result<()> {
         self.with_client(|client| {
             let Some(client) = client else {
-                debug!("No v2 events client configured, skipping command_run record");
+                trace!("No v2 events client configured, skipping command_run record");
                 return Ok(());
             };
             client.record_command_run(subcommand)
@@ -96,7 +96,7 @@ impl EventsHub {
         }
         self.with_client(|client| {
             let Some(client) = client else {
-                debug!("No v2 events client configured, skipping command_completed record");
+                trace!("No v2 events client configured, skipping command_completed record");
                 return Ok(());
             };
             client.record_command_completed(subcommand)
@@ -114,7 +114,7 @@ impl EventsHub {
     ) -> Result<()> {
         self.with_client(|client| {
             let Some(client) = client else {
-                debug!("No v2 events client configured, skipping environment.activate record");
+                trace!("No v2 events client configured, skipping environment.activate record");
                 return Ok(());
             };
             client.record_environment_activate(payload)
@@ -134,7 +134,7 @@ impl EventsHub {
     ) -> Result<()> {
         self.with_client(|client| {
             let Some(client) = client else {
-                debug!("No v2 events client configured, skipping environment.activate record");
+                trace!("No v2 events client configured, skipping environment.activate record");
                 return Ok(());
             };
             client.record_environment_activate_with(env_detail, extras)
@@ -146,7 +146,7 @@ impl EventsHub {
     pub fn record_environment_push(&self, env_detail: EnvDetail) -> Result<()> {
         self.with_client(|client| {
             let Some(client) = client else {
-                debug!("No v2 events client configured, skipping environment.push record");
+                trace!("No v2 events client configured, skipping environment.push record");
                 return Ok(());
             };
             client.record_environment_push(env_detail)
@@ -158,7 +158,7 @@ impl EventsHub {
     pub fn record_environment_pull(&self, env_detail: EnvDetail) -> Result<()> {
         self.with_client(|client| {
             let Some(client) = client else {
-                debug!("No v2 events client configured, skipping environment.pull record");
+                trace!("No v2 events client configured, skipping environment.pull record");
                 return Ok(());
             };
             client.record_environment_pull(env_detail)
@@ -170,7 +170,7 @@ impl EventsHub {
     pub fn record_package_install(&self, package: String, outcome: PackageOutcome) -> Result<()> {
         self.with_client(|client| {
             let Some(client) = client else {
-                debug!("No v2 events client configured, skipping package.install record");
+                trace!("No v2 events client configured, skipping package.install record");
                 return Ok(());
             };
             client.record_package_install(package, outcome)
@@ -182,7 +182,7 @@ impl EventsHub {
     pub fn record_package_upgrade(&self, package: String, outcome: PackageOutcome) -> Result<()> {
         self.with_client(|client| {
             let Some(client) = client else {
-                debug!("No v2 events client configured, skipping package.upgrade record");
+                trace!("No v2 events client configured, skipping package.upgrade record");
                 return Ok(());
             };
             client.record_package_upgrade(package, outcome)
@@ -194,7 +194,7 @@ impl EventsHub {
     pub fn record_package_uninstall(&self, package: String, outcome: PackageOutcome) -> Result<()> {
         self.with_client(|client| {
             let Some(client) = client else {
-                debug!("No v2 events client configured, skipping package.uninstall record");
+                trace!("No v2 events client configured, skipping package.uninstall record");
                 return Ok(());
             };
             client.record_package_uninstall(package, outcome)
@@ -206,7 +206,7 @@ impl EventsHub {
     pub fn record_environment_containerize(&self, env_detail: EnvDetail) -> Result<()> {
         self.with_client(|client| {
             let Some(client) = client else {
-                debug!("No v2 events client configured, skipping environment.containerize record");
+                trace!("No v2 events client configured, skipping environment.containerize record");
                 return Ok(());
             };
             client.record_environment_containerize(env_detail)
@@ -218,7 +218,7 @@ impl EventsHub {
     pub fn record_environment_delete(&self, env_detail: EnvDetail) -> Result<()> {
         self.with_client(|client| {
             let Some(client) = client else {
-                debug!("No v2 events client configured, skipping environment.delete record");
+                trace!("No v2 events client configured, skipping environment.delete record");
                 return Ok(());
             };
             client.record_environment_delete(env_detail)
@@ -230,7 +230,7 @@ impl EventsHub {
     pub fn record_environment_include_upgrade(&self, env_detail: EnvDetail) -> Result<()> {
         self.with_client(|client| {
             let Some(client) = client else {
-                debug!(
+                trace!(
                     "No v2 events client configured, skipping environment.include.upgrade record"
                 );
                 return Ok(());
@@ -245,7 +245,7 @@ impl EventsHub {
     pub fn record_environment_install(&self, env_detail: EnvDetail) -> Result<()> {
         self.with_client(|client| {
             let Some(client) = client else {
-                debug!("No v2 events client configured, skipping environment.install record");
+                trace!("No v2 events client configured, skipping environment.install record");
                 return Ok(());
             };
             client.record_environment_install(env_detail)
@@ -257,7 +257,7 @@ impl EventsHub {
     pub fn record_environment_list(&self, env_detail: EnvDetail) -> Result<()> {
         self.with_client(|client| {
             let Some(client) = client else {
-                debug!("No v2 events client configured, skipping environment.list record");
+                trace!("No v2 events client configured, skipping environment.list record");
                 return Ok(());
             };
             client.record_environment_list(env_detail)
@@ -270,7 +270,7 @@ impl EventsHub {
     pub fn record_environment_uninstall(&self, env_detail: EnvDetail) -> Result<()> {
         self.with_client(|client| {
             let Some(client) = client else {
-                debug!("No v2 events client configured, skipping environment.uninstall record");
+                trace!("No v2 events client configured, skipping environment.uninstall record");
                 return Ok(());
             };
             client.record_environment_uninstall(env_detail)
@@ -283,7 +283,7 @@ impl EventsHub {
     pub fn record_environment_upgrade(&self, env_detail: EnvDetail) -> Result<()> {
         self.with_client(|client| {
             let Some(client) = client else {
-                debug!("No v2 events client configured, skipping environment.upgrade record");
+                trace!("No v2 events client configured, skipping environment.upgrade record");
                 return Ok(());
             };
             client.record_environment_upgrade(env_detail)
@@ -295,7 +295,7 @@ impl EventsHub {
     pub fn record_environment_services_start(&self, env_detail: EnvDetail) -> Result<()> {
         self.with_client(|client| {
             let Some(client) = client else {
-                debug!(
+                trace!(
                     "No v2 events client configured, skipping environment.services.start record"
                 );
                 return Ok(());
@@ -309,7 +309,7 @@ impl EventsHub {
     pub fn record_environment_services_stop(&self, env_detail: EnvDetail) -> Result<()> {
         self.with_client(|client| {
             let Some(client) = client else {
-                debug!("No v2 events client configured, skipping environment.services.stop record");
+                trace!("No v2 events client configured, skipping environment.services.stop record");
                 return Ok(());
             };
             client.record_environment_services_stop(env_detail)
@@ -321,7 +321,7 @@ impl EventsHub {
     pub fn record_environment_services_restart(&self, env_detail: EnvDetail) -> Result<()> {
         self.with_client(|client| {
             let Some(client) = client else {
-                debug!(
+                trace!(
                     "No v2 events client configured, skipping environment.services.restart record"
                 );
                 return Ok(());
@@ -335,7 +335,7 @@ impl EventsHub {
     pub fn record_environment_services_status(&self, env_detail: EnvDetail) -> Result<()> {
         self.with_client(|client| {
             let Some(client) = client else {
-                debug!(
+                trace!(
                     "No v2 events client configured, skipping environment.services.status record"
                 );
                 return Ok(());
@@ -349,7 +349,7 @@ impl EventsHub {
     pub fn record_environment_services_logs(&self, env_detail: EnvDetail) -> Result<()> {
         self.with_client(|client| {
             let Some(client) = client else {
-                debug!("No v2 events client configured, skipping environment.services.logs record");
+                trace!("No v2 events client configured, skipping environment.services.logs record");
                 return Ok(());
             };
             client.record_environment_services_logs(env_detail)
@@ -361,7 +361,7 @@ impl EventsHub {
     pub fn record_environment_services_persist(&self, env_detail: EnvDetail) -> Result<()> {
         self.with_client(|client| {
             let Some(client) = client else {
-                debug!(
+                trace!(
                     "No v2 events client configured, skipping environment.services.persist record"
                 );
                 return Ok(());
@@ -375,7 +375,7 @@ impl EventsHub {
     pub fn record_environment_generations_history(&self, env_detail: EnvDetail) -> Result<()> {
         self.with_client(|client| {
             let Some(client) = client else {
-                debug!(
+                trace!(
                     "No v2 events client configured, skipping environment.generations.history record"
                 );
                 return Ok(());
@@ -389,7 +389,7 @@ impl EventsHub {
     pub fn record_environment_generations_rollback(&self, env_detail: EnvDetail) -> Result<()> {
         self.with_client(|client| {
             let Some(client) = client else {
-                debug!(
+                trace!(
                     "No v2 events client configured, skipping environment.generations.rollback record"
                 );
                 return Ok(());
@@ -403,7 +403,7 @@ impl EventsHub {
     pub fn record_environment_generations_switch(&self, env_detail: EnvDetail) -> Result<()> {
         self.with_client(|client| {
             let Some(client) = client else {
-                debug!(
+                trace!(
                     "No v2 events client configured, skipping environment.generations.switch record"
                 );
                 return Ok(());
@@ -417,7 +417,7 @@ impl EventsHub {
     pub fn record_environment_edit(&self, env_detail: EnvDetail) -> Result<()> {
         self.with_client(|client| {
             let Some(client) = client else {
-                debug!("No v2 events client configured, skipping environment.edit record");
+                trace!("No v2 events client configured, skipping environment.edit record");
                 return Ok(());
             };
             client.record_environment_edit(env_detail)
@@ -434,7 +434,7 @@ impl EventsHub {
     ) -> Result<()> {
         self.with_client(|client| {
             let Some(client) = client else {
-                debug!("No v2 events client configured, skipping environment.edit record");
+                trace!("No v2 events client configured, skipping environment.edit record");
                 return Ok(());
             };
             client.record_environment_edit_with(env_detail, extras)
@@ -446,7 +446,7 @@ impl EventsHub {
     pub fn record_environment_publish(&self, env_detail: EnvDetail) -> Result<()> {
         self.with_client(|client| {
             let Some(client) = client else {
-                debug!("No v2 events client configured, skipping environment.publish record");
+                trace!("No v2 events client configured, skipping environment.publish record");
                 return Ok(());
             };
             client.record_environment_publish(env_detail)
@@ -462,7 +462,7 @@ impl EventsHub {
     ) -> Result<()> {
         self.with_client(|client| {
             let Some(client) = client else {
-                debug!("No v2 events client configured, skipping environment.publish record");
+                trace!("No v2 events client configured, skipping environment.publish record");
                 return Ok(());
             };
             client.record_environment_publish_with(env_detail, extras)
@@ -480,7 +480,7 @@ impl EventsHub {
     ) -> Result<()> {
         self.with_client(|client| {
             let Some(client) = client else {
-                debug!(
+                trace!(
                     "No v2 events client configured, skipping environment.generations.list record"
                 );
                 return Ok(());
@@ -494,7 +494,7 @@ impl EventsHub {
     pub fn record_build(&self, has_expression_build: bool, has_manifest_build: bool) -> Result<()> {
         self.with_client(|client| {
             let Some(client) = client else {
-                debug!("No v2 events client configured, skipping build record");
+                trace!("No v2 events client configured, skipping build record");
                 return Ok(());
             };
             client.record_build(has_expression_build, has_manifest_build)
@@ -506,7 +506,7 @@ impl EventsHub {
     pub fn record_search(&self, search_term: String) -> Result<()> {
         self.with_client(|client| {
             let Some(client) = client else {
-                debug!("No v2 events client configured, skipping search record");
+                trace!("No v2 events client configured, skipping search record");
                 return Ok(());
             };
             client.record_search(search_term)

--- a/cli/flox-events/src/hub.rs
+++ b/cli/flox-events/src/hub.rs
@@ -5,7 +5,15 @@ use anyhow::Result;
 use tracing::debug;
 
 use crate::client::EventsClient;
-use crate::{CliEnvironmentActivatePayload, EnvDetail, EventKind, PackageOutcome};
+use crate::{
+    CliEnvironmentActivatePayload,
+    CliEnvironmentEditPayload,
+    CliEnvironmentGenerationsListPayload,
+    CliEnvironmentPublishPayload,
+    EnvDetail,
+    EventKind,
+    PackageOutcome,
+};
 
 static EVENTS_HUB: LazyLock<EventsHub> = LazyLock::new(EventsHub::new);
 
@@ -190,6 +198,316 @@ impl EventsHub {
                 return Ok(());
             };
             client.record_package_uninstall(package, outcome)
+        })
+    }
+
+    /// Record a `cli.environment.containerize` event. No-op when no
+    /// client is installed.
+    pub fn record_environment_containerize(&self, env_detail: EnvDetail) -> Result<()> {
+        self.with_client(|client| {
+            let Some(client) = client else {
+                debug!("No v2 events client configured, skipping environment.containerize record");
+                return Ok(());
+            };
+            client.record_environment_containerize(env_detail)
+        })
+    }
+
+    /// Record a `cli.environment.delete` event. No-op when no client
+    /// is installed.
+    pub fn record_environment_delete(&self, env_detail: EnvDetail) -> Result<()> {
+        self.with_client(|client| {
+            let Some(client) = client else {
+                debug!("No v2 events client configured, skipping environment.delete record");
+                return Ok(());
+            };
+            client.record_environment_delete(env_detail)
+        })
+    }
+
+    /// Record a `cli.environment.include` event. No-op when no client
+    /// is installed.
+    pub fn record_environment_include(&self, env_detail: EnvDetail) -> Result<()> {
+        self.with_client(|client| {
+            let Some(client) = client else {
+                debug!("No v2 events client configured, skipping environment.include record");
+                return Ok(());
+            };
+            client.record_environment_include(env_detail)
+        })
+    }
+
+    /// Record a `cli.environment.install` event (env-detail row). The
+    /// per-package detail rides on `cli.package.install` (PR 4). No-op
+    /// when no client is installed.
+    pub fn record_environment_install(&self, env_detail: EnvDetail) -> Result<()> {
+        self.with_client(|client| {
+            let Some(client) = client else {
+                debug!("No v2 events client configured, skipping environment.install record");
+                return Ok(());
+            };
+            client.record_environment_install(env_detail)
+        })
+    }
+
+    /// Record a `cli.environment.list` event. No-op when no client is
+    /// installed.
+    pub fn record_environment_list(&self, env_detail: EnvDetail) -> Result<()> {
+        self.with_client(|client| {
+            let Some(client) = client else {
+                debug!("No v2 events client configured, skipping environment.list record");
+                return Ok(());
+            };
+            client.record_environment_list(env_detail)
+        })
+    }
+
+    /// Record a `cli.environment.uninstall` event (env-detail row).
+    /// The per-package detail rides on `cli.package.uninstall` (PR 4).
+    /// No-op when no client is installed.
+    pub fn record_environment_uninstall(&self, env_detail: EnvDetail) -> Result<()> {
+        self.with_client(|client| {
+            let Some(client) = client else {
+                debug!("No v2 events client configured, skipping environment.uninstall record");
+                return Ok(());
+            };
+            client.record_environment_uninstall(env_detail)
+        })
+    }
+
+    /// Record a `cli.environment.upgrade` event (env-detail row). The
+    /// per-package detail rides on `cli.package.upgrade` (PR 4). No-op
+    /// when no client is installed.
+    pub fn record_environment_upgrade(&self, env_detail: EnvDetail) -> Result<()> {
+        self.with_client(|client| {
+            let Some(client) = client else {
+                debug!("No v2 events client configured, skipping environment.upgrade record");
+                return Ok(());
+            };
+            client.record_environment_upgrade(env_detail)
+        })
+    }
+
+    /// Record a `cli.environment.services.start` event. No-op when no
+    /// client is installed.
+    pub fn record_environment_services_start(&self, env_detail: EnvDetail) -> Result<()> {
+        self.with_client(|client| {
+            let Some(client) = client else {
+                debug!(
+                    "No v2 events client configured, skipping environment.services.start record"
+                );
+                return Ok(());
+            };
+            client.record_environment_services_start(env_detail)
+        })
+    }
+
+    /// Record a `cli.environment.services.stop` event. No-op when no
+    /// client is installed.
+    pub fn record_environment_services_stop(&self, env_detail: EnvDetail) -> Result<()> {
+        self.with_client(|client| {
+            let Some(client) = client else {
+                debug!("No v2 events client configured, skipping environment.services.stop record");
+                return Ok(());
+            };
+            client.record_environment_services_stop(env_detail)
+        })
+    }
+
+    /// Record a `cli.environment.services.restart` event. No-op when
+    /// no client is installed.
+    pub fn record_environment_services_restart(&self, env_detail: EnvDetail) -> Result<()> {
+        self.with_client(|client| {
+            let Some(client) = client else {
+                debug!(
+                    "No v2 events client configured, skipping environment.services.restart record"
+                );
+                return Ok(());
+            };
+            client.record_environment_services_restart(env_detail)
+        })
+    }
+
+    /// Record a `cli.environment.services.status` event. No-op when
+    /// no client is installed.
+    pub fn record_environment_services_status(&self, env_detail: EnvDetail) -> Result<()> {
+        self.with_client(|client| {
+            let Some(client) = client else {
+                debug!(
+                    "No v2 events client configured, skipping environment.services.status record"
+                );
+                return Ok(());
+            };
+            client.record_environment_services_status(env_detail)
+        })
+    }
+
+    /// Record a `cli.environment.services.logs` event. No-op when no
+    /// client is installed.
+    pub fn record_environment_services_logs(&self, env_detail: EnvDetail) -> Result<()> {
+        self.with_client(|client| {
+            let Some(client) = client else {
+                debug!("No v2 events client configured, skipping environment.services.logs record");
+                return Ok(());
+            };
+            client.record_environment_services_logs(env_detail)
+        })
+    }
+
+    /// Record a `cli.environment.services.persist` event. No-op when
+    /// no client is installed.
+    pub fn record_environment_services_persist(&self, env_detail: EnvDetail) -> Result<()> {
+        self.with_client(|client| {
+            let Some(client) = client else {
+                debug!(
+                    "No v2 events client configured, skipping environment.services.persist record"
+                );
+                return Ok(());
+            };
+            client.record_environment_services_persist(env_detail)
+        })
+    }
+
+    /// Record a `cli.environment.generations.history` event. No-op
+    /// when no client is installed.
+    pub fn record_environment_generations_history(&self, env_detail: EnvDetail) -> Result<()> {
+        self.with_client(|client| {
+            let Some(client) = client else {
+                debug!(
+                    "No v2 events client configured, skipping environment.generations.history record"
+                );
+                return Ok(());
+            };
+            client.record_environment_generations_history(env_detail)
+        })
+    }
+
+    /// Record a `cli.environment.generations.rollback` event. No-op
+    /// when no client is installed.
+    pub fn record_environment_generations_rollback(&self, env_detail: EnvDetail) -> Result<()> {
+        self.with_client(|client| {
+            let Some(client) = client else {
+                debug!(
+                    "No v2 events client configured, skipping environment.generations.rollback record"
+                );
+                return Ok(());
+            };
+            client.record_environment_generations_rollback(env_detail)
+        })
+    }
+
+    /// Record a `cli.environment.generations.switch` event. No-op
+    /// when no client is installed.
+    pub fn record_environment_generations_switch(&self, env_detail: EnvDetail) -> Result<()> {
+        self.with_client(|client| {
+            let Some(client) = client else {
+                debug!(
+                    "No v2 events client configured, skipping environment.generations.switch record"
+                );
+                return Ok(());
+            };
+            client.record_environment_generations_switch(env_detail)
+        })
+    }
+
+    /// Record a `cli.environment.edit` event with just env detail
+    /// (eager call site). No-op when no client is installed.
+    pub fn record_environment_edit(&self, env_detail: EnvDetail) -> Result<()> {
+        self.with_client(|client| {
+            let Some(client) = client else {
+                debug!("No v2 events client configured, skipping environment.edit record");
+                return Ok(());
+            };
+            client.record_environment_edit(env_detail)
+        })
+    }
+
+    /// Record a `cli.environment.edit` event populated by `extras`
+    /// (result-known call site). No-op when no client is installed —
+    /// the `extras` closure is not invoked in that case.
+    pub fn record_environment_edit_with(
+        &self,
+        env_detail: EnvDetail,
+        extras: impl FnOnce(CliEnvironmentEditPayload) -> CliEnvironmentEditPayload,
+    ) -> Result<()> {
+        self.with_client(|client| {
+            let Some(client) = client else {
+                debug!("No v2 events client configured, skipping environment.edit record");
+                return Ok(());
+            };
+            client.record_environment_edit_with(env_detail, extras)
+        })
+    }
+
+    /// Record a `cli.environment.publish` event with just env detail
+    /// (eager call site). No-op when no client is installed.
+    pub fn record_environment_publish(&self, env_detail: EnvDetail) -> Result<()> {
+        self.with_client(|client| {
+            let Some(client) = client else {
+                debug!("No v2 events client configured, skipping environment.publish record");
+                return Ok(());
+            };
+            client.record_environment_publish(env_detail)
+        })
+    }
+
+    /// Record a `cli.environment.publish` event populated by `extras`
+    /// (result-known call site). No-op when no client is installed.
+    pub fn record_environment_publish_with(
+        &self,
+        env_detail: EnvDetail,
+        extras: impl FnOnce(CliEnvironmentPublishPayload) -> CliEnvironmentPublishPayload,
+    ) -> Result<()> {
+        self.with_client(|client| {
+            let Some(client) = client else {
+                debug!("No v2 events client configured, skipping environment.publish record");
+                return Ok(());
+            };
+            client.record_environment_publish_with(env_detail, extras)
+        })
+    }
+
+    /// Record a `cli.environment.generations.list` event populated by
+    /// `extras`. No-op when no client is installed.
+    pub fn record_environment_generations_list_with(
+        &self,
+        env_detail: EnvDetail,
+        extras: impl FnOnce(
+            CliEnvironmentGenerationsListPayload,
+        ) -> CliEnvironmentGenerationsListPayload,
+    ) -> Result<()> {
+        self.with_client(|client| {
+            let Some(client) = client else {
+                debug!(
+                    "No v2 events client configured, skipping environment.generations.list record"
+                );
+                return Ok(());
+            };
+            client.record_environment_generations_list_with(env_detail, extras)
+        })
+    }
+
+    /// Record a `cli.build` event carrying build-kind detection
+    /// flags. No-op when no client is installed.
+    pub fn record_build(&self, has_expression_build: bool, has_manifest_build: bool) -> Result<()> {
+        self.with_client(|client| {
+            let Some(client) = client else {
+                debug!("No v2 events client configured, skipping build record");
+                return Ok(());
+            };
+            client.record_build(has_expression_build, has_manifest_build)
+        })
+    }
+
+    /// Record a `cli.search` event carrying the search term. No-op
+    /// when no client is installed.
+    pub fn record_search(&self, search_term: String) -> Result<()> {
+        self.with_client(|client| {
+            let Some(client) = client else {
+                debug!("No v2 events client configured, skipping search record");
+                return Ok(());
+            };
+            client.record_search(search_term)
         })
     }
 

--- a/cli/flox-events/src/hub.rs
+++ b/cli/flox-events/src/hub.rs
@@ -225,21 +225,23 @@ impl EventsHub {
         })
     }
 
-    /// Record a `cli.environment.include` event. No-op when no client
-    /// is installed.
-    pub fn record_environment_include(&self, env_detail: EnvDetail) -> Result<()> {
+    /// Record a `cli.environment.include.upgrade` event. No-op when
+    /// no client is installed.
+    pub fn record_environment_include_upgrade(&self, env_detail: EnvDetail) -> Result<()> {
         self.with_client(|client| {
             let Some(client) = client else {
-                debug!("No v2 events client configured, skipping environment.include record");
+                debug!(
+                    "No v2 events client configured, skipping environment.include.upgrade record"
+                );
                 return Ok(());
             };
-            client.record_environment_include(env_detail)
+            client.record_environment_include_upgrade(env_detail)
         })
     }
 
     /// Record a `cli.environment.install` event (env-detail row). The
-    /// per-package detail rides on `cli.package.install` (PR 4). No-op
-    /// when no client is installed.
+    /// per-package detail rides on `cli.package.install`. No-op when
+    /// no client is installed.
     pub fn record_environment_install(&self, env_detail: EnvDetail) -> Result<()> {
         self.with_client(|client| {
             let Some(client) = client else {
@@ -263,8 +265,8 @@ impl EventsHub {
     }
 
     /// Record a `cli.environment.uninstall` event (env-detail row).
-    /// The per-package detail rides on `cli.package.uninstall` (PR 4).
-    /// No-op when no client is installed.
+    /// The per-package detail rides on `cli.package.uninstall`. No-op
+    /// when no client is installed.
     pub fn record_environment_uninstall(&self, env_detail: EnvDetail) -> Result<()> {
         self.with_client(|client| {
             let Some(client) = client else {
@@ -276,8 +278,8 @@ impl EventsHub {
     }
 
     /// Record a `cli.environment.upgrade` event (env-detail row). The
-    /// per-package detail rides on `cli.package.upgrade` (PR 4). No-op
-    /// when no client is installed.
+    /// per-package detail rides on `cli.package.upgrade`. No-op when
+    /// no client is installed.
     pub fn record_environment_upgrade(&self, env_detail: EnvDetail) -> Result<()> {
         self.with_client(|client| {
             let Some(client) = client else {

--- a/cli/flox-events/src/lib.rs
+++ b/cli/flox-events/src/lib.rs
@@ -794,9 +794,12 @@ impl CliEnvironmentGenerationsSwitchPayload {
 // `EventKind` and same `invocation_id`, each populating only what it
 // knows. The consumer `COALESCE`s Optional fields across the rows.
 
-/// Payload for [`EventKind::CliEnvironmentEdit`]. Emitted twice per
-/// `flox edit` invocation: once eagerly with env detail, once after
-/// the edit result is known with `edited_includes`.
+/// Payload for [`EventKind::CliEnvironmentEdit`]. Emitted once eagerly
+/// with env detail; a manifest edit that changes the manifest emits a
+/// second row carrying `edited_includes`. The other edit actions
+/// (rename/sync/reset, or an unchanged manifest edit) emit only the
+/// eager row — per the sparse-merge contract above, `edited_includes`
+/// is simply absent for those.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CliEnvironmentEditPayload {
     #[serde(flatten)]

--- a/cli/flox-events/src/lib.rs
+++ b/cli/flox-events/src/lib.rs
@@ -133,6 +133,48 @@ pub enum EventKind {
     CliPackageUpgrade(CliPackageUpgradePayload),
     #[serde(rename = "cli.package.uninstall")]
     CliPackageUninstall(CliPackageUninstallPayload),
+    #[serde(rename = "cli.environment.containerize")]
+    CliEnvironmentContainerize(CliEnvironmentContainerizePayload),
+    #[serde(rename = "cli.environment.delete")]
+    CliEnvironmentDelete(CliEnvironmentDeletePayload),
+    #[serde(rename = "cli.environment.edit")]
+    CliEnvironmentEdit(CliEnvironmentEditPayload),
+    #[serde(rename = "cli.environment.include")]
+    CliEnvironmentInclude(CliEnvironmentIncludePayload),
+    #[serde(rename = "cli.environment.install")]
+    CliEnvironmentInstall(CliEnvironmentInstallPayload),
+    #[serde(rename = "cli.environment.list")]
+    CliEnvironmentList(CliEnvironmentListPayload),
+    #[serde(rename = "cli.environment.publish")]
+    CliEnvironmentPublish(CliEnvironmentPublishPayload),
+    #[serde(rename = "cli.environment.uninstall")]
+    CliEnvironmentUninstall(CliEnvironmentUninstallPayload),
+    #[serde(rename = "cli.environment.upgrade")]
+    CliEnvironmentUpgrade(CliEnvironmentUpgradePayload),
+    #[serde(rename = "cli.environment.services.start")]
+    CliEnvironmentServicesStart(CliEnvironmentServicesStartPayload),
+    #[serde(rename = "cli.environment.services.stop")]
+    CliEnvironmentServicesStop(CliEnvironmentServicesStopPayload),
+    #[serde(rename = "cli.environment.services.restart")]
+    CliEnvironmentServicesRestart(CliEnvironmentServicesRestartPayload),
+    #[serde(rename = "cli.environment.services.status")]
+    CliEnvironmentServicesStatus(CliEnvironmentServicesStatusPayload),
+    #[serde(rename = "cli.environment.services.logs")]
+    CliEnvironmentServicesLogs(CliEnvironmentServicesLogsPayload),
+    #[serde(rename = "cli.environment.services.persist")]
+    CliEnvironmentServicesPersist(CliEnvironmentServicesPersistPayload),
+    #[serde(rename = "cli.environment.generations.history")]
+    CliEnvironmentGenerationsHistory(CliEnvironmentGenerationsHistoryPayload),
+    #[serde(rename = "cli.environment.generations.list")]
+    CliEnvironmentGenerationsList(CliEnvironmentGenerationsListPayload),
+    #[serde(rename = "cli.environment.generations.rollback")]
+    CliEnvironmentGenerationsRollback(CliEnvironmentGenerationsRollbackPayload),
+    #[serde(rename = "cli.environment.generations.switch")]
+    CliEnvironmentGenerationsSwitch(CliEnvironmentGenerationsSwitchPayload),
+    #[serde(rename = "cli.build")]
+    CliBuild(CliBuildPayload),
+    #[serde(rename = "cli.search")]
+    CliSearch(CliSearchPayload),
 }
 
 /// Shared metadata fields stamped onto every `cli.*` command event payload.
@@ -439,6 +481,471 @@ impl CliPackageUninstallPayload {
             command,
             package,
             outcome,
+        }
+    }
+}
+
+// -------- PR 5: env-detail-only payloads --------
+//
+// The 16 commands below carry `CommandPayload` + `EnvDetail` and
+// nothing more. The payload structs are byte-identical to
+// `CliEnvironmentPushPayload`; they exist as separate types so each
+// `EventKind` variant owns a distinct payload — matching the PR 3
+// pattern. PR 7's in-PR-collapse section already records a
+// follow-up to consider sharing a single `EnvCommandPayload` if no
+// per-command extras have emerged by then.
+
+/// Payload for [`EventKind::CliEnvironmentContainerize`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CliEnvironmentContainerizePayload {
+    #[serde(flatten)]
+    pub command: CommandPayload,
+    #[serde(flatten)]
+    pub env_detail: EnvDetail,
+}
+
+impl CliEnvironmentContainerizePayload {
+    pub fn new(command: CommandPayload, env_detail: EnvDetail) -> Self {
+        Self {
+            command,
+            env_detail,
+        }
+    }
+}
+
+/// Payload for [`EventKind::CliEnvironmentDelete`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CliEnvironmentDeletePayload {
+    #[serde(flatten)]
+    pub command: CommandPayload,
+    #[serde(flatten)]
+    pub env_detail: EnvDetail,
+}
+
+impl CliEnvironmentDeletePayload {
+    pub fn new(command: CommandPayload, env_detail: EnvDetail) -> Self {
+        Self {
+            command,
+            env_detail,
+        }
+    }
+}
+
+/// Payload for [`EventKind::CliEnvironmentInclude`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CliEnvironmentIncludePayload {
+    #[serde(flatten)]
+    pub command: CommandPayload,
+    #[serde(flatten)]
+    pub env_detail: EnvDetail,
+}
+
+impl CliEnvironmentIncludePayload {
+    pub fn new(command: CommandPayload, env_detail: EnvDetail) -> Self {
+        Self {
+            command,
+            env_detail,
+        }
+    }
+}
+
+/// Payload for [`EventKind::CliEnvironmentInstall`]. Carries the
+/// env-detail row of a `flox install` invocation; the per-package
+/// detail rides on [`EventKind::CliPackageInstall`] (PR 4).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CliEnvironmentInstallPayload {
+    #[serde(flatten)]
+    pub command: CommandPayload,
+    #[serde(flatten)]
+    pub env_detail: EnvDetail,
+}
+
+impl CliEnvironmentInstallPayload {
+    pub fn new(command: CommandPayload, env_detail: EnvDetail) -> Self {
+        Self {
+            command,
+            env_detail,
+        }
+    }
+}
+
+/// Payload for [`EventKind::CliEnvironmentList`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CliEnvironmentListPayload {
+    #[serde(flatten)]
+    pub command: CommandPayload,
+    #[serde(flatten)]
+    pub env_detail: EnvDetail,
+}
+
+impl CliEnvironmentListPayload {
+    pub fn new(command: CommandPayload, env_detail: EnvDetail) -> Self {
+        Self {
+            command,
+            env_detail,
+        }
+    }
+}
+
+/// Payload for [`EventKind::CliEnvironmentUninstall`]. Carries the
+/// env-detail row of a `flox uninstall` invocation; the per-package
+/// detail rides on [`EventKind::CliPackageUninstall`] (PR 4).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CliEnvironmentUninstallPayload {
+    #[serde(flatten)]
+    pub command: CommandPayload,
+    #[serde(flatten)]
+    pub env_detail: EnvDetail,
+}
+
+impl CliEnvironmentUninstallPayload {
+    pub fn new(command: CommandPayload, env_detail: EnvDetail) -> Self {
+        Self {
+            command,
+            env_detail,
+        }
+    }
+}
+
+/// Payload for [`EventKind::CliEnvironmentUpgrade`]. Carries the
+/// env-detail row of a `flox upgrade` invocation; the per-package
+/// detail rides on [`EventKind::CliPackageUpgrade`] (PR 4).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CliEnvironmentUpgradePayload {
+    #[serde(flatten)]
+    pub command: CommandPayload,
+    #[serde(flatten)]
+    pub env_detail: EnvDetail,
+}
+
+impl CliEnvironmentUpgradePayload {
+    pub fn new(command: CommandPayload, env_detail: EnvDetail) -> Self {
+        Self {
+            command,
+            env_detail,
+        }
+    }
+}
+
+/// Payload for [`EventKind::CliEnvironmentServicesStart`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CliEnvironmentServicesStartPayload {
+    #[serde(flatten)]
+    pub command: CommandPayload,
+    #[serde(flatten)]
+    pub env_detail: EnvDetail,
+}
+
+impl CliEnvironmentServicesStartPayload {
+    pub fn new(command: CommandPayload, env_detail: EnvDetail) -> Self {
+        Self {
+            command,
+            env_detail,
+        }
+    }
+}
+
+/// Payload for [`EventKind::CliEnvironmentServicesStop`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CliEnvironmentServicesStopPayload {
+    #[serde(flatten)]
+    pub command: CommandPayload,
+    #[serde(flatten)]
+    pub env_detail: EnvDetail,
+}
+
+impl CliEnvironmentServicesStopPayload {
+    pub fn new(command: CommandPayload, env_detail: EnvDetail) -> Self {
+        Self {
+            command,
+            env_detail,
+        }
+    }
+}
+
+/// Payload for [`EventKind::CliEnvironmentServicesRestart`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CliEnvironmentServicesRestartPayload {
+    #[serde(flatten)]
+    pub command: CommandPayload,
+    #[serde(flatten)]
+    pub env_detail: EnvDetail,
+}
+
+impl CliEnvironmentServicesRestartPayload {
+    pub fn new(command: CommandPayload, env_detail: EnvDetail) -> Self {
+        Self {
+            command,
+            env_detail,
+        }
+    }
+}
+
+/// Payload for [`EventKind::CliEnvironmentServicesStatus`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CliEnvironmentServicesStatusPayload {
+    #[serde(flatten)]
+    pub command: CommandPayload,
+    #[serde(flatten)]
+    pub env_detail: EnvDetail,
+}
+
+impl CliEnvironmentServicesStatusPayload {
+    pub fn new(command: CommandPayload, env_detail: EnvDetail) -> Self {
+        Self {
+            command,
+            env_detail,
+        }
+    }
+}
+
+/// Payload for [`EventKind::CliEnvironmentServicesLogs`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CliEnvironmentServicesLogsPayload {
+    #[serde(flatten)]
+    pub command: CommandPayload,
+    #[serde(flatten)]
+    pub env_detail: EnvDetail,
+}
+
+impl CliEnvironmentServicesLogsPayload {
+    pub fn new(command: CommandPayload, env_detail: EnvDetail) -> Self {
+        Self {
+            command,
+            env_detail,
+        }
+    }
+}
+
+/// Payload for [`EventKind::CliEnvironmentServicesPersist`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CliEnvironmentServicesPersistPayload {
+    #[serde(flatten)]
+    pub command: CommandPayload,
+    #[serde(flatten)]
+    pub env_detail: EnvDetail,
+}
+
+impl CliEnvironmentServicesPersistPayload {
+    pub fn new(command: CommandPayload, env_detail: EnvDetail) -> Self {
+        Self {
+            command,
+            env_detail,
+        }
+    }
+}
+
+/// Payload for [`EventKind::CliEnvironmentGenerationsHistory`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CliEnvironmentGenerationsHistoryPayload {
+    #[serde(flatten)]
+    pub command: CommandPayload,
+    #[serde(flatten)]
+    pub env_detail: EnvDetail,
+}
+
+impl CliEnvironmentGenerationsHistoryPayload {
+    pub fn new(command: CommandPayload, env_detail: EnvDetail) -> Self {
+        Self {
+            command,
+            env_detail,
+        }
+    }
+}
+
+/// Payload for [`EventKind::CliEnvironmentGenerationsRollback`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CliEnvironmentGenerationsRollbackPayload {
+    #[serde(flatten)]
+    pub command: CommandPayload,
+    #[serde(flatten)]
+    pub env_detail: EnvDetail,
+}
+
+impl CliEnvironmentGenerationsRollbackPayload {
+    pub fn new(command: CommandPayload, env_detail: EnvDetail) -> Self {
+        Self {
+            command,
+            env_detail,
+        }
+    }
+}
+
+/// Payload for [`EventKind::CliEnvironmentGenerationsSwitch`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CliEnvironmentGenerationsSwitchPayload {
+    #[serde(flatten)]
+    pub command: CommandPayload,
+    #[serde(flatten)]
+    pub env_detail: EnvDetail,
+}
+
+impl CliEnvironmentGenerationsSwitchPayload {
+    pub fn new(command: CommandPayload, env_detail: EnvDetail) -> Self {
+        Self {
+            command,
+            env_detail,
+        }
+    }
+}
+
+// -------- PR 5: env-detail + Optional extras payloads --------
+//
+// Three commands carry both env-detail and per-command extras and
+// have two distinct legacy emission sites in the same handler (an
+// eager env-detail emit before the operation runs + an extras emit
+// after the operation result is known). The new path mirrors that
+// structure via PR 3's sparse-merge contract: both sites emit a
+// payload with the same `EventKind` and same `invocation_id`, each
+// populating only what it knows. The consumer
+// `COALESCE`s Optional fields across the rows.
+
+/// Payload for [`EventKind::CliEnvironmentEdit`]. Emitted twice per
+/// `flox edit` invocation: once eagerly with env detail, once after
+/// the edit result is known with `edited_includes`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CliEnvironmentEditPayload {
+    #[serde(flatten)]
+    pub command: CommandPayload,
+    #[serde(flatten)]
+    pub env_detail: EnvDetail,
+    /// `true` when the edit produced a change to one of the included
+    /// environments referenced by the manifest. `None` on the eager
+    /// env-detail emit (before the edit runs); `Some(bool)` on the
+    /// result-known emit.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub edited_includes: Option<bool>,
+}
+
+impl CliEnvironmentEditPayload {
+    pub fn new(command: CommandPayload, env_detail: EnvDetail) -> Self {
+        Self {
+            command,
+            env_detail,
+            edited_includes: None,
+        }
+    }
+
+    pub fn with_edited_includes(mut self, value: bool) -> Self {
+        self.edited_includes = Some(value);
+        self
+    }
+}
+
+/// Payload for [`EventKind::CliEnvironmentPublish`]. Emitted twice
+/// per `flox publish` invocation per sparse-merge.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CliEnvironmentPublishPayload {
+    #[serde(flatten)]
+    pub command: CommandPayload,
+    #[serde(flatten)]
+    pub env_detail: EnvDetail,
+    /// `true` when the manifest uses an `expression` build kind for
+    /// the published package; `None` on the eager env-detail emit.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub has_expression_build: Option<bool>,
+    /// `true` when the manifest uses a `manifest` build kind for the
+    /// published package; `None` on the eager env-detail emit.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub has_manifest_build: Option<bool>,
+}
+
+impl CliEnvironmentPublishPayload {
+    pub fn new(command: CommandPayload, env_detail: EnvDetail) -> Self {
+        Self {
+            command,
+            env_detail,
+            has_expression_build: None,
+            has_manifest_build: None,
+        }
+    }
+
+    pub fn with_build_kinds(
+        mut self,
+        has_expression_build: bool,
+        has_manifest_build: bool,
+    ) -> Self {
+        self.has_expression_build = Some(has_expression_build);
+        self.has_manifest_build = Some(has_manifest_build);
+        self
+    }
+}
+
+/// Payload for [`EventKind::CliEnvironmentGenerationsList`].
+/// Carries env detail + `request_tree` (`true` when the user passed
+/// `--tree`).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CliEnvironmentGenerationsListPayload {
+    #[serde(flatten)]
+    pub command: CommandPayload,
+    #[serde(flatten)]
+    pub env_detail: EnvDetail,
+    /// `true` when invoked with `--tree`; `None` is unused (single
+    /// call site populates this on the eager env-detail emit).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub request_tree: Option<bool>,
+}
+
+impl CliEnvironmentGenerationsListPayload {
+    pub fn new(command: CommandPayload, env_detail: EnvDetail) -> Self {
+        Self {
+            command,
+            env_detail,
+            request_tree: None,
+        }
+    }
+
+    pub fn with_request_tree(mut self, value: bool) -> Self {
+        self.request_tree = Some(value);
+        self
+    }
+}
+
+// -------- PR 5: no-env extras-only payloads --------
+//
+// `flox build` and `flox search` carry per-command extras but no
+// environment context (build operates on the manifest's `build`
+// table; search hits the catalog without a resolved environment).
+
+/// Payload for [`EventKind::CliBuild`]. Carries `flox build`'s
+/// per-invocation build-kind detection flags.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CliBuildPayload {
+    #[serde(flatten)]
+    pub command: CommandPayload,
+    pub has_expression_build: bool,
+    pub has_manifest_build: bool,
+}
+
+impl CliBuildPayload {
+    pub fn new(
+        command: CommandPayload,
+        has_expression_build: bool,
+        has_manifest_build: bool,
+    ) -> Self {
+        Self {
+            command,
+            has_expression_build,
+            has_manifest_build,
+        }
+    }
+}
+
+/// Payload for [`EventKind::CliSearch`]. Carries the user-supplied
+/// search term verbatim, matching the legacy `subcommand_metric!(
+/// "search", "search_term" = …)` extras (D3, 2026-05-30).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CliSearchPayload {
+    #[serde(flatten)]
+    pub command: CommandPayload,
+    pub search_term: String,
+}
+
+impl CliSearchPayload {
+    pub fn new(command: CommandPayload, search_term: String) -> Self {
+        Self {
+            command,
+            search_term,
         }
     }
 }
@@ -783,6 +1290,217 @@ mod tests {
             .expect("event serializes");
         let expected =
             package_envelope_json("cli.package.uninstall", "uninstall", "hello", "success");
+        assert_eq!(value, expected);
+    }
+
+    /// Common helper for PR 5's env-detail-only envelope goldens.
+    /// Builds an `Event` from `subcommand` + v2 env-detail
+    /// fields and the expected JSON shape it should serialize to.
+    fn env_envelope_json(event_type: &str, subcommand: &str) -> serde_json::Value {
+        let mut payload_json = expected_payload_json(subcommand);
+        let payload_obj = payload_json.as_object_mut().expect("payload object");
+        payload_obj.insert("env_kind".to_string(), json!("managed"));
+        payload_obj.insert("env_ref_or_name".to_string(), json!("alice/myenv"));
+        json!({
+            "event_id": "00000000-0000-0000-0000-000000000000",
+            "event_timestamp": EPOCH_UNIX_MS,
+            "source": "cli",
+            "invocation_id": "00000000-0000-0000-0000-000000000000",
+            "device_id": "00000000-0000-0000-0000-000000000000",
+            "event_type": event_type,
+            "payload": payload_json,
+        })
+    }
+
+    fn managed_env_detail() -> EnvDetail {
+        env_detail("managed", "alice/myenv")
+    }
+
+    #[test]
+    fn cli_environment_delete_envelope_golden() {
+        let payload =
+            CliEnvironmentDeletePayload::new(command_payload("delete"), managed_env_detail());
+        let value = serde_json::to_value(fixed_event(EventKind::CliEnvironmentDelete(payload)))
+            .expect("event serializes");
+        let expected = env_envelope_json("cli.environment.delete", "delete");
+        assert_eq!(value, expected);
+    }
+
+    #[test]
+    fn cli_environment_containerize_envelope_golden() {
+        let payload = CliEnvironmentContainerizePayload::new(
+            command_payload("containerize"),
+            managed_env_detail(),
+        );
+        let value =
+            serde_json::to_value(fixed_event(EventKind::CliEnvironmentContainerize(payload)))
+                .expect("event serializes");
+        let expected = env_envelope_json("cli.environment.containerize", "containerize");
+        assert_eq!(value, expected);
+    }
+
+    /// Representative for the six `services::*` env-detail-only
+    /// commands. The remaining five (`stop`/`restart`/`status`/`logs`/
+    /// `persist`) share this exact shape — discriminating only on the
+    /// `event_type` and `subcommand` fields.
+    #[test]
+    fn cli_environment_services_start_envelope_golden() {
+        let payload = CliEnvironmentServicesStartPayload::new(
+            command_payload("services::start"),
+            managed_env_detail(),
+        );
+        let value =
+            serde_json::to_value(fixed_event(EventKind::CliEnvironmentServicesStart(payload)))
+                .expect("event serializes");
+        let expected = env_envelope_json("cli.environment.services.start", "services::start");
+        assert_eq!(value, expected);
+    }
+
+    /// Representative for the three env-detail-only `generations::*`
+    /// commands (`history`/`rollback`/`switch`). The fourth member —
+    /// `generations::list` — carries `request_tree` extras and has
+    /// its own envelope test below.
+    #[test]
+    fn cli_environment_generations_history_envelope_golden() {
+        let payload = CliEnvironmentGenerationsHistoryPayload::new(
+            command_payload("generations::history"),
+            managed_env_detail(),
+        );
+        let value = serde_json::to_value(fixed_event(EventKind::CliEnvironmentGenerationsHistory(
+            payload,
+        )))
+        .expect("event serializes");
+        let expected = env_envelope_json(
+            "cli.environment.generations.history",
+            "generations::history",
+        );
+        assert_eq!(value, expected);
+    }
+
+    /// `cli.environment.edit` on the eager call site: env-detail is
+    /// populated, `edited_includes` defaults to `None` and is omitted
+    /// from the wire shape via `skip_serializing_if`.
+    #[test]
+    fn cli_environment_edit_eager_envelope_golden() {
+        let payload = CliEnvironmentEditPayload::new(command_payload("edit"), managed_env_detail());
+        let value = serde_json::to_value(fixed_event(EventKind::CliEnvironmentEdit(payload)))
+            .expect("event serializes");
+        let expected = env_envelope_json("cli.environment.edit", "edit");
+        assert_eq!(value, expected);
+    }
+
+    /// `cli.environment.edit` on the result-known call site:
+    /// `edited_includes` is populated and serializes as a top-level
+    /// payload field. Sparse-merge with the eager event on the
+    /// consumer side recovers the full row.
+    #[test]
+    fn cli_environment_edit_result_envelope_golden() {
+        let payload = CliEnvironmentEditPayload::new(command_payload("edit"), managed_env_detail())
+            .with_edited_includes(true);
+        let value = serde_json::to_value(fixed_event(EventKind::CliEnvironmentEdit(payload)))
+            .expect("event serializes");
+        let mut expected = env_envelope_json("cli.environment.edit", "edit");
+        expected
+            .get_mut("payload")
+            .and_then(|p| p.as_object_mut())
+            .expect("payload object")
+            .insert("edited_includes".to_string(), json!(true));
+        assert_eq!(value, expected);
+    }
+
+    /// `cli.environment.publish` result-known emit carries both
+    /// build-kind flags. The eager emit shape (extras omitted) is
+    /// covered by [`cli_environment_edit_eager_envelope_golden`]'s
+    /// pattern — they share the same `skip_serializing_if` behavior.
+    #[test]
+    fn cli_environment_publish_with_build_kinds_envelope_golden() {
+        let payload =
+            CliEnvironmentPublishPayload::new(command_payload("publish"), managed_env_detail())
+                .with_build_kinds(true, false);
+        let value = serde_json::to_value(fixed_event(EventKind::CliEnvironmentPublish(payload)))
+            .expect("event serializes");
+        let mut expected = env_envelope_json("cli.environment.publish", "publish");
+        let obj = expected
+            .get_mut("payload")
+            .and_then(|p| p.as_object_mut())
+            .expect("payload object");
+        obj.insert("has_expression_build".to_string(), json!(true));
+        obj.insert("has_manifest_build".to_string(), json!(false));
+        assert_eq!(value, expected);
+    }
+
+    /// `cli.environment.generations.list` carries `request_tree`
+    /// reflecting the user-supplied `--tree` flag.
+    #[test]
+    fn cli_environment_generations_list_envelope_golden() {
+        let payload = CliEnvironmentGenerationsListPayload::new(
+            command_payload("generations::list"),
+            managed_env_detail(),
+        )
+        .with_request_tree(true);
+        let value = serde_json::to_value(fixed_event(EventKind::CliEnvironmentGenerationsList(
+            payload,
+        )))
+        .expect("event serializes");
+        let mut expected =
+            env_envelope_json("cli.environment.generations.list", "generations::list");
+        expected
+            .get_mut("payload")
+            .and_then(|p| p.as_object_mut())
+            .expect("payload object")
+            .insert("request_tree".to_string(), json!(true));
+        assert_eq!(value, expected);
+    }
+
+    /// `cli.build` carries no env detail; both build-kind flags are
+    /// non-Optional (required on the wire).
+    #[test]
+    fn cli_build_envelope_golden() {
+        let payload = CliBuildPayload::new(command_payload("build"), true, false);
+        let value = serde_json::to_value(fixed_event(EventKind::CliBuild(payload)))
+            .expect("event serializes");
+        let mut payload_json = expected_payload_json("build");
+        payload_json
+            .as_object_mut()
+            .expect("payload object")
+            .insert("has_expression_build".to_string(), json!(true));
+        payload_json
+            .as_object_mut()
+            .expect("payload object")
+            .insert("has_manifest_build".to_string(), json!(false));
+        let expected = json!({
+            "event_id": "00000000-0000-0000-0000-000000000000",
+            "event_timestamp": EPOCH_UNIX_MS,
+            "source": "cli",
+            "invocation_id": "00000000-0000-0000-0000-000000000000",
+            "device_id": "00000000-0000-0000-0000-000000000000",
+            "event_type": "cli.build",
+            "payload": payload_json,
+        });
+        assert_eq!(value, expected);
+    }
+
+    /// `cli.search` carries the user-supplied search term verbatim
+    /// (D3, 2026-05-30) and no env detail.
+    #[test]
+    fn cli_search_envelope_golden() {
+        let payload = CliSearchPayload::new(command_payload("search"), "ripgrep".to_string());
+        let value = serde_json::to_value(fixed_event(EventKind::CliSearch(payload)))
+            .expect("event serializes");
+        let mut payload_json = expected_payload_json("search");
+        payload_json
+            .as_object_mut()
+            .expect("payload object")
+            .insert("search_term".to_string(), json!("ripgrep"));
+        let expected = json!({
+            "event_id": "00000000-0000-0000-0000-000000000000",
+            "event_timestamp": EPOCH_UNIX_MS,
+            "source": "cli",
+            "invocation_id": "00000000-0000-0000-0000-000000000000",
+            "device_id": "00000000-0000-0000-0000-000000000000",
+            "event_type": "cli.search",
+            "payload": payload_json,
+        });
         assert_eq!(value, expected);
     }
 }
@@ -1210,5 +1928,61 @@ mod pipeline_tests {
                 other => panic!("expected CliPackageInstall, got {other:?}"),
             }
         }
+    }
+
+    /// `cli.environment.edit` follows PR 3's sparse-merge contract:
+    /// the eager call site emits with env-detail only; the result-
+    /// known site emits with `edited_includes` populated. Both events
+    /// share `invocation_id` and `event_type` so the consumer's
+    /// `GROUP BY invocation_id, event_type` + `COALESCE` recovers a
+    /// single `cli.telemetry` row.
+    #[test]
+    fn environment_edit_sparse_merge_emits_two_events_per_invocation() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let connection = MockEventsConnection::default();
+        let sent_batches = connection.sent_batches();
+        let hub = EventsHub::new();
+        hub.set_client(client_with_connection(&tempdir, connection));
+
+        let env_detail = EnvDetail {
+            env_kind: "path".to_string(),
+            env_ref_or_name: "myenv".to_string(),
+        };
+
+        hub.record_environment_edit(env_detail.clone())
+            .expect("eager emit");
+        hub.record_environment_edit_with(env_detail, |p| p.with_edited_includes(true))
+            .expect("result-known emit");
+        hub.flush(true).expect("flush events");
+
+        let events: Vec<_> = sent_batches
+            .lock()
+            .unwrap()
+            .clone()
+            .into_iter()
+            .flatten()
+            .collect();
+        assert_eq!(events.len(), 2);
+        let mut eager_seen = false;
+        let mut result_seen = false;
+        for event in &events {
+            assert_eq!(event.invocation_id, INVOCATION_ID);
+            match &event.kind {
+                EventKind::CliEnvironmentEdit(p) => {
+                    assert_eq!(p.env_detail.env_kind, "path");
+                    match p.edited_includes {
+                        None => eager_seen = true,
+                        Some(true) => result_seen = true,
+                        Some(false) => panic!("unexpected edited_includes=false"),
+                    }
+                },
+                other => panic!("expected CliEnvironmentEdit, got {other:?}"),
+            }
+        }
+        assert!(eager_seen, "missing eager env-detail-only event");
+        assert!(
+            result_seen,
+            "missing result-known event with edited_includes"
+        );
     }
 }

--- a/cli/flox-events/src/lib.rs
+++ b/cli/flox-events/src/lib.rs
@@ -139,8 +139,8 @@ pub enum EventKind {
     CliEnvironmentDelete(CliEnvironmentDeletePayload),
     #[serde(rename = "cli.environment.edit")]
     CliEnvironmentEdit(CliEnvironmentEditPayload),
-    #[serde(rename = "cli.environment.include")]
-    CliEnvironmentInclude(CliEnvironmentIncludePayload),
+    #[serde(rename = "cli.environment.include.upgrade")]
+    CliEnvironmentIncludeUpgrade(CliEnvironmentIncludeUpgradePayload),
     #[serde(rename = "cli.environment.install")]
     CliEnvironmentInstall(CliEnvironmentInstallPayload),
     #[serde(rename = "cli.environment.list")]
@@ -187,7 +187,8 @@ pub enum EventKind {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CommandPayload {
     /// Subcommand name derived from the parsed bpaf command (e.g. `install`,
-    /// `activate`, or nested `services::start` under PR 5's encoding).
+    /// `activate`, or nested `services::start` using the `parent::child`
+    /// join encoding).
     pub subcommand: String,
     /// Flox CLI version string.
     pub flox_version: String,
@@ -485,15 +486,11 @@ impl CliPackageUninstallPayload {
     }
 }
 
-// -------- PR 5: env-detail-only payloads --------
-//
-// The 16 commands below carry `CommandPayload` + `EnvDetail` and
-// nothing more. The payload structs are byte-identical to
+// The env-detail-only payloads below carry `CommandPayload` +
+// `EnvDetail` and nothing more. The structs are byte-identical to
 // `CliEnvironmentPushPayload`; they exist as separate types so each
-// `EventKind` variant owns a distinct payload — matching the PR 3
-// pattern. PR 7's in-PR-collapse section already records a
-// follow-up to consider sharing a single `EnvCommandPayload` if no
-// per-command extras have emerged by then.
+// `EventKind` variant owns a distinct payload type. A future cleanup
+// may collapse them into a shared `EnvCommandPayload`.
 
 /// Payload for [`EventKind::CliEnvironmentContainerize`].
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -531,16 +528,16 @@ impl CliEnvironmentDeletePayload {
     }
 }
 
-/// Payload for [`EventKind::CliEnvironmentInclude`].
+/// Payload for [`EventKind::CliEnvironmentIncludeUpgrade`].
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct CliEnvironmentIncludePayload {
+pub struct CliEnvironmentIncludeUpgradePayload {
     #[serde(flatten)]
     pub command: CommandPayload,
     #[serde(flatten)]
     pub env_detail: EnvDetail,
 }
 
-impl CliEnvironmentIncludePayload {
+impl CliEnvironmentIncludeUpgradePayload {
     pub fn new(command: CommandPayload, env_detail: EnvDetail) -> Self {
         Self {
             command,
@@ -551,7 +548,7 @@ impl CliEnvironmentIncludePayload {
 
 /// Payload for [`EventKind::CliEnvironmentInstall`]. Carries the
 /// env-detail row of a `flox install` invocation; the per-package
-/// detail rides on [`EventKind::CliPackageInstall`] (PR 4).
+/// detail rides on [`EventKind::CliPackageInstall`].
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CliEnvironmentInstallPayload {
     #[serde(flatten)]
@@ -589,7 +586,7 @@ impl CliEnvironmentListPayload {
 
 /// Payload for [`EventKind::CliEnvironmentUninstall`]. Carries the
 /// env-detail row of a `flox uninstall` invocation; the per-package
-/// detail rides on [`EventKind::CliPackageUninstall`] (PR 4).
+/// detail rides on [`EventKind::CliPackageUninstall`].
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CliEnvironmentUninstallPayload {
     #[serde(flatten)]
@@ -609,7 +606,7 @@ impl CliEnvironmentUninstallPayload {
 
 /// Payload for [`EventKind::CliEnvironmentUpgrade`]. Carries the
 /// env-detail row of a `flox upgrade` invocation; the per-package
-/// detail rides on [`EventKind::CliPackageUpgrade`] (PR 4).
+/// detail rides on [`EventKind::CliPackageUpgrade`].
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CliEnvironmentUpgradePayload {
     #[serde(flatten)]
@@ -789,16 +786,13 @@ impl CliEnvironmentGenerationsSwitchPayload {
     }
 }
 
-// -------- PR 5: env-detail + Optional extras payloads --------
-//
-// Three commands carry both env-detail and per-command extras and
-// have two distinct legacy emission sites in the same handler (an
-// eager env-detail emit before the operation runs + an extras emit
-// after the operation result is known). The new path mirrors that
-// structure via PR 3's sparse-merge contract: both sites emit a
-// payload with the same `EventKind` and same `invocation_id`, each
-// populating only what it knows. The consumer
-// `COALESCE`s Optional fields across the rows.
+// The payloads below carry both env-detail and per-command extras,
+// and have two distinct legacy emission sites in the same handler
+// (an eager env-detail emit before the operation runs + an extras
+// emit after the operation result is known). The new path follows a
+// sparse-merge contract: both sites emit a payload with the same
+// `EventKind` and same `invocation_id`, each populating only what it
+// knows. The consumer `COALESCE`s Optional fields across the rows.
 
 /// Payload for [`EventKind::CliEnvironmentEdit`]. Emitted twice per
 /// `flox edit` invocation: once eagerly with env detail, once after
@@ -901,8 +895,6 @@ impl CliEnvironmentGenerationsListPayload {
     }
 }
 
-// -------- PR 5: no-env extras-only payloads --------
-//
 // `flox build` and `flox search` carry per-command extras but no
 // environment context (build operates on the manifest's `build`
 // table; search hits the catalog without a resolved environment).
@@ -933,7 +925,7 @@ impl CliBuildPayload {
 
 /// Payload for [`EventKind::CliSearch`]. Carries the user-supplied
 /// search term verbatim, matching the legacy `subcommand_metric!(
-/// "search", "search_term" = …)` extras (D3, 2026-05-30).
+/// "search", "search_term" = …)` extras.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CliSearchPayload {
     #[serde(flatten)]
@@ -1293,7 +1285,7 @@ mod tests {
         assert_eq!(value, expected);
     }
 
-    /// Common helper for PR 5's env-detail-only envelope goldens.
+    /// Common helper for the env-detail-only envelope goldens.
     /// Builds an `Event` from `subcommand` + v2 env-detail
     /// fields and the expected JSON shape it should serialize to.
     fn env_envelope_json(event_type: &str, subcommand: &str) -> serde_json::Value {
@@ -1336,6 +1328,26 @@ mod tests {
             serde_json::to_value(fixed_event(EventKind::CliEnvironmentContainerize(payload)))
                 .expect("event serializes");
         let expected = env_envelope_json("cli.environment.containerize", "containerize");
+        assert_eq!(value, expected);
+    }
+
+    /// `cli.environment.include.upgrade` — the only `flox include`
+    /// sub-command currently wiring a per-command event. The `.upgrade`
+    /// suffix on `event_type` matches the `parent.child` shape used by
+    /// every other nested-command event_type so a consumer
+    /// `s/::/./g` between `subcommand` and `event_type` lines up
+    /// element-for-element.
+    #[test]
+    fn cli_environment_include_upgrade_envelope_golden() {
+        let payload = CliEnvironmentIncludeUpgradePayload::new(
+            command_payload("include::upgrade"),
+            managed_env_detail(),
+        );
+        let value = serde_json::to_value(fixed_event(EventKind::CliEnvironmentIncludeUpgrade(
+            payload,
+        )))
+        .expect("event serializes");
+        let expected = env_envelope_json("cli.environment.include.upgrade", "include::upgrade");
         assert_eq!(value, expected);
     }
 
@@ -1481,7 +1493,7 @@ mod tests {
     }
 
     /// `cli.search` carries the user-supplied search term verbatim
-    /// (D3, 2026-05-30) and no env detail.
+    /// and no env detail.
     #[test]
     fn cli_search_envelope_golden() {
         let payload = CliSearchPayload::new(command_payload("search"), "ripgrep".to_string());
@@ -1930,7 +1942,7 @@ mod pipeline_tests {
         }
     }
 
-    /// `cli.environment.edit` follows PR 3's sparse-merge contract:
+    /// `cli.environment.edit` follows the sparse-merge contract:
     /// the eager call site emits with env-detail only; the result-
     /// known site emits with `edited_includes` populated. Both events
     /// share `invocation_id` and `event_type` so the consumer's

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -98,6 +98,23 @@ pub struct Activate {
     pub subcommand_or_options: ActivateSubcommandOrOptions,
 }
 
+impl Activate {
+    /// Centrally-derived subcommand string for this invocation. Returns
+    /// the `activate::allow` / `activate::deny` form for the auto-activate
+    /// permission-management sub-commands, preserving the join-key
+    /// continuity the legacy `environment_subcommand_metric!` stream
+    /// already used.
+    pub fn subcommand_name(&self) -> &'static str {
+        match &self.subcommand_or_options {
+            ActivateSubcommandOrOptions::AutoActivate { auto_activate } => match auto_activate {
+                AutoActivate::Allow => "activate::allow",
+                AutoActivate::Deny => "activate::deny",
+            },
+            ActivateSubcommandOrOptions::ActivateOptions { .. } => "activate",
+        }
+    }
+}
+
 #[derive(Bpaf, Clone)]
 pub enum ActivateSubcommandOrOptions {
     AutoActivate {

--- a/cli/flox/src/commands/beta.rs
+++ b/cli/flox/src/commands/beta.rs
@@ -16,4 +16,10 @@ impl BetaCommands {
             BetaCommands::BetaEnabled(args) => args.handle(flox).await,
         }
     }
+
+    pub fn subcommand_name(&self) -> &'static str {
+        match self {
+            BetaCommands::BetaEnabled(_) => "beta-enabled",
+        }
+    }
 }

--- a/cli/flox/src/commands/build.rs
+++ b/cli/flox/src/commands/build.rs
@@ -136,6 +136,21 @@ enum SubcommandOrBuildTargets {
 }
 
 impl Build {
+    /// Centrally-derived subcommand string for this invocation.
+    /// Returns the `build::clean` / `build::import-nixpkgs` /
+    /// `build::update-catalogs` form for the build pseudo-subcommands,
+    /// preserving the join-key continuity the legacy
+    /// `environment_subcommand_metric!` stream already used at
+    /// `cli/flox/src/commands/build.rs:146,154,162`.
+    pub fn subcommand_name(&self) -> &'static str {
+        match &self.subcommand_or_targets {
+            SubcommandOrBuildTargets::Clean { .. } => "build::clean",
+            SubcommandOrBuildTargets::ImportNixpkgs { .. } => "build::import-nixpkgs",
+            SubcommandOrBuildTargets::UpdateCatalogs {} => "build::update-catalogs",
+            SubcommandOrBuildTargets::BuildTargets { .. } => "build",
+        }
+    }
+
     pub async fn handle(self, mut flox: Flox) -> Result<()> {
         match self.subcommand_or_targets {
             SubcommandOrBuildTargets::Clean { targets } => {

--- a/cli/flox/src/commands/build.rs
+++ b/cli/flox/src/commands/build.rs
@@ -5,6 +5,7 @@ use std::process::Stdio;
 use anyhow::{Context, Result, bail};
 use bpaf::Bpaf;
 use flox_core::data::CanonicalPath;
+use flox_events::EventsHub;
 use flox_manifest::lockfile::Lockfile;
 use flox_manifest::{Manifest, MigratedTypedOnly};
 use flox_rust_sdk::flox::Flox;
@@ -293,6 +294,10 @@ impl Build {
             "has_expression_build" = has_expression_build,
             "has_manifest_build" = has_manifest_build
         );
+        if let Err(err) = EventsHub::global().record_build(has_expression_build, has_manifest_build)
+        {
+            debug!(error = %err, "Failed to record v2 event");
+        }
 
         let builder = FloxBuildMk::new(&flox, &base_dir, &expression_ref, &built_environments);
         let results = builder.build(

--- a/cli/flox/src/commands/containerize/mod.rs
+++ b/cli/flox/src/commands/containerize/mod.rs
@@ -9,6 +9,7 @@ use std::{fs, io};
 use anyhow::{Context, Result, anyhow, bail};
 use bpaf::Bpaf;
 use flox_core::activate::context::ActivateMode;
+use flox_events::EventsHub;
 use flox_manifest::interfaces::AsLatestSchema;
 use flox_manifest::lockfile::Lockfile;
 use flox_manifest::parsed::common::ContainerizeConfig;
@@ -23,6 +24,7 @@ use tracing::{debug, info, instrument};
 use super::{EnvironmentSelect, environment_select};
 use crate::commands::SHELL_COMPLETION_FILE;
 use crate::environment_subcommand_metric;
+use crate::utils::events::env_detail_from_concrete;
 use crate::utils::message;
 use crate::utils::openers::first_in_path;
 
@@ -68,6 +70,11 @@ impl Containerize {
             .detect_concrete_environment(&mut flox, "Containerize")
             .await?;
         environment_subcommand_metric!("containerize", env);
+        if let Err(err) =
+            EventsHub::global().record_environment_containerize(env_detail_from_concrete(&env))
+        {
+            debug!(error = %err, "Failed to record v2 event");
+        }
 
         // Check that a specified runtime exists.
         if let Some(runtime) = &self.runtime {

--- a/cli/flox/src/commands/delete.rs
+++ b/cli/flox/src/commands/delete.rs
@@ -1,13 +1,15 @@
 use anyhow::{Result, bail};
 use bpaf::Bpaf;
+use flox_events::EventsHub;
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::{ConcreteEnvironment, Environment};
 use indoc::formatdoc;
-use tracing::instrument;
+use tracing::{debug, instrument};
 
 use crate::commands::{DirEnvironmentSelect, dir_environment_select, environment_description};
 use crate::environment_subcommand_metric;
 use crate::utils::dialog::{Confirm, Dialog};
+use crate::utils::events::env_detail_from_concrete;
 use crate::utils::message;
 
 // Delete an environment
@@ -31,6 +33,11 @@ impl Delete {
             .detect_concrete_environment(&mut flox, "Delete")?;
 
         environment_subcommand_metric!("delete", environment);
+        if let Err(err) =
+            EventsHub::global().record_environment_delete(env_detail_from_concrete(&environment))
+        {
+            debug!(error = %err, "Failed to record v2 event");
+        }
 
         let description = environment_description(&environment)?;
 

--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -7,6 +7,7 @@ use std::process::Command;
 use anyhow::{Context, Result, bail};
 use bpaf::Bpaf;
 use flox_core::data::environment_ref::EnvironmentName;
+use flox_events::EventsHub;
 use flox_manifest::interfaces::{AsWritableManifest, WriteManifest};
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::generations::{
@@ -38,6 +39,7 @@ use super::{
 use crate::commands::{EnvironmentSelectError, SHELL_COMPLETION_FILE, ensure_auth};
 use crate::utils::dialog::{Confirm, Dialog};
 use crate::utils::errors::format_error;
+use crate::utils::events::env_detail_from_concrete;
 use crate::utils::message;
 use crate::{environment_subcommand_metric, subcommand_metric};
 
@@ -99,6 +101,11 @@ impl Edit {
             Err(e) => Err(e)?,
         };
         environment_subcommand_metric!("edit", detected_environment);
+        if let Err(err) = EventsHub::global()
+            .record_environment_edit(env_detail_from_concrete(&detected_environment))
+        {
+            debug!(error = %err, "Failed to record v2 event");
+        }
 
         match self.action {
             EditAction::EditManifest { file } => {
@@ -262,6 +269,13 @@ impl Edit {
                     .map(|compose| &compose.include);
                 let edited_includes = old_includes != new_includes;
                 subcommand_metric!("edit", "edited_includes" = edited_includes);
+                if let Err(err) = EventsHub::global()
+                    .record_environment_edit_with(env_detail_from_concrete(environment), |p| {
+                        p.with_edited_includes(edited_includes)
+                    })
+                {
+                    debug!(error = %err, "Failed to record v2 event");
+                }
             },
         }
 

--- a/cli/flox/src/commands/generations/history.rs
+++ b/cli/flox/src/commands/generations/history.rs
@@ -3,6 +3,7 @@ use std::fmt::Display;
 use anyhow::Result;
 use bpaf::Bpaf;
 use crossterm::style::Stylize;
+use flox_events::EventsHub;
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::generations::{
     self,
@@ -11,10 +12,11 @@ use flox_rust_sdk::models::environment::generations::{
     HistorySpec,
 };
 use indoc::formatdoc;
-use tracing::instrument;
+use tracing::{debug, instrument};
 
 use crate::commands::{EnvironmentSelect, environment_select};
 use crate::environment_subcommand_metric;
+use crate::utils::events::env_detail_from_concrete;
 use crate::utils::message::{page_output, stdout_supports_color};
 
 /// Arguments for the `flox generations history` command
@@ -52,6 +54,11 @@ impl History {
             .detect_concrete_environment(&mut flox, "Show history for")
             .await?;
         environment_subcommand_metric!("generations::history", env);
+        if let Err(err) = EventsHub::global()
+            .record_environment_generations_history(env_detail_from_concrete(&env))
+        {
+            debug!(error = %err, "Failed to record v2 event");
+        }
 
         let env: GenerationsEnvironment = env.try_into()?;
         let metadata = if self.upstream {

--- a/cli/flox/src/commands/generations/list.rs
+++ b/cli/flox/src/commands/generations/list.rs
@@ -3,6 +3,7 @@ use std::fmt::Display;
 use anyhow::Result;
 use bpaf::Bpaf;
 use crossterm::style::Stylize;
+use flox_events::EventsHub;
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::generations::{
     AllGenerationsMetadata,
@@ -13,10 +14,11 @@ use flox_rust_sdk::models::environment::generations::{
 };
 use indoc::formatdoc;
 use renderdag::{Ancestor, GraphRowRenderer, Renderer as _};
-use tracing::instrument;
+use tracing::{debug, instrument};
 
 use crate::commands::{EnvironmentSelect, environment_select};
 use crate::environment_subcommand_metric;
+use crate::utils::events::env_detail_from_concrete;
 use crate::utils::message::{page_output, stdout_supports_color};
 
 /// Arguments for the `flox generations list` command
@@ -56,11 +58,15 @@ impl List {
             .environment
             .detect_concrete_environment(&mut flox, "List using")
             .await?;
-        environment_subcommand_metric!(
-            "generations::list",
-            env,
-            request_tree = self.output_mode == OutputMode::Tree
-        );
+        let request_tree = self.output_mode == OutputMode::Tree;
+        environment_subcommand_metric!("generations::list", env, request_tree = request_tree);
+        if let Err(err) = EventsHub::global()
+            .record_environment_generations_list_with(env_detail_from_concrete(&env), |p| {
+                p.with_request_tree(request_tree)
+            })
+        {
+            debug!(error = %err, "Failed to record v2 event");
+        }
 
         let env: GenerationsEnvironment = env.try_into()?;
         let metadata = if self.upstream {

--- a/cli/flox/src/commands/generations/mod.rs
+++ b/cli/flox/src/commands/generations/mod.rs
@@ -50,6 +50,16 @@ impl GenerationsCommands {
 
         Ok(())
     }
+
+    pub fn subcommand_name(&self) -> &'static str {
+        match self {
+            GenerationsCommands::Help => "generations::help",
+            GenerationsCommands::List(_) => "generations::list",
+            GenerationsCommands::History(_) => "generations::history",
+            GenerationsCommands::Rollback(_) => "generations::rollback",
+            GenerationsCommands::Switch(_) => "generations::switch",
+        }
+    }
 }
 
 #[cfg(test)]

--- a/cli/flox/src/commands/generations/rollback.rs
+++ b/cli/flox/src/commands/generations/rollback.rs
@@ -1,5 +1,6 @@
 use anyhow::{Result, bail};
 use bpaf::Bpaf;
+use flox_events::EventsHub;
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::generations::{
     AllGenerationsMetadata,
@@ -13,6 +14,7 @@ use tracing::{debug, instrument};
 
 use crate::commands::{EnvironmentSelect, environment_select};
 use crate::environment_subcommand_metric;
+use crate::utils::events::env_detail_from_concrete;
 use crate::utils::message;
 
 /// Arguments for the `flox generations rollback` command
@@ -35,6 +37,11 @@ impl Rollback {
             .await?;
 
         environment_subcommand_metric!("generations::rollback", env);
+        if let Err(err) = EventsHub::global()
+            .record_environment_generations_rollback(env_detail_from_concrete(&env))
+        {
+            debug!(error = %err, "Failed to record v2 event");
+        }
         let mut env: GenerationsEnvironment = env.try_into()?;
 
         debug!("determining previous generation");

--- a/cli/flox/src/commands/generations/switch.rs
+++ b/cli/flox/src/commands/generations/switch.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use bpaf::Bpaf;
+use flox_events::EventsHub;
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::generations::{
     GenerationId,
@@ -10,6 +11,7 @@ use tracing::{debug, instrument};
 
 use crate::commands::{EnvironmentSelect, environment_select};
 use crate::environment_subcommand_metric;
+use crate::utils::events::env_detail_from_concrete;
 use crate::utils::message;
 
 /// Arguments for the `flox generations switch` command
@@ -31,6 +33,11 @@ impl Switch {
             .await?;
 
         environment_subcommand_metric!("generations::switch", env);
+        if let Err(err) = EventsHub::global()
+            .record_environment_generations_switch(env_detail_from_concrete(&env))
+        {
+            debug!(error = %err, "Failed to record v2 event");
+        }
         let mut env: GenerationsEnvironment = env.try_into()?;
 
         let to = self.target_generation;

--- a/cli/flox/src/commands/include.rs
+++ b/cli/flox/src/commands/include.rs
@@ -1,13 +1,15 @@
 use anyhow::Result;
 use bpaf::Bpaf;
+use flox_events::EventsHub;
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::Environment;
 use indoc::indoc;
-use tracing::{info_span, instrument};
+use tracing::{debug, info_span, instrument};
 
 use super::EnvironmentSelect;
 use crate::commands::{display_help, environment_description, environment_select};
 use crate::environment_subcommand_metric;
+use crate::utils::events::env_detail_from_concrete;
 use crate::utils::message::{self, print_overridden_manifest_fields};
 
 /// Include Commands.
@@ -53,6 +55,13 @@ impl IncludeCommands {
 
         Ok(())
     }
+
+    pub fn subcommand_name(&self) -> &'static str {
+        match self {
+            IncludeCommands::Help => "include::help",
+            IncludeCommands::Upgrade(_) => "include::upgrade",
+        }
+    }
 }
 
 impl Upgrade {
@@ -67,6 +76,11 @@ impl Upgrade {
             .await?;
 
         environment_subcommand_metric!("include::upgrade", environment);
+        if let Err(err) =
+            EventsHub::global().record_environment_include(env_detail_from_concrete(&environment))
+        {
+            debug!(error = %err, "Failed to record v2 event");
+        }
 
         let description = environment_description(&environment)?;
 

--- a/cli/flox/src/commands/include.rs
+++ b/cli/flox/src/commands/include.rs
@@ -76,8 +76,8 @@ impl Upgrade {
             .await?;
 
         environment_subcommand_metric!("include::upgrade", environment);
-        if let Err(err) =
-            EventsHub::global().record_environment_include(env_detail_from_concrete(&environment))
+        if let Err(err) = EventsHub::global()
+            .record_environment_include_upgrade(env_detail_from_concrete(&environment))
         {
             debug!(error = %err, "Failed to record v2 event");
         }

--- a/cli/flox/src/commands/install.rs
+++ b/cli/flox/src/commands/install.rs
@@ -60,6 +60,7 @@ use crate::utils::detect_shell::detect_shell_for_in_place;
 use crate::utils::dialog::{Dialog, Select};
 use crate::utils::didyoumean::{DidYouMean, InstallSuggestion};
 use crate::utils::errors::format_error;
+use crate::utils::events::env_detail_from_concrete;
 use crate::utils::message::{self};
 use crate::utils::tracing::sentry_set_tag;
 use crate::{Exit, environment_subcommand_metric, subcommand_metric};
@@ -186,6 +187,11 @@ impl Install {
             Err(e) => Err(e)?,
         };
         environment_subcommand_metric!("install", concrete_environment);
+        if let Err(err) = EventsHub::global()
+            .record_environment_install(env_detail_from_concrete(&concrete_environment))
+        {
+            debug!(error = %err, "Failed to record v2 event");
+        }
 
         let description = environment_description(&concrete_environment)?;
 

--- a/cli/flox/src/commands/list.rs
+++ b/cli/flox/src/commands/list.rs
@@ -3,6 +3,7 @@ use std::str::FromStr;
 
 use anyhow::{Result, bail};
 use bpaf::Bpaf;
+use flox_events::EventsHub;
 use flox_manifest::interfaces::{AsWritableManifest, WriteManifest};
 use flox_manifest::lockfile::{LockedInstallable, LockedPackageFlake, Lockfile, PackageToList};
 use flox_rust_sdk::flox::Flox;
@@ -21,6 +22,7 @@ use tracing::{debug, instrument};
 use super::{EnvironmentSelect, environment_select};
 use crate::commands::render_composition_manifest;
 use crate::environment_subcommand_metric;
+use crate::utils::events::env_detail_from_concrete;
 use crate::utils::message;
 use crate::utils::tracing::sentry_set_tag;
 
@@ -66,6 +68,11 @@ impl List {
             .detect_concrete_environment(&mut flox, "List using")
             .await?;
         environment_subcommand_metric!("list", env);
+        if let Err(err) =
+            EventsHub::global().record_environment_list(env_detail_from_concrete(&env))
+        {
+            debug!(error = %err, "Failed to record v2 event");
+        }
 
         let (manifest_contents, lockfile) = match (&mut env, self.upstream) {
             (ConcreteEnvironment::Path(_), true) => {

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -196,84 +196,27 @@ impl Commands {
     /// Centrally-derived subcommand name stamped onto v2
     /// `cli.command_run` / `cli.command_completed` events.
     ///
-    /// Nested commands use the `parent::child` join convention (see
-    /// `services::start`, `generations::switch`, etc.) — PR 5 pins this
-    /// convention against the consumer-side classifiers. The `auth`
-    /// command's downstream classifier needs the literal `auth2` —
-    /// the special-case rewrite is deferred to PR 5 per spec.
+    /// Each sub-enum owns its own [`Self::subcommand_name`] returning
+    /// the full wire string (including any `parent::child` prefix);
+    /// this top-level method just dispatches.
     ///
-    /// The `Help` arm of each nested family (e.g. `flox services
-    /// --help`) uses the `parent::help` form rather than the bare
-    /// parent name, so the wire shape distinguishes "the user
-    /// explicitly asked for help on `services`" from any future
-    /// emission that uses the bare parent name.
+    /// Nested commands use the `parent::child` join convention (see
+    /// `services::start`, `generations::switch`, etc.) — pinned
+    /// against the consumer-side classifiers in PR 5. The `auth`
+    /// command's downstream classifier needs the literal `auth2`;
+    /// that special-case lives on [`AdminCommands::subcommand_name`]
+    /// so the carve-out is co-located with the `Auth` variant.
     pub fn subcommand_name(&self) -> &'static str {
         match self {
             Commands::Help(_) => "help",
-            Commands::Manage(c) => match c {
-                ManageCommands::Init(_) => "init",
-                ManageCommands::Envs(_) => "envs",
-                ManageCommands::Delete(_) => "delete",
-            },
-            Commands::Use(c) => match c {
-                UseCommands::Activate(_) => "activate",
-                UseCommands::Deactivate(_) => "deactivate",
-                UseCommands::Services(sub) => match sub {
-                    services::ServicesCommands::Help => "services::help",
-                    services::ServicesCommands::Restart(_) => "services::restart",
-                    services::ServicesCommands::Start(_) => "services::start",
-                    services::ServicesCommands::Status(_) => "services::status",
-                    services::ServicesCommands::Stop(_) => "services::stop",
-                    services::ServicesCommands::Logs(_) => "services::logs",
-                    services::ServicesCommands::Persist(_) => "services::persist",
-                },
-            },
-            Commands::Discover(c) => match c {
-                DiscoverCommands::Search(_) => "search",
-                DiscoverCommands::Show(_) => "show",
-            },
-            Commands::Modify(c) => match c {
-                ModifyCommands::Install(_) => "install",
-                ModifyCommands::List(_) => "list",
-                ModifyCommands::Edit(_) => "edit",
-                ModifyCommands::Include(sub) => match sub {
-                    include::IncludeCommands::Help => "include::help",
-                    include::IncludeCommands::Upgrade(_) => "include::upgrade",
-                },
-                ModifyCommands::Upgrade(_) => "upgrade",
-                ModifyCommands::Uninstall(_) => "uninstall",
-                ModifyCommands::Generations(sub) => match sub {
-                    generations::GenerationsCommands::Help => "generations::help",
-                    generations::GenerationsCommands::List(_) => "generations::list",
-                    generations::GenerationsCommands::History(_) => "generations::history",
-                    generations::GenerationsCommands::Rollback(_) => "generations::rollback",
-                    generations::GenerationsCommands::Switch(_) => "generations::switch",
-                },
-            },
-            Commands::Share(c) => match c {
-                ShareCommands::Build(_) => "build",
-                ShareCommands::Publish(_) => "publish",
-                ShareCommands::Push(_) => "push",
-                ShareCommands::Pull(_) => "pull",
-                ShareCommands::Containerize(_) => "containerize",
-            },
-            Commands::Admin(c) => match c {
-                AdminCommands::Auth(_) => "auth",
-                AdminCommands::Config(_) => "config",
-                AdminCommands::Gc(_) => "gc",
-            },
-            Commands::Internal(c) => match c {
-                InternalCommands::ResetMetrics(_) => "reset-metrics",
-                InternalCommands::Upload(_) => "upload",
-                InternalCommands::LockManifest(_) => "lock-manifest",
-                InternalCommands::CheckForUpgrades(_) => "check-for-upgrades",
-                InternalCommands::ActivationState(_) => "activation-state",
-                InternalCommands::ServicesSocket(_) => "services-socket",
-                InternalCommands::HookEnv(_) => "hook-env",
-            },
-            Commands::Beta(c) => match c {
-                beta::BetaCommands::BetaEnabled(_) => "beta-enabled",
-            },
+            Commands::Manage(c) => c.subcommand_name(),
+            Commands::Use(c) => c.subcommand_name(),
+            Commands::Discover(c) => c.subcommand_name(),
+            Commands::Modify(c) => c.subcommand_name(),
+            Commands::Share(c) => c.subcommand_name(),
+            Commands::Admin(c) => c.subcommand_name(),
+            Commands::Internal(c) => c.subcommand_name(),
+            Commands::Beta(c) => c.subcommand_name(),
             // Hidden operator command group; the legacy pipeline emitted no
             // metric for it, so the bare parent name is sufficient here.
             Commands::Factory(_) => "factory",
@@ -736,6 +679,14 @@ impl ManageCommands {
         }
         Ok(())
     }
+
+    fn subcommand_name(&self) -> &'static str {
+        match self {
+            ManageCommands::Init(_) => "init",
+            ManageCommands::Envs(_) => "envs",
+            ManageCommands::Delete(_) => "delete",
+        }
+    }
 }
 
 /// Use environments
@@ -778,6 +729,14 @@ impl UseCommands {
             UseCommands::Services(args) => args.handle(config, flox).await,
         }
     }
+
+    fn subcommand_name(&self) -> &'static str {
+        match self {
+            UseCommands::Activate(_) => "activate",
+            UseCommands::Deactivate(_) => "deactivate",
+            UseCommands::Services(sub) => sub.subcommand_name(),
+        }
+    }
 }
 
 /// Discover packages
@@ -799,6 +758,13 @@ impl DiscoverCommands {
             DiscoverCommands::Show(args) => args.handle(flox).await?,
         }
         Ok(())
+    }
+
+    fn subcommand_name(&self) -> &'static str {
+        match self {
+            DiscoverCommands::Search(_) => "search",
+            DiscoverCommands::Show(_) => "show",
+        }
     }
 }
 
@@ -887,6 +853,18 @@ impl ModifyCommands {
         }
         Ok(())
     }
+
+    fn subcommand_name(&self) -> &'static str {
+        match self {
+            ModifyCommands::Install(_) => "install",
+            ModifyCommands::List(_) => "list",
+            ModifyCommands::Edit(_) => "edit",
+            ModifyCommands::Include(sub) => sub.subcommand_name(),
+            ModifyCommands::Upgrade(_) => "upgrade",
+            ModifyCommands::Uninstall(_) => "uninstall",
+            ModifyCommands::Generations(sub) => sub.subcommand_name(),
+        }
+    }
 }
 
 /// Share with others
@@ -936,6 +914,16 @@ impl ShareCommands {
         }
         Ok(())
     }
+
+    fn subcommand_name(&self) -> &'static str {
+        match self {
+            ShareCommands::Build(_) => "build",
+            ShareCommands::Publish(_) => "publish",
+            ShareCommands::Push(_) => "push",
+            ShareCommands::Pull(_) => "pull",
+            ShareCommands::Containerize(_) => "containerize",
+        }
+    }
 }
 
 /// Administration
@@ -968,6 +956,19 @@ impl AdminCommands {
             AdminCommands::Gc(args) => args.handle(flox)?,
         }
         Ok(())
+    }
+
+    /// The `Auth` arm emits `"auth2"` (not `"auth"`) to preserve the
+    /// downstream `cli.authenticated` classifier defined in
+    /// `efforts/unified-metrics/tasks/016-events-cli.md`. The legacy
+    /// `auth.rs:251` already wrote `"auth2"` on the wire; mirroring it
+    /// here keeps the consumer contract intact post-cutover.
+    fn subcommand_name(&self) -> &'static str {
+        match self {
+            AdminCommands::Auth(_) => "auth2",
+            AdminCommands::Config(_) => "config",
+            AdminCommands::Gc(_) => "gc",
+        }
     }
 }
 
@@ -1024,6 +1025,23 @@ impl InternalCommands {
             InternalCommands::HookEnv(args) => args.handle(config, flox)?,
         }
         Ok(())
+    }
+
+    /// `Deactivate(_)` always maps to `"deactivate"`. The legacy
+    /// `deactivate.rs::old_exit` emits `subcommand_metric!("exit")` —
+    /// that `"exit"` pseudo-subcommand is dropped on the new path; the
+    /// centrally-derived name is always the parsed clap command's
+    /// name, never the handler method's name.
+    fn subcommand_name(&self) -> &'static str {
+        match self {
+            InternalCommands::ResetMetrics(_) => "reset-metrics",
+            InternalCommands::Upload(_) => "upload",
+            InternalCommands::LockManifest(_) => "lock-manifest",
+            InternalCommands::CheckForUpgrades(_) => "check-for-upgrades",
+            InternalCommands::ActivationState(_) => "activation-state",
+            InternalCommands::ServicesSocket(_) => "services-socket",
+            InternalCommands::HookEnv(_) => "hook-env",
+        }
     }
 }
 
@@ -1682,4 +1700,61 @@ fn render_composition_manifest(manifest: &Manifest<TypedOnly>) -> Result<String>
     toml_edit::visit_mut::visit_document_mut(&mut Visitor::new_for_document(), &mut document);
 
     Ok(document.to_string())
+}
+
+#[cfg(test)]
+mod subcommand_name_tests {
+    use super::*;
+
+    /// Run the top-level `flox_args` parser against `argv` and return
+    /// the resulting [`Commands`] for assertion. Treats any parser
+    /// failure as a test failure so the assertion site stays terse.
+    fn parse_command(argv: &[&str]) -> Commands {
+        let parsed = flox_args()
+            .to_options()
+            .run_inner(argv)
+            .unwrap_or_else(|err| panic!("failed to parse {argv:?}: {err:?}"));
+        parsed
+            .command
+            .expect("expected an inner subcommand after parsing")
+    }
+
+    /// `auth` must derive to the literal `"auth2"` on the wire so the
+    /// consumer's `cli.authenticated` classifier (defined in
+    /// `efforts/unified-metrics/tasks/016-events-cli.md`) keeps firing
+    /// post-cutover. Removing this carve-out silently breaks the
+    /// classifier without surfacing a producer-side error.
+    #[test]
+    fn auth_command_derives_to_auth2_subcommand_name() {
+        let command = parse_command(&["auth", "status"]);
+        assert_eq!(command.subcommand_name(), "auth2");
+    }
+
+    /// `deactivate` must derive to the literal `"deactivate"`, not the
+    /// legacy `"exit"` pseudo-subcommand that `deactivate.rs::old_exit`
+    /// emits via the legacy macro. The new path is keyed off the
+    /// parsed clap command's name, not the handler method's name.
+    #[test]
+    fn deactivate_command_derives_to_deactivate_not_exit() {
+        let command = parse_command(&["deactivate"]);
+        assert_eq!(command.subcommand_name(), "deactivate");
+    }
+
+    /// Nested `services <sub>` commands must use the `parent::child`
+    /// join convention so the wire string matches the legacy
+    /// `environment_subcommand_metric!("services::start", …)` value
+    /// — the consumer's join-key continuity on `cli.telemetry`
+    /// depends on it.
+    #[test]
+    fn services_start_uses_parent_child_join_encoding() {
+        let command = parse_command(&["services", "start"]);
+        assert_eq!(command.subcommand_name(), "services::start");
+    }
+
+    /// `generations list` must use the same `parent::child` encoding.
+    #[test]
+    fn generations_list_uses_parent_child_join_encoding() {
+        let command = parse_command(&["generations", "list"]);
+        assert_eq!(command.subcommand_name(), "generations::list");
+    }
 }

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -732,7 +732,7 @@ impl UseCommands {
 
     fn subcommand_name(&self) -> &'static str {
         match self {
-            UseCommands::Activate(_) => "activate",
+            UseCommands::Activate(args) => args.subcommand_name(),
             UseCommands::Deactivate(_) => "deactivate",
             UseCommands::Services(sub) => sub.subcommand_name(),
         }
@@ -917,7 +917,7 @@ impl ShareCommands {
 
     fn subcommand_name(&self) -> &'static str {
         match self {
-            ShareCommands::Build(_) => "build",
+            ShareCommands::Build(args) => args.subcommand_name(),
             ShareCommands::Publish(_) => "publish",
             ShareCommands::Push(_) => "push",
             ShareCommands::Pull(_) => "pull",
@@ -959,10 +959,10 @@ impl AdminCommands {
     }
 
     /// The `Auth` arm emits `"auth2"` (not `"auth"`) to preserve the
-    /// downstream `cli.authenticated` classifier defined in
-    /// `efforts/unified-metrics/tasks/016-events-cli.md`. The legacy
-    /// `auth.rs:251` already wrote `"auth2"` on the wire; mirroring it
-    /// here keeps the consumer contract intact post-cutover.
+    /// downstream classifier that keys off `subcommand == "auth2"`
+    /// with `exit_code == 0`. The legacy `auth.rs:251` already wrote
+    /// `"auth2"` on the wire; mirroring it here keeps the consumer
+    /// contract intact post-cutover.
     fn subcommand_name(&self) -> &'static str {
         match self {
             AdminCommands::Auth(_) => "auth2",
@@ -1032,11 +1032,16 @@ impl InternalCommands {
     /// that `"exit"` pseudo-subcommand is dropped on the new path; the
     /// centrally-derived name is always the parsed clap command's
     /// name, never the handler method's name.
+    ///
+    /// `LockManifest(_)` maps to `"lock"` (not `"lock-manifest"`) to
+    /// preserve parity with the legacy `lock_manifest.rs:34`
+    /// `subcommand_metric!("lock")` wire string. Same shape as the
+    /// `Auth → "auth2"` carve-out on [`AdminCommands::subcommand_name`].
     fn subcommand_name(&self) -> &'static str {
         match self {
             InternalCommands::ResetMetrics(_) => "reset-metrics",
             InternalCommands::Upload(_) => "upload",
-            InternalCommands::LockManifest(_) => "lock-manifest",
+            InternalCommands::LockManifest(_) => "lock",
             InternalCommands::CheckForUpgrades(_) => "check-for-upgrades",
             InternalCommands::ActivationState(_) => "activation-state",
             InternalCommands::ServicesSocket(_) => "services-socket",
@@ -1719,11 +1724,11 @@ mod subcommand_name_tests {
             .expect("expected an inner subcommand after parsing")
     }
 
-    /// `auth` must derive to the literal `"auth2"` on the wire so the
-    /// consumer's `cli.authenticated` classifier (defined in
-    /// `efforts/unified-metrics/tasks/016-events-cli.md`) keeps firing
-    /// post-cutover. Removing this carve-out silently breaks the
-    /// classifier without surfacing a producer-side error.
+    /// `auth` must derive to the literal `"auth2"` on the wire so
+    /// the downstream classifier that keys off `subcommand == "auth2"`
+    /// keeps firing post-cutover. Removing this carve-out silently
+    /// changes the wire string without surfacing a producer-side
+    /// error; the test pins the parity contract.
     #[test]
     fn auth_command_derives_to_auth2_subcommand_name() {
         let command = parse_command(&["auth", "status"]);
@@ -1738,6 +1743,18 @@ mod subcommand_name_tests {
     fn deactivate_command_derives_to_deactivate_not_exit() {
         let command = parse_command(&["deactivate"]);
         assert_eq!(command.subcommand_name(), "deactivate");
+    }
+
+    /// `lock-manifest` must derive to the literal `"lock"` to preserve
+    /// parity with the legacy `lock_manifest.rs:34`
+    /// `subcommand_metric!("lock")` wire string. Removing the
+    /// carve-out changes the wire string silently and breaks any
+    /// downstream classifier keyed off `subcommand == "lock"`. Same
+    /// shape as the `auth → "auth2"` test above.
+    #[test]
+    fn lock_manifest_command_derives_to_lock_for_parity() {
+        let command = parse_command(&["lock-manifest", "/dev/null"]);
+        assert_eq!(command.subcommand_name(), "lock");
     }
 
     /// Nested `services <sub>` commands must use the `parent::child`
@@ -1756,5 +1773,59 @@ mod subcommand_name_tests {
     fn generations_list_uses_parent_child_join_encoding() {
         let command = parse_command(&["generations", "list"]);
         assert_eq!(command.subcommand_name(), "generations::list");
+    }
+
+    /// `include upgrade` must use the same `parent::child` encoding —
+    /// covers the third nested-command family alongside services and
+    /// generations.
+    #[test]
+    fn include_upgrade_uses_parent_child_join_encoding() {
+        let command = parse_command(&["include", "upgrade"]);
+        assert_eq!(command.subcommand_name(), "include::upgrade");
+    }
+
+    /// `activate allow` / `activate deny` are bpaf-parsed sub-commands
+    /// of `flox activate` (auto-activation permission management). The
+    /// legacy stream stamps `activate::allow` / `activate::deny` at
+    /// `cli/flox/src/commands/activate.rs:323,328`; without the
+    /// `Activate::subcommand_name` carve-out the central derivation
+    /// collapses both to bare `"activate"` and silently drops two
+    /// downstream join keys.
+    #[test]
+    fn activate_allow_uses_parent_child_join_encoding() {
+        let command = parse_command(&["activate", "allow"]);
+        assert_eq!(command.subcommand_name(), "activate::allow");
+    }
+
+    #[test]
+    fn activate_deny_uses_parent_child_join_encoding() {
+        let command = parse_command(&["activate", "deny"]);
+        assert_eq!(command.subcommand_name(), "activate::deny");
+    }
+
+    /// `flox build` has three pseudo-subcommands — `clean`,
+    /// `import-nixpkgs`, and `update-catalogs` — that the legacy
+    /// stream stamps as `build::clean` / `build::import-nixpkgs` /
+    /// `build::update-catalogs` at
+    /// `cli/flox/src/commands/build.rs:146,154,162`. Without the
+    /// `Build::subcommand_name` carve-out the central derivation
+    /// collapses all three to bare `"build"`, silently dropping
+    /// three downstream join keys.
+    #[test]
+    fn build_clean_uses_parent_child_join_encoding() {
+        let command = parse_command(&["build", "clean"]);
+        assert_eq!(command.subcommand_name(), "build::clean");
+    }
+
+    #[test]
+    fn build_import_nixpkgs_uses_parent_child_join_encoding() {
+        let command = parse_command(&["build", "import-nixpkgs", "nixpkgs#hello"]);
+        assert_eq!(command.subcommand_name(), "build::import-nixpkgs");
+    }
+
+    #[test]
+    fn build_update_catalogs_uses_parent_child_join_encoding() {
+        let command = parse_command(&["build", "update-catalogs"]);
+        assert_eq!(command.subcommand_name(), "build::update-catalogs");
     }
 }

--- a/cli/flox/src/commands/publish.rs
+++ b/cli/flox/src/commands/publish.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use anyhow::{Context, Result, bail};
 use bpaf::Bpaf;
+use flox_events::EventsHub;
 use flox_manifest::{Manifest, MigratedTypedOnly};
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::{ConcreteEnvironment, Environment};
@@ -37,6 +38,7 @@ use crate::commands::build::{
 use crate::commands::{SHELL_COMPLETION_FILE, ensure_auth};
 use crate::config::Config;
 use crate::utils::errors::display_chain;
+use crate::utils::events::env_detail_from_concrete;
 use crate::utils::message;
 use crate::{environment_subcommand_metric, subcommand_metric};
 
@@ -110,6 +112,11 @@ impl Publish {
             .environment
             .detect_concrete_environment(&mut flox, "Publish")?;
         environment_subcommand_metric!("publish", env);
+        if let Err(err) =
+            EventsHub::global().record_environment_publish(env_detail_from_concrete(&env))
+        {
+            debug!(error = %err, "Failed to record v2 event");
+        }
 
         let publish_config = PublishConfig {
             metadata_only: self.metadata_only,
@@ -152,6 +159,7 @@ impl Publish {
         let handle = ensure_auth(&mut flox).await?;
         let catalog_name = publish_config.cache_args.org.clone().unwrap_or(handle);
 
+        let env_detail = env_detail_from_concrete(&env);
         let path_env = match env {
             ConcreteEnvironment::Path(path_env) => path_env,
             ConcreteEnvironment::Managed(_) => {
@@ -222,19 +230,26 @@ impl Publish {
             .create_package_and_possibly_user_catalog(catalog, &catalog_name)
             .await?;
 
+        let has_expression_build = publish_provider
+            .package_metadata
+            .package
+            .kind()
+            .is_expression_build();
+        let has_manifest_build = publish_provider
+            .package_metadata
+            .package
+            .kind()
+            .is_manifest_build();
         subcommand_metric!(
             "publish",
-            "has_expression_build" = publish_provider
-                .package_metadata
-                .package
-                .kind()
-                .is_expression_build(),
-            "has_manifest_build" = publish_provider
-                .package_metadata
-                .package
-                .kind()
-                .is_manifest_build()
+            "has_expression_build" = has_expression_build,
+            "has_manifest_build" = has_manifest_build
         );
+        if let Err(err) = EventsHub::global().record_environment_publish_with(env_detail, |p| {
+            p.with_build_kinds(has_expression_build, has_manifest_build)
+        }) {
+            debug!(error = %err, "Failed to record v2 event");
+        }
 
         // Pre-check: ask the catalog server if this exact build already exists
         // before spending time on the build. If the check fails, warn the

--- a/cli/flox/src/commands/search.rs
+++ b/cli/flox/src/commands/search.rs
@@ -3,6 +3,7 @@ use std::num::NonZeroU8;
 
 use anyhow::{Result, bail};
 use bpaf::Bpaf;
+use flox_events::EventsHub;
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::providers::catalog::SearchTerm;
 use floxhub_client::{CatalogClientTrait, SearchResults};
@@ -53,6 +54,9 @@ impl Search {
         sentry_set_tag("show_all", self.all);
         sentry_set_tag("search_term", search_term);
         subcommand_metric!("search", search_term = search_term);
+        if let Err(err) = EventsHub::global().record_search(search_term.clone()) {
+            debug!(error = %err, "Failed to record v2 event");
+        }
 
         debug!("performing search for term: {}", search_term);
 

--- a/cli/flox/src/commands/services/logs.rs
+++ b/cli/flox/src/commands/services/logs.rs
@@ -1,5 +1,6 @@
 use anyhow::{Result, bail};
 use bpaf::Bpaf;
+use flox_events::EventsHub;
 use flox_manifest::interfaces::AsLatestSchema;
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::providers::services::process_compose::{
@@ -9,11 +10,12 @@ use flox_rust_sdk::providers::services::process_compose::{
     ProcessComposeLogTail,
     ProcessStates,
 };
-use tracing::instrument;
+use tracing::{debug, instrument};
 
 use crate::commands::services::{ServicesEnvironment, guard_service_commands_available};
 use crate::commands::{EnvironmentSelect, environment_select};
 use crate::environment_subcommand_metric;
+use crate::utils::events::env_detail_from_concrete;
 
 #[derive(Bpaf, Debug, Clone)]
 pub struct Logs {
@@ -39,6 +41,11 @@ impl Logs {
         let env =
             ServicesEnvironment::from_environment_selection(&mut flox, &self.environment).await?;
         environment_subcommand_metric!("services::logs", env.environment);
+        if let Err(err) = EventsHub::global()
+            .record_environment_services_logs(env_detail_from_concrete(&env.environment))
+        {
+            debug!(error = %err, "Failed to record v2 event");
+        }
         guard_service_commands_available(&env, &flox.system)?;
 
         let socket = env.socket();

--- a/cli/flox/src/commands/services/mod.rs
+++ b/cli/flox/src/commands/services/mod.rs
@@ -131,6 +131,18 @@ impl ServicesCommands {
 
         Ok(())
     }
+
+    pub fn subcommand_name(&self) -> &'static str {
+        match self {
+            ServicesCommands::Help => "services::help",
+            ServicesCommands::Restart(_) => "services::restart",
+            ServicesCommands::Start(_) => "services::start",
+            ServicesCommands::Status(_) => "services::status",
+            ServicesCommands::Stop(_) => "services::stop",
+            ServicesCommands::Logs(_) => "services::logs",
+            ServicesCommands::Persist(_) => "services::persist",
+        }
+    }
 }
 
 /// An augmented [ConcreteEnvironment] that has been checked for services support.

--- a/cli/flox/src/commands/services/persist.rs
+++ b/cli/flox/src/commands/services/persist.rs
@@ -4,17 +4,19 @@ use std::fs::File;
 use anyhow::{Result, bail};
 use bpaf::Bpaf;
 use flox_core::data::environment_ref::ActivateEnvironmentRef;
+use flox_events::EventsHub;
 use flox_manifest::interfaces::AsLatestSchema;
 use flox_manifest::parsed::Inner;
 use flox_manifest::parsed::common::ServiceDescriptor;
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::providers::services::systemd::render_systemd_unit_file;
-use tracing::instrument;
+use tracing::{debug, instrument};
 use xdg::BaseDirectories;
 
 use crate::commands::services::{ServicesEnvironment, guard_service_commands_available};
 use crate::commands::{EnvironmentSelect, environment_select};
 use crate::environment_subcommand_metric;
+use crate::utils::events::env_detail_from_concrete;
 use crate::utils::message;
 
 // TODO: Allow output directory to be configurable? But consider whether it
@@ -35,6 +37,11 @@ impl Persist {
         let env =
             ServicesEnvironment::from_environment_selection(&mut flox, &self.environment).await?;
         environment_subcommand_metric!("services::persist", env.environment);
+        if let Err(err) = EventsHub::global()
+            .record_environment_services_persist(env_detail_from_concrete(&env.environment))
+        {
+            debug!(error = %err, "Failed to record v2 event");
+        }
         guard_service_commands_available(&env, &flox.system)?;
 
         let manifest_services = &env.manifest.as_latest_schema().services;

--- a/cli/flox/src/commands/services/restart.rs
+++ b/cli/flox/src/commands/services/restart.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use anyhow::{Result, anyhow};
 use bpaf::Bpaf;
 use flox_core::data::System;
+use flox_events::EventsHub;
 use flox_manifest::interfaces::AsLatestSchema;
 use flox_manifest::parsed::common::Services;
 use flox_rust_sdk::flox::Flox;
@@ -25,6 +26,7 @@ use crate::commands::services::{
 use crate::commands::{EnvironmentSelect, environment_select};
 use crate::config::Config;
 use crate::environment_subcommand_metric;
+use crate::utils::events::env_detail_from_concrete;
 use crate::utils::message;
 
 #[derive(Bpaf, Debug, Clone)]
@@ -43,6 +45,11 @@ impl Restart {
         let mut env =
             ServicesEnvironment::from_environment_selection(&mut flox, &self.environment).await?;
         environment_subcommand_metric!("services::restart", env.environment);
+        if let Err(err) = EventsHub::global()
+            .record_environment_services_restart(env_detail_from_concrete(&env.environment))
+        {
+            debug!(error = %err, "Failed to record v2 event");
+        }
         let (current_mode, generation) = guard_is_within_activation(&env, "restart")?;
         guard_service_commands_available(&env, &flox.system)?;
 

--- a/cli/flox/src/commands/services/start.rs
+++ b/cli/flox/src/commands/services/start.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 
 use anyhow::{Result, anyhow};
 use bpaf::Bpaf;
+use flox_events::EventsHub;
 use flox_manifest::interfaces::AsLatestSchema;
 use flox_manifest::parsed::common::Services;
 use flox_rust_sdk::data::System;
@@ -21,6 +22,7 @@ use crate::commands::services::{
 use crate::commands::{EnvironmentSelect, environment_select};
 use crate::config::Config;
 use crate::environment_subcommand_metric;
+use crate::utils::events::env_detail_from_concrete;
 use crate::utils::message;
 
 #[derive(Bpaf, Debug, Clone)]
@@ -39,6 +41,11 @@ impl Start {
         let mut env =
             ServicesEnvironment::from_environment_selection(&mut flox, &self.environment).await?;
         environment_subcommand_metric!("services::start", env.environment);
+        if let Err(err) = EventsHub::global()
+            .record_environment_services_start(env_detail_from_concrete(&env.environment))
+        {
+            debug!(error = %err, "Failed to record v2 event");
+        }
         let (current_mode, generation) = guard_is_within_activation(&env, "start")?;
         guard_service_commands_available(&env, &flox.system)?;
 

--- a/cli/flox/src/commands/services/status.rs
+++ b/cli/flox/src/commands/services/status.rs
@@ -3,6 +3,7 @@ use std::fmt::Display;
 
 use anyhow::{Result, anyhow};
 use bpaf::Bpaf;
+use flox_events::EventsHub;
 use flox_manifest::interfaces::AsLatestSchema;
 use flox_manifest::parsed::Inner;
 use flox_rust_sdk::flox::Flox;
@@ -14,11 +15,12 @@ use flox_rust_sdk::providers::services::process_compose::{
 };
 use itertools::Itertools;
 use serde::Serialize;
-use tracing::instrument;
+use tracing::{debug, instrument};
 
 use crate::commands::services::{ServicesEnvironment, guard_service_commands_available};
 use crate::commands::{EnvironmentSelect, environment_select};
 use crate::environment_subcommand_metric;
+use crate::utils::events::env_detail_from_concrete;
 
 #[derive(Bpaf, Debug, Clone)]
 pub struct Status {
@@ -40,6 +42,11 @@ impl Status {
         let env =
             ServicesEnvironment::from_environment_selection(&mut flox, &self.environment).await?;
         environment_subcommand_metric!("services::status", env.environment);
+        if let Err(err) = EventsHub::global()
+            .record_environment_services_status(env_detail_from_concrete(&env.environment))
+        {
+            debug!(error = %err, "Failed to record v2 event");
+        }
         guard_service_commands_available(&env, &flox.system)?;
 
         let processes = ProcessStates::read(env.socket());

--- a/cli/flox/src/commands/services/stop.rs
+++ b/cli/flox/src/commands/services/stop.rs
@@ -1,13 +1,15 @@
 use anyhow::Result;
 use bpaf::Bpaf;
+use flox_events::EventsHub;
 use flox_manifest::interfaces::AsLatestSchema;
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::providers::services::process_compose::{ProcessStates, stop_services};
-use tracing::instrument;
+use tracing::{debug, instrument};
 
 use crate::commands::services::{ServicesEnvironment, guard_service_commands_available};
 use crate::commands::{EnvironmentSelect, environment_select};
 use crate::environment_subcommand_metric;
+use crate::utils::events::env_detail_from_concrete;
 use crate::utils::message;
 
 #[derive(Bpaf, Debug, Clone)]
@@ -26,6 +28,11 @@ impl Stop {
         let env =
             ServicesEnvironment::from_environment_selection(&mut flox, &self.environment).await?;
         environment_subcommand_metric!("services::stop", env.environment);
+        if let Err(err) = EventsHub::global()
+            .record_environment_services_stop(env_detail_from_concrete(&env.environment))
+        {
+            debug!(error = %err, "Failed to record v2 event");
+        }
         guard_service_commands_available(&env, &flox.system)?;
 
         let socket = env.socket();

--- a/cli/flox/src/commands/uninstall.rs
+++ b/cli/flox/src/commands/uninstall.rs
@@ -13,6 +13,7 @@ use tracing::{debug, info_span, instrument};
 use super::services::warn_manifest_changes_for_services;
 use super::{EnvironmentSelect, environment_select};
 use crate::commands::{EnvironmentSelectError, ensure_auth, environment_description};
+use crate::utils::events::env_detail_from_concrete;
 use crate::utils::message;
 use crate::utils::tracing::sentry_set_tag;
 use crate::{environment_subcommand_metric, subcommand_metric};
@@ -74,6 +75,11 @@ impl Uninstall {
             Err(e) => Err(e)?,
         };
         environment_subcommand_metric!("uninstall", concrete_environment);
+        if let Err(err) = EventsHub::global()
+            .record_environment_uninstall(env_detail_from_concrete(&concrete_environment))
+        {
+            debug!(error = %err, "Failed to record v2 event");
+        }
 
         let description = environment_description(&concrete_environment)?;
 

--- a/cli/flox/src/commands/upgrade.rs
+++ b/cli/flox/src/commands/upgrade.rs
@@ -12,6 +12,7 @@ use tracing::{debug, info_span, instrument};
 use super::services::warn_manifest_changes_for_services;
 use super::{EnvironmentSelect, environment_select};
 use crate::commands::{ensure_auth, environment_description};
+use crate::utils::events::env_detail_from_concrete;
 use crate::utils::message::{self, stderr_supports_color};
 use crate::utils::upgrade_output::{count_upgrade_categories, format_upgrade_summary};
 use crate::{environment_subcommand_metric, subcommand_metric};
@@ -51,6 +52,11 @@ impl Upgrade {
             .detect_concrete_environment(&mut flox, "Upgrade")
             .await?;
         environment_subcommand_metric!("upgrade", concrete_environment);
+        if let Err(err) = EventsHub::global()
+            .record_environment_upgrade(env_detail_from_concrete(&concrete_environment))
+        {
+            debug!(error = %err, "Failed to record v2 event");
+        }
 
         let description = environment_description(&concrete_environment)?;
 


### PR DESCRIPTION
**Part 5 of 5 — CLI producer telemetry cutover.** Closes the per-command coverage gap and pins the central subcommand derivation. The last **dormant** PR before the cutover flip.

## What this PR does

After this PR the new pipeline carries every signal the legacy `subcommand_metric!` / `environment_subcommand_metric!` stream emits — except the `exit` pseudo-subcommand and `activate#version`, which are intentionally retired. Legacy macros stay at every site so the dual-pipeline parity period continues. Three workstreams:

### 1. Pin the central derivation (`Commands::subcommand_name`)

PR&nbsp;2 landed the subcommand derivation as one large nested match. This PR splits it into per-enum `subcommand_name` methods (mirroring the per-enum `handle` methods already on `ManageCommands`, `UseCommands`, `ServicesCommands`, `GenerationsCommands`, etc.), shrinking the top-level match to one-line-per-arm dispatch. Two carve-outs ride on the per-enum methods:

- **`auth → "auth2"`** — the legacy `auth` command emits the literal `"auth2"` on the wire, and a consumer-side classifier keys off it. Without the carve-out that classifier silently stops firing after the cutover. `AdminCommands::subcommand_name` returns `"auth2"` for the `Auth(_)` arm.
- **Nested commands use `parent::child`** — `services::start`, `generations::list`, etc., preserving the legacy join-key continuity. Without it, downstream rows for every nested command would lose their join key at cutover.

Both are covered by `subcommand_name` tests that parse real argv through bpaf and assert the returned string, so a future bpaf rename or a regressed carve-out fails the test.

### 2. Retire the `exit` pseudo-subcommand

The legacy `deactivate` handler emits `subcommand_metric!("exit")` — `"exit"` is the handler-method name, not the parsed clap subcommand. The central derivation returns `"deactivate"` for the `Deactivate` variant regardless of handler, so the new path never emits `"exit"`. A test pins `deactivate → "deactivate", not "exit"`.

### 3. 21 new `EventKind` variants + emission sites (dormant)

Each remaining command with a per-command payload gets its own event variant (one event type per command, matching PR&nbsp;3):

- **16 env-detail-only** — `cli.environment.{containerize, delete, include, install, list, uninstall, upgrade}`, `cli.environment.services.{start, stop, restart, status, logs, persist}`, `cli.environment.generations.{history, rollback, switch}`. Each payload is `CommandPayload` + `EnvDetail`, byte-identical to PR&nbsp;3's push/pull payloads (intentional — the cleanup PR may collapse them into a shared payload). For `install`/`uninstall`/`upgrade`, this env-detail row (one per invocation) is distinct from PR&nbsp;4's package row (one per package).
- **3 env-detail + Optional extras** — `cli.environment.edit` (`edited_includes`), `cli.environment.publish` (`has_expression_build` + `has_manifest_build`), `cli.environment.generations.list` (`request_tree`). These use a sparse-merge contract: the eager call site (right after env detection) emits with extras `None`; the result-known site emits the same `event_type` / `invocation_id` and fills the extras; the consumer coalesces across the two rows.
- **2 no-env extras-only** — `cli.build` (`has_expression_build` + `has_manifest_build`, required on wire) and `cli.search` (`search_term`, kept verbatim for parity). Neither command resolves an environment.

Every emission site is a uniform `if let Err(err) = EventsHub::global().record_<command>(env_detail_from_concrete(&env)) { debug!(error = %err, "Failed to record v2 event"); }` block — reusing PR&nbsp;3's `env_detail_from_concrete` helper, errors logged at `debug!` and swallowed so the dormant path can't change exit codes.

## Behavior & testing

Behavior-neutral (dormant). Golden wire-shape fixtures cover representative envelopes across the new variants, a sparse-merge pipeline test (two events per invocation sharing `invocation_id` / `event_type`), and the four central-derivation tests (`auth2` / `deactivate` / `services::start` / `generations::list`). Compiles + `rustfmt`-clean under the pinned toolchain; the full `flox-events` suite (39 tests) passes.

---
### Stack — review bottom-up
1. #4414 — pipeline foundation
2. #4415 — wire the pipeline
3. #4416 — environment-group commands
4. #4417 — package-group commands
5. **#4418 — remaining subcommands (this PR)** → #4417

🤖 Generated with [Claude Code](https://claude.com/claude-code)
