### PR TITLE
feat(auth): persistent token-storage preference with --once

### DIFF
--- a/cli/flox-config/src/config.rs
+++ b/cli/flox-config/src/config.rs
@@ -37,6 +37,17 @@ pub enum AuthnMode {
     Kerberos,
 }
 
+/// Where `flox auth login` stores the FloxHub token.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum TokenStorageMode {
+    /// Store the token in the OS-native keyring (default).
+    #[default]
+    Keyring,
+    /// Store the token in plain text in flox.toml.
+    Plaintext,
+}
+
 #[derive(Clone, Debug, Deserialize, Default, Serialize)]
 pub struct Config {
     /// flox configuration options
@@ -100,6 +111,13 @@ pub struct FloxConfig {
     /// Authentication mode for FloxHub.
     /// Unset means the consumer's compiled-in default.
     pub floxhub_authn_mode: Option<AuthnMode>,
+
+    /// Where new FloxHub tokens are stored: the OS keyring (default) or plain
+    /// text in flox.toml. Set to `plaintext` by
+    /// `flox auth login --insecure-storage`; cleared with
+    /// `flox config --delete floxhub_token_storage`.
+    #[serde(default)]
+    pub floxhub_token_storage: TokenStorageMode,
 
     /// Rule whether to change the shell prompt in activated environments.
     ///

--- a/cli/flox-config/src/lib.rs
+++ b/cli/flox-config/src/lib.rs
@@ -21,5 +21,6 @@ pub use config::{
     InstallerChannel,
     PublishConfig,
     SearchLimit,
+    TokenStorageMode,
 };
 pub use write::ReadWriteError;

--- a/cli/flox-config/src/load.rs
+++ b/cli/flox-config/src/load.rs
@@ -203,6 +203,7 @@ mod tests {
     use toml_edit::Key;
 
     use super::*;
+    use crate::config::TokenStorageMode;
 
     // TODO: update the `xdg` crate and build `BaseDirectories` by hand with known (test) paths
     fn mock_flox_dirs() -> BaseDirectories {
@@ -270,6 +271,42 @@ mod tests {
         assert_eq!(config.flox.floxhub_url, Some(floxhub_url.parse().unwrap()));
         assert!(config.flox.disable_metrics);
         assert_eq!(config.flox.search_limit, Some(search_limit));
+    }
+
+    #[test]
+    fn floxhub_token_storage_parses_and_defaults() {
+        let user_config_dir = tempfile::tempdir().unwrap();
+        let system_config_dir = tempfile::tempdir().unwrap();
+        fs::write(system_config_dir.path().join(FLOX_CONFIG_FILE), "").unwrap();
+
+        // Absent → defaults to keyring.
+        fs::write(user_config_dir.path().join(FLOX_CONFIG_FILE), "").unwrap();
+        let config = Config::parse_with(
+            &mock_flox_dirs(),
+            user_config_dir.path(),
+            Some(system_config_dir.path()),
+            [],
+        )
+        .unwrap();
+        assert_eq!(config.flox.floxhub_token_storage, TokenStorageMode::Keyring);
+
+        // Explicit plaintext → parsed.
+        fs::write(
+            user_config_dir.path().join(FLOX_CONFIG_FILE),
+            "floxhub_token_storage = \"plaintext\"\n",
+        )
+        .unwrap();
+        let config = Config::parse_with(
+            &mock_flox_dirs(),
+            user_config_dir.path(),
+            Some(system_config_dir.path()),
+            [],
+        )
+        .unwrap();
+        assert_eq!(
+            config.flox.floxhub_token_storage,
+            TokenStorageMode::Plaintext
+        );
     }
 
     #[test]

--- a/cli/flox/src/commands/auth.rs
+++ b/cli/flox/src/commands/auth.rs
@@ -5,7 +5,7 @@ use anyhow::{Context, Result, bail};
 use bpaf::Bpaf;
 use chrono::offset::Utc;
 use chrono::{DateTime, Duration};
-use flox_config::Config;
+use flox_config::{Config, TokenStorageMode};
 use flox_rust_sdk::flox::{FLOX_VERSION, Flox, FloxhubToken};
 use floxhub_client::{AuthContext, AuthnMode};
 use indoc::{formatdoc, indoc};
@@ -35,6 +35,7 @@ use serde::Serialize;
 use tracing::{debug, instrument};
 use url::Url;
 
+use crate::commands::general::update_config;
 use crate::utils::credential_store::{CredentialSource, CredentialStores, TokenStorage};
 use crate::utils::dialog::{Checkpoint, Dialog, WaitResult};
 use crate::utils::message;
@@ -240,6 +241,10 @@ pub enum Auth {
         /// Store the token in plain text in flox.toml instead of the OS keyring
         #[bpaf(long("insecure-storage"))]
         insecure_storage: bool,
+        /// With --insecure-storage, store plain text only for this login without
+        /// changing the saved storage preference
+        #[bpaf(long("once"))]
+        once: bool,
     },
 
     /// Logout from FloxHub
@@ -264,15 +269,28 @@ impl Auth {
             Auth::Login {
                 token_file,
                 insecure_storage,
+                once,
             } => {
                 let span = tracing::info_span!("login");
                 let _guard = span.enter();
                 match token_file {
                     Some(path) => {
-                        login_with_token_file(&mut flox, &path, insecure_storage)?;
+                        login_with_token_file(
+                            &mut flox,
+                            &path,
+                            insecure_storage,
+                            once,
+                            config.flox.floxhub_token_storage,
+                        )?;
                     },
                     None => {
-                        login_flox(&mut flox, insecure_storage).await?;
+                        login_flox(
+                            &mut flox,
+                            insecure_storage,
+                            once,
+                            config.flox.floxhub_token_storage,
+                        )
+                        .await?;
                     },
                 }
                 Ok(())
@@ -341,6 +359,12 @@ impl Auth {
                     None => {},
                 }
 
+                if config.flox.floxhub_token_storage == TokenStorageMode::Plaintext {
+                    message::plain(formatdoc! {"
+                        Token storage preference is set to plain text.
+                        Run 'flox config --delete floxhub_token_storage' to store tokens in the system keyring."});
+                }
+
                 Ok(())
             },
             Auth::Token => {
@@ -367,7 +391,12 @@ impl Auth {
 // to handle different auth methods — for Kerberos, it should print a warning
 // that login is not needed (Kerberos authentication is handled externally via
 // `kinit`).
-pub async fn login_flox(flox: &mut Flox, insecure_storage: bool) -> Result<String> {
+pub async fn login_flox(
+    flox: &mut Flox,
+    insecure_storage: bool,
+    once: bool,
+    storage_pref: TokenStorageMode,
+) -> Result<String> {
     let client = create_oauth_client()?;
     let cred = authorize(client, flox.floxhub.base_url())
         .await
@@ -379,19 +408,49 @@ pub async fn login_flox(flox: &mut Flox, insecure_storage: bool) -> Result<Strin
     // set the token in the runtime config
     let token = FloxhubToken::new(cred.token)?;
 
-    complete_login(flox, token, insecure_storage)
+    complete_login(flox, token, insecure_storage, once, storage_pref)
 }
 
 /// Finish a login with a fresh, validated token, shared by the interactive
 /// and token-file flows: store the token in the OS keyring (falling back to
 /// the plaintext config file, or forced there by `--insecure-storage`), set
 /// the auth context, and report where the credential landed.
-fn complete_login(flox: &mut Flox, token: FloxhubToken, insecure_storage: bool) -> Result<String> {
+fn complete_login(
+    flox: &mut Flox,
+    token: FloxhubToken,
+    insecure_storage: bool,
+    once: bool,
+    storage_pref: TokenStorageMode,
+) -> Result<String> {
     let handle = token.handle().to_string();
 
+    // `--insecure-storage` forces plain text for this login; otherwise honor the
+    // standing storage preference.
+    let target = if insecure_storage {
+        TokenStorageMode::Plaintext
+    } else {
+        storage_pref
+    };
+
+    // Persist the plain-text choice as a standing preference only when
+    // `--insecure-storage` is given without `--once`. `--once` stores plain text
+    // this one time without changing where future tokens go, so the token is
+    // re-secured to the keyring once the keyring is available again.
+    if insecure_storage && !once {
+        update_config(
+            &flox.config_dir,
+            "floxhub_token_storage",
+            Some(TokenStorageMode::Plaintext),
+        )
+        .context("Could not save the token-storage preference")?;
+    }
+
+    // Store the token where `target` says: the OS keyring (with a plaintext
+    // fallback and warning on keyring failure) or the plaintext config file
+    // (explicit 0600).
     let stores = CredentialStores::from_flox(flox);
     let storage = stores
-        .persist_login_token(token.secret(), insecure_storage)
+        .persist_login_token(token.secret(), target)
         .context("Could not store token")?;
 
     let auth_context = AuthContext::from_mode(&AuthnMode::Auth0, Some(token));
@@ -402,7 +461,7 @@ fn complete_login(flox: &mut Flox, token: FloxhubToken, insecure_storage: bool) 
     if storage == TokenStorage::Plaintext {
         message::warning(formatdoc! {"
             {notice}
-            No OS keyring is available, or '--insecure-storage' was passed.",
+            No OS keyring is available, or plain-text storage was requested.",
             notice = CredentialSource::plaintext_notice(&stores.plaintext_path())
         });
     }
@@ -427,6 +486,8 @@ pub fn login_with_token_file(
     flox: &mut Flox,
     token_file: &Path,
     insecure_storage: bool,
+    once: bool,
+    storage_pref: TokenStorageMode,
 ) -> Result<String> {
     let contents = if token_file == Path::new("-") {
         let mut contents = String::new();
@@ -446,7 +507,7 @@ pub fn login_with_token_file(
         bail!("The provided token is expired.\nObtain a fresh token from FloxHub and try again.");
     }
 
-    complete_login(flox, token, insecure_storage)
+    complete_login(flox, token, insecure_storage, once, storage_pref)
 }
 
 #[cfg(test)]
@@ -470,7 +531,14 @@ mod tests {
             let token_file = flox.temp_dir.join("token");
             fs::write(&token_file, format!("{}\n", token.secret())).unwrap();
 
-            let handle = login_with_token_file(&mut flox, &token_file, false).unwrap();
+            let handle = login_with_token_file(
+                &mut flox,
+                &token_file,
+                false,
+                false,
+                TokenStorageMode::Keyring,
+            )
+            .unwrap();
 
             assert_eq!(handle, "test-user");
             let config_contents =
@@ -491,7 +559,9 @@ mod tests {
         let (mut flox, _temp_dir) = flox_instance();
         let missing = flox.temp_dir.join("nonexistent");
 
-        let err = login_with_token_file(&mut flox, &missing, false).unwrap_err();
+        let err =
+            login_with_token_file(&mut flox, &missing, false, false, TokenStorageMode::Keyring)
+                .unwrap_err();
 
         assert_eq!(
             err.to_string(),
@@ -506,7 +576,14 @@ mod tests {
         let token_file = flox.temp_dir.join("token");
         fs::write(&token_file, "not-a-jwt").unwrap();
 
-        let err = login_with_token_file(&mut flox, &token_file, false).unwrap_err();
+        let err = login_with_token_file(
+            &mut flox,
+            &token_file,
+            false,
+            false,
+            TokenStorageMode::Keyring,
+        )
+        .unwrap_err();
 
         assert_eq!(
             err.to_string(),
@@ -521,7 +598,14 @@ mod tests {
         let token_file = flox.temp_dir.join("token");
         fs::write(&token_file, FAKE_EXPIRED_TOKEN).unwrap();
 
-        let err = login_with_token_file(&mut flox, &token_file, false).unwrap_err();
+        let err = login_with_token_file(
+            &mut flox,
+            &token_file,
+            false,
+            false,
+            TokenStorageMode::Keyring,
+        )
+        .unwrap_err();
 
         assert_eq!(
             err.to_string(),

--- a/cli/flox/src/commands/auth.rs
+++ b/cli/flox/src/commands/auth.rs
@@ -477,16 +477,31 @@ fn complete_login(
 
     if storage == TokenStorage::Plaintext {
         let notice = CredentialSource::plaintext_notice(&stores.plaintext_path());
-        // Distinguish a chosen plain-text store (point at how to switch back)
-        // from a keyring-unavailable fallback (no actionable next step).
-        if target == TokenStorageMode::Plaintext {
-            message::warning(formatdoc! {"
-                {notice}
-                To use the keyring instead, run 'flox config --delete floxhub_token_storage'."});
-        } else {
+        // Suggest a next step only where one exists: 'flox config --delete'
+        // only works when the preference is in the user's own flox.toml, and
+        // the re-secure note only holds while the standing preference is
+        // still the keyring.
+        if target != TokenStorageMode::Plaintext {
+            // The keyring was the target but storing fell back to plain text.
             message::warning(formatdoc! {"
                 {notice}
                 No OS keyring is available."});
+        } else if user_config_sets_token_storage(&flox.config_dir) {
+            message::warning(formatdoc! {"
+                {notice}
+                To use the keyring instead, run 'flox config --delete floxhub_token_storage'."});
+        } else if storage_pref == TokenStorageMode::Keyring {
+            // Reached via '--insecure-storage --once': the standing
+            // preference is untouched, so the next command re-secures the
+            // token to the keyring.
+            message::warning(formatdoc! {"
+                {notice}
+                The token will be moved to the OS keyring on the next command."});
+        } else {
+            // Plain-text preference supplied by the environment or the system
+            // config: 'flox config --delete' cannot remove it, and no
+            // migration will run while it stands.
+            message::warning(notice);
         }
     }
 

--- a/cli/flox/src/commands/auth.rs
+++ b/cli/flox/src/commands/auth.rs
@@ -397,6 +397,14 @@ pub async fn login_flox(
     once: bool,
     storage_pref: TokenStorageMode,
 ) -> Result<String> {
+    // `--once` only modulates whether `--insecure-storage` persists the plain-text
+    // preference, so it is meaningless on its own. Reject the combination rather
+    // than silently ignoring it (mirrors '--generation' requiring '--copy' in
+    // 'flox pull').
+    if once && !insecure_storage {
+        bail!("'--once' has no effect without '--insecure-storage'.");
+    }
+
     let client = create_oauth_client()?;
     let cred = authorize(client, flox.floxhub.base_url())
         .await
@@ -459,11 +467,18 @@ fn complete_login(
     print_login_success(&handle);
 
     if storage == TokenStorage::Plaintext {
-        message::warning(formatdoc! {"
-            {notice}
-            No OS keyring is available, or plain-text storage was requested.",
-            notice = CredentialSource::plaintext_notice(&stores.plaintext_path())
-        });
+        let notice = CredentialSource::plaintext_notice(&stores.plaintext_path());
+        // Distinguish a chosen plain-text store (point at how to switch back)
+        // from a keyring-unavailable fallback (no actionable next step).
+        if target == TokenStorageMode::Plaintext {
+            message::warning(formatdoc! {"
+                {notice}
+                To store credentials in the system keyring instead, run 'flox config --delete floxhub_token_storage'."});
+        } else {
+            message::warning(formatdoc! {"
+                {notice}
+                No OS keyring is available."});
+        }
     }
 
     Ok(handle)

--- a/cli/flox/src/commands/auth.rs
+++ b/cli/flox/src/commands/auth.rs
@@ -5,7 +5,7 @@ use anyhow::{Context, Result, bail};
 use bpaf::Bpaf;
 use chrono::offset::Utc;
 use chrono::{DateTime, Duration};
-use flox_config::{Config, TokenStorageMode};
+use flox_config::{Config, FLOX_CONFIG_FILE, TokenStorageMode};
 use flox_rust_sdk::flox::{FLOX_VERSION, Flox, FloxhubToken};
 use floxhub_client::{AuthContext, AuthnMode};
 use indoc::{formatdoc, indoc};
@@ -273,6 +273,13 @@ impl Auth {
             } => {
                 let span = tracing::info_span!("login");
                 let _guard = span.enter();
+                // `--once` only modulates whether `--insecure-storage` persists
+                // the plain-text preference, so it is meaningless on its own.
+                // Reject the combination rather than silently ignoring it
+                // (mirrors '--generation' requiring '--copy' in 'flox pull').
+                if once && !insecure_storage {
+                    bail!("'--once' has no effect without '--insecure-storage'.");
+                }
                 match token_file {
                     Some(path) => {
                         login_with_token_file(
@@ -360,9 +367,16 @@ impl Auth {
                 }
 
                 if config.flox.floxhub_token_storage == TokenStorageMode::Plaintext {
-                    message::plain(formatdoc! {"
-                        Token storage preference is set to plain text.
-                        Run 'flox config --delete floxhub_token_storage' to store tokens in the system keyring."});
+                    message::plain("Token storage preference is set to plain text.");
+                    // Suggest the revert only when the preference actually
+                    // lives in the user's own flox.toml — 'flox config
+                    // --delete' cannot remove a value supplied by the
+                    // environment or the system config.
+                    if user_config_sets_token_storage(&flox.config_dir) {
+                        message::plain(
+                            "To use the keyring again, run 'flox config --delete floxhub_token_storage'.",
+                        );
+                    }
                 }
 
                 Ok(())
@@ -397,14 +411,6 @@ pub async fn login_flox(
     once: bool,
     storage_pref: TokenStorageMode,
 ) -> Result<String> {
-    // `--once` only modulates whether `--insecure-storage` persists the plain-text
-    // preference, so it is meaningless on its own. Reject the combination rather
-    // than silently ignoring it (mirrors '--generation' requiring '--copy' in
-    // 'flox pull').
-    if once && !insecure_storage {
-        bail!("'--once' has no effect without '--insecure-storage'.");
-    }
-
     let client = create_oauth_client()?;
     let cred = authorize(client, flox.floxhub.base_url())
         .await
@@ -440,10 +446,21 @@ fn complete_login(
         storage_pref
     };
 
+    // Store the token where `target` says: the OS keyring (with a plaintext
+    // fallback and warning on keyring failure) or the plaintext config file
+    // (explicit 0600).
+    let stores = CredentialStores::from_flox(flox);
+    let storage = stores
+        .persist_login_token(token.secret(), target)
+        .context("Could not store token")?;
+
     // Persist the plain-text choice as a standing preference only when
     // `--insecure-storage` is given without `--once`. `--once` stores plain text
     // this one time without changing where future tokens go, so the token is
     // re-secured to the keyring once the keyring is available again.
+    // Written only after the token store succeeded: a failed login must not
+    // leave a stale plaintext preference behind, which would also suppress the
+    // migration that re-secures an existing plain-text token.
     if insecure_storage && !once {
         update_config(
             &flox.config_dir,
@@ -452,14 +469,6 @@ fn complete_login(
         )
         .context("Could not save the token-storage preference")?;
     }
-
-    // Store the token where `target` says: the OS keyring (with a plaintext
-    // fallback and warning on keyring failure) or the plaintext config file
-    // (explicit 0600).
-    let stores = CredentialStores::from_flox(flox);
-    let storage = stores
-        .persist_login_token(token.secret(), target)
-        .context("Could not store token")?;
 
     let auth_context = AuthContext::from_mode(&AuthnMode::Auth0, Some(token));
     let _ = flox.set_auth_context(auth_context);
@@ -473,7 +482,7 @@ fn complete_login(
         if target == TokenStorageMode::Plaintext {
             message::warning(formatdoc! {"
                 {notice}
-                To store credentials in the system keyring instead, run 'flox config --delete floxhub_token_storage'."});
+                To use the keyring instead, run 'flox config --delete floxhub_token_storage'."});
         } else {
             message::warning(formatdoc! {"
                 {notice}
@@ -482,6 +491,19 @@ fn complete_login(
     }
 
     Ok(handle)
+}
+
+/// Whether the user's own `flox.toml` sets `floxhub_token_storage`.
+///
+/// The merged [Config] cannot distinguish where the preference came from, and
+/// the revert suggestion in `flox auth status` is only actionable when the key
+/// is in the user file: `flox config --delete` cannot remove a value supplied
+/// by the environment or the system config.
+fn user_config_sets_token_storage(config_dir: &Path) -> bool {
+    std::fs::read_to_string(config_dir.join(FLOX_CONFIG_FILE))
+        .ok()
+        .and_then(|contents| contents.parse::<toml_edit::DocumentMut>().ok())
+        .is_some_and(|document| document.get("floxhub_token_storage").is_some())
 }
 
 /// Print the success message shared by all login flows.

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -1679,7 +1679,9 @@ pub(super) async fn ensure_auth(flox: &mut Flox) -> Result<String> {
             // Implicit re-authentication stores to the secure default (keyring).
             // The standing storage preference is not threaded through the many
             // `ensure_auth` call sites, so an implicit re-login does not honor a
-            // `plaintext` preference; an explicit `flox auth login` does.
+            // `plaintext` preference; an explicit `flox auth login` does. This is
+            // an accepted limitation; see
+            // docs/superpowers/specs/2026-06-22-implicit-reauth-token-storage-followup.md.
             auth::login_flox(flox, false, false, TokenStorageMode::Keyring).await
         },
         Err(failure) => {

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -37,7 +37,7 @@ use std::{env, fmt, mem};
 
 use anyhow::{Context, Result, anyhow, bail};
 use bpaf::{Args, Bpaf, ParseFailure, Parser, ShellComp};
-use flox_config::{Config, EnvironmentTrust, FLOX_DIR_NAME};
+use flox_config::{Config, EnvironmentTrust, FLOX_DIR_NAME, TokenStorageMode};
 use flox_core::data::environment_ref::{self, DEFAULT_NAME, RemoteEnvironmentRef};
 use flox_core::floxhub::{DEFAULT_FLOXHUB_URL, Floxhub};
 use flox_core::vars::FLOX_DISABLE_METRICS_VAR;
@@ -1676,8 +1676,11 @@ pub(super) async fn ensure_auth(flox: &mut Flox) -> Result<String> {
                 AuthFailure::NotLoggedIn => "You are not logged in to FloxHub.",
                 _ => unreachable!(),
             }));
-            // Implicit re-authentication uses the secure default store.
-            auth::login_flox(flox, false).await
+            // Implicit re-authentication stores to the secure default (keyring).
+            // The standing storage preference is not threaded through the many
+            // `ensure_auth` call sites, so an implicit re-login does not honor a
+            // `plaintext` preference; an explicit `flox auth login` does.
+            auth::login_flox(flox, false, false, TokenStorageMode::Keyring).await
         },
         Err(failure) => {
             let message = match failure {

--- a/cli/flox/src/utils/credential_store/mod.rs
+++ b/cli/flox/src/utils/credential_store/mod.rs
@@ -309,8 +309,10 @@ impl CredentialStores {
 
         self.plaintext.set(token)?;
         // An explicit plain-text choice supersedes any keyring entry: drop a
-        // lingering keyring token (best effort) so a later read cannot surface
-        // it and shadow the plain-text file the user just chose. Scoped to the
+        // lingering keyring token (best effort) so it is not left behind as a
+        // stale secret, and is not surfaced on a later read if the plain-text
+        // file is removed. (The plain-text file already takes read precedence
+        // over the keyring, so this is cleanup, not shadowing.) Scoped to the
         // explicit `Plaintext` target — on a keyring-write fallback there is
         // nothing of ours in the keyring to remove.
         if target == TokenStorageMode::Plaintext
@@ -792,8 +794,9 @@ mod tests {
         assert_eq!(plaintext.get().unwrap(), Some(TOKEN.to_string()));
     }
 
-    /// Storing plain text drops any pre-existing keyring entry so it cannot
-    /// resurface on the next read and shadow the user's plain-text choice.
+    /// Storing plain text drops any pre-existing keyring entry so it is not left
+    /// behind as a stale secret (e.g. to resurface on a later read if the
+    /// plain-text file is removed).
     #[test]
     fn login_plaintext_target_removes_stale_keyring_entry() {
         let dir = tempfile::tempdir().unwrap();

--- a/cli/flox/src/utils/credential_store/mod.rs
+++ b/cli/flox/src/utils/credential_store/mod.rs
@@ -23,7 +23,7 @@ mod plaintext;
 use std::path::{Path, PathBuf};
 
 use enum_dispatch::enum_dispatch;
-use flox_config::{Config, FLOX_CONFIG_FILE};
+use flox_config::{Config, FLOX_CONFIG_FILE, TokenStorageMode};
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::floxmeta::FLOXHUB_TOKEN_ENV_VAR;
 use indoc::indoc;
@@ -276,20 +276,20 @@ impl CredentialStores {
         CredentialSource::None
     }
 
-    /// Persist a logged-in token to the most secure available store.
+    /// Persist a logged-in token according to `target`.
     ///
-    /// Unless `insecure_storage` forces plaintext, attempt the keyring first
-    /// (try-then-confirm): on success store there and remove any lingering
-    /// plaintext token so it cannot shadow the keyring entry. On any keyring
-    /// failure — or when plaintext is forced — write the plaintext file
-    /// (`0600`). The returned [TokenStorage] tells the caller whether to warn
-    /// the user.
+    /// `Keyring`: attempt the keyring first (try-then-confirm); on success
+    /// store there and remove any lingering plaintext token so it cannot
+    /// shadow the keyring entry, and on any keyring failure fall back to the
+    /// plaintext file (`0600`). `Plaintext`: write the plaintext file and drop
+    /// any existing keyring entry (best effort). The returned [TokenStorage]
+    /// tells the caller whether to warn the user.
     pub fn persist_login_token(
         &self,
         token: &str,
-        insecure_storage: bool,
+        target: TokenStorageMode,
     ) -> Result<TokenStorage, CredentialStoreError> {
-        if !insecure_storage && self.keyring.set(token).is_ok() {
+        if target == TokenStorageMode::Keyring && self.keyring.set(token).is_ok() {
             // The keyring already holds the token, so a failure to remove the
             // old plaintext copy must not fail the login. Warn instead: a
             // lingering plaintext token both leaves a secret on disk and shadows
@@ -308,6 +308,18 @@ impl CredentialStores {
         }
 
         self.plaintext.set(token)?;
+        // An explicit plain-text choice supersedes any keyring entry: drop a
+        // lingering keyring token (best effort) so a later read cannot surface
+        // it and shadow the plain-text file the user just chose. Scoped to the
+        // explicit `Plaintext` target — on a keyring-write fallback there is
+        // nothing of ours in the keyring to remove.
+        if target == TokenStorageMode::Plaintext
+            && let Err(e) = self.keyring.remove()
+        {
+            tracing::debug!(
+                "could not remove the keyring credential after storing plain text: {e}"
+            );
+        }
         Ok(TokenStorage::Plaintext)
     }
 
@@ -327,13 +339,16 @@ impl CredentialStores {
     /// read, and the prompt/hook flow does no keyring I/O. This method assumes
     /// that gate has already passed and performs the I/O unconditionally.
     ///
-    /// Migration (additive over Phase 2) runs only when both of these hold, so it
+    /// Migration (additive over Phase 2) runs only when all of these hold, so it
     /// is correct rather than merely convenient:
     /// - `FLOX_FLOXHUB_TOKEN` is not present in the environment — a transient
     ///   CI token is never persisted, and an explicit *empty* export (used to
     ///   mask saved credentials for one invocation) blocks the stores entirely.
     /// - the *user file* (`PlaintextStore::get`) holds a token — the system
     ///   `/etc/flox.toml` token never appears here, so it is never migrated.
+    /// - the storage preference (`config.flox.floxhub_token_storage`) is
+    ///   `Keyring` — when the user has chosen plain-text storage, a plaintext
+    ///   token is left in place rather than moved.
     ///
     /// The migration moves the token store-to-store only; it never writes
     /// `config.flox.floxhub_token`. The merge already populated that field with
@@ -356,10 +371,14 @@ impl CredentialStores {
             return ResolveOutcome::Unchanged;
         }
 
-        // Opportunistic migration: only the user-file token is eligible. Probe
-        // the plaintext file directly (provenance-aware) rather than trusting
-        // the merged config field, which may hold a system token instead.
-        if let Ok(Some(token)) = self.plaintext.get() {
+        // Opportunistic migration: only the user-file token is eligible, and
+        // only when the standing preference is keyring storage — a chosen
+        // plain-text token is left in place rather than moved. Probe the
+        // plaintext file directly (provenance-aware) rather than trusting the
+        // merged config field, which may hold a system token instead.
+        if config.flox.floxhub_token_storage == TokenStorageMode::Keyring
+            && let Ok(Some(token)) = self.plaintext.get()
+        {
             // Try-then-confirm: only after the keyring write succeeds do we
             // remove the plaintext token. On any keyring failure the plaintext
             // file is left exactly as it was.
@@ -706,7 +725,9 @@ mod tests {
         let plaintext = CredentialStoreImpl::Plaintext(PlaintextStore::new(dir.path()));
         let stores = CredentialStores::from_stores(keyring.clone(), plaintext.clone());
 
-        let storage = stores.persist_login_token(TOKEN, false).unwrap();
+        let storage = stores
+            .persist_login_token(TOKEN, TokenStorageMode::Keyring)
+            .unwrap();
 
         assert_eq!(storage, TokenStorage::Keyring);
         assert_eq!(keyring.get().unwrap(), Some(TOKEN.to_string()));
@@ -724,7 +745,9 @@ mod tests {
         let plaintext = CredentialStoreImpl::Plaintext(PlaintextStore::new(dir.path()));
         let stores = CredentialStores::from_stores(keyring.clone(), plaintext.clone());
 
-        let storage = stores.persist_login_token(TOKEN, false).unwrap();
+        let storage = stores
+            .persist_login_token(TOKEN, TokenStorageMode::Keyring)
+            .unwrap();
 
         assert_eq!(storage, TokenStorage::Plaintext);
         assert_eq!(keyring.get().unwrap(), None);
@@ -743,22 +766,45 @@ mod tests {
         let plaintext = CredentialStoreImpl::Mock(plaintext_mock);
         let stores = CredentialStores::from_stores(keyring.clone(), plaintext);
 
-        let storage = stores.persist_login_token(TOKEN, false).unwrap();
+        let storage = stores
+            .persist_login_token(TOKEN, TokenStorageMode::Keyring)
+            .unwrap();
 
         assert_eq!(storage, TokenStorage::Keyring);
         assert_eq!(keyring.get().unwrap(), Some(TOKEN.to_string()));
     }
 
-    /// `--insecure-storage` forces plaintext even when the keyring write would
-    /// have succeeded; the keyring is never touched.
+    /// A `Plaintext` target forces the plaintext file even when the keyring
+    /// write would have succeeded; the keyring is never written.
     #[test]
-    fn login_insecure_storage_forces_plaintext() {
+    fn login_plaintext_target_forces_plaintext() {
         let dir = tempfile::tempdir().unwrap();
         let keyring = CredentialStoreImpl::Mock(MockStore::new());
         let plaintext = CredentialStoreImpl::Plaintext(PlaintextStore::new(dir.path()));
         let stores = CredentialStores::from_stores(keyring.clone(), plaintext.clone());
 
-        let storage = stores.persist_login_token(TOKEN, true).unwrap();
+        let storage = stores
+            .persist_login_token(TOKEN, TokenStorageMode::Plaintext)
+            .unwrap();
+
+        assert_eq!(storage, TokenStorage::Plaintext);
+        assert_eq!(keyring.get().unwrap(), None);
+        assert_eq!(plaintext.get().unwrap(), Some(TOKEN.to_string()));
+    }
+
+    /// Storing plain text drops any pre-existing keyring entry so it cannot
+    /// resurface on the next read and shadow the user's plain-text choice.
+    #[test]
+    fn login_plaintext_target_removes_stale_keyring_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        let keyring = CredentialStoreImpl::Mock(MockStore::new());
+        keyring.set("stale-keyring-token").unwrap();
+        let plaintext = CredentialStoreImpl::Plaintext(PlaintextStore::new(dir.path()));
+        let stores = CredentialStores::from_stores(keyring.clone(), plaintext.clone());
+
+        let storage = stores
+            .persist_login_token(TOKEN, TokenStorageMode::Plaintext)
+            .unwrap();
 
         assert_eq!(storage, TokenStorage::Plaintext);
         assert_eq!(keyring.get().unwrap(), None);
@@ -835,6 +881,28 @@ mod tests {
             // Migration is store-to-store only: the config field is left as the
             // merge produced it.
             assert_eq!(config.flox.floxhub_token.as_deref(), Some(TOKEN));
+        });
+    }
+
+    /// When the standing storage preference is plain text, a user-file token is
+    /// not migrated into the keyring: the keyring is never written and the
+    /// plain-text token stays on disk.
+    #[test]
+    fn resolve_skips_migration_when_storage_is_plaintext() {
+        temp_env::with_var(FLOXHUB_TOKEN_ENV_VAR, None::<&str>, || {
+            let dir = tempfile::tempdir().unwrap();
+            write_flox_toml(dir.path(), &format!("floxhub_token = \"{TOKEN}\"\n"));
+            let plaintext = CredentialStoreImpl::Plaintext(PlaintextStore::new(dir.path()));
+            let keyring = CredentialStoreImpl::Mock(MockStore::new());
+            let stores = CredentialStores::from_stores(keyring.clone(), plaintext.clone());
+
+            let mut config = config_with_token(Some(TOKEN));
+            config.flox.floxhub_token_storage = TokenStorageMode::Plaintext;
+            let outcome = stores.resolve_into(&mut config);
+
+            assert_eq!(outcome, ResolveOutcome::Unchanged);
+            assert_eq!(keyring.get().unwrap(), None);
+            assert_eq!(plaintext.get().unwrap(), Some(TOKEN.to_string()));
         });
     }
 

--- a/cli/flox/src/utils/credential_store/mod.rs
+++ b/cli/flox/src/utils/credential_store/mod.rs
@@ -319,7 +319,8 @@ impl CredentialStores {
             && let Err(e) = self.keyring.remove()
         {
             tracing::debug!(
-                "could not remove the keyring credential after storing plain text: {e}"
+                error = %e,
+                "could not remove the keyring credential after storing plain text"
             );
         }
         Ok(TokenStorage::Plaintext)

--- a/docs/superpowers/plans/2026-06-22-floxhub-token-storage-preference.md
+++ b/docs/superpowers/plans/2026-06-22-floxhub-token-storage-preference.md
@@ -1,0 +1,622 @@
+# FloxHub Token-Storage Preference Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `flox auth login --insecure-storage` a *persistent* token-storage preference (`floxhub_token_storage = "keyring" | "plaintext"`), add a temporary `--insecure-storage --once`, and gate plaintext→keyring migration on the preference.
+
+**Architecture:** A new two-valued config enum `TokenStorageMode` becomes the single source of truth for *where tokens go*. It is consulted at login (where to write) and at migration (whether to move an existing plaintext token). `--insecure-storage` writes the preference (unless `--once`); a plain login honors whatever standing preference exists. The migration in `resolve_credential_into` runs only when the preference is `Keyring`.
+
+**Tech Stack:** Rust 2024, `bpaf` (CLI parsing), `serde`/`toml_edit` (config), `indoc`/`formatdoc` (messages), existing `CredentialStore`/`MockStore` test harness.
+
+## Global Constraints
+
+- **Build/test wrapping:** `IN_NIX_SHELL` is unset in this environment — every `cargo`/`just`/`git push` command MUST be wrapped with `nix develop -c`. (If `IN_NIX_SHELL` is set, run directly.)
+- **Already done in the base branch (do NOT reintroduce):** Folded-in fixes #1 (`ResolveOutcome::MigratedButPlaintextRemains` + the call-site warning in `commands/mod.rs:313`) and #3 (`indoc!` in `persist_login_token`) are **already implemented** on `implement-secure-cli-credential-storage-with-keyring-fallback`. The ONLY migration-block change in this plan is prepending the `storage == TokenStorageMode::Keyring &&` gate. Do not paste the spec's illustrative fix-#1 block — it is an older formulation that returns `Unchanged` and would undo committed work.
+- **Enum shape:** `TokenStorageMode` mirrors the existing `AutoActivate` enum exactly, plus `Copy`: `#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]`, `#[serde(rename_all = "lowercase")]`, with `#[default] Keyring`.
+- **Config commands need no changes:** `flox config --set/--delete floxhub_token_storage` works generically — `Config::write_to` re-parses the whole document into `Config`, validating the value against the enum for free.
+- **Message conventions (AGENTS.md):** complete sentences, sentence case, suggest next steps, single-quote suggested commands (`'flox config --delete floxhub_token_storage'`), one emoji max per response. Prefer overlong lines to `\`-continued messages.
+- **Test naming:** no `test_` prefix; name for the behavior verified. Use `assert_eq!` on whole values. `pretty_assertions::assert_eq` is already imported in the `credential_store.rs` test module.
+- **Branch:** `floxhub-token-storage-preference`, stacked on `implement-secure-cli-credential-storage-with-keyring-fallback`. PR base = the keyring branch (retarget to `main` after #4420 merges).
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|------|----------------|--------|
+| `cli/flox/src/config/mod.rs` | Define `TokenStorageMode`; add `floxhub_token_storage` field to `FloxConfig`; parse test. | Modify |
+| `cli/flox/src/utils/credential_store.rs` | `resolve_credential_into` migration gate; `persist_login_token` target-mode + stale-keyring removal; unit tests. | Modify |
+| `cli/flox/src/commands/auth.rs` | `--once` flag; `login_flox` target/persist logic; `auth status` plaintext line. | Modify |
+| `cli/flox/src/commands/mod.rs` | Pass `storage` to `resolve_credential_into`; pass preference to the two `login_flox` callers. | Modify |
+
+---
+
+## Task 1: Add the `TokenStorageMode` config field
+
+**Files:**
+- Modify: `cli/flox/src/config/mod.rs` (enum after `AutoActivate` ~line 190; field in `FloxConfig` after `floxhub_authn_mode` ~line 89)
+- Test: `cli/flox/src/config/mod.rs` (the `#[cfg(test)] mod tests` block)
+
+**Interfaces:**
+- Produces: `pub enum TokenStorageMode { Keyring, Plaintext }` (default `Keyring`, `Copy`), and `FloxConfig.floxhub_token_storage: TokenStorageMode` (TOML key `floxhub_token_storage`).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `tests` module in `cli/flox/src/config/mod.rs` (it already has `use super::*;`, `fs`, `tempfile`, and `mock_flox_dirs()`):
+
+```rust
+    #[test]
+    fn floxhub_token_storage_parses_and_defaults() {
+        let user_config_dir = tempfile::tempdir().unwrap();
+        let system_config_dir = tempfile::tempdir().unwrap();
+        fs::write(system_config_dir.path().join(FLOX_CONFIG_FILE), "").unwrap();
+
+        // Absent → defaults to keyring.
+        fs::write(user_config_dir.path().join(FLOX_CONFIG_FILE), "").unwrap();
+        let config = Config::parse_with(
+            &mock_flox_dirs(),
+            user_config_dir.path(),
+            Some(system_config_dir.path()),
+            [],
+        )
+        .unwrap();
+        assert_eq!(config.flox.floxhub_token_storage, TokenStorageMode::Keyring);
+
+        // Explicit plaintext → parsed.
+        fs::write(
+            user_config_dir.path().join(FLOX_CONFIG_FILE),
+            "floxhub_token_storage = \"plaintext\"\n",
+        )
+        .unwrap();
+        let config = Config::parse_with(
+            &mock_flox_dirs(),
+            user_config_dir.path(),
+            Some(system_config_dir.path()),
+            [],
+        )
+        .unwrap();
+        assert_eq!(config.flox.floxhub_token_storage, TokenStorageMode::Plaintext);
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `nix develop -c cargo test -p flox --lib config::tests::floxhub_token_storage_parses_and_defaults`
+Expected: **compile error** — no field `floxhub_token_storage` on `FloxConfig` and no `TokenStorageMode`. (A test that does not compile is the "fail" state in Rust.)
+
+- [ ] **Step 3: Add the enum**
+
+In `cli/flox/src/config/mod.rs`, after the `AutoActivate` enum (immediately after its closing `}` near line 190), add:
+
+```rust
+/// Where `flox auth login` stores the FloxHub token.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum TokenStorageMode {
+    /// Store the token in the OS-native keyring (default).
+    #[default]
+    Keyring,
+    /// Store the token in plain text in flox.toml.
+    Plaintext,
+}
+```
+
+- [ ] **Step 4: Add the field**
+
+In `FloxConfig`, immediately after the `floxhub_authn_mode` field (line 89), add:
+
+```rust
+    /// Where new FloxHub tokens are stored: the OS keyring (default) or plain
+    /// text in flox.toml. Set to `plaintext` by
+    /// `flox auth login --insecure-storage`; cleared with
+    /// `flox config --delete floxhub_token_storage`.
+    #[serde(default)]
+    pub floxhub_token_storage: TokenStorageMode,
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `nix develop -c cargo test -p flox --lib config::tests::floxhub_token_storage_parses_and_defaults`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+nix develop -c git add cli/flox/src/config/mod.rs
+nix develop -c git commit -m "feat(auth): add floxhub_token_storage config preference"
+```
+
+---
+
+## Task 2: Gate plaintext→keyring migration on the storage preference
+
+**Files:**
+- Modify: `cli/flox/src/utils/credential_store.rs` (import ~line 28; `resolve_credential_into` signature ~line 565 and migration `if` ~line 585; all in-module test call sites)
+- Modify: `cli/flox/src/commands/mod.rs` (import line 80; call site ~line 302)
+- Test: `cli/flox/src/utils/credential_store.rs` (tests module)
+
+**Interfaces:**
+- Consumes: `TokenStorageMode` (Task 1).
+- Produces: `resolve_credential_into(config, keyring, plaintext, is_hook, is_auth0, storage: TokenStorageMode) -> ResolveOutcome`. Migration runs only when `storage == TokenStorageMode::Keyring`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the migration test group in `cli/flox/src/utils/credential_store.rs` (after `resolve_does_not_migrate_outside_auth0_mode`, ~line 1172):
+
+```rust
+    /// When the standing storage preference is plain text, a user-file token is
+    /// not migrated into the keyring: the keyring is never written and the
+    /// plain-text token stays on disk.
+    #[test]
+    fn resolve_skips_migration_when_storage_is_plaintext() {
+        temp_env::with_var(FLOXHUB_TOKEN_ENV_VAR, None::<&str>, || {
+            let dir = tempfile::tempdir().unwrap();
+            write_flox_toml(dir.path(), &format!("floxhub_token = \"{TOKEN}\"\n"));
+            let plaintext = CredentialStoreImpl::Plaintext(PlaintextStore::new(dir.path()));
+            let keyring = CredentialStoreImpl::Mock(MockStore::new());
+
+            let mut config = config_with_token(Some(TOKEN));
+            let outcome = resolve_credential_into(
+                &mut config,
+                &keyring,
+                &plaintext,
+                false,
+                true,
+                TokenStorageMode::Plaintext,
+            );
+
+            assert_eq!(outcome, ResolveOutcome::Unchanged);
+            assert_eq!(keyring.get().unwrap(), None);
+            assert_eq!(plaintext.get().unwrap(), Some(TOKEN.to_string()));
+        });
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `nix develop -c cargo test -p flox --lib credential_store`
+Expected: **compile error** — `resolve_credential_into` takes 5 args, not 6, and `TokenStorageMode` is unresolved in this module.
+
+- [ ] **Step 3: Add the import**
+
+In `cli/flox/src/utils/credential_store.rs`, change line 28:
+
+```rust
+use crate::config::{Config, FLOX_CONFIG_FILE};
+```
+to:
+```rust
+use crate::config::{Config, FLOX_CONFIG_FILE, TokenStorageMode};
+```
+
+- [ ] **Step 4: Add the parameter and the gate**
+
+Change the `resolve_credential_into` signature (~line 565) to add a final parameter:
+
+```rust
+pub fn resolve_credential_into(
+    config: &mut Config,
+    keyring: &CredentialStoreImpl,
+    plaintext: &CredentialStoreImpl,
+    is_hook: bool,
+    is_auth0: bool,
+    storage: TokenStorageMode,
+) -> ResolveOutcome {
+```
+
+Then change ONLY the migration `if` condition (~line 585) — leave the `keyring.set` / `plaintext.remove` / `MigratedButPlaintextRemains` body exactly as-is:
+
+```rust
+    if storage == TokenStorageMode::Keyring && !env_set && let Ok(Some(token)) = plaintext.get() {
+```
+
+Update the doc comment's migration-conditions list (~line 544) to add a bullet:
+
+```rust
+/// - the storage preference is `Keyring` (`storage`) — when the user has chosen
+///   plain-text storage, a plaintext token is left in place rather than moved.
+```
+
+- [ ] **Step 5: Update the production call site**
+
+In `cli/flox/src/commands/mod.rs`, add `TokenStorageMode` to the config import (line 80):
+
+```rust
+use crate::config::{Config, EnvironmentTrust, FLOX_DIR_NAME, TokenStorageMode};
+```
+
+Then change the call site (~line 301-308). Read `storage` into a local **before** the call to avoid borrowing `config` while it is mutably borrowed (`TokenStorageMode` is `Copy`, mirroring the `is_auth0` line above it):
+
+```rust
+        let is_auth0 = matches!(config.flox.floxhub_authn_mode, AuthnMode::Auth0);
+        let storage = config.flox.floxhub_token_storage;
+        let outcome = resolve_credential_into(
+            &mut config,
+            &keyring,
+            &plaintext,
+            self.is_prompt_hook_flow(),
+            is_auth0,
+            storage,
+        );
+```
+
+- [ ] **Step 6: Update existing in-module test call sites**
+
+In `cli/flox/src/utils/credential_store.rs`, every existing `resolve_credential_into(&mut config, &keyring, &plaintext, <is_hook>, <is_auth0>)` call must gain a trailing `, TokenStorageMode::Keyring` (the default preference, correct for all existing migration/read tests). These are at lines ~968, 1064, 1083, 1099, 1119, 1141, 1164, 1189, 1211, 1229. Example — line 1064:
+
+```rust
+            let outcome = resolve_credential_into(
+                &mut config,
+                &keyring,
+                &plaintext,
+                false,
+                true,
+                TokenStorageMode::Keyring,
+            );
+```
+
+Apply the same `, TokenStorageMode::Keyring` to each call. (The line-968 call inside `probe_after_resolver_reports_keyring_not_system_config` discards the result; add the arg there too.)
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `nix develop -c cargo test -p flox --lib credential_store`
+Expected: PASS, including `resolve_skips_migration_when_storage_is_plaintext` and all pre-existing `resolve_*` tests.
+
+- [ ] **Step 8: Commit**
+
+```bash
+nix develop -c git add cli/flox/src/utils/credential_store.rs cli/flox/src/commands/mod.rs
+nix develop -c git commit -m "feat(auth): gate token migration on floxhub_token_storage preference"
+```
+
+---
+
+## Task 3: Login honors the preference (`persist_login_token` target + `--once`)
+
+**Files:**
+- Modify: `cli/flox/src/utils/credential_store.rs` (`persist_login_token` ~line 492; its 4 tests ~lines 980-1044)
+- Modify: `cli/flox/src/commands/auth.rs` (imports; `Auth::Login` arm ~line 267; `login_flox` ~line 364)
+- Modify: `cli/flox/src/commands/mod.rs` (`ensure_auth` call ~line 1505)
+- Test: `cli/flox/src/utils/credential_store.rs` (persist test group)
+
+**Interfaces:**
+- Consumes: `TokenStorageMode` (Task 1); `update_config` (`crate::commands::general::update_config`).
+- Produces: `persist_login_token(token, target: TokenStorageMode, keyring, plaintext) -> Result<TokenStorage, CredentialStoreError>`; `login_flox(flox, insecure_storage: bool, once: bool, storage_pref: TokenStorageMode) -> Result<String>`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the persist test group in `cli/flox/src/utils/credential_store.rs` (after `login_insecure_storage_forces_plaintext`, ~line 1044):
+
+```rust
+    /// Storing plain text drops any pre-existing keyring entry so it cannot
+    /// resurface on the next read and shadow the user's plain-text choice.
+    #[test]
+    fn login_plaintext_target_removes_stale_keyring_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        let keyring = CredentialStoreImpl::Mock(MockStore::new());
+        keyring.set("stale-keyring-token").unwrap();
+        let plaintext = CredentialStoreImpl::Plaintext(PlaintextStore::new(dir.path()));
+
+        let storage =
+            persist_login_token(TOKEN, TokenStorageMode::Plaintext, &keyring, &plaintext).unwrap();
+
+        assert_eq!(storage, TokenStorage::Plaintext);
+        assert_eq!(keyring.get().unwrap(), None);
+        assert_eq!(plaintext.get().unwrap(), Some(TOKEN.to_string()));
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `nix develop -c cargo test -p flox --lib credential_store::tests::login_plaintext_target_removes_stale_keyring_entry`
+Expected: **compile error** — `persist_login_token` takes a `bool`, not `TokenStorageMode`.
+
+- [ ] **Step 3: Change `persist_login_token` to take a target mode**
+
+Replace the `persist_login_token` body (~lines 492-514) with:
+
+```rust
+pub fn persist_login_token(
+    token: &str,
+    target: TokenStorageMode,
+    keyring: &CredentialStoreImpl,
+    plaintext: &CredentialStoreImpl,
+) -> Result<TokenStorage, CredentialStoreError> {
+    if target == TokenStorageMode::Keyring && keyring.set(token).is_ok() {
+        // The keyring already holds the token, so a failure to remove the old
+        // plaintext copy must not fail the login. Warn instead: a lingering
+        // plaintext token both leaves a secret on disk and shadows the keyring
+        // on the next read (user file > keyring).
+        if let Err(e) = plaintext.remove() {
+            tracing::warn!("could not remove the plaintext credential after a keyring write: {e}");
+            message::warning(indoc! {"
+                Stored your credential in the system keyring, but could not remove the existing plain-text credential from flox.toml.
+                Remove the 'floxhub_token' line from flox.toml so it does not shadow the keyring."});
+        }
+        return Ok(TokenStorage::Keyring);
+    }
+
+    plaintext.set(token)?;
+    // An explicit plain-text choice supersedes any keyring entry: drop a
+    // lingering keyring token (best effort) so a later read cannot surface it
+    // and shadow the plain-text file the user just chose. Scoped to the explicit
+    // `Plaintext` target — on a keyring-write fallback there is nothing of ours
+    // in the keyring to remove.
+    if target == TokenStorageMode::Plaintext {
+        if let Err(e) = keyring.remove() {
+            tracing::debug!("could not remove the keyring credential after storing plain text: {e}");
+        }
+    }
+    Ok(TokenStorage::Plaintext)
+}
+```
+
+Update its doc comment (~lines 485-491) to describe the target parameter instead of `insecure_storage`:
+
+```rust
+/// Persist a logged-in token according to `target`.
+///
+/// `Keyring`: attempt the keyring first (try-then-confirm); on success store
+/// there and remove any lingering plaintext token so it cannot shadow the
+/// keyring entry, and on any keyring failure fall back to the plaintext file
+/// (`0600`). `Plaintext`: write the plaintext file and drop any existing keyring
+/// entry (best effort). The returned [TokenStorage] tells the caller whether to
+/// warn the user.
+```
+
+- [ ] **Step 4: Update the three existing keyring-path persist tests**
+
+In `cli/flox/src/utils/credential_store.rs`, change the `false` argument to `TokenStorageMode::Keyring` in these three tests:
+- `login_stores_in_keyring_and_clears_plaintext` (~line 990)
+- `login_falls_back_to_plaintext_on_keyring_error` (~line 1007)
+- `login_succeeds_when_keyring_stored_but_plaintext_cleanup_fails` (~line 1025)
+
+Each becomes, e.g.:
+
+```rust
+        let storage =
+            persist_login_token(TOKEN, TokenStorageMode::Keyring, &keyring, &plaintext).unwrap();
+```
+
+- [ ] **Step 5: Rename and update the forced-plaintext test**
+
+Replace `login_insecure_storage_forces_plaintext` (~lines 1031-1044) with the renamed, target-based version:
+
+```rust
+    /// A `Plaintext` target forces the plaintext file even when the keyring
+    /// write would have succeeded; the keyring is never written.
+    #[test]
+    fn login_plaintext_target_forces_plaintext() {
+        let dir = tempfile::tempdir().unwrap();
+        let keyring = CredentialStoreImpl::Mock(MockStore::new());
+        let plaintext = CredentialStoreImpl::Plaintext(PlaintextStore::new(dir.path()));
+
+        let storage =
+            persist_login_token(TOKEN, TokenStorageMode::Plaintext, &keyring, &plaintext).unwrap();
+
+        assert_eq!(storage, TokenStorage::Plaintext);
+        assert_eq!(keyring.get().unwrap(), None);
+        assert_eq!(plaintext.get().unwrap(), Some(TOKEN.to_string()));
+    }
+```
+
+- [ ] **Step 6: Add the `--once` flag and thread the preference through `login_flox`**
+
+In `cli/flox/src/commands/auth.rs`:
+
+Add imports — extend the `crate::config` import (line 34) and add the `update_config` import below it:
+
+```rust
+use crate::config::{Config, FLOX_CONFIG_FILE, TokenStorageMode};
+use crate::commands::general::update_config;
+```
+
+Add the `once` flag to the `Login` variant (~lines 242-246):
+
+```rust
+    Login {
+        /// Store the token in plain text in flox.toml instead of the OS keyring
+        #[bpaf(long("insecure-storage"))]
+        insecure_storage: bool,
+        /// With --insecure-storage, store plain text only for this login without
+        /// changing the saved storage preference
+        #[bpaf(long("once"))]
+        once: bool,
+    },
+```
+
+Update the `Auth::Login` match arm (~lines 267-272):
+
+```rust
+            Auth::Login {
+                insecure_storage,
+                once,
+            } => {
+                let span = tracing::info_span!("login");
+                let _guard = span.enter();
+                login_flox(
+                    &mut flox,
+                    insecure_storage,
+                    once,
+                    config.flox.floxhub_token_storage,
+                )
+                .await?;
+                Ok(())
+            },
+```
+
+Replace the `login_flox` signature and storage logic (~lines 364-397). Keep the OAuth/`authorize` lines unchanged; change from the `insecure_storage` argument onward:
+
+```rust
+pub async fn login_flox(
+    flox: &mut Flox,
+    insecure_storage: bool,
+    once: bool,
+    storage_pref: TokenStorageMode,
+) -> Result<String> {
+    let client = create_oauth_client()?;
+    let cred = authorize(client, flox.floxhub.base_url())
+        .await
+        .context("Could not authorize via oauth")?;
+
+    debug!("Credentials received: {cred:#?}");
+    debug!("Writing token to config");
+
+    // set the token in the runtime config
+    let token = FloxhubToken::new(cred.token)?;
+    let handle = token.handle().to_string();
+
+    // `--insecure-storage` forces plain text for this login; otherwise honor the
+    // standing storage preference.
+    let target = if insecure_storage {
+        TokenStorageMode::Plaintext
+    } else {
+        storage_pref
+    };
+
+    // Persist the plain-text choice as a standing preference only when
+    // `--insecure-storage` is given without `--once`. `--once` stores plain text
+    // this one time without changing where future tokens go, so the token is
+    // re-secured to the keyring once the keyring is available again.
+    if insecure_storage && !once {
+        update_config(
+            &flox.config_dir,
+            "floxhub_token_storage",
+            Some(TokenStorageMode::Plaintext),
+        )
+        .context("Could not save the token-storage preference")?;
+    }
+
+    let keyring = CredentialStoreImpl::Keyring(KeyringStore::new(flox.floxhub.base_url()));
+    let plaintext = CredentialStoreImpl::Plaintext(PlaintextStore::new(&flox.config_dir));
+    let storage = persist_login_token(token.secret(), target, &keyring, &plaintext)
+        .context("Could not store token")?;
+
+    let auth_context = AuthContext::from_mode(&AuthnMode::Auth0, Some(token.clone()));
+    let _ = flox.set_auth_context(auth_context);
+
+    message::updated("Authentication complete");
+    message::updated(format!("Logged in as {handle}"));
+
+    if storage == TokenStorage::Plaintext {
+        message::warning(formatdoc! {"
+            Credential stored in plain text at '{}'.
+            No OS keyring is available, or plain-text storage was requested.",
+            flox.config_dir.join(FLOX_CONFIG_FILE).display()
+        });
+    }
+
+    Ok(handle)
+}
+```
+
+- [ ] **Step 7: Update the implicit re-auth caller**
+
+In `cli/flox/src/commands/mod.rs`, update the `ensure_auth` call (~lines 1504-1505). `TokenStorageMode` is already imported (Task 2, Step 5):
+
+```rust
+            // Implicit re-authentication stores to the secure default (keyring).
+            // The standing storage preference is not threaded through the many
+            // `ensure_auth` call sites, so an implicit re-login does not honor a
+            // `plaintext` preference; an explicit `flox auth login` does.
+            auth::login_flox(flox, false, false, TokenStorageMode::Keyring).await
+```
+
+- [ ] **Step 8: Run tests to verify they pass**
+
+Run: `nix develop -c cargo test -p flox --lib credential_store`
+Expected: PASS — `login_plaintext_target_removes_stale_keyring_entry`, `login_plaintext_target_forces_plaintext`, and the three keyring-path tests.
+
+Then build the whole crate to confirm the `auth.rs`/`mod.rs` wiring compiles:
+
+Run: `nix develop -c cargo build -p flox`
+Expected: builds clean.
+
+- [ ] **Step 9: Commit**
+
+```bash
+nix develop -c git add cli/flox/src/utils/credential_store.rs cli/flox/src/commands/auth.rs cli/flox/src/commands/mod.rs
+nix develop -c git commit -m "feat(auth): persist --insecure-storage preference, add --once"
+```
+
+---
+
+## Task 4: `flox auth status` reports a plain-text preference
+
+**Files:**
+- Modify: `cli/flox/src/commands/auth.rs` (`Auth::Status` arm, after the source-reporting `match`, ~line 336)
+
+**Interfaces:**
+- Consumes: `TokenStorageMode` (imported in Task 3), `config.flox.floxhub_token_storage`.
+
+- [ ] **Step 1: Add the preference line**
+
+In the `Auth::Status` arm, immediately after the `match source { … }` block and before `Ok(())` (~line 336), add:
+
+```rust
+                if config.flox.floxhub_token_storage == TokenStorageMode::Plaintext {
+                    message::plain(formatdoc! {"
+                        Token storage preference is set to plain text.
+                        Run 'flox config --delete floxhub_token_storage' to store tokens in the system keyring."});
+                }
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `nix develop -c cargo build -p flox`
+Expected: builds clean (`formatdoc` and `config` are already in scope in `auth.rs`).
+
+- [ ] **Step 3: Manual smoke (optional, documents the behavior)**
+
+```bash
+nix develop -c cargo run -p flox -- config --set floxhub_token_storage plaintext
+nix develop -c cargo run -p flox -- config --delete floxhub_token_storage
+```
+Expected: both succeed; `--set garbage` would be rejected by config validation.
+
+- [ ] **Step 4: Commit**
+
+```bash
+nix develop -c git add cli/flox/src/commands/auth.rs
+nix develop -c git commit -m "feat(auth): note plain-text storage preference in auth status"
+```
+
+---
+
+## Final Verification
+
+- [ ] **Full crate test suite** (the `--once` flag changes `flox auth login --help`; a usage/bats snapshot may assert on it):
+
+Run: `nix develop -c cargo test -p flox`
+Expected: PASS.
+
+- [ ] **Lint:**
+
+Run: `nix develop -c cargo clippy --all`
+Expected: no warnings.
+
+- [ ] **Format:**
+
+Run: `nix develop -c cargo fmt --all` then `nix develop -c git diff --exit-code`
+Expected: no diff (already formatted).
+
+---
+
+## Spec Coverage Check
+
+| Spec requirement | Task |
+|---|---|
+| `TokenStorageMode` enum + `floxhub_token_storage` field, lowercase serde, default keyring | Task 1 |
+| Parses from `flox.toml`; defaults to keyring when absent | Task 1 (test) |
+| Migration runs only when preference is `Keyring`; read-fallback unchanged | Task 2 |
+| `resolve_credential_into` gains `storage` param computed at call site | Task 2 |
+| Fix #1 (`MigratedButPlaintextRemains`) preserved, not reverted | Constraint + Task 2 (gate only) |
+| Fix #3 (`indoc!`) preserved | Already in base; `persist_login_token` keeps `indoc!` (Task 3) |
+| `--once` flag on `Login` | Task 3 |
+| `login_flox`: compute target, persist pref only when `insecure && !once` | Task 3 |
+| Plaintext target stores plaintext + removes stale keyring entry | Task 3 |
+| Keyring target uses keyring-first-with-fallback | Task 3 |
+| Plain login / implicit re-auth honor a standing preference (explicit; re-auth keeps secure default by design) | Task 3 |
+| `flox config --set/--delete floxhub_token_storage` | Constraint (works generically; verified Task 4) |
+| `auth status` reports plain-text preference + revert command | Task 4 |
+| `--secure-storage`, per-env/time-boxed storage, runtime-rep changes — OUT | Not implemented (YAGNI) |

--- a/docs/superpowers/specs/2026-06-22-implicit-reauth-token-storage-followup.md
+++ b/docs/superpowers/specs/2026-06-22-implicit-reauth-token-storage-followup.md
@@ -1,0 +1,166 @@
+# Follow-up: honor the token-storage preference during implicit re-authentication
+
+**Date:** 2026-06-22
+**Status:** Deferred — accepted limitation in PR #4422; this document is the design input for the follow-up if/when we decide to close the gap.
+**Related:**
+- PR #4422 (`feat(auth): persistent token-storage preference with --once`) — introduced `floxhub_token_storage` and gated migration/login on it.
+- Design spec: `docs/superpowers/specs/2026-06-22-floxhub-token-storage-preference-design.md`.
+- Review item: Codex (`chatgpt-codex-connector[bot]`) **P2** on PR #4422, `cli/flox/src/commands/mod.rs` (the `ensure_auth` re-auth call), "Honor plaintext preference during implicit re-auth".
+
+## Problem
+
+`floxhub_token_storage = "plaintext"` is meant to be a **standing** preference: tokens stay in
+plain text in `flox.toml`, and the startup resolver does not migrate them into the OS keyring.
+PR #4422 honors this for **explicit** `flox auth login` and for the startup migration.
+
+It is **not** honored on the **implicit re-authentication** path. When a token is expired or
+missing and the user runs any command that calls `ensure_auth` interactively (e.g. `flox push`,
+`flox publish`, `flox install` into a remote env), `ensure_auth` re-enters the login flow with a
+hard-coded `TokenStorageMode::Keyring`:
+
+```rust
+// cli/flox/src/commands/mod.rs — ensure_auth()
+// Implicit re-authentication stores to the secure default (keyring). The standing
+// storage preference is not threaded through the many `ensure_auth` call sites,
+// so an implicit re-login does not honor a `plaintext` preference; an explicit
+// `flox auth login` does.
+auth::login_flox(flox, false, false, TokenStorageMode::Keyring).await
+```
+
+### Trace (what actually happens)
+
+1. Preference is `plaintext`; the plain-text token in `flox.toml` has expired.
+2. `flox push` → `ensure_auth` → `login_flox(flox, insecure_storage=false, once=false, storage_pref=Keyring)`.
+3. `target = Keyring` (because `insecure_storage` is false and the passed `storage_pref` is `Keyring`).
+4. `persist_login_token(.., Keyring, ..)` writes the new token to the **keyring** and, on success,
+   **removes the plain-text token** from `flox.toml`.
+5. The config key `floxhub_token_storage` is still `plaintext` (it is only written by
+   `--insecure-storage` without `--once`), but the **token now lives in the keyring**.
+
+### Why it matters
+
+- It silently violates a stated **goal** of the design spec: *"A plain `flox auth login` honors
+  the standing preference (it never silently changes where tokens are stored)."* The implicit
+  re-auth path is not a "plain `flox auth login`", so it was never in the behavior matrix — but
+  from the user's point of view it is a silent relocation of their credential off plain text.
+- It produces a mildly contradictory state: `flox auth status` reports both *"Token storage
+  preference is set to plain text"* (from the config key) **and** *"Credential stored in your
+  system keyring"* (from the live probe).
+
+### Severity / likelihood
+
+**P2, edge case.** Requires the conjunction of: (a) the user set `plaintext`, (b) the token is
+expired/missing, and (c) they run an interactive, auth-requiring command (so `Dialog::can_prompt()`
+is true). It is not data loss and not a security regression (the keyring is the *more* secure
+store); it is a correctness/consistency gap against the user's explicit preference.
+
+## Why this was deferred (the blocker)
+
+`ensure_auth(flox: &mut Flox)` has **no `Config`** in scope, and the token-storage preference lives
+in `Config` (`config.flox.floxhub_token_storage`). The naive "just pass the preference" is not a
+one-liner because of where `Config` is — and is not — available, and because of crate layering.
+
+### Research: `ensure_auth` call sites and `Config` availability
+
+`ensure_auth` is called from **11 sites**; only **1** has a `Config` in scope.
+
+| Call site | Enclosing function | `Config` in scope? |
+|---|---|---|
+| `cli/flox/src/commands/publish.rs:152` | `Publish::publish(config: Config, flox: Flox, …)` | ✅ yes |
+| `cli/flox/src/commands/install.rs:135` | `Install::handle(self, flox: Flox)` | ❌ no |
+| `cli/flox/src/commands/install.rs:628` | `try_create_default_environment_interactive(...)` | ❌ no |
+| `cli/flox/src/commands/uninstall.rs:47` | `Uninstall::handle(self, flox: Flox)` | ❌ no |
+| `cli/flox/src/commands/upgrade.rs:45` | `Upgrade::handle(self, flox: Flox)` | ❌ no |
+| `cli/flox/src/commands/push.rs:55` | `Push::handle(self, flox: Flox)` | ❌ no |
+| `cli/flox/src/commands/edit.rs:89` | `Edit::handle(self, flox: Flox)` | ❌ no |
+| `cli/flox/src/commands/upload.rs:47` | `Upload::handle(self, flox: Flox)` | ❌ no |
+| `cli/flox/src/commands/init/mod.rs:155` | `Init::handle(self, flox: Flox)` | ❌ no |
+| `cli/flox/src/commands/mod.rs:1132` | `EnvironmentSelect::to_concrete_environment(&self, flox, …)` | ❌ no |
+| `cli/flox/src/commands/mod.rs:1195` | `EnvironmentSelect::detect_concrete_environment(&self, flox, …)` | ❌ no |
+
+Most command `handle()` methods take only `Flox`, not `Config`: `FloxCli::handle()` constructs
+`Flox` from `Config` and passes only `Flox` downstream. So "thread the preference to `ensure_auth`"
+really means "first make the preference reachable at 10 sites that currently have only `Flox`".
+
+### Research: `Flox` cannot carry `TokenStorageMode` directly (crate layering)
+
+- `TokenStorageMode` is defined in the **`flox` binary crate** (`cli/flox/src/config/mod.rs`).
+- `Flox` is defined in **`flox-rust-sdk`** (`cli/flox-rust-sdk/src/flox.rs`).
+- `flox-rust-sdk` must **not** depend on the `flox` binary crate (that would be a dependency cycle).
+- Therefore `Flox` cannot hold a `TokenStorageMode` field without first moving the enum to a crate
+  the SDK already depends on.
+
+**Precedent:** `AuthnMode` (used by `config.flox.floxhub_authn_mode`) lives in `floxhub-client`, and
+is **applied at `Flox` construction** rather than carried on `Flox`
+(`cli/flox/src/commands/mod.rs`: `AuthContext::from_mode(&config.flox.floxhub_authn_mode, …)`).
+The house pattern is: mode/preference stays in `Config`; it is consumed at construction time.
+
+## Options
+
+### Option A — Thread `storage: TokenStorageMode` through `ensure_auth` and its callers
+
+Change `ensure_auth(flox)` → `ensure_auth(flox, storage)`, and pass
+`config.flox.floxhub_token_storage` at each call site.
+
+- **Blast radius:** the `ensure_auth` signature + **11 call sites**, but **10 of those call sites
+  have no `Config`**. Closing the gap therefore requires plumbing `Config` (or the preference) into
+  ~10 command `handle()` methods and the helper functions in `mod.rs`, which in turn means changing
+  `FloxCli::handle()`'s dispatch to pass `Config`/preference alongside `Flox` to those subcommands.
+- **Pros:** no enum relocation; the preference stays exactly where the spec put it
+  (`config/mod.rs`); explicit and greppable.
+- **Cons / implications:** the largest change of the three. It touches ~12 files and the central
+  command-dispatch surface, expands several public-ish `handle()` signatures, and risks merge
+  conflicts with unrelated command work. High review cost for a P2.
+- **Risk:** easy to miss a call site or pass the wrong value; each new `ensure_auth` caller in the
+  future must remember to plumb the preference.
+
+### Option B — Relocate `TokenStorageMode` to a shared crate and carry it on `Flox`
+
+Move `TokenStorageMode` next to `AuthnMode` in `floxhub-client` (or another crate the SDK already
+depends on); `FloxConfig` imports it from there (only the import path changes). Add
+`floxhub_token_storage: TokenStorageMode` to `Flox`, set it once at construction in
+`FloxCli::handle()` from `config.flox.floxhub_token_storage`, and have `ensure_auth` pass
+`flox.floxhub_token_storage`.
+
+- **Blast radius:** ~6 files — define the enum in `floxhub-client`; update imports in
+  `config/mod.rs`, `utils/credential_store.rs`, `commands/auth.rs`, `commands/mod.rs`; add one field
+  to `Flox` + set it at construction; one-line change at `ensure_auth`. **No change to the other 10
+  callers.**
+- **Pros:** clean and localized at call sites; `ensure_auth` (and any future caller) gets the
+  preference "for free" from `flox`; mirrors how `auth_context`/`AuthnMode` already flow.
+- **Cons / implications:** **deviates from the approved spec**, which explicitly says
+  *"`TokenStorageMode` is defined in `config/mod.rs` next to the other config enums."* Moving it adds
+  a config-shaped enum to a lower layer (though `AuthnMode` is precedent for exactly that). Adds a
+  field to the widely-used `Flox` struct.
+- **Risk:** low/mechanical, but the relocation is a design decision that should be agreed before
+  implementing (it changes the home of a type the rest of the codebase imports).
+
+### Option C — Accept the limitation (chosen for PR #4422)
+
+Leave implicit re-auth using the secure keyring default; document the gap in code and here.
+
+- **Blast radius:** none (already in place; the `ensure_auth` comment documents it and points here).
+- **Pros:** zero risk; keeps PR #4422 scoped to what the spec's behavior matrix covers (explicit
+  login + startup migration); the keyring is the more secure store, so the fallback is safe.
+- **Cons / implications:** the standing `plaintext` preference is not honored for implicit re-auth;
+  `flox auth status` can show the contradictory pair noted above until the next explicit action.
+
+## Recommendation
+
+If/when we pursue this, **Option B** is the cleanest: it fixes every `ensure_auth` caller at once,
+matches the existing `AuthnMode`/`AuthContext` construction pattern, and is ~6 mechanical files. Its
+only real cost is a **deliberate decision to relocate `TokenStorageMode`** out of `config/mod.rs`
+(get sign-off first, since it moves a type the codebase imports). **Option A** should be chosen only
+if we specifically want to keep the enum in `config/mod.rs`, accepting a much larger,
+dispatch-touching change. **Option C** (status quo) is appropriate until a user actually reports the
+inconsistency, given the P2 severity.
+
+### Suggested acceptance criteria for the follow-up
+
+- With `floxhub_token_storage = "plaintext"` and an expired token, an implicit re-auth (e.g.
+  `flox push`) **keeps** the token in plain text (does not write the keyring, does not remove the
+  plain-text file), matching an explicit `flox auth login` under the same preference.
+- A unit test exercising `ensure_auth`'s storage decision (or the chosen carrier) for both
+  `Keyring` and `Plaintext` preferences.
+- `flox auth status` no longer reports "preference is plain text" alongside "stored in your system
+  keyring" after an implicit re-auth.

--- a/docs/superpowers/specs/README.md
+++ b/docs/superpowers/specs/README.md
@@ -6,4 +6,5 @@ test-first.
 
 | Spec | Status |
 |------|--------|
-| [2026-06-22-floxhub-token-storage-preference-design.md](2026-06-22-floxhub-token-storage-preference-design.md) | **Approved — ready to implement.** Makes `--insecure-storage` a persistent `floxhub_token_storage = "keyring" \| "plaintext"` config preference, with `--insecure-storage --once` for a temporary plain-text login. Follow-up to PR #4420 (`claude[bot]` review item #2). **Start here:** run `writing-plans` on the spec, then implement test-first. |
+| [2026-06-22-floxhub-token-storage-preference-design.md](2026-06-22-floxhub-token-storage-preference-design.md) | **Implemented** in PR #4422. Makes `--insecure-storage` a persistent `floxhub_token_storage = "keyring" \| "plaintext"` config preference, with `--insecure-storage --once` for a temporary plain-text login. Follow-up to PR #4420 (`claude[bot]` review item #2). |
+| [2026-06-22-implicit-reauth-token-storage-followup.md](2026-06-22-implicit-reauth-token-storage-followup.md) | **Deferred follow-up.** Implicit re-auth (`flox push`/`publish`/… on an expired token) does not honor a `plaintext` preference — an accepted P2 limitation from PR #4422. Documents the three fix options (thread, relocate-and-carry, accept) with blast radius and implications for when we pursue it. |

--- a/docs/superpowers/specs/README.md
+++ b/docs/superpowers/specs/README.md
@@ -1,0 +1,9 @@
+# Specs
+
+Design specs for upcoming or in-flight work. Each spec is the source of truth for its
+feature: implement it by running the `writing-plans` workflow on the spec, then executing
+test-first.
+
+| Spec | Status |
+|------|--------|
+| [2026-06-22-floxhub-token-storage-preference-design.md](2026-06-22-floxhub-token-storage-preference-design.md) | **Approved — ready to implement.** Makes `--insecure-storage` a persistent `floxhub_token_storage = "keyring" \| "plaintext"` config preference, with `--insecure-storage --once` for a temporary plain-text login. Follow-up to PR #4420 (`claude[bot]` review item #2). **Start here:** run `writing-plans` on the spec, then implement test-first. |


### PR DESCRIPTION
## Summary

Follow-up to #4420 (addresses `claude[bot]` review item #2). Makes
`flox auth login --insecure-storage` a **persistent** token-storage preference
instead of a one-shot setting that the next command silently reverts.

A new `floxhub_token_storage` config key (`keyring` | `plaintext`, default
`keyring`) is the single source of truth for where the FloxHub token is stored.
It is consulted at login (where to write) and at migration (whether to move an
existing plain-text token into the OS keyring), and merges through the usual
`/etc/flox.toml` → user → env precedence.

### Behavior

| Invocation | Writes the setting? | Token stored | Migration on later commands |
|---|---|---|---|
| `flox auth login` (default) | no | keyring (fallback → plaintext + warn) | n/a |
| `flox auth login` (pref = plaintext) | no | plaintext (honors pref) | skipped |
| `flox auth login --insecure-storage` | sets `= plaintext` | plaintext | skipped |
| `flox auth login --insecure-storage --once` | no | plaintext (this time) | re-secured to keyring next command if available |
| `flox config --delete floxhub_token_storage` | clears (→ keyring) | unchanged | next command migrates plaintext → keyring |

`flox auth status` now notes when the preference is plain text and names
`flox config --delete floxhub_token_storage` to revert.

### Implementation notes

- `persist_login_token` takes a target `TokenStorageMode` instead of an
  `insecure_storage` bool. This deviates from the spec's "inline
  `PlaintextStore::set`" factoring, but keeps the storage decision
  unit-testable and removes any stale keyring entry when storing plain text.
  The behavior matrix above is unchanged.
- `resolve_credential_into` gains a `storage` parameter; only the migration is
  gated on it — the keyring read-fallback is unchanged.
- Implicit re-auth (`ensure_auth`) keeps the secure keyring default: the
  preference is not threaded through its many call sites, so only an explicit
  `flox auth login` honors it.
- The login persistence decision and the status line are not unit-tested
  because `login_flox`/`Status` are OAuth/TTY-coupled; per repo conventions
  (don't extract single-use helpers, don't test thin wrappers) I didn't extract
  them. Verified the config round-trip manually (`--set`/`--delete`, and that an
  invalid value is rejected with `unknown variant 'garbage', expected 'keyring'
  or 'plaintext'`), and confirmed no bats help-snapshot asserts on
  `flox auth login` flags.
- Folded-in review fixes #1 (silent migration partial-failure) and #3 (`indoc!`
  for the C5 warning) were already implemented on #4420's branch; this PR only
  adds the `storage == keyring` gate to that migration block.

### Testing

- Unit: `TokenStorageMode` parse + default; migration skipped when the
  preference is plaintext; `persist_login_token` for both targets including
  stale-keyring removal.
- `cargo test -p flox` (338 passed) and `cargo clippy --all` (clean).

## Release Notes

`flox auth login --insecure-storage` is now a persistent preference: the FloxHub
token stays in plain text in `flox.toml` on subsequent commands instead of being
moved into the OS keyring on the next invocation. Use
`flox auth login --insecure-storage --once` to store plain text for a single
login without changing the preference, and
`flox config --delete floxhub_token_storage` (or
`--set floxhub_token_storage keyring`) to switch back to keyring storage (which
re-secures the token on the next command). `flox auth status` now reports when
plain-text storage is in effect.

---

> **Stacked PR:** based on `implement-secure-cli-credential-storage-with-keyring-fallback`
> (#4420). The base will be rebased onto `main` and retargeted once #4420 merges.
