### PR TITLE
feat(floxhub): catalog URL off the FloxHub base; unhide --floxhub-url

### DIFF
--- a/cli/flox-rust-sdk/src/flox.rs
+++ b/cli/flox-rust-sdk/src/flox.rs
@@ -117,6 +117,15 @@ pub static PUBLIC_FLOXHUB_URL: LazyLock<Url> =
 pub static PUBLIC_GIT_URL: LazyLock<Url> =
     LazyLock::new(|| Url::parse("https://api.flox.dev/git").unwrap());
 
+/// The hosted (SaaS) catalog API endpoint paired with [`PUBLIC_FLOXHUB_URL`].
+///
+/// Hardcoded (like [`PUBLIC_GIT_URL`]) rather than sourced from the recompilable
+/// [`DEFAULT_CATALOG_URL`]: this constant is the *hosted* realm's identity used
+/// by [`Floxhub::catalog_url`], and must not shift when an on-premise build
+/// recompiles its own default catalog host.
+pub static PUBLIC_CATALOG_URL: LazyLock<Url> =
+    LazyLock::new(|| Url::parse("https://api.flox.dev").unwrap());
+
 /// Compiled-in default FloxHub base, used when no `floxhub_url` is configured.
 ///
 /// Defaults to the hosted realm ([`PUBLIC_FLOXHUB_URL`]); an on-premise build
@@ -201,6 +210,25 @@ impl Floxhub {
             .pop_if_empty()
             .push(route);
         Ok(url)
+    }
+
+    /// Resolve the catalog API base URL from a FloxHub base URL.
+    ///
+    /// Mirrors [`Floxhub::resolve_git_url`]: the hosted (SaaS) realm base
+    /// ([`PUBLIC_FLOXHUB_URL`]) maps to the fixed hosted catalog constant
+    /// [`PUBLIC_CATALOG_URL`] (`api.flox.dev`); any other base IS the catalog
+    /// base (the generated client appends `/api/v1/catalog`). Keyed on
+    /// [`PUBLIC_FLOXHUB_URL`], not [`DEFAULT_FLOXHUB_URL`], so a recompiled
+    /// on-premise default still routes the catalog off its own base.
+    ///
+    /// An explicit `catalog_url`/`FLOX_CATALOG_URL` override is applied by the
+    /// caller and takes precedence over this derivation.
+    pub fn catalog_url(base_url: &Url) -> Url {
+        if base_url == &*PUBLIC_FLOXHUB_URL {
+            PUBLIC_CATALOG_URL.clone()
+        } else {
+            base_url.clone()
+        }
     }
 }
 
@@ -475,6 +503,22 @@ pub mod tests {
             floxhub.git_url().as_str(),
             "https://onprem.example.internal/git",
         );
