### PR TITLE
feat: incorporate NEF catalog input locking into package builds

### DIFF
--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -57,11 +57,24 @@ pub trait ManifestBuilder {
     /// The build process will start in the background.
     /// To process the output, the caller should iterate over the returned [BuildOutput].
     /// Once the process is complete, the [BuildOutput] will yield an [Output::Exit] message.
+    ///
+    /// `nef_targets` is the complete set of Nix expression build target names
+    /// present in the environment.
+    /// The builder passes this list to the underlying Makefile so that NEF
+    /// prerequisites of manifest builds (e.g. `${foo}` references) are known
+    /// at Makefile parse time without requiring a second `nix eval` discovery
+    /// call.
+    ///
+    /// `nef_stability` is the stability used to resolve the catalog build
+    /// inputs of NEF (expression) builds, as selected by the `--stability`
+    /// flag. When [None] the Makefile falls back to its default stability.
+    #[allow(clippy::too_many_arguments)]
     fn build(
         self,
         expression_build_nixpkgs: &Url,
         flox_interpreter: &Path,
-        package: &[PackageTargetName],
+        packages: &[PackageTargetName],
+        nef_stability: Option<String>,
         build_cache: Option<bool>,
         system_override: Option<String>,
     ) -> Result<BuildResults, ManifestBuilderError>;
@@ -296,11 +309,13 @@ impl ManifestBuilder for FloxBuildMk<'_> {
     /// of manifest and expression build if `expression_build_nixpkgs_url`
     /// is different from the environments toplevel group,
     /// i.e. manifest builds and expression builds would use incompatible nixpkgs.
+    #[allow(clippy::too_many_arguments)]
     fn build(
         self,
         expression_build_nixpkgs_url: &Url,
         flox_interpreter: &Path,
         packages: &[PackageTargetName],
+        nef_stability: Option<String>,
         build_cache: Option<bool>,
         system_override: Option<String>,
     ) -> Result<BuildResults, ManifestBuilderError> {
@@ -310,6 +325,13 @@ impl ManifestBuilder for FloxBuildMk<'_> {
         command.arg(format!(
             "EXPRESSION_BUILD_NIXPKGS_URL={expression_build_nixpkgs_url}"
         ));
+
+        // The stability used to resolve NEF catalog build inputs. Only passed
+        // when the caller selected one via `--stability`; otherwise the
+        // Makefile applies its own default.
+        if let Some(nef_stability) = nef_stability {
+            command.arg(format!("EXPRESSION_BUILD_STABILITY={nef_stability}"));
+        }
 
         if let Some(system_override) = system_override {
             command.arg(format!("NIX_SYSTEM={system_override}"));
@@ -855,6 +877,7 @@ pub mod test_helpers {
             &toplevel_or_common_nixpkgs,
             &env.rendered_env_links(flox).unwrap().dev,
             &[PackageTargetName::new_unchecked(&package)],
+            None,
             build_cache,
             None,
         );

--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -57,19 +57,11 @@ pub trait ManifestBuilder {
     /// The build process will start in the background.
     /// To process the output, the caller should iterate over the returned [BuildOutput].
     /// Once the process is complete, the [BuildOutput] will yield an [Output::Exit] message.
-    ///
-    /// `nef_targets` is the complete set of Nix expression build target names
-    /// present in the environment.
-    /// The builder passes this list to the underlying Makefile so that NEF
-    /// prerequisites of manifest builds (e.g. `${foo}` references) are known
-    /// at Makefile parse time without requiring a second `nix eval` discovery
-    /// call.
     fn build(
         self,
         expression_build_nixpkgs: &Url,
         flox_interpreter: &Path,
-        packages: &[PackageTargetName],
-        nef_targets: &[PackageTargetName],
+        package: &[PackageTargetName],
         build_cache: Option<bool>,
         system_override: Option<String>,
     ) -> Result<BuildResults, ManifestBuilderError>;
@@ -309,7 +301,6 @@ impl ManifestBuilder for FloxBuildMk<'_> {
         expression_build_nixpkgs_url: &Url,
         flox_interpreter: &Path,
         packages: &[PackageTargetName],
-        nef_targets: &[PackageTargetName],
         build_cache: Option<bool>,
         system_override: Option<String>,
     ) -> Result<BuildResults, ManifestBuilderError> {
@@ -356,34 +347,6 @@ impl ManifestBuilder for FloxBuildMk<'_> {
             .expect("failed to keep build result fifo");
 
         command.arg(format!("BUILD_RESULT_FILE={}", build_result_path.display()));
-
-        let empty_catalog_lock = NamedTempFile::new_in(self.temp_dir)
-            .map_err(ManifestBuilderError::CreateBuildResultFile)?
-            .into_temp_path();
-        // SAFETY: according to the docs, this is only fallible on _Windows_
-        let empty_catalog_lock = empty_catalog_lock
-            .keep()
-            .expect("failed to keep empty catalog lock file");
-        nef_lock_catalog::write_lock(&nef_lock_catalog::BuildLock::default(), &empty_catalog_lock)
-            .map_err(|e| ManifestBuilderError::CreateBuildResultFile(std::io::Error::other(e)))?;
-
-        // TODO(SL-002): point each `catalogLockfile_<pname>` at the
-        // per-package in-tree lockfile (follow-up) or the resolved
-        // BuildLock from CLI dispatch (SL-003 follow-up). For now,
-        // every NEF target gets the same empty-default lock.
-        //
-        // Only NEF (expression) builds use `catalogLockfile_<pname>`;
-        // manifest builds don't.  `nef_targets` is the complete set of
-        // expression build targets, covering both directly-requested
-        // expression builds and any NEF prerequisites of manifest builds
-        // (referenced via `${pname}` in their build scripts).
-        for name in nef_targets {
-            command.arg(format!(
-                "catalogLockfile_{}={}",
-                name.as_ref(),
-                empty_catalog_lock.display()
-            ));
-        }
 
         let build_cache = build_cache.unwrap_or(true);
         if !build_cache {
@@ -602,7 +565,7 @@ pub fn find_toplevel_group_nixpkgs(lockfile: &Lockfile) -> Option<BaseCatalogUrl
 /// only needs to resolve to a directory containing `pkgs` dir,
 /// and it _does not_ have to use a git fetcher
 /// or give access to the entire project.
-pub(crate) fn get_nix_expression_targets(
+fn get_nix_expression_targets(
     expression_ref: &NixFlakeref,
 ) -> Result<Vec<(String, ExpressionBuildMetadata)>, ManifestBuilderError> {
     #[derive(Debug, Deserialize)]
@@ -831,18 +794,6 @@ impl PackageTargets {
             })
             .collect()
     }
-
-    /// Returns the names of all Nix expression (NEF) build targets.
-    ///
-    /// The returned names are borrowed from the internal target map,
-    /// so they are valid for the lifetime of this [PackageTargets].
-    pub fn nef_target_names(&self) -> Vec<PackageTargetName<'_>> {
-        self.targets
-            .iter()
-            .filter(|(_, kind)| kind.is_expression_build())
-            .map(|(name, _)| PackageTargetName(name.as_str()))
-            .collect()
-    }
 }
 
 #[cfg(any(test, feature = "tests"))]
@@ -889,19 +840,6 @@ pub mod test_helpers {
                 .map(|toplevel_nixpkgs| toplevel_nixpkgs.as_flake_ref().unwrap())
                 .unwrap_or_else(|| COMMON_NIXPKGS_URL.clone());
 
-        // Discover all NEF targets so every expression build gets a
-        // `catalogLockfile_<pname>` argument, including any that serve
-        // as prerequisites for manifest builds.
-        let nef_target_names: Vec<String> = get_nix_expression_targets(expression_ref)
-            .unwrap_or_default()
-            .into_iter()
-            .map(|(name, _)| name)
-            .collect();
-        let nef_targets: Vec<PackageTargetName<'_>> = nef_target_names
-            .iter()
-            .map(|n| PackageTargetName::new_unchecked(n))
-            .collect();
-
         let mut output_stdout = String::new();
         let mut output_stderr = String::new();
 
@@ -917,7 +855,6 @@ pub mod test_helpers {
             &toplevel_or_common_nixpkgs,
             &env.rendered_env_links(flox).unwrap().dev,
             &[PackageTargetName::new_unchecked(&package)],
-            &nef_targets,
             build_cache,
             None,
         );

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -904,6 +904,9 @@ pub fn check_build_metadata(
         &base_nixpkgs_url.as_flake_ref()?,
         &built_environments.dev,
         &[pkg.name()],
+        // The base nixpkgs url is resolved for the publish flow ahead of time,
+        // so the NEF catalog inputs use the Makefile's default stability.
+        None,
         Some(false),
         system_override,
     )?;

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -39,7 +39,6 @@ use super::build::{
     PackageTarget,
     PackageTargetError,
     PackageTargetKind,
-    PackageTargetName,
     find_toplevel_group_nixpkgs,
 };
 use super::buildenv::BuildEnvOutputs;
@@ -891,7 +890,6 @@ pub fn check_build_metadata(
     system_override: Option<String>,
     env_metadata: &CheckedEnvironmentMetadata,
     pkg: &PackageTarget,
-    nef_targets: &[PackageTargetName<'_>],
 ) -> Result<CheckedBuildMetadata, PublishError> {
     let workdir = if sandbox_is_local(pkg) {
         BuildWorkdir::SharedClone
@@ -902,17 +900,10 @@ pub fn check_build_metadata(
 
     let builder = FloxBuildMk::new(flox, &base_dir, &expression_ref, &built_environments);
 
-    // Build the package and collect the outputs.
-    // `nef_targets` carries the complete set of Nix expression build target
-    // names for this environment (supplied by the caller). The Makefile needs
-    // a `catalogLockfile_<pname>` argument for every NEF target so that
-    // expression builds — including those that serve as prerequisites for the
-    // manifest package being published — can proceed.
     let build_results = builder.build(
         &base_nixpkgs_url.as_flake_ref()?,
         &built_environments.dev,
         &[pkg.name()],
-        nef_targets,
         Some(false),
         system_override,
     )?;
@@ -1569,7 +1560,6 @@ pub mod tests {
             None,
             &env_metadata,
             &EXAMPLE_MANIFEST_PACKAGE_TARGET,
-            &[EXAMPLE_MANIFEST_PACKAGE_TARGET.name()],
         )
         .unwrap();
 
@@ -1616,7 +1606,6 @@ pub mod tests {
             None,
             &env_metadata,
             &EXAMPLE_MANIFEST_PACKAGE_TARGET_MISSING_FIELDS,
-            &[EXAMPLE_MANIFEST_PACKAGE_TARGET_MISSING_FIELDS.name()],
         )
         .unwrap();
 
@@ -1673,7 +1662,6 @@ pub mod tests {
             None,
             &env_metadata,
             &pure_pkg,
-            &[pure_pkg.name()],
         )
         .unwrap();
 
@@ -1713,7 +1701,6 @@ pub mod tests {
             None,
             &env_metadata,
             &package_metadata.package,
-            &[package_metadata.package.name()],
         )
         .unwrap();
 
@@ -1775,7 +1762,6 @@ pub mod tests {
             None,
             &env_metadata,
             &package_metadata.package,
-            &[package_metadata.package.name()],
         )
         .unwrap();
 
@@ -2081,7 +2067,6 @@ pub mod tests {
             None,
             &env_metadata,
             &package_metadata.package,
-            &[package_metadata.package.name()],
         )
         .unwrap();
 

--- a/cli/flox/src/commands/build.rs
+++ b/cli/flox/src/commands/build.rs
@@ -285,6 +285,13 @@ impl Build {
             nixpkgs_url_select.is_some(),
         )?;
 
+        // The `--stability` selection also determines the stability used to
+        // resolve the catalog build inputs of NEF (expression) builds.
+        let nef_stability = match &nixpkgs_url_select {
+            Some(BaseCatalogUrlSelect::Stability(stability)) => Some(stability.clone()),
+            _ => None,
+        };
+
         let base_nixpkgs_url =
             base_nixpkgs_url_from_url_select(&flox, nixpkgs_url_select, Some(&lockfile))
                 .await?
@@ -318,6 +325,7 @@ impl Build {
             &base_nixpkgs_url,
             &FLOX_INTERPRETER,
             &target_names,
+            nef_stability,
             None,
             system_override,
         )?;

--- a/cli/flox/src/commands/build.rs
+++ b/cli/flox/src/commands/build.rs
@@ -220,8 +220,7 @@ impl Build {
         let lockfile: Lockfile = env.lockfile(&flox)?.into();
 
         let lockfile_manifest = lockfile.migrated_manifest()?;
-        let (packages_to_clean, _) =
-            packages_to_build(&lockfile_manifest, &expression_ref, &packages)?;
+        let packages_to_clean = packages_to_build(&lockfile_manifest, &expression_ref, &packages)?;
         let target_names = packages_to_clean
             .iter()
             .map(|target| target.name())
@@ -265,23 +264,24 @@ impl Build {
         prefetch_flake_ref(&COMMON_NIXPKGS_URL)?;
 
         let lockfile_manifest = lockfile.migrated_manifest()?;
-        let (selected_packages, all_targets, expression_ref) = {
+        let (packages_to_build, expression_ref) = {
             // TODO: decouple from env
             let expression_parent_dir = env.dot_flox_path();
             let expression_path_ref = NixFlakeref::from_path(&expression_parent_dir)?;
-            let (selected, all_targets) =
+            let packages_to_build =
                 packages_to_build(&lockfile_manifest, &expression_path_ref, &packages)?;
-            let expression_git_ref =
-                check_git_tracking_for_expression_builds(&selected, &expression_parent_dir)?;
+            let expression_git_ref = check_git_tracking_for_expression_builds(
+                &packages_to_build,
+                &expression_parent_dir,
+            )?;
             (
-                selected,
-                all_targets,
+                packages_to_build,
                 expression_git_ref.unwrap_or(expression_path_ref),
             )
         };
 
         disallow_base_url_select_for_manifest_builds(
-            &selected_packages,
+            &packages_to_build,
             nixpkgs_url_select.is_some(),
         )?;
 
@@ -290,19 +290,17 @@ impl Build {
                 .await?
                 .as_flake_ref()?;
 
-        prefetch_expression_build_flake_ref(&selected_packages, &base_nixpkgs_url)?;
+        prefetch_expression_build_flake_ref(&packages_to_build, &base_nixpkgs_url)?;
 
-        let target_names = selected_packages
+        let target_names = packages_to_build
             .iter()
             .map(|target| target.name())
             .collect::<Vec<_>>();
 
-        let nef_target_names = all_targets.nef_target_names();
-
-        let has_expression_build = selected_packages
+        let has_expression_build = packages_to_build
             .iter()
             .any(|target| target.kind().is_expression_build());
-        let has_manifest_build = selected_packages
+        let has_manifest_build = packages_to_build
             .iter()
             .any(|target| target.kind().is_manifest_build());
         subcommand_metric!(
@@ -320,7 +318,6 @@ impl Build {
             &base_nixpkgs_url,
             &FLOX_INTERPRETER,
             &target_names,
-            &nef_target_names,
             None,
             system_override,
         )?;
@@ -747,7 +744,7 @@ pub(crate) fn packages_to_build<'o>(
     manifest: &'o Manifest<MigratedTypedOnly>,
     expression_ref: &'o NixFlakeref,
     packages: &[impl AsRef<str>],
-) -> Result<(Vec<PackageTarget>, PackageTargets)> {
+) -> Result<Vec<PackageTarget>> {
     let available_targets = PackageTargets::new(manifest, expression_ref)?;
 
     if available_targets.is_empty() {
@@ -766,7 +763,7 @@ pub(crate) fn packages_to_build<'o>(
         available_targets.all()
     };
 
-    Ok((selected, available_targets))
+    Ok(selected)
 }
 
 #[cfg(test)]

--- a/cli/flox/src/commands/publish.rs
+++ b/cli/flox/src/commands/publish.rs
@@ -6,7 +6,7 @@ use flox_events::EventsHub;
 use flox_manifest::{Manifest, MigratedTypedOnly};
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::{ConcreteEnvironment, Environment};
-use flox_rust_sdk::providers::build::{COMMON_NIXPKGS_URL, PackageTarget, PackageTargets};
+use flox_rust_sdk::providers::build::{COMMON_NIXPKGS_URL, PackageTarget};
 use flox_rust_sdk::providers::catalog::SystemEnum;
 use flox_rust_sdk::providers::nix_auth::NixAuth;
 use flox_rust_sdk::providers::publish::{
@@ -132,14 +132,15 @@ impl Publish {
         manifest: &Manifest<MigratedTypedOnly>,
         expression_ref: &NixFlakeref,
         target_arg: Option<PublishTarget>,
-    ) -> Result<(PackageTarget, PackageTargets)> {
-        let (selected, all_targets) = packages_to_build(
+    ) -> Result<PackageTarget> {
+        match packages_to_build(
             manifest,
             expression_ref,
             &Vec::from_iter(target_arg.map(|arg| arg.target)),
-        )?;
-        match selected.as_slice() {
-            [target] => Ok((target.clone(), all_targets)),
+        )?
+        .as_slice()
+        {
+            [target] => Ok(target.clone()),
             [] => bail!("Cannot publish without a build specified"),
             _ => bail!("Must specify an artifact to publish"),
         }
@@ -181,17 +182,17 @@ impl Publish {
         prefetch_flake_ref(&COMMON_NIXPKGS_URL)?;
 
         let lockfile_manifest = lockfile.migrated_manifest()?;
-        let (package, all_targets) = {
+        let package = {
             let expression_dir_parent = path_env.dot_flox_path();
             let expression_ref_local = NixFlakeref::from_path(&expression_dir_parent)?;
-            let (package, all_targets) =
+            let package =
                 Self::get_publish_target(&lockfile_manifest, &expression_ref_local, package_arg)?;
 
             // Note: when publishing an expression build,
             // this causes us to discover the containing git repo twice.
             // While slightly redundant it outweighs the complexity of reusing git instances.
             check_git_tracking_for_expression_builds([&package], &expression_dir_parent)?;
-            (package, all_targets)
+            package
         };
 
         disallow_base_url_select_for_manifest_builds(
@@ -314,14 +315,12 @@ impl Publish {
             },
         }
 
-        let nef_targets = all_targets.nef_target_names();
         let build_metadata = check_build_metadata(
             &flox,
             &selected_base_nixpkgs_url,
             system_override_inner,
             &publish_provider.env_metadata,
             &publish_provider.package_metadata.package,
-            &nef_targets,
         )?;
 
         // CLI args take precedence over config
@@ -407,7 +406,7 @@ mod tests {
             .unwrap()
             .as_migrated_typed_only();
 
-        let (target, _) =
+        let target =
             Publish::get_publish_target(&manifest, prepare_empty_expressions_ref(), None).unwrap();
         assert_eq!(
             target,
@@ -473,7 +472,7 @@ mod tests {
         let manifest = Manifest::parse_and_migrate(manifest_contents, None)
             .unwrap()
             .as_migrated_typed_only();
-        let (target, _) = Publish::get_publish_target(
+        let target = Publish::get_publish_target(
             &manifest,
             prepare_empty_expressions_ref(),
             Some(PublishTarget {
@@ -504,7 +503,7 @@ mod tests {
         let manifest = Manifest::parse_and_migrate(manifest_contents, None)
             .unwrap()
             .as_migrated_typed_only();
-        let (target, _) = Publish::get_publish_target(
+        let target = Publish::get_publish_target(
             &manifest,
             prepare_empty_expressions_ref(),
             Some(PublishTarget {

--- a/cli/nef-lock-catalog/src/bin/lock.rs
+++ b/cli/nef-lock-catalog/src/bin/lock.rs
@@ -19,6 +19,7 @@ use nef_lock_catalog::{
     CatalogRef,
     LockError,
     lock_references,
+    render_lock,
     render_unresolvable,
     scan_package,
     write_lock,
@@ -44,9 +45,10 @@ struct Cli {
     #[arg(long = "rel-path", required = true)]
     rel_paths: Vec<PathBuf>,
 
-    /// Path to write the resulting build lock to.
+    /// Path to write the resulting build lock to. When omitted, the lock is
+    /// printed to stdout.
     #[arg(long)]
-    out: PathBuf,
+    out: Option<PathBuf>,
 
     /// Catalog stability channel.
     #[arg(long, default_value = "stable")]
@@ -98,7 +100,7 @@ async fn main() -> ExitCode {
     fields(
         base_dir = %cli.base_dir.display(),
         rel_paths = cli.rel_paths.len(),
-        out = %cli.out.display(),
+        out = cli.out.as_deref().map(|out| out.display().to_string()).unwrap_or_else(|| "<stdout>".to_string()),
         stability = cli.stability,
     )
 )]
@@ -138,7 +140,12 @@ async fn run(cli: Cli) -> Result<()> {
         Err(other) => return Err(other.into()),
     };
 
-    write_lock(&lock, &cli.out)?;
+    // Write to the requested file, or print to stdout when `--out` is omitted
+    // (convenient for firing the helper off by hand on the command line).
+    match cli.out {
+        Some(out) => write_lock(&lock, &out)?,
+        None => println!("{}", render_lock(&lock)?),
+    }
     Ok(())
 }
 

--- a/cli/nef-lock-catalog/src/lib.rs
+++ b/cli/nef-lock-catalog/src/lib.rs
@@ -23,7 +23,7 @@ impl Display for CatalogId {
     }
 }
 
-pub use lock::build_lock::{BuildLock, write_lock};
+pub use lock::build_lock::{BuildLock, render_lock, write_lock};
 pub use lock::flakeref::NixFlakeref;
 pub use lock::lookup::{LockError, lock_references};
 pub use lock::render::render_unresolvable;

--- a/cli/nef-lock-catalog/src/lock/build_lock.rs
+++ b/cli/nef-lock-catalog/src/lock/build_lock.rs
@@ -35,12 +35,19 @@ pub struct BuildLock {
 
 impl BuildLock {}
 
+/// Serialize a `BuildLock` to the pretty-printed JSON format consumed by the
+/// NEF. Shared by [write_lock] and callers that stream the lock elsewhere
+/// (e.g. stdout).
+pub fn render_lock(lock: &BuildLock) -> Result<String> {
+    serde_json::to_string_pretty(lock).context("failed to serialize lockfile")
+}
+
 /// Write a `BuildLock` to the specified file.
 /// The file is written in a pretty-printed JSON format
 /// and consumed by the NEF.
 #[instrument(skip(lock), fields(path = %path.as_ref().display()))]
 pub fn write_lock(lock: &BuildLock, path: impl AsRef<Path>) -> Result<()> {
-    let json = serde_json::to_string_pretty(&lock).context("failed to serialize lockfile")?;
+    let json = format!("{}\n", render_lock(lock)?);
     fs::write(&path, &json)
         .with_context(|| format!("failed to write {path:?}", path = path.as_ref()))?;
     debug!(bytes = json.len(), "wrote build lock");

--- a/package-builder/flox-build.mk
+++ b/package-builder/flox-build.mk
@@ -28,6 +28,12 @@ endif
 space := $(subst x,,x x)
 comma := ,
 
+# Define macro for sanitizing build targets to be represented within
+# a Makefile variable name.
+define mkVarname =
+  $(subst -,_,$(1))
+endef
+
 # Substitute Nix store paths for packages required by this Makefile.
 __bash := @bash@
 __coreutils := @coreutils@
@@ -131,32 +137,46 @@ PROJECT_TMPDIR := $(TMPDIR)/$(shell echo $(PWD) | $(_sha256sum) | $(_head) -c8)
 # Use the wildcard operator to identify builds in the provided $FLOX_ENV.
 MANIFEST_BUILDS := $(wildcard $(FLOX_ENV)/package-builds.d/*)
 
-# TODO NIX_EXPRESSION_REF may be absent
+# If NIX_EXPRESSION_REF provided then use it to take inventory of NEF builds.
 ifneq (,$(NIX_EXPRESSION_REF))
-  NIX_EXPRESSION_REF_ARGS := \
-  --argstr source-ref '$(NIX_EXPRESSION_REF)'
+  # Unique separator string that is unlikely to appear in a filename or path.
+  __split = :/:/:
 
-  NIX_EXPRESSION_BUILDS := \
-  $(shell $(_nix) eval \
-  --argstr nixpkgs-url '$(BUILDTIME_NIXPKGS_URL)' \
-  --argstr system $(NIX_SYSTEM) \
-  $(NIX_EXPRESSION_REF_ARGS) \
-  --file $(_nef) \
-  reflect.targets --raw)
+  # Construct list of "<attrPath>:<absDirPath>:<relFilePath>" tuples for known
+  # NEF builds, e.g. "my.package:/path/to/.flox/pkgs:my/package.nix" or
+  # "my.package:/path/to/.flox/pkgs:my/package/default.nix".
+  __nix_expression_build_tuples := $(shell \
+    $(_nix) eval \
+      --argstr source-ref '$(NIX_EXPRESSION_REF)' \
+      --argstr nixpkgs-url '$(BUILDTIME_NIXPKGS_URL)' \
+      --argstr system '$(NIX_SYSTEM)' \
+      --file $(_nef) \
+      reflect.attrPaths --json | \
+    $(_jq) -r --arg x '$(__split)' \
+      '.[] | .attrPathStr + $$x + .relFilePath + $$x + .absDirPath')
+
+  # Iterate through __nix_expression_build_tuples building NIX_EXPRESSION_BUILDS
+  # as we define NIX_EXPRESSION_RELFILEPATH_<attrPath> for each build.
+  $(foreach _build_and_path,$(__nix_expression_build_tuples),\
+    $(eval _attrPath := $(firstword $(subst $(__split), ,$(_build_and_path)))) \
+    $(eval NIX_EXPRESSION_BUILDS += $(_attrPath)) \
+    $(eval __remain := $(subst $(_attrPath)$(__split),,$(_build_and_path))) \
+    $(eval _relFilePath := $(firstword $(subst $(__split), ,$(__remain)))) \
+    $(eval _absDirPath := $(subst $(_relFilePath)$(__split),,$(__remain))) \
+    $(eval _pvarname = $(call mkVarname,$(_attrPath))) \
+    $(eval NIX_EXPRESSION_ABSDIRPATH_$(_pvarname) := $(_absDirPath)) \
+    $(eval NIX_EXPRESSION_RELFILEPATH_$(_pvarname) := $(_relFilePath)) \
+  )
+
+  # Cleanup temporary variables scoped to above block.
+  undefine _attrPath
+  undefine _relFilePath
+  undefine _absDirPath
+  undefine _pvarname
+  undefine __remain
+  undefine __nix_expression_build_tuples
+  undefine __split
 endif
-
-
-
-# Construct three orthogonal arguments for nef:
-#   source-ref: flakeref to the source root (for fetching/tracking)
-#   pkgs-dir:   relative path to packages directory within the source
-#   catalogs-lock: relative path to catalog lock file within the source (if present)
-
-
-
-
-
-
 
 # Quick sanity check; if no MANIFEST_BUILDS then what are we doing?
 $(if $(MANIFEST_BUILDS),,\
@@ -204,7 +224,7 @@ $(PROJECT_TMPDIR)/check-build-prerequisites:
 BUILDGOALS = $(if $(MAKECMDGOALS),$(MAKECMDGOALS),$(notdir $(MANIFEST_BUILDS)))
 $(foreach _build,$(BUILDGOALS),\
   $(eval _pname = $(notdir $(_build)))\
-  $(eval _pvarname = $(subst -,_,$(_pname)))\
+  $(eval _pvarname = $(call mkVarname,$(_pname))) \
   $(foreach _buildtype,local sandbox,\
     $(eval $(_pvarname)_$(_buildtype)_build: $(PROJECT_TMPDIR)/check-build-prerequisites)))
 
@@ -219,7 +239,7 @@ define COMMON_BUILD_VARS_template =
   # We want to create build-specific variables, and variable names cannot
   # have "-" in them so we create a version of the build "pname" replacing
   # this with "_" for use in variable names.
-  $(eval _pvarname = $(subst -,_,$(_pname)))
+  $(eval _pvarname = $(call mkVarname,$(_pname)))
   # Define build-specific result symlink basename.
   $(eval $(_pvarname)_result = result-$(_pname))
   # Compute 32-character stable string for use in stable path generation
@@ -245,6 +265,7 @@ define COMMON_BUILD_VARS_template =
   $(eval $(_pvarname)_evalJSON = $($(_pvarname)_tmpBasename)/eval.json)
   $(eval $(_pvarname)_buildJSON = $($(_pvarname)_tmpBasename)/build.json)
   $(eval $(_pvarname)_buildMetaJSON = $($(_pvarname)_tmpBasename)/build-meta.json)
+  $(eval $(_pvarname)_catalogLockfile = $($(_pvarname)_tmpBasename)/catalog.lock)
 
   # Create a temporary file for collecting log output from the build.
   $(eval $(_pvarname)_logfile = $($(_pvarname)_tmpBasename)/build.log)
@@ -289,7 +310,7 @@ $(foreach _pname,$(NIX_EXPRESSION_BUILDS) $(notdir $(MANIFEST_BUILDS)), \
 # target prerequisites for any inter-package prerequisites, letting make
 # flag any circular dependencies encountered along the way.
 define MANIFEST_BUILD_DEPENDS_template =
-  $(eval _pvarname = $(subst -,_,$(notdir $(build))))
+  $(eval _pvarname = $(call mkVarname,$(notdir $(build))))
 
   # Iterate over each possible {build,package} pair looking for references to
   # ${package} in the build script, being careful to avoid looking for references
@@ -509,7 +530,7 @@ define BUILD_local_template =
 	  --slurpfile manifest "$(MANIFEST_LOCK)" \
 	  --arg log "$(shell $(_readlink) $($(_pvarname)_result)-log)" \
 	  --argjson resultLinks '$$($(_pvarname)_resultLinks_json)' \
-	  '($$$$manifest[0].manifest.build."$(_pname)" | with_entries(select(.key == "description" or .key == "license"))) * { "outputsToInstall":["out"] } as $$$$meta | .[0] * { name:$$$$name, pname:$$$$pname, system: $$$$system, version:$$$$version, log:$$$$log, resultLinks: $$$$resultLinks, meta: $$$$meta }' $$< > $$@
+	  '($$$$manifest[0].manifest.build."$(_pname)" | with_entries(select(.key == "description" or .key == "license"))) * { "outputsToInstall":["out"] } as $$$$meta | .[0] * { name:$$$$name, pname:$$$$pname, system:$$$$system, version:$$$$version, log:$$$$log, resultLinks:$$$$resultLinks, meta:$$$$meta }' $$< > $$@
 	@echo "Completed build of $(_name) in local mode" && echo ""
 
 endef
@@ -596,7 +617,7 @@ define BUILD_nix_sandbox_template =
 	  --arg system "$(NIX_SYSTEM)" \
 	  --slurpfile manifest "$(MANIFEST_LOCK)" \
 	  --argjson resultLinks '$$($(_pvarname)_resultLinks_json)' \
-	  '($$$$manifest[0].manifest.build."$(_pname)" | with_entries(select(.key == "description" or .key == "license"))) * { "outputsToInstall":["out"] } as $$$$meta | .[0] * { name:$$$$name, pname:$$$$pname, system: $$$$system, version:$$$$version, log:.[0].outputs.log, resultLinks:$$$$resultLinks, meta: $$$$meta }' $$< > $$@
+	  '($$$$manifest[0].manifest.build."$(_pname)" | with_entries(select(.key == "description" or .key == "license"))) * { "outputsToInstall":["out"] } as $$$$meta | .[0] * { name:$$$$name, pname:$$$$pname, system:$$$$system, version:$$$$version, log:.[0].outputs.log, resultLinks:$$$$resultLinks, meta:$$$$meta }' $$< > $$@
 	@echo "Completed build of $(_name) in Nix sandbox mode" && echo ""
 	@# Check to see if a new buildCache has been created, and if so then go
 	@# ahead and run 'nix store delete' on the previous cache, keeping in
@@ -637,7 +658,7 @@ define MANIFEST_BUILD_template =
   # We want to create build-specific variables, and variable names cannot
   # have "-" in them so we create a version of the build "pname" replacing
   # this with "_" for use in variable names.
-  $(eval _pvarname = $(subst -,_,$(_pname)))
+  $(eval _pvarname = $(call mkVarname,$(_pname)))
   # Calculate name.
   $(eval _name = $(_pname)-$(_version))
 
@@ -789,21 +810,26 @@ define NIX_EXPRESSION_BUILD_template =
   # We want to create build-specific variables, and variable names cannot
   # have "-" in them so we create a version of the build "pname" replacing
   # this with "_" for use in variable names.
-  $(eval _pvarname = $(subst -,_,$(_pname)))
+  $(eval _pvarname = $(call mkVarname,$(_pname)))
 
-  # Start by evaluating the build
+  # Start by calculating the catalog inputs lock.
+  # TODO: pass stability from build.rs to Makefile
+  $($(_pvarname)_catalogLockfile): $(PROJECT_TMPDIR)/check-build-prerequisites
+	$(_V_) $(_mkdir) -p $$(@D)
+	$(_V_) $(_lock) \
+	  --base-dir '$$(NIX_EXPRESSION_ABSDIRPATH_$(_pvarname))' \
+	  --rel-path '$$(NIX_EXPRESSION_RELFILEPATH_$(_pvarname))' \
+	  --stability unstable \
+	  --out $$@
 
-  # TODO(SL-002): point at the per-package in-tree lockfile (follow-up) or
-  # the resolved BuildLock from CLI dispatch (SL-003 follow-up). For now,
-  # `catalogLockfile_<pname>` is supplied by the caller and points at an
-  # empty default lock.
-  $($(_pvarname)_evalJSON): $(PROJECT_TMPDIR)/check-build-prerequisites
+  # Continue by evaluating the build
+  $($(_pvarname)_evalJSON): $($(_pvarname)_catalogLockfile)
 	$(_V_) $(_mkdir) -p $$(@D)
 	$(_V_) $(_nix) eval -L --file $(_nef) \
 	  --argstr nixpkgs-url '$(EXPRESSION_BUILD_NIXPKGS_URL)' \
-	  --argstr system $(NIX_SYSTEM) \
-	  $(NIX_EXPRESSION_REF_ARGS) \
-	  --argstr catalog-lockfile $(catalogLockfile_$(_pname)) \
+	  --argstr system '$(NIX_SYSTEM)' \
+	  --argstr source-ref '$(NIX_EXPRESSION_REF)' \
+	  --argstr catalog-lockfile $$< \
 	  --json \
 	  --apply 'pkg: { \
 	    drvPath = pkg.drvPath; \
@@ -850,12 +876,13 @@ define NIX_EXPRESSION_BUILD_template =
   # Following a successful build, merge in the eval json.
   $($(_pvarname)_buildMetaJSON): $($(_pvarname)_evalJSON) $($(_pvarname)_buildJSON) $($(_pvarname)_result)-log
 	$(_V_) $(_jq) -n \
-	  --arg logfile $$(shell $(_readlink) $($(_pvarname)_result)-log) \
 	  --arg system $(NIX_SYSTEM) \
+	  --arg catalogLockfile '$$($(_pvarname)_catalogLockfile)' \
+	  --arg logfile $$(shell $(_readlink) $($(_pvarname)_result)-log) \
 	  --argjson resultLinks '$$($(_pvarname)_resultLinks_json)' \
 	  --slurpfile eval $($(_pvarname)_evalJSON) \
 	  --slurpfile build $($(_pvarname)_buildJSON) \
-	  '$$$$build[0][0] * $$$$eval[0] * { system: $$$$system, log: $$$$logfile, resultLinks: $$$$resultLinks }' > $$@
+	  '$$$$build[0][0] * $$$$eval[0] * { system:$$$$system, catalogLockfile:$$$$catalogLockfile, log:$$$$logfile, resultLinks:$$$$resultLinks }' > $$@
 	@echo -e "Completed build of $$(_name) in Nix expression mode\n"
 
   # Create targets for cleaning up the result and log symlinks.

--- a/package-builder/flox-build.mk
+++ b/package-builder/flox-build.mk
@@ -121,6 +121,13 @@ ifeq (,$(NIX_SYSTEM))
   NIX_SYSTEM = $(NIX_SYSTEM_CURRENT)
 endif
 
+# Stability used to resolve the catalog build inputs of NEF builds. The flox
+# CLI passes this through from the --stability flag; default to "unstable"
+# when it is not provided.
+ifeq (,$(EXPRESSION_BUILD_STABILITY))
+  EXPRESSION_BUILD_STABILITY = unstable
+endif
+
 # Set the default goal to be all builds if one is not specified.
 .DEFAULT_GOAL := usage
 
@@ -813,13 +820,12 @@ define NIX_EXPRESSION_BUILD_template =
   $(eval _pvarname = $(call mkVarname,$(_pname)))
 
   # Start by calculating the catalog inputs lock.
-  # TODO: pass stability from build.rs to Makefile
   $($(_pvarname)_catalogLockfile): $(PROJECT_TMPDIR)/check-build-prerequisites
 	$(_V_) $(_mkdir) -p $$(@D)
 	$(_V_) $(_lock) \
 	  --base-dir '$$(NIX_EXPRESSION_ABSDIRPATH_$(_pvarname))' \
 	  --rel-path '$$(NIX_EXPRESSION_RELFILEPATH_$(_pvarname))' \
-	  --stability unstable \
+	  --stability '$(EXPRESSION_BUILD_STABILITY)' \
 	  --out $$@
 
   # Continue by evaluating the build

--- a/package-builder/nef/lib/reflect.nix
+++ b/package-builder/nef/lib/reflect.nix
@@ -25,18 +25,21 @@ let
         attrPath = ["foo"];
         attrPathStr = "foo";
         relFilePath = "foo";
+        absDirPath = "<expression_dir>";
         absFilePath = "<expression_dir>/foo.nix";
       }
       {
         attrPath = ["bar" "baz"];
         attrPathStr = "bar.baz";
         relFilePath = "bar/baz.nix";
+        absDirPath = "<expression_dir>";
         absFilePath = "<expression_dir>/bar/baz.nix";
       }
       {
         attrPath = ["bar" "bam"];
         attrPathStr = "bar.bam";
         relFilePath = "bar/bam/default.nix";
+        absDirPath = "<expression_dir>";
         absFilePath = "<expression_dir>/bar/bam/default.nix";
       }
     ]
@@ -50,6 +53,7 @@ let
     TargetMetadata :: {
       attrPath :: [ String ],
       attrPathStr :: String,
+      absDirPath :: Path,
       absFilePath :: Path,
       relFilePath :: Path,
     }
@@ -73,6 +77,7 @@ let
           "nix" = {
             inherit attrPath;
             attrPathStr = lib.showAttrPath attrPath;
+            absDirPath = attrsFromDirTop.path;
             absFilePath = attrsFromDir.path;
             relFilePath = lib.removePrefix "${attrsFromDirTop.path}/" attrsFromDir.path;
           };

--- a/package-builder/nef/tests/reflectTests/default.nix
+++ b/package-builder/nef/tests/reflectTests/default.nix
@@ -43,6 +43,7 @@ in
           "nestedPkg"
         ];
         attrPathStr = "nestedPkgs.nestedPkg";
+        absDirPath = "${baseDir}/nested";
         absFilePath = "${baseDir}/nested/nestedPkgs/nestedPkg.nix";
         relFilePath = "nestedPkgs/nestedPkg.nix";
       }
@@ -52,12 +53,14 @@ in
           "otherNestedPkg"
         ];
         attrPathStr = "nestedPkgs.otherNestedPkg";
+        absDirPath = "${baseDir}/nested";
         absFilePath = "${baseDir}/nested/nestedPkgs/otherNestedPkg/default.nix";
         relFilePath = "nestedPkgs/otherNestedPkg/default.nix";
       }
       {
         attrPath = [ "toplevelPkg" ];
         attrPathStr = "toplevelPkg";
+        absDirPath = "${baseDir}/nested";
         absFilePath = "${baseDir}/nested/toplevelPkg.nix";
         relFilePath = "toplevelPkg.nix";
       }


### PR DESCRIPTION
Compute catalog inputs for NEF builds and provide it to the NEF library evaluation, then incorporate the path to the catalog inputs lockfile as part of the build results.