### PR TITLE
fix(auth): derive OAuth audience from the configured FloxHub base

### DIFF
--- a/cli/flox-rust-sdk/src/flox.rs
+++ b/cli/flox-rust-sdk/src/flox.rs
@@ -101,6 +101,27 @@ pub struct Features {
     pub auto_activate: bool,
 }
 
+/// The hosted (SaaS) FloxHub realm — fixed constants.
+///
+/// The hosted service splits its components across separate hosts
+/// (`hub.flox.dev` for FloxHub, `api.flox.dev/git` for git), so the realm is
+/// described by fixed constants rather than routed off one base. This identity
+/// is deliberately independent of [`DEFAULT_FLOXHUB_URL`]: an on-premise build
+/// may recompile the default base, but the hosted-realm mapping in
+/// [`Floxhub::resolve_git_url`] must always identify the *hosted* service —
+/// never whatever the local build's default happens to be.
+pub static PUBLIC_FLOXHUB_URL: LazyLock<Url> =
+    LazyLock::new(|| Url::parse("https://hub.flox.dev").unwrap());
+
+/// The hosted (SaaS) git endpoint paired with [`PUBLIC_FLOXHUB_URL`].
+pub static PUBLIC_GIT_URL: LazyLock<Url> =
+    LazyLock::new(|| Url::parse("https://api.flox.dev/git").unwrap());
+
+/// Compiled-in default FloxHub base, used when no `floxhub_url` is configured.
+///
+/// Defaults to the hosted realm ([`PUBLIC_FLOXHUB_URL`]); an on-premise build
+/// may recompile this to its own base without disturbing the hosted-realm
+/// mapping (which keys on [`PUBLIC_FLOXHUB_URL`], not this default).
 pub static DEFAULT_FLOXHUB_URL: LazyLock<Url> =
     LazyLock::new(|| Url::parse("https://hub.flox.dev").unwrap());
 
