### PR TITLE
 feat(factory): Add logs command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1443,6 +1443,7 @@ dependencies = [
 name = "flox"
 version = "0.0.0"
 dependencies = [
+ "anstream",
  "anyhow",
  "beta",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ edition = "2024"
 version = "0.0.0"
 
 [workspace.dependencies]
+anstream = "0.6"
 anyhow = "1"
 async-stream = "0.3.6"
 blake3 = "1.8.2"

--- a/cli/flox/Cargo.toml
+++ b/cli/flox/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 ignored = ["sapling-renderdag"]
 
 [dependencies]
+anstream.workspace = true
 anyhow.workspace = true
 beta.workspace = true
 bpaf.workspace = true

--- a/cli/flox/src/commands/factory/logs.rs
+++ b/cli/flox/src/commands/factory/logs.rs
@@ -1,0 +1,205 @@
+use std::io::{BufWriter, Write};
+use std::num::NonZeroU64;
+use std::process::ExitCode;
+
+use anstream::adapter::StripBytes;
+use anyhow::Result;
+use bpaf::Bpaf;
+use floxhub_client::{FactoryClientError, FactoryClientTrait};
+use futures::StreamExt;
+use tracing::instrument;
+
+use crate::utils::message;
+use crate::{Exit, subcommand_metric};
+
+/// Print the logs for a single Flox Factory build.
+#[derive(Debug, Clone, PartialEq, Bpaf)]
+pub struct Logs {
+    /// Print the raw log bytes without sanitizing terminal escape sequences
+    #[bpaf(long)]
+    pub raw: bool,
+
+    /// Build ID to fetch logs for
+    #[bpaf(positional("ID"))]
+    pub id: NonZeroU64,
+}
+
+impl Logs {
+    #[instrument(name = "logs", skip_all)]
+    pub async fn handle(self, client: &impl FactoryClientTrait) -> Result<()> {
+        subcommand_metric!("factory::logs");
+
+        let mut stream = match client.get_build_logs(self.id.get() as i64).await {
+            Ok(stream) => stream,
+            Err(FactoryClientError::NotFound) => {
+                message::error(format!("No logs available for build {}.", self.id));
+                return Err(Exit(ExitCode::from(2)).into());
+            },
+            Err(other) => return Err(super::user_facing_error(other, None)),
+        };
+
+        // stdout is always `LineWriter`-backed, so it flushes on every newline.
+        // Wrap it in a BufWriter to batch the log into ~8KB writes and spare
+        // that per-line flush — this is a one-shot dump, not a live tail.
+        // `finish` does the single explicit flush at the end, which also
+        // surfaces a write error that BufWriter's drop-flush would swallow.
+        let stdout = std::io::stdout();
+        let mut writer = LogWriter::new(BufWriter::new(stdout.lock()), self.raw);
+
+        while let Some(chunk) = stream.next().await {
+            writer.write_chunk(chunk?.as_ref())?;
+        }
+        writer.finish()?;
+
+        Ok(())
+    }
+}
+
+/// Streams log byte-chunks to an output, either:
+///
+/// - sanitized (default): strips all terminal escape sequences, including
+///   colour, to prevent injection: https://cwe.mitre.org/data/definitions/150.html
+/// - raw: prints verbatim, byte-for-byte.
+///
+/// `StripBytes` holds the parser's cross-chunk state, so a sequence or
+/// multibyte UTF-8 character that straddles a chunk boundary is handled.
+struct LogWriter<W: Write> {
+    writer: W,
+    /// `None` selects raw, byte-for-byte output.
+    stripper: Option<StripBytes>,
+}
+
+impl<W: Write> LogWriter<W> {
+    fn new(writer: W, raw: bool) -> Self {
+        Self {
+            writer,
+            stripper: (!raw).then(StripBytes::new),
+        }
+    }
+
+    /// Write one chunk: sanitized text, or the raw bytes unchanged.
+    fn write_chunk(&mut self, chunk: &[u8]) -> std::io::Result<()> {
+        let Some(stripper) = &mut self.stripper else {
+            return self.writer.write_all(chunk);
+        };
+        for printable in stripper.strip_next(chunk) {
+            self.writer.write_all(printable)?;
+        }
+        Ok(())
+    }
+
+    /// Flush the underlying buffer.
+    fn finish(mut self) -> std::io::Result<()> {
+        self.writer.flush()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroU64;
+
+    use flox_rust_sdk::utils::logging::test_helpers::test_subscriber_message_only;
+    use pretty_assertions::assert_eq;
+    use tracing::instrument::WithSubscriber;
+
+    use super::*;
+    use crate::Exit;
+    use crate::commands::factory::test_helpers::StubFactoryClient;
+
+    /// Render chunks through a `LogWriter`, returning the bytes written.
+    fn render(chunks: &[&[u8]], raw: bool) -> Vec<u8> {
+        let mut out: Vec<u8> = Vec::new();
+        let mut writer = LogWriter::new(&mut out, raw);
+        for chunk in chunks {
+            writer.write_chunk(chunk).unwrap();
+        }
+        writer.finish().unwrap();
+        out
+    }
+
+    #[test]
+    fn raw_writes_bytes_byte_for_byte() {
+        // The escape sequences must survive unchanged under --raw.
+        let input: &[u8] = b"\x1b[31mred\x1b[0m\x1b]0;title\x07\x9bdata\n";
+        assert_eq!(render(&[input], true), input);
+    }
+
+    #[test]
+    fn sanitized_strips_ansi_escapes() {
+        // A representative mix: SGR colour, an OSC title terminated by BEL, and
+        // an OSC hyperlink terminated by ST. All escapes go; text stays.
+        let out = render(
+            &[b"\x1b[31mred\x1b[0m \x1b]0;title\x07tail \x1b]8;;http://x\x1b\\link\n"],
+            false,
+        );
+        assert_eq!(out, b"red tail link\n");
+    }
+
+    #[test]
+    fn sanitized_strips_escape_split_across_chunk_boundary() {
+        // The CSI sequence is split mid-escape across the two chunks; one
+        // `StripBytes` carried across both must still strip it.
+        let out = render(&[b"foo\x1b[3", b"1mbar\n"], false);
+        assert_eq!(out, b"foobar\n");
+    }
+
+    #[test]
+    fn sanitized_keeps_text_tabs_newlines_and_carriage_returns() {
+        // Whitespace controls are structural in logs and must survive.
+        let input: &[u8] = b"line1\r\n\tline2";
+        assert_eq!(render(&[input], false), input);
+    }
+
+    #[test]
+    fn sanitized_strips_esc_and_all_c1_control_bytes() {
+        // The security guarantee: no byte that can drive the terminal may reach
+        // it. Feed each byte value on its own — so the outcome depends only on
+        // that byte, not on neighbouring stream state — and confirm that ESC
+        // (0x1b) and every 8-bit C1 control (0x80..=0x9f, which includes the
+        // CSI 0x9b and OSC 0x9d introducers) is stripped. The loop also exercises
+        // sanitizing over every byte value without panicking. Surviving bytes
+        // are ordinary text (e.g. UTF-8 lead bytes) that cannot introduce an
+        // escape sequence.
+        for byte in 0u8..=255 {
+            let out = render(&[&[byte]], false);
+            if byte == 0x1b || (0x80..=0x9f).contains(&byte) {
+                assert!(
+                    !out.contains(&byte),
+                    "escape control byte {byte:#04x} survived sanitizing: {out:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn sanitized_leaves_c1_sequence_payload_as_text() {
+        // A sequence introduced by a raw 8-bit C1 byte has its introducer (and
+        // any terminator) removed so it cannot drive the terminal, but the
+        // payload bytes are not escapes and remain as inert visible text.
+        //
+        // CSI 0x9b loses only the introducer.
+        assert_eq!(render(&[b"\x9b31mRED\x9b0m"], false), b"31mRED0m");
+        // OSC 0x9d loses the introducer and its BEL terminator.
+        assert_eq!(render(&[b"\x9d0;title\x07tail"], false), b"0;titletail");
+    }
+
+    #[tokio::test]
+    async fn not_found_renders_message_and_returns_exit_error() {
+        let client = StubFactoryClient::with_not_found();
+        let args = Logs {
+            raw: false,
+            id: NonZeroU64::new(42).unwrap(),
+        };
+
+        let (subscriber, writer) = test_subscriber_message_only();
+        let err = async { args.handle(&client).await.unwrap_err() }
+            .with_subscriber(subscriber)
+            .await;
+
+        assert!(err.is::<Exit>(), "expected an Exit error, got {err:?}");
+        assert_eq!(
+            writer.to_string(),
+            "✘ ERROR: No logs available for build 42.\n"
+        );
+    }
+}

--- a/cli/flox/src/commands/factory/mod.rs
+++ b/cli/flox/src/commands/factory/mod.rs
@@ -4,6 +4,7 @@
 //! (ECO-99) and `Cancel` (ECO-100) are future verbs.
 
 mod list;
+mod logs;
 mod status;
 
 use anyhow::{Result, anyhow};
@@ -94,7 +95,10 @@ pub enum FactoryCommands {
     /// List Flox Factory builds
     #[bpaf(command)]
     List(#[bpaf(external(list::list))] list::List),
-    // ECO-99 will add: Logs(#[bpaf(external(logs::logs))] logs::Logs),
+
+    /// Print the logs for a single Flox Factory build
+    #[bpaf(command)]
+    Logs(#[bpaf(external(logs::logs))] logs::Logs),
     // ECO-100 will add: Cancel(#[bpaf(external(cancel::cancel))] cancel::Cancel),
 }
 
@@ -111,13 +115,14 @@ impl FactoryCommands {
             },
             FactoryCommands::Status(args) => args.handle(&flox.floxhub_client).await,
             FactoryCommands::List(args) => args.handle(&flox.floxhub_client).await,
+            FactoryCommands::Logs(args) => args.handle(&flox.floxhub_client).await,
         }
     }
 }
 
 #[cfg(test)]
 pub(crate) mod test_helpers {
-    //! Shared test fixtures for the `status` and `list` verb handler tests.
+    //! Shared test fixtures for the factory verb handler tests.
 
     use chrono::TimeZone;
     use factory_api_v1::types::TaskResponse;
@@ -201,7 +206,16 @@ pub(crate) mod test_helpers {
             &self,
             _build_id: i64,
         ) -> Result<FactoryByteStream, FactoryClientError> {
-            unimplemented!("StubFactoryClient does not implement get_build_logs")
+            if self.not_found {
+                return Err(FactoryClientError::NotFound);
+            }
+            let lines: [&[u8]; 2] = [b"Building hello...\n", b"Build completed.\n"];
+            let chunks = lines
+                .into_iter()
+                .map(|line| Ok::<_, reqwest::Error>(line.into()));
+            Ok(FactoryByteStream::new(Box::pin(futures::stream::iter(
+                chunks,
+            ))))
         }
     }
 }

--- a/cli/floxhub-client/src/factory.rs
+++ b/cli/floxhub-client/src/factory.rs
@@ -194,12 +194,17 @@ impl FactoryClientTrait for crate::FloxhubClient {
     }
 
     async fn get_build_logs(&self, build_id: i64) -> Result<ByteStream, FactoryClientError> {
+        // A 404 on this resource-specific endpoint means there are no logs to
+        // serve — the build does not exist, was never dispatched, or its
+        // coordinator counterpart is gone. Reclassify it so the caller can say
+        // so. Other endpoints leave a 404 as the underlying API error.
         Ok(self
             .factory
             .get_build_logs_api_v1_factory_builds_build_id_logs_get(build_id)
             .await
             .map_api_error()
-            .await?
+            .await
+            .map_err(not_found_on_404)?
             .into_inner())
     }
 }
@@ -481,6 +486,36 @@ pub mod tests {
         };
         let client = crate::FloxhubClient::new(config).unwrap();
         let err = client.get_build(7).await.unwrap_err();
+
+        mock.assert();
+        assert!(
+            matches!(err, FactoryClientError::NotFound),
+            "expected NotFound, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_build_logs_maps_404_to_not_found() {
+        // The logs endpoint returns 404 when the build does not exist, was
+        // never dispatched (no task), or the coordinator itself 404s. All three
+        // mean "no logs available", so get_build_logs classifies the 404 as
+        // NotFound and lets the verb render a cause-agnostic message.
+        let server = MockServer::start_async().await;
+        let mock = server.mock(|when, then| {
+            when.method("GET").path("/api/v1/factory/builds/7/logs");
+            then.status(404)
+                .json_body(json!({ "detail": "Build not found" }));
+        });
+
+        let config = FloxhubClientConfig {
+            base_url: server.base_url(),
+            ..client_config(&server.base_url())
+        };
+        let client = crate::FloxhubClient::new(config).unwrap();
+        // `ByteStream` is not `Debug`, so destructure rather than `unwrap_err`.
+        let Err(err) = client.get_build_logs(7).await else {
+            panic!("expected an error, got an Ok stream");
+        };
 
         mock.assert();
         assert!(


### PR DESCRIPTION
## Proposed Changes

https://linear.app/floxdotdev/issue/ECO-99/sl-005-flox-cli-flox-factory-logs-verb-cli-side-sanitizer

Add a currently hidden `flox factory logs <id>` command so that
operators can retrieve a single build's logs.

Logs are sanitised of escape sequences (including colour) by default to
prevent terminal injection attacks. This can be disabled with `--raw`.

The original design in Forge called for hand rolling the sanitiser but
we save ~200 LoC and a few first-pass bugs by using `anstream`, which was
already pulled in as a transitive dependency.

I've also omitted the originally specced STDERR warning when using
`--raw` for now because the "one time" notice was under-designed, it's
explicitly opt-in, and already too late by the time the output's reached
the terminal.

A 404 from the build-logs endpoint is reclassified to `NotFound`, which
the `logs` verb renders as "No logs available for build <ID>." with exit
code 2. This mirrors `get_build` and covers every 404 cause (unknown
build, never dispatched, coordinator gone). The listing endpoint
deliberately keeps its 404 as a generic error, since there a 404 is a
route or config error rather than a missing resource.

Manually verified against local FloxHub:

    % flox factory logs 2167
    ! Using https://api.local.flox.dev:8000/floxem-gitolite as FloxHub host
    '$_FLOX_FLOXHUB_GIT_URL' is used for testing purposes only,
    alternative FloxHub hosts are not yet supported!

    Cloning into '/tmp/factory-build-2167'...
    Already on 'main'
    Your branch is up to date with 'origin/main'.
    HEAD is now at 70cd3bb Bump version
    ! Using https://api.local.flox.dev:8000/floxem-gitolite as FloxHub host
    '$_FLOX_FLOXHUB_GIT_URL' is used for testing purposes only,
    alternative FloxHub hosts are not yet supported!

    make: Entering directory '/private/tmp/factory-build-2167/packages'
    /nix/store/akih5l2yxpzqyh63xvyc6zsxl7kl2x4v-coreutils-9.10/bin/mkdir -p /var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.C2lc0E/cdddba40/hello
    /nix/store/zk0lbn5kx16dii9bc5pw766hagkzy6kz-nix-2.31.5/bin/nix --extra-experimental-features "flakes nix-command fetch-tree" --trace-verbose eval -L --file /nix/store/pf6bybinyj5svz0m272cwy7vhiv7g2aj-package-builder-1.0.0/libexec/nef --argstr nixpkgs-url 'git+https://github.com/flox/nixpkgs?rev=567a49d1913ce81ac6e9582e3553dd90a955875f&shallow=1' --argstr system aarch64-darwin --argstr source-ref 'git+file:///private/tmp/factory-build-2167?dir=packages/.flox&rev=70cd3bb42a867bd4a9a278f84b46fc4d89786f20' --json --apply 'pkg: { drvPath = pkg.drvPath; version = pkg.version or "unknown"; name = pkg.name; pname = pkg.pname or pkg.name; meta = pkg.meta or null; }' pkgs.hello > /var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.C2lc0E/cdddba40/hello/eval.json
    Building hello in Nix expression mode
    /nix/store/zk0lbn5kx16dii9bc5pw766hagkzy6kz-nix-2.31.5/bin/nix --extra-experimental-features "flakes nix-command fetch-tree" --trace-verbose build --json -L --out-link result-hello /nix/store/1xsm3nzw8zhzg0gp0nfb1lvqpwpgzwf9-hello.drv'^*' > /var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.C2lc0E/cdddba40/hello/build.json
    this derivation will be built:
      /nix/store/1xsm3nzw8zhzg0gp0nfb1lvqpwpgzwf9-hello.drv
    these 11 paths will be fetched (1.67 MiB download, 15.39 MiB unpacked):
      /nix/store/a6r9ryv9pqcvwv8ffmzi4ichd5br0vl6-bzip2-1.0.8-bin
      /nix/store/37rdk8zsdbqcp73l3nrmwilwb2ixkacv-diffutils-3.12
      /nix/store/clinbqq0dm364gzdglc78q7010lwmgzl-ed-1.22.5
      /nix/store/dax63li7wwcbqxxkkgzc4g2rx7d4w86x-file-5.47
      /nix/store/smy9r0qsipvnyidnpzfa12jkdrb92iys-gnu-config-2024-01-01
      /nix/store/3aikbnf5fq99gvw1wb242wrjnbj7fcr9-gnutar-1.35
      /nix/store/ngbqdfvv2l12jysz56iy45g1gld2n126-locale-118
      /nix/store/zn3jzk0zwhml7pgx8slyiwmk5zv0ylmh-patch-2.8
      /nix/store/0y3vzjqz42dmyasywgr6ipcfb0nwdzvy-stdenv-darwin
      /nix/store/araamnqpqfa6zp3lqsxvz3lwa6cmn2wl-update-autotools-gnu-config-scripts-hook
      /nix/store/h7484di7imn15ihxmhzqrzbaszcaxyhw-xz-5.8.3-bin
    copying path '/nix/store/ngbqdfvv2l12jysz56iy45g1gld2n126-locale-118' from 'https://cache.flox.dev'...
    copying path '/nix/store/a6r9ryv9pqcvwv8ffmzi4ichd5br0vl6-bzip2-1.0.8-bin' from 'https://cache.flox.dev'...
    copying path '/nix/store/3aikbnf5fq99gvw1wb242wrjnbj7fcr9-gnutar-1.35' from 'https://cache.flox.dev'...
    copying path '/nix/store/37rdk8zsdbqcp73l3nrmwilwb2ixkacv-diffutils-3.12' from 'https://cache.flox.dev'...
    copying path '/nix/store/dax63li7wwcbqxxkkgzc4g2rx7d4w86x-file-5.47' from 'https://cache.flox.dev'...
    copying path '/nix/store/h7484di7imn15ihxmhzqrzbaszcaxyhw-xz-5.8.3-bin' from 'https://cache.flox.dev'...
    copying path '/nix/store/clinbqq0dm364gzdglc78q7010lwmgzl-ed-1.22.5' from 'https://cache.flox.dev'...
    copying path '/nix/store/smy9r0qsipvnyidnpzfa12jkdrb92iys-gnu-config-2024-01-01' from 'https://cache.flox.dev'...
    copying path '/nix/store/zn3jzk0zwhml7pgx8slyiwmk5zv0ylmh-patch-2.8' from 'https://cache.flox.dev'...
    copying path '/nix/store/araamnqpqfa6zp3lqsxvz3lwa6cmn2wl-update-autotools-gnu-config-scripts-hook' from 'https://cache.flox.dev'...
    copying path '/nix/store/0y3vzjqz42dmyasywgr6ipcfb0nwdzvy-stdenv-darwin' from 'https://cache.nixos.org'...
    building '/nix/store/1xsm3nzw8zhzg0gp0nfb1lvqpwpgzwf9-hello.drv'...
    ( /nix/store/zk0lbn5kx16dii9bc5pw766hagkzy6kz-nix-2.31.5/bin/nix --extra-experimental-features "flakes nix-command fetch-tree" --trace-verbose log /nix/store/1xsm3nzw8zhzg0gp0nfb1lvqpwpgzwf9-hello.drv 2>/dev/null || echo "No logs available" ) > /var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.C2lc0E/cdddba40/hello/build.log
    /nix/store/zk0lbn5kx16dii9bc5pw766hagkzy6kz-nix-2.31.5/bin/nix --extra-experimental-features "flakes nix-command fetch-tree" --trace-verbose build -L --out-link result-hello-log /nix/store/4b1f200hjv088z0dwfadnabryhbn88p2-build.log
    /nix/store/bb450vb2gl547zwba8sihcyilsg2rqfa-jq-1.8.1-bin/bin/jq -n --arg logfile /nix/store/4b1f200hjv088z0dwfadnabryhbn88p2-build.log --arg system aarch64-darwin --argjson resultLinks '{ "/private/tmp/factory-build-2167/packages/result-hello":"/nix/store/jzb0vds5yyk4l5vfddjhwifj481qvx94-hello" }' --slurpfile eval /var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.C2lc0E/cdddba40/hello/eval.json --slurpfile build /var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.C2lc0E/cdddba40/hello/build.json '$build[0][0] * $eval[0] * { system: $system, log: $logfile, resultLinks: $resultLinks }' > /var/folders/8q/spckhr654cv4xrcv0fxsrlvc0000gn/T/nix-shell.C2lc0E/cdddba40/hello/build-meta.json
    Completed build of hello in Nix expression mode

    make: Leaving directory '/private/tmp/factory-build-2167/packages'
    ✔ Package published successfully.

    Use 'flox install dcarley/hello' to install it.

## Release Notes

N/A, unreleased