### PR TITLE
test(services): services stop after auto-activated environment is deactivated

### DIFF
--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -1735,17 +1735,16 @@ EOF
     '$FLOX_BIN' services start
     '${TESTS_DIR}'/services/wait_for_service_status.sh one:Running
 
-    # Capture the executive log path before leaving.
-    executive_log=\"\$(ls '${PROJECT_DIR}/.flox/log/executive.'*.log.* 2>/dev/null | head -1)\"
-
     # CD away; _flox_hook auto-deactivates the services project.
     cd '$BATS_TEST_TMPDIR'
     _flox_hook
-
-    # Wait for cleanup_all (executive logs 'finished cleanup' after stopping process-compose).
-    wait_for_partial_file_content \"\$executive_log\" 'finished cleanup'
   "
   assert_success
+
+  # wait_for_partial_file_content is a bats helper not available inside bash -c,
+  # so we poll the executive log here in the test body after the subshell exits.
+  executive_log="$(ls "$PROJECT_DIR/.flox/log/executive."*.log.* 2>/dev/null | head -1)"
+  wait_for_partial_file_content "$executive_log" "finished cleanup"
 }
 
 @test "vars: service-level variables are set" {

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -1721,6 +1721,7 @@ EOF
   "$FLOX_BIN" init -d "$OUTER_DIR"
 
   run --separate-stderr bash -c "
+    set -euo pipefail
     export FLOX_FEATURES_AUTO_ACTIVATE=true
     export FLOX_SHELL=\$(which bash)
 
@@ -1743,7 +1744,8 @@ EOF
 
   # wait_for_partial_file_content is a bats helper not available inside bash -c,
   # so we poll the executive log here in the test body after the subshell exits.
-  executive_log="$(ls "$PROJECT_DIR/.flox/log/executive."*.log.* 2>/dev/null | head -1)"
+  executive_log="$(echo "$PROJECT_DIR/.flox/log/executive."*.log.*)"
+  wait_for_partial_file_content "$executive_log" "woof"
   wait_for_partial_file_content "$executive_log" "finished cleanup"
 }
 

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -1708,6 +1708,46 @@ EOF
   '
 }
 
+# bats test_tags=services:auto-deactivate
+@test "services stop after auto-activated environment is deactivated" {
+  setup_sleeping_services
+
+  export FLOX_FEATURES_AUTO_ACTIVATE=true
+  "$FLOX_BIN" activate allow -d "$PROJECT_DIR"
+
+  # Minimal outer project to register _flox_hook without services.
+  local OUTER_DIR="$BATS_TEST_TMPDIR/outer-$BATS_TEST_NUMBER"
+  mkdir -p "$OUTER_DIR"
+  "$FLOX_BIN" init -d "$OUTER_DIR"
+
+  run --separate-stderr bash -c "
+    export FLOX_FEATURES_AUTO_ACTIVATE=true
+    export FLOX_SHELL=\$(which bash)
+
+    # Manually activate the outer project to get _flox_hook defined.
+    eval \"\$('$FLOX_BIN' activate -d '$OUTER_DIR')\"
+
+    # CD into the services project; _flox_hook auto-activates it.
+    cd '$PROJECT_DIR'
+    _flox_hook
+
+    # Start services after auto-activation.
+    '$FLOX_BIN' services start
+    '${TESTS_DIR}'/services/wait_for_service_status.sh one:Running
+
+    # Capture the executive log path before leaving.
+    executive_log=\"\$(ls '${PROJECT_DIR}/.flox/log/executive.'*.log.* 2>/dev/null | head -1)\"
+
+    # CD away; _flox_hook auto-deactivates the services project.
+    cd '$BATS_TEST_TMPDIR'
+    _flox_hook
+
+    # Wait for cleanup_all (executive logs 'finished cleanup' after stopping process-compose).
+    wait_for_partial_file_content \"\$executive_log\" 'finished cleanup'
+  "
+  assert_success
+}
+
 @test "vars: service-level variables are set" {
 
   MANIFEST_CONTENTS="$(cat << "EOF"


### PR DESCRIPTION
## Summary

- Adds a regression test verifying that services are torn down when an
  auto-activated environment is deactivated by CDing away
- Confirms the executive's `cleanup_all` path fires correctly for
  in-place auto-deactivation (the `StateFileChanged` → `attached_pids_is_empty`
  → `process_compose_down` chain)

## Context

Reported in DEV-112: Daniel encountered unexpected service behavior with the
`omlx` environment (local LLM inference) when using auto-activate. Investigation
confirmed the teardown mechanism exists but no test covered the auto-activate
+ service-lifecycle path.

## Test design

The test follows the established `_flox_hook` subshell pattern from
`hook.bats`: manually activates a minimal outer project to register the hook
function, CDs into the services project to trigger auto-activation, starts
services explicitly, then CDs away to trigger auto-deactivation. After the
subshell exits, it polls the executive log for `finished cleanup` to confirm
`process-compose` was stopped.

## Test plan

- [ ] Run `just integ-tests services.bats -- --filter "auto-activated.*deactivated"`
      and confirm the new test passes
- [ ] Confirm no regressions in the broader `services.bats` suite

Refs: DEV-112

---
*Via Forge (interactive) • 9d1aec1f*