### PR TITLE
feat(factory): add cancel command with exit code space

### DIFF
--- a/cli/flox/src/commands/factory/cancel.rs
+++ b/cli/flox/src/commands/factory/cancel.rs
@@ -1,0 +1,605 @@
+use std::num::NonZeroU64;
+use std::process::ExitCode;
+
+use anyhow::Result;
+use bpaf::Bpaf;
+use floxhub_client::{BuildResponse, FactoryClientError, FactoryClientTrait, FactoryStatus};
+use indoc::{formatdoc, indoc};
+use tracing::instrument;
+
+use crate::utils::message;
+use crate::{Exit, subcommand_metric};
+
+/// Cancel a single Flox Factory build.
+///
+/// Exit codes: 0 success, 1 service error, 2 not found, 4 unreachable,
+/// 5 authentication rejected.
+#[derive(Debug, Clone, PartialEq, Bpaf)]
+pub struct Cancel {
+    /// Display output as JSON
+    #[bpaf(long)]
+    pub json: bool,
+
+    /// Build ID to cancel
+    #[bpaf(positional("ID"))]
+    pub id: NonZeroU64,
+}
+
+impl Cancel {
+    #[instrument(name = "cancel", skip_all)]
+    pub async fn handle(self, client: &impl FactoryClientTrait) -> Result<()> {
+        subcommand_metric!("factory::cancel");
+
+        // Build IDs are `i64` server-side, so an ID beyond `i64::MAX` cannot
+        // name a real build. Reject it as not found rather than cast with `as`,
+        // whose silent wrap would put a negative ID on the destructive endpoint;
+        // this returns before any request is issued.
+        let Ok(build_id) = i64::try_from(self.id.get()) else {
+            return Err(self.fail(&FactoryClientError::NotFound));
+        };
+
+        // Issue the idempotent cancel. A 200 carries the build's effective
+        // status, from which the outcome (initiated vs already terminal) is
+        // read; every HTTP and transport failure is classified in the client
+        // layer into the typed error the exit-code contract maps.
+        match client.cancel_build(build_id).await {
+            Ok(build) => match success_outcome(&build, self.id) {
+                // Terminal: the cancel is fully resolved. Print to stdout, exit 0.
+                CancelOutcome::Resolved(message) => {
+                    print!("{}", render(&build, &message, self.json)?);
+                    Ok(())
+                },
+                // Accepted but not yet terminal: the idempotent DELETE succeeded,
+                // so exit 0 (automation must not retry). Warn about the caveat,
+                // and still emit the body under `--json`.
+                CancelOutcome::Accepted(message) => {
+                    if self.json {
+                        print!("{}", render(&build, &message, true)?);
+                    }
+                    message::warning(message);
+                    Ok(())
+                },
+                // A 200 with a status outside the lifecycle vocabulary is a
+                // service contract violation, not a successful cancel.
+                CancelOutcome::Unexpected(message) => {
+                    message::error(message);
+                    Err(Exit(ExitCode::from(1)).into())
+                },
+            },
+            Err(err) => Err(self.fail(&err)),
+        }
+    }
+
+    /// Print the error message for a failed step and return the carrying
+    /// [`Exit`], so the process exit code alone tells automation what to do.
+    fn fail(&self, err: &FactoryClientError) -> anyhow::Error {
+        let (message, code) = classify_error(err, self.id);
+        message::error(message);
+        Exit(ExitCode::from(code)).into()
+    }
+}
+
+/// Map a client error to a user-facing message and exit code.
+///
+/// Pure, so the exit-code contract is tested exhaustively without driving I/O.
+/// An unrecognised response degrades to a generic service error (exit 1),
+/// following the codebase's graceful handling of unexpected responses rather
+/// than escalating it to a bespoke outcome.
+fn classify_error(err: &FactoryClientError, id: NonZeroU64) -> (String, u8) {
+    match err {
+        // No such build: exit 2.
+        FactoryClientError::NotFound => (
+            formatdoc! {"
+                No Flox Factory build found with ID {id}.
+                Use 'flox factory list' to see existing builds."},
+            2,
+        ),
+        // Auth is never retryable: exit 5.
+        FactoryClientError::AuthRejected(_) => (
+            indoc! {"
+                Authentication was rejected by the Flox Factory.
+                Run 'flox auth login' and try again."}
+            .to_string(),
+            5,
+        ),
+        // No HTTP response at all: the service is unreachable. Exit 4.
+        FactoryClientError::Transport(_) => (
+            indoc! {"
+                Could not reach the Flox Factory.
+                Check your network connection and try again."}
+            .to_string(),
+            4,
+        ),
+        // A server-side error (5xx/422): the host answered over HTTP and erred,
+        // so it is retryable. Exit 1; the cancel endpoint documents 502 as
+        // retry-with-backoff.
+        FactoryClientError::Server(_) => (
+            formatdoc! {"
+                The Flox Factory reported a server error for build {id}.
+                This is usually temporary; wait a moment and try again."},
+            1,
+        ),
+        // A non-auth 4xx, or a body that did not parse as a build: an
+        // unrecognised response, reported as a generic service error and retried
+        // rather than escalated. Exit 1. Naming the variant rather than `_` makes
+        // a future error variant a compile error rather than a silent default.
+        FactoryClientError::APIError(_) => (
+            formatdoc! {"
+                The Flox Factory could not cancel build {id}.
+                This is usually temporary; wait a moment and try again."},
+            1,
+        ),
+    }
+}
+
+/// The outcome of a successful (HTTP 200) cancel response, read from the
+/// build's effective `status`.
+#[derive(Debug, PartialEq)]
+enum CancelOutcome {
+    /// The build reached a terminal state; the cancel is fully resolved.
+    /// Printed to stdout, exit 0.
+    Resolved(String),
+    /// The cancel was accepted but the build has not yet reached a terminal
+    /// state. Surfaced as a warning, exit 0: the idempotent DELETE succeeded,
+    /// so automation must not retry it.
+    Accepted(String),
+    /// A 200 whose status is outside the lifecycle vocabulary: a contract
+    /// violation, not a successful cancel. Surfaced as an error, exit 1.
+    Unexpected(String),
+}
+
+/// Classify a successful (HTTP 200) cancel response from the build's effective
+/// `status`.
+///
+/// The seven wire statuses parse into [`FactoryStatus`]; matching the enum makes
+/// a newly added server status a compile error here (once the client is
+/// regenerated) rather than a silent contract violation. `pending` is the one
+/// effective status the enum cannot represent: it is synthesized server-side for
+/// an undispatched build (`task_id IS NULL`), so it is matched on the string.
+///
+/// A satisfied cancel reports a terminal `cancelled`/`completed`/`failed`/
+/// `timed_out`. A non-terminal status (`running`/`queued`/`dispatching`/
+/// `pending`) means the cancel was accepted but the build has not yet stopped;
+/// like the read verbs, that is a normal outcome, not a retryable error. Only a
+/// status outside the lifecycle vocabulary is a contract violation.
+fn success_outcome(build: &BuildResponse, id: NonZeroU64) -> CancelOutcome {
+    let status = build.status.as_str();
+    match build.status.parse::<FactoryStatus>() {
+        Ok(FactoryStatus::Cancelled) => {
+            CancelOutcome::Resolved(format!("Cancellation initiated for build {id}."))
+        },
+        // `timed_out` is a terminal status in the factory `Status` vocabulary;
+        // the service normalizes it to `failed` on a response (see the
+        // `BuildResponse.status` docs), so it should not appear here, but a
+        // known terminal status must not read as a contract violation.
+        Ok(FactoryStatus::Completed | FactoryStatus::Failed | FactoryStatus::TimedOut) => {
+            CancelOutcome::Resolved(format!(
+                "Build {id} is already {status}; nothing to cancel."
+            ))
+        },
+        Ok(FactoryStatus::Running | FactoryStatus::Queued | FactoryStatus::Dispatching) => {
+            CancelOutcome::Accepted(accepted_message(id, status))
+        },
+        // `pending`: an undispatched build's synthesized status, outside the
+        // `FactoryStatus` enum but a known, non-terminal outcome.
+        Err(_) if status == "pending" => CancelOutcome::Accepted(accepted_message(id, status)),
+        // A status outside the lifecycle vocabulary is a contract violation, not
+        // a successful cancel.
+        Err(_) => CancelOutcome::Unexpected(formatdoc! {"
+            The Flox Factory returned an unexpected status '{status}' for build {id}.
+            Run 'flox factory status {id}' to check the build."}),
+    }
+}
+
+/// The "accepted but not yet terminal" message, shared by the non-terminal wire
+/// statuses and the synthesized `pending`.
+fn accepted_message(id: NonZeroU64, status: &str) -> String {
+    formatdoc! {"
+        Cancellation accepted for build {id}; it is {status} and not yet terminal.
+        Run 'flox factory status {id}' to follow it."}
+}
+
+/// Render a successful cancel: the human outcome line, or the raw build as JSON
+/// when `--json` is set (mirrors `status.rs`'s split).
+fn render(build: &BuildResponse, outcome: &str, json: bool) -> Result<String> {
+    if json {
+        Ok(format!("{}\n", serde_json::to_string_pretty(build)?))
+    } else {
+        Ok(format!("{outcome}\n"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroU64;
+
+    use flox_rust_sdk::utils::logging::test_helpers::test_subscriber_message_only;
+    use floxhub_client::FactoryApiError;
+    use pretty_assertions::assert_eq;
+    use tracing::instrument::WithSubscriber;
+
+    use super::*;
+    use crate::commands::factory::test_helpers::{StubFactoryClient, StubResult, make_build};
+
+    fn id(n: u64) -> NonZeroU64 {
+        NonZeroU64::new(n).unwrap()
+    }
+
+    // -------------------------------------------------------------------------
+    // success_outcome — the body-status -> outcome mapping
+    // -------------------------------------------------------------------------
+
+    fn build_with_status(status: &str) -> BuildResponse {
+        make_build(42, "x86_64-linux", "hello", Some(status))
+    }
+
+    #[test]
+    fn cancelled_status_is_resolved() {
+        assert_eq!(
+            success_outcome(&build_with_status("cancelled"), id(42)),
+            CancelOutcome::Resolved("Cancellation initiated for build 42.".to_string())
+        );
+    }
+
+    #[test]
+    fn completed_status_is_resolved() {
+        assert_eq!(
+            success_outcome(&build_with_status("completed"), id(42)),
+            CancelOutcome::Resolved(
+                "Build 42 is already completed; nothing to cancel.".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn failed_status_is_resolved() {
+        assert_eq!(
+            success_outcome(&build_with_status("failed"), id(42)),
+            CancelOutcome::Resolved("Build 42 is already failed; nothing to cancel.".to_string())
+        );
+    }
+
+    #[test]
+    fn timed_out_status_is_resolved() {
+        // `timed_out` is terminal, so it is an "already terminal" exit-0
+        // outcome, not a contract violation.
+        assert_eq!(
+            success_outcome(&build_with_status("timed_out"), id(42)),
+            CancelOutcome::Resolved(
+                "Build 42 is already timed_out; nothing to cancel.".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn non_terminal_status_is_accepted() {
+        // A 200 with a non-terminal status means the cancel was accepted but the
+        // build has not yet stopped: a normal exit-0 outcome, not a retry.
+        assert_eq!(
+            success_outcome(&build_with_status("running"), id(42)),
+            CancelOutcome::Accepted(
+                indoc! {"
+                    Cancellation accepted for build 42; it is running and not yet terminal.
+                    Run 'flox factory status 42' to follow it."}
+                .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn pending_status_is_accepted() {
+        // `pending` is an undispatched build's synthesized status: not in the
+        // `FactoryStatus` enum, but a known non-terminal outcome, so the cancel
+        // is accepted (exit 0) rather than read as a contract violation.
+        assert_eq!(
+            success_outcome(&build_with_status("pending"), id(42)),
+            CancelOutcome::Accepted(
+                indoc! {"
+                    Cancellation accepted for build 42; it is pending and not yet terminal.
+                    Run 'flox factory status 42' to follow it."}
+                .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn out_of_vocabulary_status_is_unexpected() {
+        // Only a status outside the lifecycle vocabulary is a contract violation.
+        assert_eq!(
+            success_outcome(&build_with_status("frobnicated"), id(42)),
+            CancelOutcome::Unexpected(
+                indoc! {"
+                    The Flox Factory returned an unexpected status 'frobnicated' for build 42.
+                    Run 'flox factory status 42' to check the build."}
+                .to_string()
+            )
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // classify_error — the exhaustive exit-code contract
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn not_found_is_exit_2() {
+        assert_eq!(
+            classify_error(&FactoryClientError::NotFound, id(7)),
+            (
+                indoc! {"
+                    No Flox Factory build found with ID 7.
+                    Use 'flox factory list' to see existing builds."}
+                .to_string(),
+                2,
+            )
+        );
+    }
+
+    #[test]
+    fn auth_rejected_is_exit_5() {
+        let err =
+            FactoryClientError::AuthRejected(FactoryApiError::InvalidRequest("auth".to_string()));
+        assert_eq!(
+            classify_error(&err, id(7)),
+            (
+                indoc! {"
+                    Authentication was rejected by the Flox Factory.
+                    Run 'flox auth login' and try again."}
+                .to_string(),
+                5,
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn transport_is_exit_4() {
+        // Port 0 is never a valid connection target, so the request always fails
+        // at the transport layer regardless of which ports are closed.
+        let transport = reqwest::get("http://127.0.0.1:0").await.unwrap_err();
+        assert_eq!(
+            classify_error(&FactoryClientError::Transport(transport), id(7)),
+            (
+                indoc! {"
+                    Could not reach the Flox Factory.
+                    Check your network connection and try again."}
+                .to_string(),
+                4,
+            )
+        );
+    }
+
+    #[test]
+    fn server_is_service_error_exit_1() {
+        // A 5xx is a retryable service fault; the cancel endpoint documents 502
+        // as retry-with-backoff.
+        let err = FactoryClientError::Server(FactoryApiError::InvalidRequest("5xx".to_string()));
+        assert_eq!(
+            classify_error(&err, id(7)),
+            (
+                indoc! {"
+                    The Flox Factory reported a server error for build 7.
+                    This is usually temporary; wait a moment and try again."}
+                .to_string(),
+                1,
+            )
+        );
+    }
+
+    #[test]
+    fn unrecognised_response_degrades_to_service_error_exit_1() {
+        // A non-auth 4xx, or a 200 whose body did not parse as a build, lands in
+        // the generic API error and degrades to a retryable service error rather
+        // than escalating to a bespoke outcome.
+        let err = FactoryClientError::APIError(FactoryApiError::InvalidRequest("boom".to_string()));
+        assert_eq!(
+            classify_error(&err, id(7)),
+            (
+                indoc! {"
+                    The Flox Factory could not cancel build 7.
+                    This is usually temporary; wait a moment and try again."}
+                .to_string(),
+                1,
+            )
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // render — the --json / human split
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn render_human_prints_the_outcome_line() {
+        let build = make_build(42, "x86_64-linux", "hello", Some("running"));
+        assert_eq!(
+            render(&build, "Cancellation initiated for build 42.", false).unwrap(),
+            "Cancellation initiated for build 42.\n"
+        );
+    }
+
+    #[test]
+    fn render_json_emits_the_build_and_ignores_the_outcome() {
+        let build = make_build(42, "x86_64-linux", "hello", Some("running"));
+        let rendered = render(&build, "OUTCOME LINE", true).unwrap();
+        // The JSON branch serializes the build and drops the human outcome
+        // line. Assert the behavior of the branch, not serde's round-trip
+        // fidelity (AGENTS.md).
+        assert!(!rendered.contains("OUTCOME LINE"));
+        assert!(rendered.contains("\"build_id\": 42"));
+        assert!(rendered.contains("\"status\": \"running\""));
+    }
+
+    // -------------------------------------------------------------------------
+    // handle — wiring the DELETE outcome to the exit-code contract
+    // -------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn successful_cancel_issues_delete_and_returns_ok() {
+        let client = StubFactoryClient::with_cancel(StubResult::Build("cancelled".to_string()));
+        let args = Cancel {
+            json: false,
+            id: id(42),
+        };
+
+        let result = async { args.handle(&client).await }
+            .with_subscriber(test_subscriber_message_only().0)
+            .await;
+
+        assert!(result.is_ok(), "expected Ok, got {result:?}");
+        assert!(
+            client.cancel_was_called(),
+            "the DELETE should have been issued"
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_failure_returns_exit_after_issuing_delete() {
+        let client = StubFactoryClient::with_cancel(StubResult::Server);
+        let args = Cancel {
+            json: false,
+            id: id(42),
+        };
+
+        let (subscriber, writer) = test_subscriber_message_only();
+        let err = async { args.handle(&client).await.unwrap_err() }
+            .with_subscriber(subscriber)
+            .await;
+
+        assert!(err.is::<Exit>(), "expected an Exit error, got {err:?}");
+        assert!(
+            client.cancel_was_called(),
+            "the DELETE should have been issued"
+        );
+        assert_eq!(writer.to_string(), indoc! {"
+            ✘ ERROR: The Flox Factory reported a server error for build 42.
+            This is usually temporary; wait a moment and try again.
+        "});
+    }
+
+    #[tokio::test]
+    async fn delete_non_terminal_status_warns_and_exits_zero() {
+        // A 200 with a non-terminal status means the cancel was accepted but the
+        // build has not yet stopped: a normal success (exit 0) with a warning,
+        // not a retryable error.
+        let client = StubFactoryClient::with_cancel(StubResult::Build("running".to_string()));
+        let args = Cancel {
+            json: false,
+            id: id(42),
+        };
+
+        let (subscriber, writer) = test_subscriber_message_only();
+        let result = async { args.handle(&client).await }
+            .with_subscriber(subscriber)
+            .await;
+
+        assert!(result.is_ok(), "expected Ok, got {result:?}");
+        assert!(
+            client.cancel_was_called(),
+            "the DELETE should have been issued"
+        );
+        assert_eq!(writer.to_string(), indoc! {"
+            ! Cancellation accepted for build 42; it is running and not yet terminal.
+            Run 'flox factory status 42' to follow it.
+        "});
+    }
+
+    #[tokio::test]
+    async fn delete_out_of_vocabulary_status_is_a_service_error() {
+        // A 200 whose status is outside the lifecycle vocabulary is a contract
+        // violation, not a successful cancel: the verb returns exit 1 and emits
+        // the error to stderr rather than printing the build to stdout.
+        let client = StubFactoryClient::with_cancel(StubResult::Build("frobnicated".to_string()));
+        let args = Cancel {
+            json: false,
+            id: id(42),
+        };
+
+        let (subscriber, writer) = test_subscriber_message_only();
+        let err = async { args.handle(&client).await.unwrap_err() }
+            .with_subscriber(subscriber)
+            .await;
+
+        assert!(err.is::<Exit>(), "expected an Exit error, got {err:?}");
+        assert!(
+            client.cancel_was_called(),
+            "the DELETE should have been issued"
+        );
+        assert_eq!(writer.to_string(), indoc! {"
+            ✘ ERROR: The Flox Factory returned an unexpected status 'frobnicated' for build 42.
+            Run 'flox factory status 42' to check the build.
+        "});
+    }
+
+    #[tokio::test]
+    async fn delete_not_found_returns_exit_2() {
+        // A DELETE against a missing build 404s; the client maps it to NotFound
+        // and the verb exits 2. The DELETE is what produced the 404, so it was
+        // issued.
+        let client = StubFactoryClient::with_cancel(StubResult::NotFound);
+        let args = Cancel {
+            json: false,
+            id: id(42),
+        };
+
+        let (subscriber, writer) = test_subscriber_message_only();
+        let err = async { args.handle(&client).await.unwrap_err() }
+            .with_subscriber(subscriber)
+            .await;
+
+        assert!(err.is::<Exit>(), "expected an Exit error, got {err:?}");
+        assert!(
+            client.cancel_was_called(),
+            "the DELETE should have been issued"
+        );
+        assert_eq!(writer.to_string(), indoc! {"
+            ✘ ERROR: No Flox Factory build found with ID 42.
+            Use 'flox factory list' to see existing builds.
+        "});
+    }
+
+    #[tokio::test]
+    async fn delete_auth_rejected_returns_exit_5() {
+        // Auth rejected on the DELETE is never retryable: exit 5.
+        let client = StubFactoryClient::with_cancel(StubResult::AuthRejected);
+        let args = Cancel {
+            json: false,
+            id: id(42),
+        };
+
+        let (subscriber, writer) = test_subscriber_message_only();
+        let err = async { args.handle(&client).await.unwrap_err() }
+            .with_subscriber(subscriber)
+            .await;
+
+        assert!(err.is::<Exit>(), "expected an Exit error, got {err:?}");
+        assert_eq!(writer.to_string(), indoc! {"
+            ✘ ERROR: Authentication was rejected by the Flox Factory.
+            Run 'flox auth login' and try again.
+        "});
+    }
+
+    #[tokio::test]
+    async fn id_beyond_i64_max_is_not_found_without_a_request() {
+        // An ID above i64::MAX cannot name a real build. The stub would answer
+        // the DELETE successfully, so reaching the not-found path at all proves
+        // the range guard fired before any request — and no DELETE was issued.
+        let client = StubFactoryClient::with_cancel(StubResult::Build("cancelled".to_string()));
+        let args = Cancel {
+            json: false,
+            id: NonZeroU64::new(u64::MAX).unwrap(),
+        };
+
+        let (subscriber, writer) = test_subscriber_message_only();
+        let err = async { args.handle(&client).await.unwrap_err() }
+            .with_subscriber(subscriber)
+            .await;
+
+        assert!(err.is::<Exit>(), "expected an Exit error, got {err:?}");
+        assert!(
+            !client.cancel_was_called(),
+            "no DELETE should be issued for an out-of-range ID"
+        );
+        assert_eq!(writer.to_string(), indoc! {"
+            ✘ ERROR: No Flox Factory build found with ID 18446744073709551615.
+            Use 'flox factory list' to see existing builds.
+        "});
+    }
+}

--- a/cli/flox/src/commands/factory/mod.rs
+++ b/cli/flox/src/commands/factory/mod.rs
@@ -1,8 +1,9 @@
-//! `flox factory` command namespace: read-only build inspection for operators.
+//! `flox factory` command namespace: read-only build inspection for operators,
+//! plus the destructive `cancel` verb.
 //!
-//! Hidden from `flox --help`; discoverable via the operator runbook. `Logs`
-//! (ECO-99) and `Cancel` (ECO-100) are future verbs.
+//! Hidden from `flox --help`; discoverable via the operator runbook.
 
+mod cancel;
 mod list;
 mod logs;
 mod status;
@@ -99,7 +100,10 @@ pub enum FactoryCommands {
     /// Print the logs for a single Flox Factory build
     #[bpaf(command)]
     Logs(#[bpaf(external(logs::logs))] logs::Logs),
-    // ECO-100 will add: Cancel(#[bpaf(external(cancel::cancel))] cancel::Cancel),
+
+    /// Cancel a single Flox Factory build
+    #[bpaf(command)]
+    Cancel(#[bpaf(external(cancel::cancel))] cancel::Cancel),
 }
 
 impl FactoryCommands {
@@ -116,6 +120,7 @@ impl FactoryCommands {
             FactoryCommands::Status(args) => args.handle(&flox.floxhub_client).await,
             FactoryCommands::List(args) => args.handle(&flox.floxhub_client).await,
             FactoryCommands::Logs(args) => args.handle(&flox.floxhub_client).await,
+            FactoryCommands::Cancel(args) => args.handle(&flox.floxhub_client).await,
         }
     }
 }
@@ -124,13 +129,17 @@ impl FactoryCommands {
 pub(crate) mod test_helpers {
     //! Shared test fixtures for the factory verb handler tests.
 
+    use std::sync::atomic::{AtomicBool, Ordering};
+
     use chrono::TimeZone;
     use factory_api_v1::types::TaskResponse;
     use floxhub_client::{
         BuildResponse,
+        FactoryApiError,
         FactoryByteStream,
         FactoryClientError,
         FactoryClientTrait,
+        FactoryErrorResponse,
     };
 
     /// Construct a `BuildResponse` fixture. A `Some(task_status)` attaches a
@@ -172,15 +181,87 @@ pub(crate) mod test_helpers {
         }
     }
 
-    /// In-test stub implementing [`FactoryClientTrait`], used to drive the
-    /// `status` handler down its not-found path without a live service.
+    /// The outcome a [`StubFactoryClient`] method yields.
+    ///
+    /// [`FactoryClientError`] is not `Clone` (its `Transport` case wraps a
+    /// `reqwest::Error`), so the error cases are named here and the variant is
+    /// built on demand rather than stored. `Transport` is omitted because it
+    /// cannot be constructed without a live failed request; the cancel verb's
+    /// transport path is covered by the pure classifier tests instead.
+    #[derive(Clone)]
+    pub enum StubResult {
+        /// Return a build whose top-level `status` is this string.
+        Build(String),
+        /// Return [`FactoryClientError::NotFound`].
+        NotFound,
+        /// Return [`FactoryClientError::AuthRejected`].
+        AuthRejected,
+        /// Return [`FactoryClientError::Server`].
+        Server,
+    }
+
+    impl StubResult {
+        fn realize(&self) -> Result<BuildResponse, FactoryClientError> {
+            match self {
+                // Build the fixture coherently: `Some(status)` sets both the
+                // task lifecycle status and the top-level status, preserving
+                // `make_build`'s invariant rather than mutating after the fact.
+                StubResult::Build(status) => {
+                    Ok(make_build(1, "x86_64-linux", "hello", Some(status)))
+                },
+                StubResult::NotFound => Err(FactoryClientError::NotFound),
+                StubResult::AuthRejected => Err(FactoryClientError::AuthRejected(stub_api_error())),
+                StubResult::Server => Err(FactoryClientError::Server(stub_api_error())),
+            }
+        }
+    }
+
+    /// A placeholder API error for the stub's typed-error outcomes. The cancel
+    /// handler renders its own curated message for `AuthRejected`/`Server`, so
+    /// the handler tests never inspect this payload (the client-layer detail
+    /// assertion uses a mock, not the stub); it exists only to satisfy the
+    /// variant shape now that those variants wrap the underlying error.
+    fn stub_api_error() -> FactoryApiError<FactoryErrorResponse> {
+        FactoryApiError::<FactoryErrorResponse>::InvalidRequest("stubbed factory error".to_string())
+    }
+
+    /// In-test stub implementing [`FactoryClientTrait`].
+    ///
+    /// Drives `get_build` (the `status` lookup) and `cancel_build` (the DELETE)
+    /// to independent [`StubResult`] outcomes, and records whether the DELETE was
+    /// issued so a cancel test can assert the range guard short-circuits before
+    /// it.
     pub struct StubFactoryClient {
-        not_found: bool,
+        get_build: StubResult,
+        cancel_build: StubResult,
+        cancel_called: AtomicBool,
     }
 
     impl StubFactoryClient {
+        /// A stub whose every lookup reports the build as missing.
         pub fn with_not_found() -> Self {
-            Self { not_found: true }
+            Self::with_outcomes(StubResult::NotFound, StubResult::NotFound)
+        }
+
+        /// A stub whose `get_build` (the `status` lookup) yields `get_build` and
+        /// whose DELETE (`cancel_build`) yields `cancel_build`.
+        pub fn with_outcomes(get_build: StubResult, cancel_build: StubResult) -> Self {
+            Self {
+                get_build,
+                cancel_build,
+                cancel_called: AtomicBool::new(false),
+            }
+        }
+
+        /// A stub exercising only the DELETE (`cancel_build`). The `cancel` verb
+        /// issues no `get_build`, so that slot is an inert `NotFound` placeholder.
+        pub fn with_cancel(cancel_build: StubResult) -> Self {
+            Self::with_outcomes(StubResult::NotFound, cancel_build)
+        }
+
+        /// Whether `cancel_build` (the DELETE) was ever invoked.
+        pub fn cancel_was_called(&self) -> bool {
+            self.cancel_called.load(Ordering::SeqCst)
         }
     }
 
@@ -189,9 +270,9 @@ pub(crate) mod test_helpers {
             &self,
             _status: Option<&str>,
         ) -> Result<floxhub_client::ResultsPage<BuildResponse>, FactoryClientError> {
-            if self.not_found {
-                return Err(FactoryClientError::NotFound);
-            }
+            // Mirror the get_build outcome's error, if any, so a not-found stub
+            // stays not-found across endpoints; otherwise an empty page.
+            self.get_build.realize()?;
             Ok(floxhub_client::ResultsPage {
                 results: vec![],
                 count: Some(0),
@@ -199,19 +280,21 @@ pub(crate) mod test_helpers {
         }
 
         async fn get_build(&self, _build_id: i64) -> Result<BuildResponse, FactoryClientError> {
-            if self.not_found {
-                return Err(FactoryClientError::NotFound);
-            }
-            Ok(make_build(1, "x86_64-linux", "hello", Some("running")))
+            self.get_build.realize()
+        }
+
+        async fn cancel_build(&self, _build_id: i64) -> Result<BuildResponse, FactoryClientError> {
+            self.cancel_called.store(true, Ordering::SeqCst);
+            self.cancel_build.realize()
         }
 
         async fn get_build_logs(
             &self,
             _build_id: i64,
         ) -> Result<FactoryByteStream, FactoryClientError> {
-            if self.not_found {
-                return Err(FactoryClientError::NotFound);
-            }
+            // Mirror the get_build outcome's error, if any, so a not-found stub
+            // stays not-found across endpoints; otherwise serve the canned stream.
+            self.get_build.realize()?;
             let lines: [&[u8]; 2] = [b"Building hello...\n", b"Build completed.\n"];
             let chunks = lines
                 .into_iter()

--- a/cli/floxhub-client/src/factory.rs
+++ b/cli/floxhub-client/src/factory.rs
@@ -40,7 +40,28 @@ pub enum FactoryClientError {
     #[error("could not reach the Flox Factory")]
     Transport(#[source] reqwest::Error),
 
+    /// Authentication or authorization was rejected (HTTP 401/403).
+    ///
+    /// Distinct from a generic API error because it is never retryable: the
+    /// caller must re-authenticate, not back off. Wraps the underlying error so
+    /// the server's `detail` still renders, matching the `APIError` variant.
+    #[error("{}", fmt_api_error(.0))]
+    AuthRejected(APIError<ErrorResponse>),
+
+    /// The Flox Factory reported a server-side error (HTTP 5xx, or 422).
+    ///
+    /// Distinct from [`FactoryClientError::Transport`] because the host did
+    /// respond: the failure is the service's, and the same request may succeed
+    /// on retry. Wraps the underlying error so the server's `detail` still
+    /// renders, matching the `APIError` variant.
+    #[error("{}", fmt_api_error(.0))]
+    Server(APIError<ErrorResponse>),
+
     /// Any other factory API error, rendered from the generated error type.
+    ///
+    /// This includes an unrecognised response (a non-auth 4xx, or a 200 whose
+    /// body did not parse as a `BuildResponse`): it degrades to this generic
+    /// case rather than escalating to a bespoke variant.
     #[error("{}", fmt_api_error(.0))]
     APIError(APIError<ErrorResponse>),
 }
@@ -123,6 +144,34 @@ fn not_found_on_404(err: FactoryClientError) -> FactoryClientError {
     }
 }
 
+/// Classify a single-build resource error into the typed variants that the
+/// cancel verb's exit-code space distinguishes.
+///
+/// Applied by [`FactoryClientTrait::cancel_build`], whose caller must tell apart
+/// a missing build, an auth rejection, a server-side fault, and a 200 whose body
+/// did not come from Factory Service. Builds on [`not_found_on_404`] for the 404
+/// case. Endpoints without that need (`get_build`, the listing endpoint) keep
+/// the underlying API error.
+fn classify_build_error(err: FactoryClientError) -> FactoryClientError {
+    let api = match not_found_on_404(err) {
+        FactoryClientError::APIError(api) => api,
+        // NotFound, Transport, and the typed variants are already classified.
+        other => return other,
+    };
+
+    match api.status().map(|status| status.as_u16()) {
+        // Auth failures are never retryable; keep them distinct from 5xx.
+        Some(401 | 403) => FactoryClientError::AuthRejected(api),
+        // 5xx is a service fault. 422 only arises from a non-integer path
+        // (FastAPI request validation), which an `i64` never produces, so it is
+        // mapped here defensively rather than left as a generic API error.
+        Some(422 | 500..=599) => FactoryClientError::Server(api),
+        // Everything else (a non-auth 4xx, or a 200 whose body did not parse as
+        // a `BuildResponse`) degrades to the generic API error.
+        _ => FactoryClientError::APIError(api),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // FactoryClientTrait
 // ---------------------------------------------------------------------------
@@ -142,6 +191,13 @@ pub trait FactoryClientTrait {
 
     /// Fetch a single build by its numeric ID.
     async fn get_build(&self, build_id: i64) -> Result<BuildResponse, FactoryClientError>;
+
+    /// Cancel a single build by its numeric ID (DELETE).
+    ///
+    /// Idempotent: a satisfied-intent cancel returns the build with its
+    /// effective `status`; the caller reads that field to distinguish a
+    /// just-initiated cancellation from an already-terminal build.
+    async fn cancel_build(&self, build_id: i64) -> Result<BuildResponse, FactoryClientError>;
 
     /// Proxy the raw log stream for a build.
     async fn get_build_logs(&self, build_id: i64) -> Result<ByteStream, FactoryClientError>;
@@ -181,8 +237,8 @@ impl FactoryClientTrait for crate::FloxhubClient {
 
     async fn get_build(&self, build_id: i64) -> Result<BuildResponse, FactoryClientError> {
         // A 404 on this resource-specific endpoint means the build ID does not
-        // exist; reclassify it so the caller can say so. Other endpoints leave
-        // a 404 as the underlying API error.
+        // exist; reclassify it so the `status` verb can report it as such. Other
+        // endpoints leave a 404 as the underlying API error.
         Ok(self
             .factory
             .get_build_api_v1_factory_builds_build_id_get(build_id)
@@ -190,6 +246,20 @@ impl FactoryClientTrait for crate::FloxhubClient {
             .map_api_error()
             .await
             .map_err(not_found_on_404)?
+            .into_inner())
+    }
+
+    async fn cancel_build(&self, build_id: i64) -> Result<BuildResponse, FactoryClientError> {
+        // The slice's one destructive call. Every HTTP and transport outcome is
+        // classified here so the verb can map each to a distinct exit code
+        // without re-inspecting raw responses at the call site.
+        Ok(self
+            .factory
+            .cancel_build_api_v1_factory_builds_build_id_delete(build_id)
+            .await
+            .map_api_error()
+            .await
+            .map_err(classify_build_error)?
             .into_inner())
     }
 
@@ -475,7 +545,8 @@ pub mod tests {
         // does not exist, so get_build classifies it as NotFound.
         let server = MockServer::start_async().await;
         let mock = server.mock(|when, then| {
-            when.method("GET").path("/api/v1/factory/builds/7");
+            when.method("GET")
+                .path(format!("/api/v1/factory/builds/{BUILD_ID}"));
             then.status(404)
                 .json_body(json!({ "detail": "Build not found" }));
         });
@@ -485,12 +556,185 @@ pub mod tests {
             ..client_config(&server.base_url())
         };
         let client = crate::FloxhubClient::new(config).unwrap();
-        let err = client.get_build(7).await.unwrap_err();
+        let err = client.get_build(BUILD_ID).await.unwrap_err();
 
         mock.assert();
         assert!(
             matches!(err, FactoryClientError::NotFound),
             "expected NotFound, got {err:?}"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // cancel_build / classify_build_error
+    //
+    // Each test drives `cancel_build` against a mock and asserts the DELETE
+    // outcome maps to the right `FactoryClientError` variant — the exhaustive
+    // coverage of the classification the verb's exit-code space depends on.
+    // -------------------------------------------------------------------------
+
+    /// The build ID every single-build mock in this module serves.
+    const BUILD_ID: i64 = 7;
+
+    /// A complete `BuildResponse` body with the given effective `status`, built
+    /// from the typed `BuildResponse` and serialized so the wire fixture fails
+    /// loudly if a required field is added or changed, rather than silently
+    /// omitting it and parsing a degenerate body.
+    fn valid_build_json(status: &str) -> serde_json::Value {
+        serde_json::to_value(BuildResponse {
+            attr_path: "hello".to_string(),
+            build_id: BUILD_ID,
+            build_type: "nixpkgs".to_string(),
+            catalog_name: "my-catalog".to_string(),
+            created_at: "2025-01-01T00:00:00Z".parse().unwrap(),
+            exit_code: None,
+            nixpkgs_revision: "deadbeef1234567890deadbeef1234567890dead".to_string(),
+            source_commit_sha: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2".to_string(),
+            source_repo_url: "https://github.com/example/repo".to_string(),
+            status: status.to_string(),
+            system: "x86_64-linux".to_string(),
+            task: None,
+        })
+        .expect("BuildResponse serializes")
+    }
+
+    /// Start a mock server returning `status`/`body` for the single-build DELETE,
+    /// then call `cancel_build` and return its result.
+    async fn cancel_build_against_mock(
+        status: u16,
+        body: serde_json::Value,
+    ) -> Result<BuildResponse, FactoryClientError> {
+        let server = MockServer::start_async().await;
+        let mock = server.mock(|when, then| {
+            when.method("DELETE")
+                .path(format!("/api/v1/factory/builds/{BUILD_ID}"));
+            then.status(status).json_body(body);
+        });
+
+        let config = FloxhubClientConfig {
+            base_url: server.base_url(),
+            ..client_config(&server.base_url())
+        };
+        let client = crate::FloxhubClient::new(config).unwrap();
+        let result = client.cancel_build(BUILD_ID).await;
+
+        mock.assert();
+        result
+    }
+
+    #[tokio::test]
+    async fn cancel_build_returns_build_on_200() {
+        // A satisfied cancel returns the build; the caller reads the effective
+        // `status` to tell a fresh cancellation from an already-terminal build.
+        let build = cancel_build_against_mock(200, valid_build_json("cancelled"))
+            .await
+            .unwrap();
+        let expected = BuildResponse {
+            attr_path: "hello".to_string(),
+            build_id: BUILD_ID,
+            build_type: "nixpkgs".to_string(),
+            catalog_name: "my-catalog".to_string(),
+            created_at: "2025-01-01T00:00:00Z".parse().unwrap(),
+            exit_code: None,
+            nixpkgs_revision: "deadbeef1234567890deadbeef1234567890dead".to_string(),
+            source_commit_sha: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2".to_string(),
+            source_repo_url: "https://github.com/example/repo".to_string(),
+            status: "cancelled".to_string(),
+            system: "x86_64-linux".to_string(),
+            task: None,
+        };
+        assert_eq!(build, expected);
+    }
+
+    #[tokio::test]
+    async fn cancel_build_maps_404_to_not_found() {
+        let err = cancel_build_against_mock(404, json!({ "detail": "Build not found" }))
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, FactoryClientError::NotFound),
+            "expected NotFound, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancel_build_maps_401_to_auth_rejected() {
+        let err = cancel_build_against_mock(401, json!({ "detail": "Unauthorized" }))
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, FactoryClientError::AuthRejected(_)),
+            "expected AuthRejected, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancel_build_maps_403_to_auth_rejected() {
+        let err = cancel_build_against_mock(403, json!({ "detail": "Forbidden" }))
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, FactoryClientError::AuthRejected(_)),
+            "expected AuthRejected, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancel_build_maps_502_to_server() {
+        let err =
+            cancel_build_against_mock(502, json!({ "detail": "Build Coordinator unreachable" }))
+                .await
+                .unwrap_err();
+        assert!(
+            matches!(err, FactoryClientError::Server(_)),
+            "expected Server, got {err:?}"
+        );
+        // The typed variant still renders the server's own `detail`, so callers
+        // like `flox factory status` keep the diagnostic context.
+        assert!(
+            err.to_string().contains("Build Coordinator unreachable"),
+            "expected the server detail to survive, got {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancel_build_maps_422_to_server() {
+        let err = cancel_build_against_mock(422, json!({ "detail": "Unprocessable" }))
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, FactoryClientError::Server(_)),
+            "expected Server, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancel_build_maps_200_wrong_shape_to_api_error() {
+        // A 200 whose body is not a `BuildResponse` degrades to the generic API
+        // error rather than escalating to a bespoke variant; the verb reports it
+        // as a retryable service error.
+        let err = cancel_build_against_mock(200, json!({ "unexpected": "shape" }))
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, FactoryClientError::APIError(_)),
+            "expected APIError, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancel_build_maps_connection_failure_to_transport() {
+        // Port 0 is never a valid connection target, so the DELETE always fails
+        // at the transport layer regardless of which ports are closed.
+        let config = FloxhubClientConfig {
+            base_url: "http://127.0.0.1:0".to_string(),
+            ..client_config("http://127.0.0.1:0")
+        };
+        let client = crate::FloxhubClient::new(config).unwrap();
+        let err = client.cancel_build(7).await.unwrap_err();
+        assert!(
+            matches!(err, FactoryClientError::Transport(_)),
+            "expected Transport, got {err:?}"
         );
     }
 


### PR DESCRIPTION
## Proposed Changes

Closes [ECO-100](https://linear.app/floxdotdev/issue/ECO-100/sl-005-flox-cli-flox-factory-cancel-verb-exit-code-space-fail-closed).

Add a currently hidden `flox factory cancel <ID>` command, the one
destructive verb in the `factory` operator namespace. It cancels a single
build by issuing `DELETE /api/v1/factory/builds/{id}` and prints a one-line
outcome.

The verb is built for scripting, so its process exit code alone tells
automation what to do next; no stdout parsing is required. Cancellation is
idempotent (a satisfied cancel always returns 200; ADR-008), so the success
cases are told apart by the response body's effective `status` field rather
than by the HTTP code.

| Exit | Outcome | Condition |
|------|---------|-----------|
| `0` | cancellation initiated | `status` is `cancelled` |
| `0` | already terminal | `status` is `completed`, `failed`, or `timed_out` |
| `0` | accepted, not yet terminal | non-terminal `status` (`running`/`queued`/`dispatching`/`pending`); warns, does not retry |
| `1` | service error | 5xx/422, a 200 with an out-of-vocabulary status, or any other unrecognized response |
| `2` | not found | no such build |
| `4` | unreachable | no HTTP response (DNS, refused, TLS, timeout) |
| `5` | auth rejected | 401/403, not retryable |

A 200 that carries a non-terminal status means the cancel was accepted but
the build has not yet stopped. Like the read verbs (`status`, `list`), the
CLI treats that as a normal, successful outcome (exit 0 with a warning)
rather than a retryable error. The effective `status` is parsed into the
generated `FactoryStatus` enum and matched exhaustively, so a status added
to the wire vocabulary becomes a compile error in the CLI after the client
is regenerated rather than a silent fallthrough; the one effective value the
enum cannot represent, the pre-dispatch `pending`, is matched explicitly
alongside the other non-terminal statuses.

An earlier revision gated the `DELETE` behind a read-only pre-flight `GET`,
on the premise that a well-formed `BuildResponse` proved the target host was
Factory Service. That check was removed on review. A host that is not
Factory Service has no destructive handler at `/api/v1/factory/builds/{id}`,
so the `DELETE` is already inert there; and a different but valid Factory
answers the pre-flight exactly as it answers the `DELETE`, so the gate could
not tell the intended host from the wrong one. Because the factory client
shares its base URL with the catalog client, pointing `FLOX_CATALOG_URL` at
the wrong host stays an operator responsibility rather than a CLI guard (the
accepted shared-URL risk; decisions.md Key Decision 2). The verb keeps one
narrow guard: an ID beyond the server's signed-integer range cannot name a
real build, so it is rejected as not found before any request is issued,
keeping a wrapped negative ID off the destructive endpoint.

All HTTP and transport classification lives in the client error layer
(`floxhub-client`): new `FactoryClientError` variants (`AuthRejected`,
`Server`) and a `classify_build_error` reclassifier map each response to a
typed error, so the verb holds only policy (exit codes and messages). The
reclassifier is applied to `cancel_build`, whose exit-code space needs to
tell those cases apart; `get_build` keeps the lighter `not_found_on_404`,
which is all the `status` verb needs, so that verb's error output is
unchanged from `main`. The typed variants wrap the underlying error and
render via `fmt_api_error`, so the server's own `detail` is preserved.

Typing the Factory Service `BuildResponse.status` field as an enum in the
schema (it is a free string today, which is why the CLI parses it into
`FactoryStatus` at the boundary) is tracked as a separate follow-up,
[ECO-111](https://linear.app/floxdotdev/issue/ECO-111/sl-005-factory-service-type-buildresponsestatus-as-an-enum),
sequenced after the effective-status contract design in
[ECO-97](https://linear.app/floxdotdev/issue/ECO-97/factory-design-the-get-builds-list-query-contract-effective-status).

Tests are unit-only; the end-to-end bats coverage for cancel is deferred to
ECO-81. Verified locally:

- `cargo test` for the verb and client layers passes; `cargo clippy` and
  `cargo fmt` are clean.
- `flox --help` does not list `factory` (hidden), and `flox factory cancel
  --help` renders `[--json] ID` and the exit-code list without the bpaf
  help-render panic the namespace guards against.
- The full exit code space is exercised by a pure classifier under unit
  test, plus a smoke against an unreachable host (exit 4). A live smoke
  against a running dev Factory Service is still outstanding; it needs a
  service to point at, and the exit code contract is covered without one.

One operator-runbook item is owed externally: the Build Coordinator
cancel-race window (a just-finished build yields exit `1`, self-correcting
on one retry). The `FLOX_CATALOG_URL` verification noted above is the other
operator-facing caveat.

## Release Notes

N/A, unreleased