+    }
+
+    #[test]
+    fn catalog_url_hosted_base_uses_hosted_catalog_constant() {
+        assert_eq!(
+            Floxhub::catalog_url(&PUBLIC_FLOXHUB_URL),
+            *PUBLIC_CATALOG_URL
+        );
+    }
+
+    #[test]
+    fn catalog_url_other_base_is_the_base() {
+        // On-prem (and a recompiled default) base: the catalog is the base
+        // itself; the generated client appends `/api/v1/catalog`.
+        let base = Url::from_str("https://onprem.example.internal").unwrap();
+        assert_eq!(Floxhub::catalog_url(&base), base);
     }
 
     #[test]

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -178,11 +178,8 @@ pub struct FloxArgs {
     #[bpaf(long, hide)]
     pub beta: bool,
 
-    /// Address of the FloxHub instance to target for this invocation
-    ///
-    /// On-premise deployments serve all services from this one base URL;
-    /// per-service URLs default to routes appended to it.
-    #[bpaf(long, argument("URL"), optional, hide)]
+    /// Base URL of the FloxHub instance to target for this invocation
+    #[bpaf(long, argument("URL"), optional)]
     pub floxhub_url: Option<Url>,
 
     /// Print the version of the program
@@ -366,7 +363,7 @@ impl FloxArgs {
         let credential =
             AuthContext::from_mode(&config.flox.floxhub_authn_mode, floxhub_token.clone());
 
-        let floxhub_client = init_floxhub_client(&config, metrics_device_uuid)?;
+        let floxhub_client = init_floxhub_client(&config, &floxhub, metrics_device_uuid)?;
 
         // we already make sure $USER corresponds to **euid** earlier on in the process.
         let system_user_name =

--- a/cli/flox/src/utils/init/floxhub_client.rs
+++ b/cli/flox/src/utils/init/floxhub_client.rs
@@ -1,11 +1,10 @@
 use std::collections::BTreeMap;
 use std::str::FromStr;
 
-use flox_rust_sdk::flox::FLOX_VERSION;
+use flox_rust_sdk::flox::{FLOX_VERSION, Floxhub};
 use flox_rust_sdk::utils::{HEADER_DEVICE_UUID, INVOCATION_SOURCES};
 use floxhub_client::{
     AuthContext,
-    DEFAULT_CATALOG_URL,
     FloxhubClient,
     FloxhubClientConfig,
     FloxhubMockMode,
@@ -18,11 +17,15 @@ use crate::config::Config;
 
 /// Initialize the FloxHub API client.
 ///
-/// - Reads the catalog URL from config (defaults to the production catalog URL)
+/// - The catalog URL is an explicit `catalog_url`/`FLOX_CATALOG_URL` override
+///   if set, otherwise derived from the FloxHub base via
+///   [`Floxhub::catalog_url`] (hosted realm → `api.flox.dev`; any other base →
+///   the base, with the client appending `/api/v1/catalog`).
 /// - Configures mock replay mode if `_FLOX_USE_CATALOG_MOCK` is set
 /// - Includes device UUID and invocation-source headers when available
 pub fn init_floxhub_client(
     config: &Config,
+    floxhub: &Floxhub,
     metrics_device_uuid: Option<Uuid>,
 ) -> Result<FloxhubClient, anyhow::Error> {
     let mut extra_headers = BTreeMap::new();
@@ -40,12 +43,18 @@ pub fn init_floxhub_client(
 
     let mock_mode = FloxhubMockMode::default_from_env();
 
+    // The generated client joins request paths onto `base_url`, so a trailing
+    // slash would yield `//api/v1/catalog`. `Url` serializes a bare host with a
+    // trailing slash, and a user-supplied `FLOX_CATALOG_URL` override may carry
+    // one too, so trim it in both cases.
+    let catalog_url = config
+        .flox
+        .catalog_url
+        .clone()
+        .unwrap_or_else(|| Floxhub::catalog_url(floxhub.base_url()).to_string());
+
     let client_config = FloxhubClientConfig {
-        base_url: config
-            .flox
-            .catalog_url
-            .clone()
-            .unwrap_or_else(|| DEFAULT_CATALOG_URL.to_string()),
+        base_url: catalog_url.trim_end_matches('/').to_string(),
         extra_headers,
         mock_mode,
         auth_context: AuthContext::from_mode(

--- a/cli/tests/usage.bats
+++ b/cli/tests/usage.bats
@@ -75,50 +75,52 @@ Flox is a virtual environment and package manager all in one.
 With Flox you create environments that layer and replace dependencies just where
 it matters, making them portable across the full software lifecycle.
 
-Usage: flox [[-v]... | -q] [-V] [COMMAND ...]
+Usage: flox [[-v]... | -q] [--floxhub-url=URL] [-V] [COMMAND ...]
 
 Manage environments
-    init           Create an environment in the current directory
-    envs           Show active and available environments
-    delete         Delete an environment
+    init                   Create an environment in the current directory
+    envs                   Show active and available environments
+    delete                 Delete an environment
 
 Use environments
-    activate       Enter the environment, run 'flox deactivate' to leave
-    deactivate     Deactivate the current environment
-    run            Run a command from a Flox Catalog package
-    services       Manage services in an environment
+    activate               Enter the environment, run 'flox deactivate' to leave
+    deactivate             Deactivate the current environment
+    run                    Run a command from a Flox Catalog package
+    services               Manage services in an environment
 
 Discover packages
-    search         Search for system or library packages to install
-    show           Show details about a single package
+    search                 Search for system or library packages to install
+    show                   Show details about a single package
 
 Modify environments
-    install, i     Install packages into an environment
-    list, l        List packages installed in an environment
-    edit           Edit declarative environment configuration file
-    include        Compose environments together
-    upgrade        Upgrade packages in an environment
-    uninstall      Uninstall installed packages from an environment
-    generations    Version control for environments pushed to FloxHub
+    install, i             Install packages into an environment
+    list, l                List packages installed in an environment
+    edit                   Edit declarative environment configuration file
+    include                Compose environments together
+    upgrade                Upgrade packages in an environment
+    uninstall              Uninstall installed packages from an environment
+    generations            Version control for environments pushed to FloxHub
 
 Share with others
-    build          Build packages for Flox
-    publish        Publish packages for Flox
-    push           Send an environment to FloxHub
-    pull           Pull an environment from FloxHub
-    containerize   Containerize an environment
+    build                  Build packages for Flox
+    publish                Publish packages for Flox
+    push                   Send an environment to FloxHub
+    pull                   Pull an environment from FloxHub
+    containerize           Containerize an environment
 
 Administration
-    auth           FloxHub authentication commands
-    config         View and set configuration options
-    gc             Garbage collects any data for deleted environments.
+    auth                   FloxHub authentication commands
+    config                 View and set configuration options
+    gc                     Garbage collects any data for deleted environments.
 
 Available options:
-    -v, --verbose  Increase logging verbosity
-                   Invoke multiple times for increasing detail.
-    -q, --quiet    Silence logs except for errors
-    -V, --version  Print the version of the program
-    -h, --help     Prints help information
+    -v, --verbose          Increase logging verbosity
+                           Invoke multiple times for increasing detail.
+    -q, --quiet            Silence logs except for errors
+        --floxhub-url=URL  Base URL of the FloxHub instance to target for this
+                           invocation
+    -V, --version          Print the version of the program
+    -h, --help             Prints help information
 
 Run 'man flox' for more details.
 EOF


### PR DESCRIPTION
Stacked on #4435.

## Proposed Changes

Extends the authoritative-base model to the **catalog** API, mirroring the
git resolution:

- An explicit `catalog_url` / `FLOX_CATALOG_URL` override wins.
- Otherwise the catalog base is derived from the FloxHub base via
  `Floxhub::catalog_url`: the hosted realm (`PUBLIC_FLOXHUB_URL`) maps to the
  fixed hosted catalog constant (`PUBLIC_CATALOG_URL` = `api.flox.dev`); any
  other base **is** the catalog base (the generated client appends
  `/api/v1/catalog`).
- Keyed on `PUBLIC_FLOXHUB_URL`, not the compiled default, so a recompiled
  on-prem default routes the catalog off its own base (same fix as the git
  side in #4435).
- `--floxhub-url` is unhidden now that both git and catalog route off the
  base.

So setting the FloxHub base (flag / `FLOXHUB_URL` / `flox.toml` `floxhub_url`
/ recompiled default) points the CLI's catalog calls (resolve, search,
publish, build) at the on-prem host with **no separate `FLOX_CATALOG_URL`**.

## Out of scope

The `nef-lock-catalog` `lock` libexec still reads `FLOX_CATALOG_URL`
directly; threading the resolved catalog URL into its invocation lands with
the lock build target (ECO-95). Manual lock runs keep using
`FLOX_CATALOG_URL` until then.

## Release Notes

When a self-hosted FloxHub is configured (`floxhub_url` in `flox.toml`,
`FLOXHUB_URL`, or `--floxhub-url`), the catalog API now defaults to that host
too — no separate catalog URL needed. An explicit `FLOX_CATALOG_URL` still
overrides it. The `--floxhub-url` flag is now documented.