### PR TITLE
fix(flox-activations): treat stop signal as normal exit, not error

### DIFF
--- a/cli/flox-activations/src/cli/executive/mod.rs
+++ b/cli/flox-activations/src/cli/executive/mod.rs
@@ -265,10 +265,12 @@ fn run_event_loop(
                 reap_orphaned_children();
             },
             Ok(ExecutiveEvent::TerminationSignal) => {
-                // If we get a SIGINT/SIGTERM/SIGQUIT we leave behind the activation in the registry,
-                // but there's not much we can do about that because we don't know who sent us one of those
-                // signals or why.
-                bail!("received stop signal, exiting without cleanup");
+                // A termination signal (SIGINT/SIGTERM/SIGQUIT) is a normal exit for this
+                // long-lived background process, not an error. We intentionally leave the
+                // activation in the registry: we don't know who sent the signal or why, so
+                // we can't safely run cleanup.
+                info!(reason = "termination signal", "exiting without cleanup");
+                return Ok(());
             },
             Err(_) => {
                 bail!("event channel disconnected unexpectedly");
@@ -575,7 +577,7 @@ mod test {
     }
 
     #[test]
-    fn monitoring_loop_bails_on_termination_signal() {
+    fn monitoring_loop_exits_without_cleanup_on_termination_signal() {
         let temp_dir = tempfile::tempdir().unwrap();
         let runtime_dir = temp_dir.path();
         let dot_flox_path = PathBuf::from(".flox");
@@ -621,12 +623,8 @@ mod test {
             0,
         );
 
-        // Verify the loop exited with the expected error
-        let err = result.expect_err("should return error on termination signal");
-        assert!(
-            err.to_string().contains("received stop signal"),
-            "error should indicate stop signal was received: {err}"
-        );
+        // Verify the loop exited normally (a termination signal is not an error)
+        result.expect("termination signal should exit cleanly without error");
 
         // Verify cleanup did NOT occur - state directory should still exist
         assert!(


### PR DESCRIPTION
fixes [DEV-138](https://linear.app/floxdotdev/issue/DEV-138/downgrade-stop-signal-log-from-error-to-warn-cli-flox-s)

Receiving SIGINT/SIGTERM/SIGQUIT is how this background process is normally told to stop, firing on every Ctrl-C and shell teardown. The monitoring loop treated it as an error and bailed, which Sentry captured as an exception — 34,216 occurrences across 374 users, drowning out real errors.

The capture came not from the bail but from `#[instrument(..., err(Debug))]`, which records an ERROR span-error for any Err return. So a normal exit was being modeled as a failure. Rather than mask it with a log level or a Sentry filter, correct the model: return Ok and log at info. Every genuine failure path still returns Err and is reported; the activation is still left in the registry, since we can't know who sent the signal.

## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->


## Release Notes

N/A no user-facing change. This only stops the activation executive from reporting normal shutdown (Ctrl-C / shell teardown) as an error to Sentry.


<!-- Many thanks! -->