@@ -126,17 +147,26 @@ impl Floxhub {
     ///
     /// Precedence:
     /// 1. An explicit override (e.g. `_FLOX_FLOXHUB_GIT_URL`) — used verbatim.
-    /// 2. Derived from the base URL — see [`Floxhub::derive_git_url`].
+    /// 2. The hosted (SaaS) realm base ([`PUBLIC_FLOXHUB_URL`]) — the paired
+    ///    hosted git constant [`PUBLIC_GIT_URL`] (`api.flox.dev/git`), since the
+    ///    hosted service's components live on separate hosts. This also covers
+    ///    existing managed-environment pointers, which persist the hosted base.
+    /// 3. Any other base — `<base>/git` on the same host (single-host,
+    ///    on-premise deployments, **including a recompiled default base**).
     ///
-    /// This is the single seam through which the git URL is resolved. A future
-    /// authoritative base URL (`FLOXHUB_URL`) will add a tier between these two
-    /// (derive `<base>/git` on the same host) without changing this contract;
-    /// see the Enterprise On-Premise SL-003 design.
+    /// Keyed on [`PUBLIC_FLOXHUB_URL`], not [`DEFAULT_FLOXHUB_URL`]: an
+    /// on-premise build that recompiles the default base must still route its
+    /// own git off that base, not fall back to the hosted git constant. No
+    /// host-name inference is performed. See the Enterprise On-Premise SL-003
+    /// design.
     fn resolve_git_url(base_url: &Url, git_url_override: Option<Url>) -> Result<Url, FloxhubError> {
-        match git_url_override {
-            Some(git_url_override) => Ok(git_url_override),
-            None => Self::derive_git_url(base_url),
+        if let Some(git_url_override) = git_url_override {
+            return Ok(git_url_override);
         }
+        if base_url == &*PUBLIC_FLOXHUB_URL {
+            return Ok(PUBLIC_GIT_URL.clone());
+        }
+        Self::route_url(base_url, "git")
     }
 
     /// Return the base url of the FloxHub instance
@@ -158,31 +188,26 @@ impl Floxhub {
         &self.git_url
     }
 
-    fn derive_git_url(base_url: &Url) -> Result<Url, FloxhubError> {
-        let mut git_url = base_url.clone();
-        let host = git_url
-            .host_str()
-            .ok_or(FloxhubError::NoHost(base_url.to_string()))?;
-        let without_hub = host
-            .strip_prefix("hub.")
-            .ok_or(FloxhubError::NoHubPrefix(base_url.to_string()))?;
-        let with_api_prefix = format!("api.{}", without_hub);
-        git_url
-            .set_host(Some(&with_api_prefix))
-            .map_err(|e| FloxhubError::InvalidFloxhubBaseUrl(with_api_prefix, e))?;
-        git_url.set_path("git");
-        Ok(git_url)
+    /// Append a path-segment `route` to `base_url`, preserving any existing
+    /// path prefix and collapsing a trailing slash (e.g. `https://host/git`,
+    /// or `https://host/floxhub/` + `git` -> `https://host/floxhub/git`).
+    ///
+    /// Errors only for a cannot-be-a-base URL (e.g. `mailto:`); valid http(s)
+    /// bases always succeed.
+    pub(crate) fn route_url(base_url: &Url, route: &str) -> Result<Url, FloxhubError> {
+        let mut url = base_url.clone();
+        url.path_segments_mut()
+            .map_err(|()| FloxhubError::CannotBeABase(base_url.to_string()))?
+            .pop_if_empty()
+            .push(route);
+        Ok(url)
     }
 }
 
 #[derive(Error, Debug)]
 pub enum FloxhubError {
-    #[error("Invalid FloxHub URL: '{0}'. URL must contain a host.")]
-    NoHost(String),
-    #[error("Invalid FloxHub URL: '{0}'. URL must begin with 'hub.'")]
-    NoHubPrefix(String),
-    #[error("Couldn't set git URL host to '{0}'")]
-    InvalidFloxhubBaseUrl(String, #[source] url::ParseError),
+    #[error("Invalid FloxHub URL: '{0}'. URL must be a valid base URL (http or https).")]
+    CannotBeABase(String),
 }
 
 pub mod test_helpers {
@@ -390,25 +415,8 @@ pub mod tests {
     }
 
     #[test]
-    fn test_derive_git_url() {
-        assert_eq!(
-            Floxhub::derive_git_url(&Url::from_str("https://hub.flox.dev").unwrap()).unwrap(),
-            Url::from_str("https://api.flox.dev/git").unwrap()
-        );
-    }
-
-    #[test]
-    fn test_derive_git_url_dev() {
-        assert_eq!(
-            Floxhub::derive_git_url(&Url::from_str("https://hub.preview.flox.dev").unwrap())
-                .unwrap(),
-            Url::from_str("https://api.preview.flox.dev/git").unwrap()
-        );
-    }
-
-    #[test]
     fn resolve_git_url_uses_override_verbatim() {
-        let base = Url::from_str("https://hub.flox.dev").unwrap();
+        let base = Url::from_str("https://flox.example.internal").unwrap();
         let override_url = Url::from_str("https://git.example.internal/git").unwrap();
         assert_eq!(
             Floxhub::resolve_git_url(&base, Some(override_url.clone())).unwrap(),
@@ -417,18 +425,65 @@ pub mod tests {
     }
 
     #[test]
-    fn resolve_git_url_derives_when_no_override() {
-        let base = Url::from_str("https://hub.flox.dev").unwrap();
+    fn resolve_git_url_hosted_base_uses_hosted_git_constant() {
+        // The hosted realm's components live on separate hosts; the hosted base
+        // maps to the fixed hosted git URL (also covers existing pointers).
         assert_eq!(
-            Floxhub::resolve_git_url(&base, None).unwrap(),
-            Url::from_str("https://api.flox.dev/git").unwrap(),
+            Floxhub::resolve_git_url(&PUBLIC_FLOXHUB_URL, None).unwrap(),
+            *PUBLIC_GIT_URL,
         );
     }
 
     #[test]
-    fn derive_git_url_rejects_non_hub_host() {
-        let err = Floxhub::derive_git_url(&Url::from_str("https://flox.example.internal").unwrap())
-            .unwrap_err();
-        assert!(matches!(err, FloxhubError::NoHubPrefix(_)));
+    fn resolve_git_url_other_base_routes_off_base() {
+        assert_eq!(
+            Floxhub::resolve_git_url(
+                &Url::from_str("https://flox.example.internal").unwrap(),
+                None,
+            )
+            .unwrap(),
+            Url::from_str("https://flox.example.internal/git").unwrap(),
+        );
+    }
+
+    #[test]
+    fn resolve_git_url_routes_off_base_even_when_it_is_the_default() {
+        // An on-premise build may recompile DEFAULT_FLOXHUB_URL to its own
+        // base. The hosted-realm mapping is keyed on PUBLIC_FLOXHUB_URL, so a
+        // non-hosted base still routes off itself — it must NOT fall back to
+        // the hosted git constant just because it equals the compiled default.
+        let recompiled_default = Url::from_str("https://onprem.example.internal").unwrap();
+        assert_ne!(recompiled_default, *PUBLIC_FLOXHUB_URL);
+        assert_eq!(
+            Floxhub::resolve_git_url(&recompiled_default, None)
+                .unwrap()
+                .as_str(),
+            "https://onprem.example.internal/git",
+        );
+    }
+
+    #[test]
+    fn floxhub_new_routes_onprem_pointer_to_base_git() {
+        // Mirrors floxmeta `open_at` reconstructing a Floxhub from a managed-
+        // environment pointer whose base is an on-prem host (with the trailing
+        // slash the pointer persists) and no git override.
+        let base = Url::from_str("https://onprem.example.internal/").unwrap();
+        let floxhub = Floxhub::new(base, None).unwrap();
+        assert_eq!(
+            floxhub.git_url().as_str(),
+            "https://onprem.example.internal/git",
+        );
+    }
+
+    #[test]
+    fn route_url_preserves_path_prefix_and_trailing_slash() {
+        assert_eq!(
+            Floxhub::route_url(
+                &Url::from_str("https://host.internal/floxhub/").unwrap(),
+                "git"
+            )
+            .unwrap(),
+            Url::from_str("https://host.internal/floxhub/git").unwrap(),
+        );
     }
 }

--- a/cli/flox-rust-sdk/src/flox.rs
+++ b/cli/flox-rust-sdk/src/flox.rs
@@ -117,6 +117,14 @@ pub static PUBLIC_FLOXHUB_URL: LazyLock<Url> =
 pub static PUBLIC_GIT_URL: LazyLock<Url> =
     LazyLock::new(|| Url::parse("https://api.flox.dev/git").unwrap());
 
+/// The hosted (SaaS) catalog API endpoint paired with [`PUBLIC_FLOXHUB_URL`].
+///
+/// Sourced from [`floxhub_client::DEFAULT_CATALOG_URL`] so the hosted catalog
+/// host has a single definition.
+pub static PUBLIC_CATALOG_URL: LazyLock<Url> = LazyLock::new(|| {
+    Url::parse(floxhub_client::DEFAULT_CATALOG_URL).expect("hosted catalog URL is valid")
+});
+
 /// Compiled-in default FloxHub base, used when no `floxhub_url` is configured.
 ///
 /// Defaults to the hosted realm ([`PUBLIC_FLOXHUB_URL`]); an on-premise build
@@ -201,6 +209,25 @@ impl Floxhub {
             .pop_if_empty()
             .push(route);
         Ok(url)
+    }
+
+    /// Resolve the catalog API base URL from a FloxHub base URL.
+    ///
+    /// Mirrors [`Floxhub::resolve_git_url`]: the hosted (SaaS) realm base
+    /// ([`PUBLIC_FLOXHUB_URL`]) maps to the fixed hosted catalog constant
+    /// [`PUBLIC_CATALOG_URL`] (`api.flox.dev`); any other base IS the catalog
+    /// base (the generated client appends `/api/v1/catalog`). Keyed on
+    /// [`PUBLIC_FLOXHUB_URL`], not [`DEFAULT_FLOXHUB_URL`], so a recompiled
+    /// on-premise default still routes the catalog off its own base.
+    ///
+    /// An explicit `catalog_url`/`FLOX_CATALOG_URL` override is applied by the
+    /// caller and takes precedence over this derivation.
+    pub fn catalog_url(base_url: &Url) -> Url {
+        if base_url == &*PUBLIC_FLOXHUB_URL {
+            PUBLIC_CATALOG_URL.clone()
+        } else {
+            base_url.clone()
+        }
     }
 }
 
@@ -473,6 +500,22 @@ pub mod tests {
             floxhub.git_url().as_str(),
             "https://onprem.example.internal/git",
         );
+    }
+
+    #[test]
+    fn catalog_url_hosted_base_uses_hosted_catalog_constant() {
+        assert_eq!(
+            Floxhub::catalog_url(&PUBLIC_FLOXHUB_URL),
+            *PUBLIC_CATALOG_URL
+        );
+    }
+
+    #[test]
+    fn catalog_url_other_base_is_the_base() {
+        // On-prem (and a recompiled default) base: the catalog is the base
+        // itself; the generated client appends `/api/v1/catalog`.
+        let base = Url::from_str("https://onprem.example.internal").unwrap();
+        assert_eq!(Floxhub::catalog_url(&base), base);
     }
 
     #[test]

--- a/cli/flox-rust-sdk/src/flox.rs
+++ b/cli/flox-rust-sdk/src/flox.rs
@@ -202,7 +202,7 @@ impl Floxhub {
     ///
     /// Errors only for a cannot-be-a-base URL (e.g. `mailto:`); valid http(s)
     /// bases always succeed.
-    pub(crate) fn route_url(base_url: &Url, route: &str) -> Result<Url, FloxhubError> {
+    pub fn route_url(base_url: &Url, route: &str) -> Result<Url, FloxhubError> {
         let mut url = base_url.clone();
         url.path_segments_mut()
             .map_err(|()| FloxhubError::CannotBeABase(base_url.to_string()))?
@@ -516,6 +516,18 @@ pub mod tests {
         // itself; the generated client appends `/api/v1/catalog`.
         let base = Url::from_str("https://onprem.example.internal").unwrap();
         assert_eq!(Floxhub::catalog_url(&base), base);
+    }
+
+    #[test]
+    fn route_url_api_audience_hosted_preserves_legacy_value() {
+        // The OAuth audience is `<base>/api`. For the hosted realm it must stay
+        // the historical hard-coded value so production auth is unchanged.
+        assert_eq!(
+            Floxhub::route_url(&PUBLIC_FLOXHUB_URL, "api")
+                .unwrap()
+                .as_str(),
+            "https://hub.flox.dev/api",
+        );
     }
 
     #[test]

--- a/cli/flox/src/commands/auth.rs
+++ b/cli/flox/src/commands/auth.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result, bail};
 use bpaf::Bpaf;
 use chrono::offset::Utc;
 use chrono::{DateTime, Duration};
-use flox_rust_sdk::flox::{FLOX_VERSION, Flox, FloxhubToken};
+use flox_rust_sdk::flox::{FLOX_VERSION, Flox, Floxhub, FloxhubToken};
 use floxhub_client::{AuthContext, AuthnMode};
 use indoc::formatdoc;
 use oauth2::basic::{
@@ -103,14 +103,18 @@ pub async fn authorize(client: ConfiguredClient, floxhub_url: &Url) -> Result<Cr
         .build()
         .expect("Failed to build OAuth HTTP client");
 
+    // The OAuth audience is the FloxHub API for the configured instance —
+    // `<floxhub_url>/api` — not a hard-coded host (hosted realm still resolves
+    // to `https://hub.flox.dev/api`).
+    let audience = Floxhub::route_url(floxhub_url, "api")
+        .context("invalid FloxHub URL for OAuth audience")?
+        .to_string();
+
     let details: StandardDeviceAuthorizationResponse = client
         .exchange_device_code()
         .add_scope(Scope::new("openid".to_string()))
         .add_scope(Scope::new("profile".to_string()))
-        .add_extra_param(
-            "audience".to_string(),
-            "https://hub.flox.dev/api".to_string(),
-        )
+        .add_extra_param("audience".to_string(), audience)
         .request_async(&http_client)
         .await
         .context("Could not request device code")?;

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -177,6 +177,13 @@ pub struct FloxArgs {
     #[bpaf(long, hide)]
     pub beta: bool,
 
+    /// Address of the FloxHub instance to target for this invocation
+    ///
+    /// On-premise deployments serve all services from this one base URL;
+    /// per-service URLs default to routes appended to it.
+    #[bpaf(long, argument("URL"), optional, hide)]
+    pub floxhub_url: Option<Url>,
+
     /// Print the version of the program
     #[allow(dead_code)] // fake arg, `--version` is checked for separately (see [Version])
     #[bpaf(long, short('V'))]
@@ -306,27 +313,46 @@ impl FloxArgs {
             debug!(error = %err, "Failed to record v2 cli.command_run event");
         }
 
-        let git_url_override = {
-            if let Ok(env_set_host) = std::env::var("_FLOX_FLOXHUB_GIT_URL") {
-                if !self.is_prompt_hook_flow() {
-                    message::warning(formatdoc! {"
-                        Using {env_set_host} as FloxHub host
-                        '$_FLOX_FLOXHUB_GIT_URL' is used for testing purposes only,
-                        alternative FloxHub hosts are not yet supported!
-                    "});
-                }
-                Some(Url::parse(&env_set_host)?)
-            } else {
-                None
-            }
+        // The single authoritative FloxHub base URL. When defined, every other
+        // service URL is a route off it; when undefined, the compiled-in
+        // public-realm defaults apply. Precedence (high to low):
+        //   --floxhub-url flag > FLOXHUB_URL env > FLOX_FLOXHUB_URL env /
+        //   user flox.toml > /etc/flox.toml > default (public realm).
+        // `FLOXHUB_URL` is a FloxHub attribute, not a flox-CLI one, so it is
+        // wired explicitly rather than via the `FLOX_` config prefix. The
+        // `FLOX_FLOXHUB_URL` env and the config file both land in
+        // `config.flox.floxhub_url`.
+        let floxhub_url = match self.floxhub_url.clone() {
+            Some(url) => Some(url),
+            None => match std::env::var("FLOXHUB_URL") {
+                Ok(value) if !value.is_empty() => Some(Url::parse(&value)?),
+                _ => config.flox.floxhub_url.clone(),
+            },
         };
 
+        // `FLOX_FLOXHUB_URL` still feeds `config.flox.floxhub_url`, but its name
+        // is superseded by `FLOXHUB_URL`.
+        if std::env::var_os("FLOX_FLOXHUB_URL").is_some() && !self.is_prompt_hook_flow() {
+            message::warning("'FLOX_FLOXHUB_URL' is deprecated. Use 'FLOXHUB_URL' instead.");
+        }
+
+        // Explicit git-endpoint override, for testing against a local FloxHub.
+        let git_url_override = if let Ok(env_set_host) = std::env::var("_FLOX_FLOXHUB_GIT_URL") {
+            if !self.is_prompt_hook_flow() {
+                message::warning(formatdoc! {"
+                    Using {env_set_host} as the FloxHub git endpoint.
+                    '$_FLOX_FLOXHUB_GIT_URL' overrides the git endpoint and is intended for testing only.
+                "});
+            }
+            Some(Url::parse(&env_set_host)?)
+        } else {
+            None
+        };
+
+        // Floxhub derives the git URL from the base (and persists/reconstructs
+        // it via the managed-environment pointer), so it is the single seam.
         let floxhub = Floxhub::new(
-            config
-                .flox
-                .floxhub_url
-                .clone()
-                .unwrap_or_else(|| DEFAULT_FLOXHUB_URL.clone()),
+            floxhub_url.unwrap_or_else(|| DEFAULT_FLOXHUB_URL.clone()),
             git_url_override,
         )?;
 

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -180,8 +180,8 @@ pub struct FloxArgs {
     /// Address of the FloxHub instance to target for this invocation
     ///
     /// On-premise deployments serve all services from this one base URL;
-    /// per-service URLs default to routes appended to it.
-    #[bpaf(long, argument("URL"), optional, hide)]
+    /// per-service URLs (git, catalog) default to routes appended to it.
+    #[bpaf(long, argument("URL"), optional)]
     pub floxhub_url: Option<Url>,
 
     /// Print the version of the program
@@ -365,7 +365,7 @@ impl FloxArgs {
         let credential =
             AuthContext::from_mode(&config.flox.floxhub_authn_mode, floxhub_token.clone());
 
-        let floxhub_client = init_floxhub_client(&config, metrics_device_uuid)?;
+        let floxhub_client = init_floxhub_client(&config, &floxhub, metrics_device_uuid)?;
 
         // we already make sure $USER corresponds to **euid** earlier on in the process.
         let system_user_name =

--- a/cli/flox/src/utils/init/floxhub_client.rs
+++ b/cli/flox/src/utils/init/floxhub_client.rs
@@ -1,11 +1,10 @@
 use std::collections::BTreeMap;
 use std::str::FromStr;
 
-use flox_rust_sdk::flox::FLOX_VERSION;
+use flox_rust_sdk::flox::{FLOX_VERSION, Floxhub};
 use flox_rust_sdk::utils::{HEADER_DEVICE_UUID, INVOCATION_SOURCES};
 use floxhub_client::{
     AuthContext,
-    DEFAULT_CATALOG_URL,
     FloxhubClient,
     FloxhubClientConfig,
     FloxhubMockMode,
@@ -18,11 +17,15 @@ use crate::config::Config;
 
 /// Initialize the FloxHub API client.
 ///
-/// - Reads the catalog URL from config (defaults to the production catalog URL)
+/// - The catalog URL is an explicit `catalog_url`/`FLOX_CATALOG_URL` override
+///   if set, otherwise derived from the FloxHub base via
+///   [`Floxhub::catalog_url`] (hosted realm → `api.flox.dev`; any other base →
+///   the base, with the client appending `/api/v1/catalog`).
 /// - Configures mock replay mode if `_FLOX_USE_CATALOG_MOCK` is set
 /// - Includes device UUID and invocation-source headers when available
 pub fn init_floxhub_client(
     config: &Config,
+    floxhub: &Floxhub,
     metrics_device_uuid: Option<Uuid>,
 ) -> Result<FloxhubClient, anyhow::Error> {
     let mut extra_headers = BTreeMap::new();
@@ -45,7 +48,7 @@ pub fn init_floxhub_client(
             .flox
             .catalog_url
             .clone()
-            .unwrap_or_else(|| DEFAULT_CATALOG_URL.to_string()),
+            .unwrap_or_else(|| Floxhub::catalog_url(floxhub.base_url()).to_string()),
         extra_headers,
         mock_mode,
         auth_context: AuthContext::from_mode(


### PR DESCRIPTION
Stacked on #4437.

## Proposed Changes

The device-code OAuth flow hard-coded the audience as
`https://hub.flox.dev/api`, ignoring the `floxhub_url` already passed to
`authorize()`. This derives it as `<floxhub_url>/api` (via
`Floxhub::route_url`), so a non-default FloxHub instance gets the correct
audience.

- Hosted realm still resolves to `https://hub.flox.dev/api` — production auth
  is unchanged (locked by a regression test).
- OAuth endpoints themselves stay override-only Auth0 constants, never
  derived from the base (on-premise does not use the CLI OAuth flow); this
  only corrects the audience claim.
- The `FLOX_FLOXHUB_URL` deprecation notice already landed with the base
  change (#4435); no further deprecation work needed here.

## Release Notes

N/A — corrects the OAuth audience for non-default FloxHub instances;
production behavior is unchanged.