### PR TITLE
fix(flox-activations): handle TOCTOU race in cleanup_all instead of panicking

### DIFF
--- a/cli/flox-activations/src/cli/executive/mod.rs
+++ b/cli/flox-activations/src/cli/executive/mod.rs
@@ -250,14 +250,18 @@ fn run_event_loop(
                 // on the state-file change instead.
                 if activations.attached_pids_is_empty() {
                     info!("all PIDs gone after state.json change, running cleanup");
-                    cleanup_all(
+                    if cleanup_all(
                         (activations, lock),
                         &process_compose_bin,
                         &socket_path,
                         &activation_state_dir,
                     )
-                    .context("cleanup failed after StateFileChanged with empty PIDs")?;
-                    return Ok(());
+                    .context("cleanup failed after StateFileChanged with empty PIDs")?
+                    {
+                        return Ok(());
+                    }
+                    // A PID raced in between the empty check and cleanup_all;
+                    // continue the event loop so the new PID stays monitored.
                 }
                 // lock drops here when PIDs remain
             },
@@ -369,14 +373,14 @@ fn handle_process_exited(
         },
         Ok(Some(locked_activations)) => {
             info!("running cleanup after all PIDs terminated");
-            cleanup_all(
+            let cleaned_up = cleanup_all(
                 locked_activations,
                 process_compose_bin,
                 socket_path,
                 activation_state_dir,
             )
             .context("cleanup failed")?;
-            Ok(true)
+            Ok(cleaned_up)
         },
         Err(err) => {
             info!("running cleanup after error");
@@ -442,18 +446,20 @@ fn handle_start_services_signal(
 
 /// Shutdown `process-compose` if running and remove all activation state.
 /// To be called when there are no longer any PIDs attached.
+/// Returns `true` if cleanup ran, `false` if PIDs were found and cleanup was skipped.
 fn cleanup_all(
     locked_activations: LockedActivationState,
     process_compose_bin: &Path,
     socket_path: impl AsRef<Path>,
     activation_state_dir_path: impl AsRef<Path>,
-) -> Result<()> {
+) -> Result<bool> {
     info!("running cleanup");
 
     let (activations_json, _hold_the_lock) = locked_activations;
 
     if !activations_json.attached_pids_is_empty() {
-        unreachable!("cleanup should only be called when there are no more attached PIDs");
+        warn!("cleanup called with PIDs still attached, skipping");
+        return Ok(false);
     }
     let socket_path = socket_path.as_ref();
     if socket_path.exists() {
@@ -479,7 +485,7 @@ fn cleanup_all(
 
     info!("finished cleanup");
 
-    Ok(())
+    Ok(true)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Problem

`cleanup_all` in `cli/flox-activations/src/cli/executive/mod.rs` used `unreachable!()` to assert that no PIDs are attached when cleanup runs. This assertion is reachable via a TOCTOU race: a new `flox activate` can write a PID to `state.json` between the caller observing an empty PID list and `cleanup_all` re-checking — causing a panic crash.

Sentry signature **CLI-FLOX-3F** — 16 occurrences / 8 users.

## Discovery

The naive fix of replacing `unreachable!()` with `warn!` + `return Ok(())` would still terminate the executive. Both active call sites exit the event loop as soon as `cleanup_all` returns:

- `StateFileChanged` handler: `return Ok(())` exits the loop unconditionally after the call
- `handle_process_exited` `Ok(Some)` arm: returns `Ok(true)` → `run_event_loop` returns `Ok(())`

So `Ok(())` from a skipped cleanup looks identical to `Ok(())` from a completed cleanup — the executive terminates either way, leaving the newly-attached PIDs permanently unmonitored and their activation state directory never cleaned up.

## Fix

Change `cleanup_all` to return `Result<bool>` — `true` when cleanup ran, `false` when PIDs were found and cleanup was skipped. Update both active call sites to only exit the event loop on `true`:

- `StateFileChanged`: wraps the call in `if cleanup_all(...)? { return Ok(()); }` — falls through on `false`, loop continues
- `handle_process_exited` `Ok(Some)`: propagates the bool directly as the "should exit" signal

When `false` is returned, the newly-attached PID will have already written to `state.json`, triggering a `StateFileChanged` event that the continuing executive processes to pick up monitoring. Cleanup fires again when that PID exits.

The `Err` call site (`let _ = cleanup_all(...)`) is unaffected — it ignores the result and bails on the upstream error regardless.

## Test plan

- [x] `cargo test -p flox-activations` — 97/97 pass
- [ ] Deploy and confirm no new `CLI-FLOX-3F` occurrences in Sentry

Closes DEV-136.

---
*Via Forge (forge-work) • 44adb9f5*