### PR TITLE
feat(run): DEV-139 add build-from-source fallback when binary not in cache

### DIFF
--- a/cli/flox-rust-sdk/src/providers/buildenv.rs
+++ b/cli/flox-rust-sdk/src/providers/buildenv.rs
@@ -318,13 +318,10 @@ pub fn build_catalog_pkg_from_source(
     let flake_ref = if let Some(rev) = locked_url.strip_prefix(NIXPKGS_CATALOG_URL_PREFIX) {
         format!("{FLOX_NIXPKGS_PROXY_FLAKE_REF_BASE}/{rev}")
     } else {
-        return Err(BuildEnvError::Realise2 {
-            install_id: attr_path.to_string(),
-            message: format!(
-                "Locked package '{}' does not use the expected nixpkgs URL prefix '{}'",
-                attr_path, NIXPKGS_CATALOG_URL_PREFIX
-            ),
-        });
+        return Err(BuildEnvError::LockfileContents(format!(
+            "Locked package '{}' is a base catalog package, but the locked url '{}' does not start with the expected prefix '{}'",
+            attr_path, locked_url, NIXPKGS_CATALOG_URL_PREFIX
+        )));
     };
 
     // Build all outputs (^*) from legacyPackages.<system>.<attr_path>.

--- a/cli/flox-rust-sdk/src/providers/buildenv.rs
+++ b/cli/flox-rust-sdk/src/providers/buildenv.rs
@@ -293,6 +293,84 @@ pub fn substitute_store_paths(
     Ok(success)
 }
 
+/// Build a catalog package from source when the binary cache does not have it.
+///
+/// Constructs the `flox-nixpkgs` flake installable from `locked_url` and
+/// `attr_path`, then invokes `nix build` with the Nix plugins that allow
+/// unfree and broken packages.
+///
+/// When `gc_root_prefix` is `Some(p)`, passes `--out-link <p>` so the build
+/// output is registered as a GC root. When `None`, passes `--no-link`.
+///
+/// Returns `Err(BuildEnvError::Realise2)` if the build fails.
+pub fn build_catalog_pkg_from_source(
+    locked_url: &str,
+    attr_path: &str,
+    system: &str,
+    unfree: Option<bool>,
+    broken: Option<bool>,
+    gc_root_prefix: Option<&Path>,
+) -> Result<(), BuildEnvError> {
+    // Transform the locked URL: strip the nixpkgs GitHub prefix and replace
+    // it with the flox-nixpkgs fetcher reference so that evaluation checks
+    // (allowUnfree, allowBroken) are controlled by manifest options rather
+    // than Nix's built-in guards.
+    let flake_ref = if let Some(rev) = locked_url.strip_prefix(NIXPKGS_CATALOG_URL_PREFIX) {
+        format!("{FLOX_NIXPKGS_PROXY_FLAKE_REF_BASE}/{rev}")
+    } else {
+        return Err(BuildEnvError::Realise2 {
+            install_id: attr_path.to_string(),
+            message: format!(
+                "Locked package '{}' does not use the expected nixpkgs URL prefix '{}'",
+                attr_path, NIXPKGS_CATALOG_URL_PREFIX
+            ),
+        });
+    };
+
+    // Build all outputs (^*) from legacyPackages.<system>.<attr_path>.
+    let installable = format!("{flake_ref}#legacyPackages.{system}.{attr_path}^*");
+
+    let reason = match (unfree, broken) {
+        (Some(true), _) => " (unfree license)",
+        (_, Some(true)) => " (upstream build marked as broken)",
+        _ => "",
+    };
+
+    let _span = info_span!(
+        "build_catalog_pkg_from_source",
+        progress = format!("Building '{attr_path}' from source{reason}")
+    )
+    .entered();
+
+    let mut cmd = base_command();
+    cmd.args(["--option", "extra-plugin-files", &*NIX_PLUGINS]);
+    cmd.arg("build");
+    cmd.arg("--no-write-lock-file");
+    cmd.arg("--no-update-lock-file");
+    cmd.args(["--option", "pure-eval", "true"]);
+    match gc_root_prefix {
+        Some(prefix) => {
+            cmd.arg("--out-link").arg(prefix);
+        },
+        None => {
+            cmd.arg("--no-link");
+        },
+    }
+    cmd.arg(&installable);
+
+    debug!(%installable, cmd=%cmd.display(), "building catalog package from source");
+
+    let output = cmd.output().map_err(BuildEnvError::CallNixBuild)?;
+    if !output.status.success() {
+        return Err(BuildEnvError::Realise2 {
+            install_id: attr_path.to_string(),
+            message: String::from_utf8_lossy(&output.stderr).to_string(),
+        });
+    }
+
+    Ok(())
+}
+
 impl<A> BuildEnvNix<A>
 where
     A: AuthProvider,

--- a/cli/flox-rust-sdk/src/providers/buildenv.rs
+++ b/cli/flox-rust-sdk/src/providers/buildenv.rs
@@ -360,15 +360,26 @@ pub fn build_catalog_pkg_from_source(
 
     debug!(%installable, cmd=%cmd.display(), "building catalog package from source");
 
-    let output = cmd.output().map_err(BuildEnvError::CallNixBuild)?;
-    if !output.status.success() {
-        return Err(BuildEnvError::Realise2 {
-            install_id: attr_path.to_string(),
-            message: String::from_utf8_lossy(&output.stderr).to_string(),
-        });
+    // Retry up to MAX_RETRIES times. Transient failures (GC pressure during
+    // evaluation, network hiccups fetching source tarballs) can cause spurious
+    // non-zero exits; retrying mirrors the discipline in materialise_with_retry.
+    // Spawn errors (CallNixBuild) are not transient — propagate immediately.
+    const MAX_RETRIES: usize = 3;
+    let mut last_stderr = String::new();
+    for attempt in 1..=MAX_RETRIES {
+        let output = cmd.output().map_err(BuildEnvError::CallNixBuild)?;
+        if output.status.success() {
+            return Ok(());
+        }
+        last_stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        if attempt < MAX_RETRIES {
+            debug!(attempt, MAX_RETRIES, stderr=%last_stderr, "nix build failed, retrying");
+        }
     }
-
-    Ok(())
+    Err(BuildEnvError::Realise2 {
+        install_id: attr_path.to_string(),
+        message: last_stderr,
+    })
 }
 
 impl<A> BuildEnvNix<A>

--- a/cli/flox-rust-sdk/src/providers/buildenv.rs
+++ b/cli/flox-rust-sdk/src/providers/buildenv.rs
@@ -2944,7 +2944,7 @@ mod materialise_retry_tests {
         init_tracing();
         // Paths always disappear after build_env fails — exhausts all retries.
         let missing_call = Cell::new(0usize);
-        let result = materialise_with_retry(
+        let result: Result<BuildEnvOutputs, _> = materialise_with_retry(
             || Ok(()),
             || {
                 missing_call.set(missing_call.get() + 1);
@@ -2977,7 +2977,7 @@ mod materialise_retry_tests {
         // before propagating the error.
         let realise_calls = Cell::new(0usize);
         let build_calls = Cell::new(0usize);
-        let result = materialise_with_retry(
+        let result: Result<BuildEnvOutputs, _> = materialise_with_retry(
             || {
                 realise_calls.set(realise_calls.get() + 1);
                 Ok(())

--- a/cli/flox-rust-sdk/src/providers/buildenv.rs
+++ b/cli/flox-rust-sdk/src/providers/buildenv.rs
@@ -357,25 +357,13 @@ pub fn build_catalog_pkg_from_source(
 
     debug!(%installable, cmd=%cmd.display(), "building catalog package from source");
 
-    // Retry up to MAX_RETRIES times. Transient failures (GC pressure during
-    // evaluation, network hiccups fetching source tarballs) can cause spurious
-    // non-zero exits; retrying mirrors the discipline in materialise_with_retry.
-    // Spawn errors (CallNixBuild) are not transient — propagate immediately.
-    const MAX_RETRIES: usize = 3;
-    let mut last_stderr = String::new();
-    for attempt in 1..=MAX_RETRIES {
-        let output = cmd.output().map_err(BuildEnvError::CallNixBuild)?;
-        if output.status.success() {
-            return Ok(());
-        }
-        last_stderr = String::from_utf8_lossy(&output.stderr).to_string();
-        if attempt < MAX_RETRIES {
-            debug!(attempt, MAX_RETRIES, stderr=%last_stderr, "nix build failed, retrying");
-        }
+    let output = cmd.output().map_err(BuildEnvError::CallNixBuild)?;
+    if output.status.success() {
+        return Ok(());
     }
     Err(BuildEnvError::Realise2 {
         install_id: attr_path.to_string(),
-        message: last_stderr,
+        message: String::from_utf8_lossy(&output.stderr).to_string(),
     })
 }
 

--- a/cli/flox-rust-sdk/src/providers/buildenv.rs
+++ b/cli/flox-rust-sdk/src/providers/buildenv.rs
@@ -808,73 +808,15 @@ where
         }
 
         // If we get here it means we need to build a package from source.
-
-        let installable = {
-            // We swap out the locked URL of the package (which points at our nixpkgs
-            // fork) for a flake reference that uses our custom `flox-nixpkgs` URL
-            // scheme. This disables certain built-in evaluation checks (allowUnfree, etc).
-            // That's important because we move those checks into manifest options, and
-            // don't want conflicts or duplicates.
-            let mut locked_url = locked_pkg.locked_url.to_string();
-            if let Some(revision_suffix) = locked_url.strip_prefix(NIXPKGS_CATALOG_URL_PREFIX) {
-                locked_url = format!("{FLOX_NIXPKGS_PROXY_FLAKE_REF_BASE}/{revision_suffix}");
-            } else {
-                return Err(BuildEnvError::LockfileContents(format!(
-                    "Locked package '{}' is a base catalog package, but the locked url '{}' does not start with the expected prefix '{}'",
-                    locked_pkg.install_id, locked_pkg.locked_url, NIXPKGS_CATALOG_URL_PREFIX
-                )));
-            }
-
-            // For the attribute path we construct a real installable's attribute path
-            // by prepending `legacyPackages.<system>` to the `pkg-path`/`attr_path`.
-            //
-            // The `^*` bit builds all outputs.
-            let attrpath = format!(
-                "legacyPackages.{}.{}^*",
-                locked_pkg.system, locked_pkg.attr_path
-            );
-
-            format!("{}#{}", locked_url, attrpath)
-        };
-
-        let reason = match (locked_pkg.unfree, locked_pkg.broken) {
-            (Some(true), _) => " (unfree license)",
-            (_, Some(true)) => " (upstream build marked as broken)",
-            _ => "",
-        };
-
-        let _span = info_span!(
-            parent: span.clone(),
-            "build from catalog",
-            progress = format!("Building '{}' from source{reason}", locked_pkg.attr_path)
+        // Delegate to the shared function so buildenv and `flox run` stay in sync.
+        build_catalog_pkg_from_source(
+            &locked_pkg.locked_url,
+            &locked_pkg.attr_path,
+            &locked_pkg.system,
+            locked_pkg.unfree,
+            locked_pkg.broken,
+            None, // buildenv manages its own GC roots; use --no-link here
         )
-        .entered();
-
-        let mut nix_build_command = base_command();
-
-        nix_build_command.args(["--option", "extra-plugin-files", &*NIX_PLUGINS]);
-
-        nix_build_command.arg("build");
-        nix_build_command.arg("--no-write-lock-file");
-        nix_build_command.arg("--no-update-lock-file");
-        nix_build_command.args(["--option", "pure-eval", "true"]);
-        nix_build_command.arg("--no-link");
-        nix_build_command.arg(&installable);
-
-        debug!(%installable, cmd=%nix_build_command.display(), "building catalog package");
-
-        let output = nix_build_command
-            .output()
-            .map_err(BuildEnvError::CallNixBuild)?;
-
-        if !output.status.success() {
-            return Err(BuildEnvError::Realise2 {
-                install_id: locked_pkg.install_id.clone(),
-                message: String::from_utf8_lossy(&output.stderr).to_string(),
-            });
-        }
-
-        Ok(())
     }
 
     /// Realise a package from a flake.
@@ -1221,12 +1163,12 @@ fn nix_path_info_null_paths(paths: &[String]) -> Result<Vec<String>, std::io::Er
 /// `expected_paths` returns the full list of store paths the environment
 /// depends on. It is called once per attempt for diagnostic logging and
 /// for the `nix path-info` store-database check on failure.
-fn materialise_with_retry(
+pub fn materialise_with_retry<T>(
     mut realise: impl FnMut() -> Result<(), BuildEnvError>,
     mut missing_paths: impl FnMut() -> Vec<String>,
     expected_paths: impl Fn() -> Vec<String>,
-    mut build_env: impl FnMut() -> Result<BuildEnvOutputs, BuildEnvError>,
-) -> Result<BuildEnvOutputs, BuildEnvError> {
+    mut build_env: impl FnMut() -> Result<T, BuildEnvError>,
+) -> Result<T, BuildEnvError> {
     const MAX_RETRIES: usize = 3;
     for attempt in 1..=MAX_RETRIES {
         realise()?;

--- a/cli/flox/doc/flox-run.md
+++ b/cli/flox/doc/flox-run.md
@@ -156,15 +156,19 @@ in a future release:
 ## Binary cache requirement
 
 `flox run` fetches packages by store path using substitution only.
-It does not evaluate Nix expressions or build packages from source.
+It does not evaluate Nix expressions or build packages from source
+unless the binary cache does not have the package.
 A package must have a pre-built binary available in the Nix binary
-cache to work with `flox run`.
+cache, or be buildable from source.
 
 Packages that require building from source — including those with
-unfree licenses that are not pre-cached — will fail with a
-"not available in the binary cache" error.
-Use `flox install` to add such packages to an environment instead;
-`flox install` can build packages from source when needed.
+unfree licenses that are not pre-cached — cannot be substituted
+directly. `flox run` will offer to build such packages from source.
+When running interactively you will be prompted to confirm;
+non-interactive invocations (e.g. in scripts) proceed automatically.
+Built packages are stored in a temporary GC root that is removed when
+the command exits.
+Use `flox install` to add a package to a persistent environment instead.
 
 # SEE ALSO
 

--- a/cli/flox/doc/flox-run.md
+++ b/cli/flox/doc/flox-run.md
@@ -163,9 +163,9 @@ cache, or be buildable from source.
 
 Packages that require building from source — including those with
 unfree licenses that are not pre-cached — cannot be substituted
-directly. `flox run` will offer to build such packages from source.
-When running interactively you will be prompted to confirm;
-non-interactive invocations (e.g. in scripts) proceed automatically.
+directly. `flox run` will build such packages from source automatically,
+displaying a progress indicator while the build runs.
+Press Ctrl-C to cancel if you do not want to wait.
 Built packages are stored in a temporary GC root that is removed when
 the command exits.
 Use `flox install` to add a package to a persistent environment instead.

--- a/cli/flox/src/commands/run.rs
+++ b/cli/flox/src/commands/run.rs
@@ -131,10 +131,6 @@ pub enum RunError {
     #[error("Failed to prepare the cache directory for '{0}'.")]
     CreateGcRootDir(String, #[source] std::io::Error),
 
-    /// The `nix build` invocation to download store paths failed at the process level.
-    #[error("Failed to run nix while downloading package '{0}'.")]
-    Substitute(String, #[source] BuildEnvError),
-
     /// The `nix build` invocation for building from source failed.
     #[error("Failed to build '{0}' from source.\n{1}")]
     BuildFailed(String, #[source] BuildEnvError),
@@ -440,61 +436,59 @@ async fn exec_run(run_args: RunArgs, flox: &Flox) -> Result<()> {
     let gc_root_exists = gc_root_prefix.exists();
     let all_present = store_paths.iter().all(|p| Path::new(p).exists());
     if !all_present || !gc_root_exists {
-        let _span = info_span!(
-            "run_download",
-            progress = format!("Downloading '{pkg_spec}'...")
+        // Per-run GC root for source builds; keyed on PID so concurrent
+        // runs don't clobber each other's outputs.
+        let pid = std::process::id();
+        let build_gc_root =
+            gc_root_dir.join(format!("build-{}.{}-{}", flox.system, attr_path, pid));
+
+        // Substitution and source-build are both inside the realise closure so
+        // materialise_with_retry can retry the whole sequence on a GC race.
+        materialise_with_retry(
+            || {
+                let ok = {
+                    let _dl = info_span!(
+                        "run_download",
+                        progress = format!("Downloading '{pkg_spec}'...")
+                    )
+                    .entered();
+                    substitute_store_paths(&store_paths, Some(&gc_root_prefix))?
+                };
+                if !ok {
+                    // Cache miss; build from source.
+                    build_catalog_pkg_from_source(
+                        &resolved_pkg.locked_url,
+                        &attr_path,
+                        &flox.system,
+                        resolved_pkg.unfree,
+                        resolved_pkg.broken,
+                        Some(&build_gc_root),
+                    )
+                } else {
+                    Ok(())
+                }
+            },
+            || {
+                store_paths
+                    .iter()
+                    .filter(|p| std::fs::metadata(p).is_err())
+                    .cloned()
+                    .collect()
+            },
+            || store_paths.clone(),
+            || Ok::<(), BuildEnvError>(()),
         )
-        .entered();
-        let ok = substitute_store_paths(&store_paths, Some(&gc_root_prefix))
-            .map_err(|e| RunError::Substitute(pkg_spec.clone(), e))?;
-        drop(_span);
-        if !ok {
-            // Package is not in the binary cache; build from source.
-            // The progress spinner from info_span is sufficient feedback —
-            // no prompt needed; users can Ctrl-C if they don't want to wait.
+        .map_err(|e| RunError::BuildFailed(pkg_spec.clone(), e))?;
 
-            // Use a per-run GC root keyed on system + attr_path + PID so
-            // concurrent runs don't clobber each other's build outputs.
-            let pid = std::process::id();
-            let build_gc_root =
-                gc_root_dir.join(format!("build-{}.{}-{}", flox.system, attr_path, pid));
-
-            {
-                let _span = info_span!(
-                    "run_build",
-                    progress = format!("Building '{pkg_spec}' from source...")
-                )
-                .entered();
-                materialise_with_retry(
-                    || {
-                        build_catalog_pkg_from_source(
-                            &resolved_pkg.locked_url,
-                            &attr_path,
-                            &flox.system,
-                            resolved_pkg.unfree,
-                            resolved_pkg.broken,
-                            Some(&build_gc_root),
-                        )
-                    },
-                    || {
-                        collect_store_paths_from_gc_root(&build_gc_root)
-                            .into_iter()
-                            .filter(|p| std::fs::metadata(p).is_err())
-                            .collect()
-                    },
-                    || collect_store_paths_from_gc_root(&build_gc_root),
-                    || Ok::<(), BuildEnvError>(()),
-                )
-                .map_err(|e| RunError::BuildFailed(pkg_spec.clone(), e))?;
-                drop(_span);
-            }
-
-            // Fork a background watcher that removes the temporary GC root
-            // symlinks when the exec'd command exits.
+        // Source build was used if the GC root has symlinks; exec via its PATH.
+        // Substitution leaves build_gc_root empty — fall through to store_paths exec.
+        let build_paths = collect_store_paths_from_gc_root(&build_gc_root);
+        if !build_paths.is_empty() {
+            // Fork a background watcher that removes the GC root when the
+            // exec'd command exits.
             fork_gc_root_watcher(&build_gc_root)
                 .map_err(|e| RunError::ExecFailed("fork gc watcher".into(), e))?;
 
-            // Locate the executable from the build output symlinks.
             let bin_dirs = collect_bin_dirs_from_gc_root(&build_gc_root);
             let new_path = prepend_path_dirs(&bin_dirs);
 

--- a/cli/flox/src/commands/run.rs
+++ b/cli/flox/src/commands/run.rs
@@ -132,7 +132,10 @@ pub enum RunError {
     CreateGcRootDir(String, #[source] std::io::Error),
 
     /// The `nix build` invocation for building from source failed.
-    #[error("Failed to build '{0}' from source.\n{1}")]
+    #[error(
+        "Failed to build '{0}' from source.\n\
+         Use 'flox install {0}' to add it to a persistent environment."
+    )]
     BuildFailed(String, #[source] BuildEnvError),
 
     /// The requested executable was not found in `bin/` or `sbin/` of any output.
@@ -490,7 +493,11 @@ async fn exec_run(run_args: RunArgs, flox: &Flox) -> Result<()> {
             },
             || {
                 let gc_paths = collect_store_paths_from_gc_root(&build_gc_root);
-                if gc_paths.is_empty() { store_paths.clone() } else { gc_paths }
+                if gc_paths.is_empty() {
+                    store_paths.clone()
+                } else {
+                    gc_paths
+                }
             },
             || Ok::<(), BuildEnvError>(()),
         )
@@ -755,7 +762,9 @@ pub fn fork_gc_root_watcher(gc_root_prefix: &Path) -> Result<(), std::io::Error>
                 }
             }
 
-            std::process::exit(0);
+            // Use _exit, not exit: after fork() the child must not run
+            // atexit handlers or flush stdio buffers shared with the parent.
+            unsafe { nix::libc::_exit(0) };
         },
         ForkResult::Parent { .. } => {
             // Parent: close read end. Write end stays open — it will be inherited

--- a/cli/flox/src/commands/run.rs
+++ b/cli/flox/src/commands/run.rs
@@ -28,6 +28,7 @@ use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::providers::buildenv::{
     BuildEnvError,
     build_catalog_pkg_from_source,
+    materialise_with_retry,
     substitute_store_paths,
 };
 use floxhub_client::{
@@ -483,13 +484,25 @@ async fn exec_run(run_args: RunArgs, flox: &Flox) -> Result<()> {
                     progress = format!("Building '{pkg_spec}' from source...")
                 )
                 .entered();
-                build_catalog_pkg_from_source(
-                    &resolved_pkg.locked_url,
-                    &attr_path,
-                    &flox.system,
-                    resolved_pkg.unfree,
-                    resolved_pkg.broken,
-                    Some(&build_gc_root),
+                materialise_with_retry(
+                    || {
+                        build_catalog_pkg_from_source(
+                            &resolved_pkg.locked_url,
+                            &attr_path,
+                            &flox.system,
+                            resolved_pkg.unfree,
+                            resolved_pkg.broken,
+                            Some(&build_gc_root),
+                        )
+                    },
+                    || {
+                        collect_store_paths_from_gc_root(&build_gc_root)
+                            .into_iter()
+                            .filter(|p| std::fs::metadata(p).is_err())
+                            .collect()
+                    },
+                    || collect_store_paths_from_gc_root(&build_gc_root),
+                    || Ok::<(), BuildEnvError>(()),
                 )
                 .map_err(|e| RunError::BuildFailed(pkg_spec.clone(), e))?;
                 drop(_span);
@@ -636,6 +649,38 @@ pub fn collect_bin_dirs_from_gc_root(prefix: &Path) -> Vec<PathBuf> {
         }
     }
     bin_dirs
+}
+
+/// Collect the Nix store-path targets of build output symlinks rooted at `prefix`.
+///
+/// After `nix build --out-link <prefix>`, symlinks like `<prefix>`,
+/// `<prefix>-doc`, `<prefix>-dev` point into the Nix store.  This function
+/// returns those store-path strings so callers can check whether they are
+/// present on disk (used as the `missing_paths` / `expected_paths` closures
+/// passed to `materialise_with_retry`).
+pub fn collect_store_paths_from_gc_root(prefix: &Path) -> Vec<String> {
+    let parent = match prefix.parent() {
+        Some(p) => p,
+        None => return vec![],
+    };
+    let file_name = match prefix.file_name().and_then(OsStr::to_str) {
+        Some(n) => n.to_string(),
+        None => return vec![],
+    };
+    let Ok(entries) = std::fs::read_dir(parent) else {
+        return vec![];
+    };
+    entries
+        .flatten()
+        .filter(|e| {
+            let n = e.file_name();
+            let s = n.to_string_lossy();
+            s == file_name || s.starts_with(&format!("{file_name}-"))
+        })
+        .filter(|e| e.path().is_symlink())
+        .filter_map(|e| std::fs::read_link(e.path()).ok())
+        .filter_map(|t| t.to_str().map(|s| s.to_string()))
+        .collect()
 }
 
 /// Prepend `dirs` to the current `PATH`, returning the combined value.

--- a/cli/flox/src/commands/run.rs
+++ b/cli/flox/src/commands/run.rs
@@ -15,7 +15,6 @@
 //! arguments with `std::env::args_os()`.
 
 use std::ffi::{OsStr, OsString};
-use std::io::{BufRead as _, IsTerminal as _};
 use std::os::unix::fs::PermissionsExt;
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
@@ -135,10 +134,6 @@ pub enum RunError {
     /// The `nix build` invocation to download store paths failed at the process level.
     #[error("Failed to run nix while downloading package '{0}'.")]
     Substitute(String, #[source] BuildEnvError),
-
-    /// User declined the offer to build the package from source.
-    #[error("Cancelled building '{0}' from source.")]
-    BuildDeclined(String),
 
     /// The `nix build` invocation for building from source failed.
     #[error("Failed to build '{0}' from source.\n{1}")]
@@ -454,23 +449,9 @@ async fn exec_run(run_args: RunArgs, flox: &Flox) -> Result<()> {
             .map_err(|e| RunError::Substitute(pkg_spec.clone(), e))?;
         drop(_span);
         if !ok {
-            // Package is not in the binary cache. Offer to build from source.
-            //
-            // Interactive sessions prompt the user; non-interactive sessions
-            // (scripts, CI) proceed automatically to avoid blocking.
-            if std::io::stderr().is_terminal() {
-                eprint!(
-                    "⚠️  Package '{pkg_spec}' is not in the binary cache and must be built \
-                     from source. This may take a while. Continue? [Y/n] "
-                );
-                let stdin = std::io::stdin();
-                let mut input = String::new();
-                stdin.lock().read_line(&mut input)?;
-                let trimmed = input.trim().to_lowercase();
-                if trimmed == "n" || trimmed == "no" {
-                    return Err(RunError::BuildDeclined(pkg_spec.clone()).into());
-                }
-            }
+            // Package is not in the binary cache; build from source.
+            // The progress spinner from info_span is sufficient feedback —
+            // no prompt needed; users can Ctrl-C if they don't want to wait.
 
             // Use a per-run GC root keyed on system + attr_path + PID so
             // concurrent runs don't clobber each other's build outputs.

--- a/cli/flox/src/commands/run.rs
+++ b/cli/flox/src/commands/run.rs
@@ -511,10 +511,11 @@ async fn exec_run(run_args: RunArgs, flox: &Flox) -> Result<()> {
                 .env("PATH", &new_path)
                 .exec();
 
-            return Err(
-                RunError::ExecFailed(run_args.executable.to_string_lossy().into_owned(), err)
-                    .into(),
-            );
+            return Err(RunError::ExecFailed(
+                run_args.executable.to_string_lossy().into_owned(),
+                err,
+            )
+            .into());
         }
     }
 
@@ -623,9 +624,9 @@ pub fn collect_bin_dirs_from_gc_root(prefix: &Path) -> Vec<PathBuf> {
             continue;
         }
         // Follow the symlink (nix build creates symlinks into the store).
-        let target = match std::fs::read_link(entry.path()).or_else(|_| {
-            std::fs::canonicalize(entry.path())
-        }) {
+        let target = match std::fs::read_link(entry.path())
+            .or_else(|_| std::fs::canonicalize(entry.path()))
+        {
             Ok(t) => t,
             Err(_) => continue,
         };

--- a/cli/flox/src/commands/run.rs
+++ b/cli/flox/src/commands/run.rs
@@ -681,15 +681,11 @@ pub fn fork_gc_root_watcher(gc_root_prefix: &Path) -> Result<(), std::io::Error>
 
     // Clear FD_CLOEXEC on the write end so it survives the exec() call and
     // stays open until the exec'd command exits.
-    let flags =
-        nix::fcntl::fcntl(&write_owned, nix::fcntl::FcntlArg::F_GETFD).map_err(|e| {
-            std::io::Error::other(format!("fcntl F_GETFD: {e}"))
-        })?;
-    let new_flags =
-        nix::fcntl::FdFlag::from_bits_retain(flags) & !nix::fcntl::FdFlag::FD_CLOEXEC;
-    nix::fcntl::fcntl(&write_owned, nix::fcntl::FcntlArg::F_SETFD(new_flags)).map_err(|e| {
-        std::io::Error::other(format!("fcntl F_SETFD: {e}"))
-    })?;
+    let flags = nix::fcntl::fcntl(&write_owned, nix::fcntl::FcntlArg::F_GETFD)
+        .map_err(|e| std::io::Error::other(format!("fcntl F_GETFD: {e}")))?;
+    let new_flags = nix::fcntl::FdFlag::from_bits_retain(flags) & !nix::fcntl::FdFlag::FD_CLOEXEC;
+    nix::fcntl::fcntl(&write_owned, nix::fcntl::FcntlArg::F_SETFD(new_flags))
+        .map_err(|e| std::io::Error::other(format!("fcntl F_SETFD: {e}")))?;
 
     // Convert to raw fds before fork; each process is responsible for closing
     // its own copies. After fork, Rust's drop semantics do not apply — both
@@ -1148,7 +1144,9 @@ mod tests {
             let store_out = tmp.path().join(format!("store-out{suffix}"));
             let bin = store_out.join("bin");
             std::fs::create_dir_all(&bin).unwrap();
-            let link = tmp.path().join(format!("build-aarch64-darwin.pkg-99{suffix}"));
+            let link = tmp
+                .path()
+                .join(format!("build-aarch64-darwin.pkg-99{suffix}"));
             std::os::unix::fs::symlink(&store_out, &link).unwrap();
         }
 

--- a/cli/flox/src/commands/run.rs
+++ b/cli/flox/src/commands/run.rs
@@ -469,13 +469,29 @@ async fn exec_run(run_args: RunArgs, flox: &Flox) -> Result<()> {
                 }
             },
             || {
-                store_paths
-                    .iter()
-                    .filter(|p| std::fs::metadata(p).is_err())
-                    .cloned()
-                    .collect()
+                // Source-built paths (different hash from catalog) are tracked
+                // via GC root symlinks, not store_paths. If build_gc_root has
+                // symlinks, the source-build path was taken — check those real
+                // output paths. Otherwise, substitution was used — check the
+                // catalog store_paths directly.
+                let gc_paths = collect_store_paths_from_gc_root(&build_gc_root);
+                if gc_paths.is_empty() {
+                    store_paths
+                        .iter()
+                        .filter(|p| std::fs::metadata(p).is_err())
+                        .cloned()
+                        .collect()
+                } else {
+                    gc_paths
+                        .into_iter()
+                        .filter(|p| std::fs::metadata(p).is_err())
+                        .collect()
+                }
             },
-            || store_paths.clone(),
+            || {
+                let gc_paths = collect_store_paths_from_gc_root(&build_gc_root);
+                if gc_paths.is_empty() { store_paths.clone() } else { gc_paths }
+            },
             || Ok::<(), BuildEnvError>(()),
         )
         .map_err(|e| RunError::BuildFailed(pkg_spec.clone(), e))?;

--- a/cli/flox/src/commands/run.rs
+++ b/cli/flox/src/commands/run.rs
@@ -14,7 +14,8 @@
 //! flags that belong to the invoked command. `handle()` re-reads raw process
 //! arguments with `std::env::args_os()`.
 
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
+use std::io::{BufRead as _, IsTerminal as _};
 use std::os::unix::fs::PermissionsExt;
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
@@ -24,7 +25,11 @@ use anyhow::Result;
 use bpaf::Bpaf;
 use flox_manifest::raw::{CatalogPackage, RawManifestError};
 use flox_rust_sdk::flox::Flox;
-use flox_rust_sdk::providers::buildenv::{BuildEnvError, substitute_store_paths};
+use flox_rust_sdk::providers::buildenv::{
+    BuildEnvError,
+    build_catalog_pkg_from_source,
+    substitute_store_paths,
+};
 use floxhub_client::{
     CatalogClientTrait,
     MessageLevel,
@@ -130,14 +135,13 @@ pub enum RunError {
     #[error("Failed to run nix while downloading package '{0}'.")]
     Substitute(String, #[source] BuildEnvError),
 
-    /// Substitution returned `false` (nix build reported failure).
-    #[error(
-        "Package '{0}' is not available in the binary cache.\n\
-         'flox run' requires a pre-built binary. \
-         Use 'flox install {0}' to add it to an environment instead.\n\
-         If you expect this package to be cached, check your network connection and try again."
-    )]
-    DownloadFailed(String),
+    /// User declined the offer to build the package from source.
+    #[error("Cancelled building '{0}' from source.")]
+    BuildDeclined(String),
+
+    /// The `nix build` invocation for building from source failed.
+    #[error("Failed to build '{0}' from source.\n{1}")]
+    BuildFailed(String, #[source] BuildEnvError),
 
     /// The requested executable was not found in `bin/` or `sbin/` of any output.
     #[error(
@@ -449,7 +453,68 @@ async fn exec_run(run_args: RunArgs, flox: &Flox) -> Result<()> {
             .map_err(|e| RunError::Substitute(pkg_spec.clone(), e))?;
         drop(_span);
         if !ok {
-            return Err(RunError::DownloadFailed(pkg_spec.clone()).into());
+            // Package is not in the binary cache. Offer to build from source.
+            //
+            // Interactive sessions prompt the user; non-interactive sessions
+            // (scripts, CI) proceed automatically to avoid blocking.
+            if std::io::stderr().is_terminal() {
+                eprint!(
+                    "⚠️  Package '{pkg_spec}' is not in the binary cache and must be built \
+                     from source. This may take a while. Continue? [Y/n] "
+                );
+                let stdin = std::io::stdin();
+                let mut input = String::new();
+                stdin.lock().read_line(&mut input)?;
+                let trimmed = input.trim().to_lowercase();
+                if trimmed == "n" || trimmed == "no" {
+                    return Err(RunError::BuildDeclined(pkg_spec.clone()).into());
+                }
+            }
+
+            // Use a per-run GC root keyed on system + attr_path + PID so
+            // concurrent runs don't clobber each other's build outputs.
+            let pid = std::process::id();
+            let build_gc_root =
+                gc_root_dir.join(format!("build-{}.{}-{}", flox.system, attr_path, pid));
+
+            {
+                let _span = info_span!(
+                    "run_build",
+                    progress = format!("Building '{pkg_spec}' from source...")
+                )
+                .entered();
+                build_catalog_pkg_from_source(
+                    &resolved_pkg.locked_url,
+                    &attr_path,
+                    &flox.system,
+                    resolved_pkg.unfree,
+                    resolved_pkg.broken,
+                    Some(&build_gc_root),
+                )
+                .map_err(|e| RunError::BuildFailed(pkg_spec.clone(), e))?;
+                drop(_span);
+            }
+
+            // Fork a background watcher that removes the temporary GC root
+            // symlinks when the exec'd command exits.
+            fork_gc_root_watcher(&build_gc_root)
+                .map_err(|e| RunError::ExecFailed("fork gc watcher".into(), e))?;
+
+            // Locate the executable from the build output symlinks.
+            let bin_dirs = collect_bin_dirs_from_gc_root(&build_gc_root);
+            let new_path = prepend_path_dirs(&bin_dirs);
+
+            debug!(path = ?new_path, "exec via build output PATH");
+
+            let err = std::process::Command::new(&run_args.executable)
+                .args(&run_args.args)
+                .env("PATH", &new_path)
+                .exec();
+
+            return Err(
+                RunError::ExecFailed(run_args.executable.to_string_lossy().into_owned(), err)
+                    .into(),
+            );
         }
     }
 
@@ -523,6 +588,151 @@ pub fn find_executable(
         executable: executable.to_string_lossy().into_owned(),
         package: pkg_spec.to_string(),
     })
+}
+
+// ---------------------------------------------------------------------------
+// Build-from-source helpers
+// ---------------------------------------------------------------------------
+
+/// Collect `bin/` directories from build output symlinks rooted at `prefix`.
+///
+/// `nix build --out-link <prefix>` creates `<prefix>`, `<prefix>-doc`,
+/// `<prefix>-dev`, etc. This function scans the parent directory for any
+/// entry whose name starts with the file_name component of `prefix`, follows
+/// each symlink to its store-path target, and collects any `bin/` subdirs
+/// that exist there.
+pub fn collect_bin_dirs_from_gc_root(prefix: &Path) -> Vec<PathBuf> {
+    let parent = match prefix.parent() {
+        Some(p) => p,
+        None => return vec![],
+    };
+    let file_name = match prefix.file_name().and_then(OsStr::to_str) {
+        Some(n) => n.to_string(),
+        None => return vec![],
+    };
+
+    let Ok(entries) = std::fs::read_dir(parent) else {
+        return vec![];
+    };
+
+    let mut bin_dirs = Vec::new();
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+        if !name_str.starts_with(&file_name) {
+            continue;
+        }
+        // Follow the symlink (nix build creates symlinks into the store).
+        let target = match std::fs::read_link(entry.path()).or_else(|_| {
+            std::fs::canonicalize(entry.path())
+        }) {
+            Ok(t) => t,
+            Err(_) => continue,
+        };
+        let bin = target.join("bin");
+        if bin.is_dir() {
+            bin_dirs.push(bin);
+        }
+    }
+    bin_dirs
+}
+
+/// Prepend `dirs` to the current `PATH`, returning the combined value.
+///
+/// Each directory is joined with `:` and the current `PATH` is appended.
+pub fn prepend_path_dirs(dirs: &[PathBuf]) -> OsString {
+    use std::os::unix::ffi::OsStringExt as _;
+
+    let current_path = std::env::var_os("PATH").unwrap_or_default();
+    let mut parts: Vec<u8> = Vec::new();
+    for dir in dirs {
+        if !parts.is_empty() {
+            parts.push(b':');
+        }
+        parts.extend_from_slice(dir.as_os_str().as_encoded_bytes());
+    }
+    if !parts.is_empty() && !current_path.is_empty() {
+        parts.push(b':');
+    }
+    parts.extend_from_slice(current_path.as_encoded_bytes());
+    OsString::from_vec(parts)
+}
+
+/// Fork a background watcher child that removes `prefix`* symlinks when the
+/// parent (exec'd command) exits.
+///
+/// The parent holds the write end of a pipe open across the `exec` call.
+/// When the exec'd command exits, the write end is closed, causing the child's
+/// blocking read to return EOF. On EOF the child removes all symlinks whose
+/// name starts with `prefix.file_name()` in the same directory, then exits.
+///
+/// This ensures temporary GC-root symlinks created by `nix build --out-link`
+/// are cleaned up even though we `exec` into the target command and can no
+/// longer run cleanup code ourselves.
+pub fn fork_gc_root_watcher(gc_root_prefix: &Path) -> Result<(), std::io::Error> {
+    use std::os::unix::io::IntoRawFd as _;
+
+    use nix::unistd::{ForkResult, fork};
+
+    // Obtain raw file descriptors before fork so both parent and child can
+    // operate on them independently without Rust ownership conflicts.
+    let (read_owned, write_owned) = nix::unistd::pipe()?;
+
+    // Clear FD_CLOEXEC on the write end so it survives the exec() call and
+    // stays open until the exec'd command exits.
+    let flags =
+        nix::fcntl::fcntl(&write_owned, nix::fcntl::FcntlArg::F_GETFD).map_err(|e| {
+            std::io::Error::other(format!("fcntl F_GETFD: {e}"))
+        })?;
+    let new_flags =
+        nix::fcntl::FdFlag::from_bits_retain(flags) & !nix::fcntl::FdFlag::FD_CLOEXEC;
+    nix::fcntl::fcntl(&write_owned, nix::fcntl::FcntlArg::F_SETFD(new_flags)).map_err(|e| {
+        std::io::Error::other(format!("fcntl F_SETFD: {e}"))
+    })?;
+
+    // Convert to raw fds before fork; each process is responsible for closing
+    // its own copies. After fork, Rust's drop semantics do not apply — both
+    // processes hold identical fd numbers that are independent OS handles.
+    let read_fd = read_owned.into_raw_fd();
+    let write_fd = write_owned.into_raw_fd();
+
+    match unsafe { fork() }.map_err(std::io::Error::from)? {
+        ForkResult::Child => {
+            // Child: close write end, then block until parent (exec'd command) closes it.
+            // SAFETY: raw fd is valid in this process; we own it after fork.
+            unsafe { nix::libc::close(write_fd) };
+            let mut buf = [0u8; 1];
+            // Blocking read — returns 0 (EOF) when the last write-end holder exits.
+            unsafe { nix::libc::read(read_fd, buf.as_mut_ptr().cast(), 1) };
+            unsafe { nix::libc::close(read_fd) };
+
+            // EOF means the exec'd process exited. Remove GC root symlinks.
+            if let (Some(parent), Some(file_name)) =
+                (gc_root_prefix.parent(), gc_root_prefix.file_name())
+            {
+                let scan_prefix = file_name.to_string_lossy().into_owned();
+                if let Ok(entries) = std::fs::read_dir(parent) {
+                    for entry in entries.flatten() {
+                        let name = entry.file_name();
+                        let name_str = name.to_string_lossy();
+                        if name_str.starts_with(&scan_prefix) && entry.path().is_symlink() {
+                            let _ = std::fs::remove_file(entry.path());
+                        }
+                    }
+                }
+            }
+
+            std::process::exit(0);
+        },
+        ForkResult::Parent { .. } => {
+            // Parent: close read end. Write end stays open — it will be inherited
+            // by the exec'd command and closed when that process exits.
+            // SAFETY: raw fd is valid in this process.
+            unsafe { nix::libc::close(read_fd) };
+            // write_fd intentionally left open for exec() inheritance.
+            Ok(())
+        },
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -902,5 +1112,83 @@ mod tests {
 
         let result = find_executable(&[sp1, sp2], &os("readelf"), "binutils").unwrap();
         assert_eq!(result, exe_path);
+    }
+
+    // -----------------------------------------------------------------------
+    // collect_bin_dirs_from_gc_root tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn collect_bin_dirs_finds_bin_under_symlink() {
+        let tmp = tempfile::TempDir::new().unwrap();
+
+        // Simulate a nix store output: a real directory with a bin/ subdir.
+        let store_out = tmp.path().join("store-out");
+        let bin_dir = store_out.join("bin");
+        std::fs::create_dir_all(&bin_dir).unwrap();
+
+        // Create a symlink that looks like nix build --out-link output.
+        let prefix = tmp.path().join("build-aarch64-darwin.hello-42");
+        std::os::unix::fs::symlink(&store_out, &prefix).unwrap();
+
+        let result = collect_bin_dirs_from_gc_root(&prefix);
+        assert_eq!(result, vec![bin_dir]);
+    }
+
+    #[test]
+    fn collect_bin_dirs_collects_suffix_symlinks() {
+        let tmp = tempfile::TempDir::new().unwrap();
+
+        // Simulate nix build creating multiple output symlinks with the same
+        // prefix: <prefix>, <prefix>-doc, <prefix>-dev.
+        let prefix = tmp.path().join("build-aarch64-darwin.pkg-99");
+
+        for suffix in &["", "-doc", "-dev"] {
+            let store_out = tmp.path().join(format!("store-out{suffix}"));
+            let bin = store_out.join("bin");
+            std::fs::create_dir_all(&bin).unwrap();
+            let link = tmp.path().join(format!("build-aarch64-darwin.pkg-99{suffix}"));
+            std::os::unix::fs::symlink(&store_out, &link).unwrap();
+        }
+
+        let mut result = collect_bin_dirs_from_gc_root(&prefix);
+        result.sort();
+        assert_eq!(result.len(), 3);
+    }
+
+    #[test]
+    fn collect_bin_dirs_skips_outputs_without_bin() {
+        let tmp = tempfile::TempDir::new().unwrap();
+
+        let store_out = tmp.path().join("store-out-no-bin");
+        // No bin/ subdir.
+        std::fs::create_dir_all(&store_out).unwrap();
+
+        let prefix = tmp.path().join("build-aarch64-darwin.no-bin-42");
+        std::os::unix::fs::symlink(&store_out, &prefix).unwrap();
+
+        let result = collect_bin_dirs_from_gc_root(&prefix);
+        assert!(result.is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // prepend_path_dirs tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn prepend_path_dirs_prepends_to_existing_path() {
+        // We cannot rely on the process-level PATH in tests; check structure.
+        let dirs = vec![PathBuf::from("/my/bin"), PathBuf::from("/other/bin")];
+        let result = prepend_path_dirs(&dirs);
+        let result_str = result.to_string_lossy();
+        assert!(result_str.starts_with("/my/bin:/other/bin"));
+    }
+
+    #[test]
+    fn prepend_path_dirs_empty_dirs_returns_existing_path() {
+        let result = prepend_path_dirs(&[]);
+        // When no dirs are passed, the result should equal the current PATH.
+        let current = std::env::var_os("PATH").unwrap_or_default();
+        assert_eq!(result, current);
     }
 }

--- a/cli/tests/run.bats
+++ b/cli/tests/run.bats
@@ -185,6 +185,22 @@ teardown() {
   refute_output --partial "flox run -p"
 }
 
+# ---------------------------------------------------------------------------- #
+# Source-build fallback (require Nix access to attempt the build)
+# ---------------------------------------------------------------------------- #
+
+# bats test_tags=run:store
+@test "flox run falls back to source build when binary not in cache [run:store]" {
+  # terraform is unfree; the mock returns a store path that won't exist in
+  # the local Nix store, so substitution fails and the source-build path is
+  # taken. Since stderr is not a TTY in bats, no prompt is shown and the
+  # build proceeds automatically.
+  export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/run/terraform.yaml"
+  run "$FLOX_BIN" run -p terraform -- terraform --version
+  assert_success
+  assert_output --partial "Terraform"
+}
+
 # bats test_tags=run:store
 @test "stable GC root: second run -p hello hello skips download [run:store]" {
   export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/run/hello.yaml"

--- a/test_data/generated/resolve/run/terraform.yaml
+++ b/test_data/generated/resolve/run/terraform.yaml
@@ -8,7 +8,7 @@ then:
   - name: content-type
     value: application/json
   - name: content-length
-    value: '983'
+    value: '976'
   - name: server
     value: uvicorn
   body: '{"items":[{"name":"toplevel","page":{"page":982522,"url":"","packages":[{"catalog":"nixpkgs","attr_path":"terraform","pkg_path":"terraform","derivation":"/nix/store/placeholder-terraform-1.9.8-aarch64-darwin.drv","name":"terraform-1.9.8","pname":"terraform","version":"1.9.8","system":"aarch64-darwin","outputs":[{"name":"out","store_path":"/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0-terraform-1.9.8"}],"outputs_to_install":["out"],"description":"Tool for building, changing, and versioning infrastructure","license":"BSL-1.1","locked_url":"https://github.com/flox/nixpkgs?rev=b12141ef619e0a9c1c84dc8c684040326f27cdcc","rev":"b12141ef619e0a9c1c84dc8c684040326f27cdcc","rev_count":982522,"rev_date":"2026-04-18T21:33:21Z","broken":false,"insecure":false,"unfree":true,"missing_builds":false,"stabilities":["unstable"],"scrape_date":"2026-04-21T06:03:34.910020Z","cache_uri":null,"install_id":"terraform"}],"messages":[],"complete":true},"candidate_pages":null,"messages":[]}]}'
@@ -23,7 +23,7 @@ then:
   - name: content-type
     value: application/json
   - name: content-length
-    value: '981'
+    value: '973'
   - name: server
     value: uvicorn
   body: '{"items":[{"name":"toplevel","page":{"page":982522,"url":"","packages":[{"catalog":"nixpkgs","attr_path":"terraform","pkg_path":"terraform","derivation":"/nix/store/placeholder-terraform-1.9.8-aarch64-linux.drv","name":"terraform-1.9.8","pname":"terraform","version":"1.9.8","system":"aarch64-linux","outputs":[{"name":"out","store_path":"/nix/store/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb0-terraform-1.9.8"}],"outputs_to_install":["out"],"description":"Tool for building, changing, and versioning infrastructure","license":"BSL-1.1","locked_url":"https://github.com/flox/nixpkgs?rev=b12141ef619e0a9c1c84dc8c684040326f27cdcc","rev":"b12141ef619e0a9c1c84dc8c684040326f27cdcc","rev_count":982522,"rev_date":"2026-04-18T21:33:21Z","broken":false,"insecure":false,"unfree":true,"missing_builds":false,"stabilities":["unstable"],"scrape_date":"2026-04-21T06:03:34.910020Z","cache_uri":null,"install_id":"terraform"}],"messages":[],"complete":true},"candidate_pages":null,"messages":[]}]}'
@@ -38,7 +38,7 @@ then:
   - name: content-type
     value: application/json
   - name: content-length
-    value: '981'
+    value: '973'
   - name: server
     value: uvicorn
   body: '{"items":[{"name":"toplevel","page":{"page":982522,"url":"","packages":[{"catalog":"nixpkgs","attr_path":"terraform","pkg_path":"terraform","derivation":"/nix/store/placeholder-terraform-1.9.8-x86_64-darwin.drv","name":"terraform-1.9.8","pname":"terraform","version":"1.9.8","system":"x86_64-darwin","outputs":[{"name":"out","store_path":"/nix/store/cccccccccccccccccccccccccccccc0-terraform-1.9.8"}],"outputs_to_install":["out"],"description":"Tool for building, changing, and versioning infrastructure","license":"BSL-1.1","locked_url":"https://github.com/flox/nixpkgs?rev=b12141ef619e0a9c1c84dc8c684040326f27cdcc","rev":"b12141ef619e0a9c1c84dc8c684040326f27cdcc","rev_count":982522,"rev_date":"2026-04-18T21:33:21Z","broken":false,"insecure":false,"unfree":true,"missing_builds":false,"stabilities":["unstable"],"scrape_date":"2026-04-21T07:08:27.302720Z","cache_uri":null,"install_id":"terraform"}],"messages":[],"complete":true},"candidate_pages":null,"messages":[]}]}'
@@ -53,7 +53,7 @@ then:
   - name: content-type
     value: application/json
   - name: content-length
-    value: '980'
+    value: '971'
   - name: server
     value: uvicorn
   body: '{"items":[{"name":"toplevel","page":{"page":982522,"url":"","packages":[{"catalog":"nixpkgs","attr_path":"terraform","pkg_path":"terraform","derivation":"/nix/store/placeholder-terraform-1.9.8-x86_64-linux.drv","name":"terraform-1.9.8","pname":"terraform","version":"1.9.8","system":"x86_64-linux","outputs":[{"name":"out","store_path":"/nix/store/dddddddddddddddddddddddddddddd0-terraform-1.9.8"}],"outputs_to_install":["out"],"description":"Tool for building, changing, and versioning infrastructure","license":"BSL-1.1","locked_url":"https://github.com/flox/nixpkgs?rev=b12141ef619e0a9c1c84dc8c684040326f27cdcc","rev":"b12141ef619e0a9c1c84dc8c684040326f27cdcc","rev_count":982522,"rev_date":"2026-04-18T21:33:21Z","broken":false,"insecure":false,"unfree":true,"missing_builds":false,"stabilities":["unstable"],"scrape_date":"2026-04-21T07:44:59.797392Z","cache_uri":null,"install_id":"terraform"}],"messages":[],"complete":true},"candidate_pages":null,"messages":[]}]}'

--- a/test_data/generated/resolve/run/terraform.yaml
+++ b/test_data/generated/resolve/run/terraform.yaml
@@ -1,0 +1,59 @@
+when:
+  path: /api/v1/catalog/resolve
+  method: POST
+  body: '{"items":[{"descriptors":[{"allow_broken":null,"allow_insecure":null,"allow_pre_releases":null,"allow_unfree":null,"attr_path":"terraform","install_id":"terraform","systems":["aarch64-darwin"]}],"name":"toplevel"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  - name: content-length
+    value: '983'
+  - name: server
+    value: uvicorn
+  body: '{"items":[{"name":"toplevel","page":{"page":982522,"url":"","packages":[{"catalog":"nixpkgs","attr_path":"terraform","pkg_path":"terraform","derivation":"/nix/store/placeholder-terraform-1.9.8-aarch64-darwin.drv","name":"terraform-1.9.8","pname":"terraform","version":"1.9.8","system":"aarch64-darwin","outputs":[{"name":"out","store_path":"/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0-terraform-1.9.8"}],"outputs_to_install":["out"],"description":"Tool for building, changing, and versioning infrastructure","license":"BSL-1.1","locked_url":"https://github.com/flox/nixpkgs?rev=b12141ef619e0a9c1c84dc8c684040326f27cdcc","rev":"b12141ef619e0a9c1c84dc8c684040326f27cdcc","rev_count":982522,"rev_date":"2026-04-18T21:33:21Z","broken":false,"insecure":false,"unfree":true,"missing_builds":false,"stabilities":["unstable"],"scrape_date":"2026-04-21T06:03:34.910020Z","cache_uri":null,"install_id":"terraform"}],"messages":[],"complete":true},"candidate_pages":null,"messages":[]}]}'
+---
+when:
+  path: /api/v1/catalog/resolve
+  method: POST
+  body: '{"items":[{"descriptors":[{"allow_broken":null,"allow_insecure":null,"allow_pre_releases":null,"allow_unfree":null,"attr_path":"terraform","install_id":"terraform","systems":["aarch64-linux"]}],"name":"toplevel"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  - name: content-length
+    value: '981'
+  - name: server
+    value: uvicorn
+  body: '{"items":[{"name":"toplevel","page":{"page":982522,"url":"","packages":[{"catalog":"nixpkgs","attr_path":"terraform","pkg_path":"terraform","derivation":"/nix/store/placeholder-terraform-1.9.8-aarch64-linux.drv","name":"terraform-1.9.8","pname":"terraform","version":"1.9.8","system":"aarch64-linux","outputs":[{"name":"out","store_path":"/nix/store/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb0-terraform-1.9.8"}],"outputs_to_install":["out"],"description":"Tool for building, changing, and versioning infrastructure","license":"BSL-1.1","locked_url":"https://github.com/flox/nixpkgs?rev=b12141ef619e0a9c1c84dc8c684040326f27cdcc","rev":"b12141ef619e0a9c1c84dc8c684040326f27cdcc","rev_count":982522,"rev_date":"2026-04-18T21:33:21Z","broken":false,"insecure":false,"unfree":true,"missing_builds":false,"stabilities":["unstable"],"scrape_date":"2026-04-21T06:03:34.910020Z","cache_uri":null,"install_id":"terraform"}],"messages":[],"complete":true},"candidate_pages":null,"messages":[]}]}'
+---
+when:
+  path: /api/v1/catalog/resolve
+  method: POST
+  body: '{"items":[{"descriptors":[{"allow_broken":null,"allow_insecure":null,"allow_pre_releases":null,"allow_unfree":null,"attr_path":"terraform","install_id":"terraform","systems":["x86_64-darwin"]}],"name":"toplevel"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  - name: content-length
+    value: '981'
+  - name: server
+    value: uvicorn
+  body: '{"items":[{"name":"toplevel","page":{"page":982522,"url":"","packages":[{"catalog":"nixpkgs","attr_path":"terraform","pkg_path":"terraform","derivation":"/nix/store/placeholder-terraform-1.9.8-x86_64-darwin.drv","name":"terraform-1.9.8","pname":"terraform","version":"1.9.8","system":"x86_64-darwin","outputs":[{"name":"out","store_path":"/nix/store/cccccccccccccccccccccccccccccc0-terraform-1.9.8"}],"outputs_to_install":["out"],"description":"Tool for building, changing, and versioning infrastructure","license":"BSL-1.1","locked_url":"https://github.com/flox/nixpkgs?rev=b12141ef619e0a9c1c84dc8c684040326f27cdcc","rev":"b12141ef619e0a9c1c84dc8c684040326f27cdcc","rev_count":982522,"rev_date":"2026-04-18T21:33:21Z","broken":false,"insecure":false,"unfree":true,"missing_builds":false,"stabilities":["unstable"],"scrape_date":"2026-04-21T07:08:27.302720Z","cache_uri":null,"install_id":"terraform"}],"messages":[],"complete":true},"candidate_pages":null,"messages":[]}]}'
+---
+when:
+  path: /api/v1/catalog/resolve
+  method: POST
+  body: '{"items":[{"descriptors":[{"allow_broken":null,"allow_insecure":null,"allow_pre_releases":null,"allow_unfree":null,"attr_path":"terraform","install_id":"terraform","systems":["x86_64-linux"]}],"name":"toplevel"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  - name: content-length
+    value: '980'
+  - name: server
+    value: uvicorn
+  body: '{"items":[{"name":"toplevel","page":{"page":982522,"url":"","packages":[{"catalog":"nixpkgs","attr_path":"terraform","pkg_path":"terraform","derivation":"/nix/store/placeholder-terraform-1.9.8-x86_64-linux.drv","name":"terraform-1.9.8","pname":"terraform","version":"1.9.8","system":"x86_64-linux","outputs":[{"name":"out","store_path":"/nix/store/dddddddddddddddddddddddddddddd0-terraform-1.9.8"}],"outputs_to_install":["out"],"description":"Tool for building, changing, and versioning infrastructure","license":"BSL-1.1","locked_url":"https://github.com/flox/nixpkgs?rev=b12141ef619e0a9c1c84dc8c684040326f27cdcc","rev":"b12141ef619e0a9c1c84dc8c684040326f27cdcc","rev_count":982522,"rev_date":"2026-04-18T21:33:21Z","broken":false,"insecure":false,"unfree":true,"missing_builds":false,"stabilities":["unstable"],"scrape_date":"2026-04-21T07:44:59.797392Z","cache_uri":null,"install_id":"terraform"}],"messages":[],"complete":true},"candidate_pages":null,"messages":[]}]}'


### PR DESCRIPTION
## Proposed Changes

\`flox run -p <pkg> -- <cmd>\` previously failed with a "not available in
the binary cache" error when the package had no pre-built binary (e.g.
unfree packages like \`terraform\`, or packages that are build-only).

This PR extends \`flox run\` to fall back to building from source when
substitution fails, using the same \`flox-nixpkgs\` fetcher path that the
environment builder already uses.

**Behavior:**
- When substitution returns a cache miss, \`flox run\` automatically builds
  the package from source using \`nix build\` with the \`flox-nixpkgs\`
  proxy flake ref.
- A temporary per-PID GC root is created for the build output; a forked
  background watcher removes it when the exec'd command exits.
- The entire realise sequence (substitution + optional source build) runs
  inside \`materialise_with_retry\` so a GC race at any point triggers a
  clean retry rather than a crash.

Fixes https://linear.app/floxdotdev/issue/DEV-139

**Changes:**
- \`buildenv.rs\`: new \`build_catalog_pkg_from_source\` pub fn; performs
  the URL transform (\`https://github.com/flox/nixpkgs?rev=X\` →
  \`flox-nixpkgs:v0/flox/X\`) and invokes \`nix build\` with the Nix plugins;
  single attempt (no inner retry loop — \`materialise_with_retry\` handles
  GC-race retries)
- \`run.rs\`: both substitution and source-build are inside the
  \`materialise_with_retry\` \`realise\` closure; post-call dispatch checks
  whether \`build_gc_root\` has symlinks to decide exec path (GC root PATH
  for source builds, store paths for substitution); adds
  \`fork_gc_root_watcher\`, \`collect_bin_dirs_from_gc_root\`,
  \`prepend_path_dirs\`, and \`collect_store_paths_from_gc_root\` helpers
- \`flox-run.md\`: update binary-cache-requirement section
- \`run.bats\`: add terraform fixture and \`run:store\` smoke test
- \`test_data/generated/resolve/run/terraform.yaml\`: new mock fixture
  (unfree=true, non-existent store paths trigger the cache-miss path)

## Release Notes

\`flox run\` now falls back to building from source when a package is not
available in the Nix binary cache. This enables packages like \`terraform\`
(unfree license) that were previously unavailable via \`flox run\`. The
build runs automatically with a progress indicator; press Ctrl-C to cancel.

---
*Via Forge (claude-code) • $(cd /Users/stephen/Sites/flox/_worktrees/dev-74-flox-run && git rev-parse --short HEAD)*