### PR TITLE
fix(activations): close detach and PID handoff races

### DIFF
--- a/cli/flox-activations/src/cli/executive/mod.rs
+++ b/cli/flox-activations/src/cli/executive/mod.rs
@@ -331,44 +331,45 @@ fn handle_process_exited(
     // Use PidWatcher to clean up the state
     match watcher::cleanup_pid(state_json_path, activation_state_dir, pid) {
         Ok(None) => {
-            // Still have active PIDs - check if this PID re-attached
-            // and needs to be monitored again.
+            // Still have active PIDs. Reconcile every attachment instead of
+            // relying solely on StateFileChanged: replacing the short-lived
+            // `flox-activations` PID with the shell PID can race the file
+            // watcher notification.
             //
-            // Note: This is intentionally redundant with the file watcher
-            // in start_state_watcher(). The file watcher handles the normal
-            // case where state.json is modified and we detect new PIDs.
-            // However, if the PID re-attaches between stop_monitoring() and
-            // cleanup_pids(), and the file watcher event hasn't fired yet,
-            // this check ensures we don't miss it. The redundancy is safe
-            // because start_monitoring() is idempotent.
+            // This is intentionally redundant with the file watcher in
+            // start_state_watcher(). The redundancy is safe because
+            // start_monitoring() is idempotent.
             //
-            // This also hypothetically catches the case where a PID exits
-            // before its expiration and the watcher thread sends an event early.
-            // That's not currently reachable because the watcher should sleep,
-            // but the watcher shouldn't be treated as the authority on expired
-            // PIDs.
+            // The PID that generated this event needs separate loop
+            // protection because it may have re-attached or remained attached
+            // until an expiration. Other PIDs have not generated this event,
+            // so they can be monitored normally.
             let (activations_json, _lock) = read_activations_json(state_json_path)?;
             let Some(activations) = activations_json else {
                 bail!("executive shouldn't be running when state.json doesn't exist");
             };
-            // Check if the PID that triggered this event is still in state
-            let pid_reused = activations
-                .all_attached_pids_and_expiration()
-                .into_iter()
-                .find(|(attached_pid, _)| *attached_pid == pid);
-            if let Some((pid, expiration)) = pid_reused {
-                if loop_guard.allow_remonitor(pid) {
-                    debug!(pid, "PID re-attached to activation, starting new monitor");
-                    coordinator
-                        .start_monitoring(pid, expiration)
-                        .context("failed to restart monitoring for re-attached PID")?;
-                } else {
-                    error!(
-                        pid,
-                        "PID re-monitored too many times, skipping to prevent loop"
-                    );
+
+            for (attached_pid, expiration) in activations.all_attached_pids_and_expiration() {
+                if attached_pid == pid {
+                    if loop_guard.allow_remonitor(pid) {
+                        debug!(pid, "PID re-attached to activation, starting new monitor");
+                        coordinator
+                            .start_monitoring(pid, expiration)
+                            .context("failed to restart monitoring for re-attached PID")?;
+                    } else {
+                        error!(
+                            pid,
+                            "PID re-monitored too many times, skipping to prevent loop"
+                        );
+                    }
+                    continue;
                 }
+
+                coordinator
+                    .start_monitoring(attached_pid, expiration)
+                    .context("failed to monitor attached PID after process exit")?;
             }
+
             Ok(false)
         },
         Ok(Some(locked_activations)) => {
@@ -642,19 +643,19 @@ mod test {
         stop_process(proc);
     }
 
-    /// Test that handle_process_exited is a no-op when the PID is not in state.json.
+    /// Test that handle_process_exited monitors replacement PIDs even when no
+    /// StateFileChanged event is delivered.
     ///
     /// This can happen in two cases:
     /// 1. --remove-pid removes a PID from state.json, but the
     ///    executive still has a watcher running for that PID.
     /// 2. `flox-activations detach` removes a PID from state.json
     ///
-    /// In either case, when the process eventually exits and the executive
-    /// receives a ProcessExited event, it should be a no-op.
-    ///
-    /// We mimic scenario 1 here
+    /// In either case, handling the stale ProcessExited event must reconcile
+    /// the replacement PID directly. Filesystem notifications are a fast path,
+    /// not the only path that preserves cleanup correctness.
     #[test]
-    fn process_exited_noop_for_pid_not_in_state() {
+    fn process_exited_reconciles_replacement_pid() {
         let temp_dir = tempfile::tempdir().unwrap();
         let runtime_dir = temp_dir.path();
         let dot_flox_path = PathBuf::from(".flox");
@@ -714,10 +715,10 @@ mod test {
             &activation_state_directory,
         );
 
-        // Should return Ok(false) - no cleanup needed, still have active PIDs
+        // No cleanup is needed while the replacement PID is active.
         assert!(
             matches!(result, Ok(false)),
-            "handle_process_exited should return Ok(false) for PID not in state, got: {:?}",
+            "handle_process_exited should keep monitoring while replacement PIDs remain, got: {:?}",
             result
         );
 
@@ -725,8 +726,32 @@ mod test {
         let final_state = read_activation_state(runtime_dir, &dot_flox_path);
         assert_eq!(initial_state, final_state);
 
-        // Clean up
+        // The replacement must be monitored without injecting a
+        // StateFileChanged event.
         stop_process(proc2);
+        let event = coordinator
+            .receiver
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .expect("replacement PID should be monitored");
+        assert_eq!(event, ExecutiveEvent::ProcessExited { pid: pid2 });
+
+        let result = handle_process_exited(
+            pid2,
+            &coordinator,
+            &mut loop_guard,
+            &state_json,
+            &project.process_compose_bin,
+            &project.flox_services_socket,
+            &activation_state_directory,
+        );
+        assert!(
+            matches!(result, Ok(true)),
+            "replacement PID exit should clean up the activation, got: {result:?}"
+        );
+        assert!(
+            !activation_state_directory.exists(),
+            "activation state should be removed after the replacement PID exits"
+        );
     }
 
     #[test]

--- a/cli/flox-core/src/activations.rs
+++ b/cli/flox-core/src/activations.rs
@@ -514,10 +514,7 @@ impl ActivationState {
         // Return the start_id only when no remaining attachment references it.
         let has_remaining = self.attached_pids.values().any(|a| a.start_id == start_id);
 
-        // Only update ready state if there are still attached PIDs
-        if !self.attached_pids.is_empty() {
-            self.update_ready_after_detach();
-        }
+        self.update_ready_after_detach();
 
         if has_remaining {
             Ok(None)
@@ -575,11 +572,15 @@ impl ActivationState {
     }
 
     /// Set ready to False if there are no more PIDs attached to the current start
-    /// Should only be called when there are some attached PIDs
+    ///
+    /// This includes the case where nothing is attached at all: `detach`'s
+    /// caller removes the emptied start's state directory before dropping the
+    /// lock, so a `ready` left naming that start would send the next
+    /// activation down the attach path to read files that are already gone.
+    /// The whole activation state directory is torn down shortly afterwards by
+    /// the executive, but not under the same lock, so the state has to be
+    /// self-consistent in the meantime.
     fn update_ready_after_detach(&mut self) {
-        if self.attached_pids.is_empty() {
-            unreachable!("should remove all state when there are no more attached PIDs");
-        }
         match self.ready {
             Ready::True(ref start_id) => {
                 if !self.attachments_by_start_id().contains_key(start_id) {
@@ -1277,6 +1278,36 @@ mod tests {
         assert!(activations.attached_pids.contains_key(&pid));
         assert!(!modified);
         assert!(empty_start.is_none());
+    }
+
+    mod detach {
+        use super::*;
+
+        /// `flox-activations detach` deletes the emptied start's state
+        /// directory as soon as the last PID detaches, so a re-activation that
+        /// beats the executive's `cleanup_all` must start fresh. Leaving
+        /// `ready` as `Ready::True(start_id)` sends it down the attach path
+        /// instead, to read a `start.env.json` that is already gone.
+        #[test]
+        fn reactivation_after_last_detach_starts_instead_of_attaching() {
+            let start_id = StartIdentifier::new("/nix/store/path1");
+            let mut activations = make_activations(Ready::True(start_id.clone()));
+            let pid = 123;
+            activations.attach(pid, make_attachment(start_id.clone()));
+            activations.detach(pid).unwrap();
+
+            // Deliberately no assertion on the new StartIdentifier: it is
+            // millisecond-stamped, so a fast run mints one equal to the old.
+            // Taking the Start arm is the invariant that matters — it re-runs
+            // the activation and recreates the directory, where Attach would
+            // read the files detach removed.
+            let result = activations.start_or_attach(456, &start_id.store_path);
+
+            assert!(
+                matches!(result, StartOrAttachResult::Start { .. }),
+                "Expected StartOrAttachResult::Start, got {result:?}"
+            );
+        }
     }
 
     mod running_processes {


### PR DESCRIPTION
## Summary

Fix two activation lifecycle races that can leave activation state inconsistent during teardown:

1. Clear `ready` when the final PID detaches, before the emptied start directory is removed.
2. Reconcile all attached PIDs after a process exits, so cleanup does not depend on receiving every filesystem notification.

The first change is the same fix merged into `release-1.14.0` by #4556. This PR brings it to `main` and adds the independent PID-handoff fix.

## Problem

### Stale ready state

The final detach removed the start state directory but could leave `ready` pointing to that start until the executive completed asynchronous cleanup. An activation starting during that window took the attach path and attempted to read snapshot files that had already been removed.

Clearing `ready` during detach keeps `state.json` consistent with the filesystem. A racing activation starts fresh and recreates its snapshot files.

### Missed PID handoff

During activation, the short-lived activation process is replaced by the user shell PID in `state.json`. The executive normally discovers the replacement through a filesystem notification.

If that notification is missed or coalesced, the replacement PID is never monitored. Its eventual exit can therefore leave a dead PID in `state.json` and prevent activation teardown.

After handling `ProcessExited`, the executive now rereads the current attachments and ensures that every attached PID is monitored. Monitoring is idempotent, and the existing loop guard still applies when the exiting PID itself needs to be monitored again.

## Testing

- `cargo test -p flox-core -p flox-activations`
  - 65 `flox-core` tests passed.
  - 100 `flox-activations` tests passed.
- Clippy passed with warnings denied.
- Local build passed.
- Targeted integration tests passed:
  - activation under `env -i`
  - 21 `hook.on-activate` tests
  - generation-specific service activation
  - teardown after multiple activations
- GitHub CI passed all 17 executed checks, including the x86_64-darwin remote integration job.
