### PR TITLE
fix(flox-activations): downgrade stop_monitoring log from error to debug

### DIFF
--- a/cli/flox-activations/src/cli/executive/event_coordinator.rs
+++ b/cli/flox-activations/src/cli/executive/event_coordinator.rs
@@ -221,10 +221,13 @@ impl EventCoordinator {
             debug!(pid, "stopped monitoring PID, joining watcher thread");
             if handle.is_finished() {
                 if let Err(err) = handle.join() {
-                    error!(pid, ?err, "couldn't join watcher thread");
+                    warn!(pid, ?err, "couldn't join watcher thread");
                 }
             } else {
-                error!(pid, "expected watcher thread for PID to be finished");
+                // Common case: thread sent ProcessExited as its last action and
+                // is finishing its stack unwind. Release the handle; the thread
+                // completes independently in microseconds.
+                debug!(pid, "watcher thread not yet finished, releasing handle");
             }
         } else {
             error!(pid, "stop_monitoring called for PID not in known set");


### PR DESCRIPTION
## Summary

Fixes CLI-FLOX-3A — the single highest-volume error in `cli-flox` (144,061 occurrences / 18,265 users).

- `stop_monitoring` logged at `error!` level when `is_finished()` returned false, which Sentry captured as an event every time
- Root cause: pure timing race — the watcher thread sends `ProcessExited` as its last action, then begins stack unwind; `is_finished()` may still be false by the time the executive calls `stop_monitoring`
- Fix: downgrade the else branch from `error!` to `debug!`, and join-failure from `error!` to `warn!`; the thread completes independently in microseconds

## Why not "always join"

The ticket proposed unconditional `join()`. That works for the timing-race case but blocks indefinitely in the re-monitoring / loop guard path, where `stop_monitoring` is called while a new watcher thread is actively blocking on a live process. The existing test `handle_process_exited_increments_loop_guard` catches this. See the Linear comment on DEV-135 for the full analysis.

## Test plan

- [ ] `cargo test -p flox-activations` passes (97/97)
- [ ] CLI-FLOX-3A events drop to near-zero in Sentry after rollout

Closes DEV-135

---
*Via Forge (forge-work) • 9a3d01ae*