### PR TITLE
fix(nef-lock-catalog): send catalog-relative references to build-inputs/lookup

### DIFF
--- a/cli/nef-lock-catalog/src/lock/lookup.rs
+++ b/cli/nef-lock-catalog/src/lock/lookup.rs
@@ -91,8 +91,7 @@ fn build_request(
 ) -> BuildInputsLookupRequest {
     let group = LookupGroup {
         key: LOOKUP_GROUP_KEY.to_string(),
-        // Move each reference's inner string out — no per-string reallocation.
-        references: references.into_iter().map(String::from).collect(),
+        references: references.iter().map(wire_reference).collect(),
     };
 
     BuildInputsLookupRequest {
@@ -100,6 +99,20 @@ fn build_request(
         reference_point: None,
         stability,
     }
+}
+
+/// Render a scanned reference for the wire.
+///
+/// The scanner records references rooted at the NEF `catalogs` lambda parameter
+/// (`catalogs.<catalog>.<package>`), but the catalog server's reference
+/// namespace is catalog-relative (`<catalog>.<package>`). Drop the leading root
+/// segment so the request matches what the server expects.
+fn wire_reference(reference: &CatalogRef) -> String {
+    let reference = reference.as_str();
+    reference
+        .split_once('.')
+        .map(|(_root, rest)| rest.to_string())
+        .unwrap_or_else(|| reference.to_string())
 }
 
 /// Map a lookup response into a [BuildLock], or fail with the unresolvable
@@ -151,11 +164,13 @@ mod tests {
 
         let wire = build_request(references, "stable".parse().unwrap());
 
-        // All references collapse into a single wire group.
+        // All references collapse into a single wire group, and the leading
+        // `catalogs` root segment is dropped — the server's reference namespace
+        // is catalog-relative (`<catalog>.<package>`).
         assert_eq!(wire.groups.len(), 1);
         assert_eq!(
             serde_json::to_value(&wire.groups[0].references).unwrap(),
-            json!(["catalogs.myorg.hello", "catalogs.myorg.world"])
+            json!(["myorg.hello", "myorg.world"])
         );
         assert_eq!(
             serde_json::to_value(&wire.stability).unwrap(),

--- a/cli/nef-lock-catalog/src/lock/render.rs
+++ b/cli/nef-lock-catalog/src/lock/render.rs
@@ -11,6 +11,19 @@ use floxhub_client::UnresolvableEntry;
 use indent::indent_all_by;
 use indoc::formatdoc;
 
+/// The NEF catalog root the scanner strips before sending references to the
+/// server (see `lock::lookup::wire_reference`). The server echoes back
+/// catalog-relative references (`<catalog>.<package>`); restore the root so the
+/// developer sees the attribute exactly as written in their expression
+/// (`catalogs.<catalog>.<package>`).
+const CATALOG_ROOT: &str = "catalogs";
+
+/// Prefix a server-returned, catalog-relative reference with the NEF
+/// [`CATALOG_ROOT`] for display.
+fn display_reference(reference: &str) -> String {
+    format!("{CATALOG_ROOT}.{reference}")
+}
+
 /// Render the unresolvable references from a failed lock into a developer-facing
 /// error body per REQ-013:
 /// - a `→`-arrow dependency path per reference, ending in `(unresolvable)`,
@@ -40,7 +53,10 @@ fn render_path(chain: &[String]) -> String {
         .map(|(i, reference)| {
             let arrow = if i == 0 { "" } else { "→ " };
             let leaf = if i == last { " (unresolvable)" } else { "" };
-            format!("{arrow}{reference}{leaf}")
+            format!(
+                "{arrow}{reference}{leaf}",
+                reference = display_reference(reference)
+            )
         })
         .collect::<Vec<_>>()
         .join("\n")
@@ -56,7 +72,7 @@ fn render_single(entry: &UnresolvableEntry) -> String {
           Possible causes: the input may not be visible to you, may have no
           published revision, or may have aged out of retention. Verify
           availability with the owner of the relevant catalog.",
-        reference = entry.reference,
+        reference = display_reference(&entry.reference),
         path = indent_all_by(4, render_path(&entry.chain)),
     }
 }
@@ -71,7 +87,7 @@ fn render_many(entries: &[UnresolvableEntry]) -> String {
                      Dependency path:
                 {path}",
                 n = i + 1,
-                reference = entry.reference,
+                reference = display_reference(&entry.reference),
                 path = indent_all_by(7, render_path(&entry.chain)),
             }
         })
@@ -106,10 +122,9 @@ mod tests {
 
     #[test]
     fn single_unresolvable() {
-        let entries = [entry("catalogs.acme.tool", &[
-            "catalogs.acme.app",
-            "catalogs.acme.tool",
-        ])];
+        // The server returns catalog-relative references; rendering restores
+        // the `catalogs.` root for the developer.
+        let entries = [entry("acme.tool", &["acme.app", "acme.tool"])];
 
         let expected = "\
 'catalogs.acme.tool' is unresolvable in this context.
@@ -128,11 +143,8 @@ mod tests {
     #[test]
     fn multiple_unresolvable_numbered() {
         let entries = [
-            entry("catalogs.acme.tool", &[
-                "catalogs.acme.app",
-                "catalogs.acme.tool",
-            ]),
-            entry("catalogs.other.lib", &["catalogs.other.lib"]),
+            entry("acme.tool", &["acme.app", "acme.tool"]),
+            entry("other.lib", &["other.lib"]),
         ];
 
         let expected = "\


### PR DESCRIPTION
## Bug

The `lock` libexec sends catalog references to the catalog
`/build-inputs/lookup` endpoint with the NEF `catalogs` root prefix
intact, but the server's reference namespace is catalog-relative
(`<catalog>.<package>`), so it cannot resolve them.

Observed on the wire — the server received:

```
{"groups":[{"key":"default","references":["catalogs.brantley.flox-utils"]}],"stability":"staging"}
```

…but the server expects:

```
{"groups":[{"key":"default","references":["brantley.flox-utils"]}],"stability":"staging"}
```

## Cause

The scanner records references rooted at the NEF `catalogs` lambda
parameter (`catalogs.<catalog>.<package>`), and `build_request`
(`cli/nef-lock-catalog/src/lock/lookup.rs`) serialized that full path
verbatim onto the wire.

## Fix

Drop the leading root segment when serializing references for the wire,
so `catalogs.brantley.flox-utils` is sent as `brantley.flox-utils`.

The response→lock transform is unaffected: `build_lock_from_locked_inputs`
keys off each entry's `catalog`/`attr_path` fields, not the request
reference (and the `success.json` fixture already keys locks without the
prefix).

## Test

- Updated `build_request_maps_references_and_stability` to assert the
  root segment is dropped.
- `cargo test -p nef-lock-catalog` — 57 passed; `cargo clippy -p
  nef-lock-catalog --all-targets` clean.

Stacked on the lock-binary branch (ECO-94). Ready to cherry-pick for an
on-prem test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)