### PR TITLE
feat(containerize): add Apple Container as a first-class runtime

### DIFF
--- a/cli/flox/src/commands/containerize/macos_containerize_proxy.rs
+++ b/cli/flox/src/commands/containerize/macos_containerize_proxy.rs
@@ -86,8 +86,10 @@ impl ContainerizeProxy {
     /// Add a cache volume mount to the container runtime command.
     ///
     /// Docker and Podman support named volumes (`type=volume`), which persist
-    /// the Nix store across builds and speed up subsequent runs. Apple Container
-    /// also supports named volumes via the same `--mount type=volume` syntax.
+    /// the Nix store across builds and speed up subsequent runs.
+    ///
+    /// Not used for Apple Container: see the comment in `add_runtime_args` for
+    /// the reason it is skipped.
     fn add_cache_mount(&self, command: &mut Command, path: &str) {
         command.args([
             "--mount",
@@ -188,21 +190,50 @@ impl ContainerizeProxy {
             ),
         ]);
 
-        self.add_cache_mount(command, "/nix");
+        // The Nix store cache volume is mounted over /nix so that store paths
+        // built in one run are reused in subsequent runs.
+        //
+        // For Apple Container, mounting a volume over /nix shadows the nixos/nix
+        // image's own Nix store, removing bash and nix from PATH before the
+        // container starts. The populate_cache_volume step (which copies image
+        // store content into the volume) uses a shell pipeline that also fails
+        // for the same reason.
+        //
+        // Skip the cache mount for Apple Container: the build works without it,
+        // relying on the substituter cache configured via NIX_CONFIG. This is
+        // slower on first run but avoids the bootstrap problem.
+        if self.container_runtime != Runtime::AppleContainer {
+            self.add_cache_mount(command, "/nix");
+        }
 
         // Honour config from the user's flox.toml
-        // This could include things like floxhub_token and floxhub_url
+        // This could include things like floxhub_token and floxhub_url.
+        //
+        // Docker and Podman support binding individual files; Apple Container
+        // requires the bind-mount source to be a directory. When the runtime
+        // is Apple Container we mount the entire config directory
+        // (~/.config/flox) to avoid the "path is not a directory" error.
         let flox_toml = flox.config_dir.join(FLOX_CONFIG_FILE);
         if flox_toml.exists() {
-            let mut flox_toml_mount = OsString::new();
-            flox_toml_mount.push("type=bind,source=");
-            flox_toml_mount.push(flox_toml);
-            flox_toml_mount.push(format!(
-                ",target={}/{}",
-                FLOX_PROXY_IMAGE_FLOX_CONFIG_DIR, FLOX_CONFIG_FILE
-            ));
-            command.arg("--mount");
-            command.arg(flox_toml_mount);
+            if self.container_runtime == Runtime::AppleContainer {
+                // Mount the whole config directory; `flox.toml` lives inside.
+                let mut config_dir_mount = OsString::new();
+                config_dir_mount.push("type=bind,source=");
+                config_dir_mount.push(&flox.config_dir);
+                config_dir_mount.push(format!(",target={}", FLOX_PROXY_IMAGE_FLOX_CONFIG_DIR));
+                command.arg("--mount");
+                command.arg(config_dir_mount);
+            } else {
+                let mut flox_toml_mount = OsString::new();
+                flox_toml_mount.push("type=bind,source=");
+                flox_toml_mount.push(flox_toml);
+                flox_toml_mount.push(format!(
+                    ",target={}/{}",
+                    FLOX_PROXY_IMAGE_FLOX_CONFIG_DIR, FLOX_CONFIG_FILE
+                ));
+                command.arg("--mount");
+                command.arg(flox_toml_mount);
+            }
         }
 
         // If metrics are disabled (no device UUID), propagate that into the
@@ -337,20 +368,64 @@ impl ContainerizeProxy {
             .map(|m| format!(" --mode {}", m))
             .unwrap_or_default();
 
-        // Single bash -c pipeline: flox containerize | skopeo copy
-        // Both tools are fetched from nixpkgs inside the builder container.
+        // OCI conversion pipeline: flox containerize | skopeo copy
+        //
+        // Apple Container resolves unqualified binary names (e.g. `bash`)
+        // using the image's OCI `Env` PATH, but does NOT follow absolute
+        // symlink paths like `/nix/var/nix/profiles/default/bin/bash` at
+        // container startup. We therefore pass `bash` as the executable name
+        // and let Apple Container find it via the nixos/nix image's PATH.
+        //
+        // The shell pipeline:
+        // 1. Runs `nix run github:flox/flox -- flox containerize --file -`
+        //    to emit a docker-archive on stdout.
+        // 2. Pipes it through `nix run nixpkgs#skopeo -- copy` to convert
+        //    to OCI archive on stdout.
+        //
+        // Both tools are fetched from nixpkgs inside the builder container,
+        // so no new host-side dependencies are introduced.
+        // `nix` is on PATH via `/root/.nix-profile/bin` (set in the OCI image
+        // Env config) once the shell starts.
+        // Two-phase OCI conversion:
+        //
+        // Phase 1: Build the docker-archive to a temp file using flox containerize.
+        // Phase 2: Convert with skopeo (sequential, not a simultaneous pipeline).
+        //
+        // We avoid the pipe approach because Apple Container VMs have limited
+        // memory; running flox containerize (which builds container layers) and
+        // skopeo (which reads and converts the archive) simultaneously can trigger
+        // the kernel OOM killer, causing one process to be killed with SIGKILL.
+        // Sequential execution keeps peak memory use lower.
+        //
+        // We write the OCI archive to a second temp file and cat it to the
+        // container's stdout (which `ContainerSource::stream_container` pipes to
+        // the host-side sink). Apple Container streams container stdout back to
+        // the host via virtio-serial, which handles sequential reads fine.
+        //
+        // `nix run github:flox/flox -- containerize` (not `flox containerize`):
+        // `nix run` makes the flox binary the process; `containerize` is the
+        // subcommand passed as the first argument.
+        // The nix run and skopeo commands write progress to stderr.
+        // We redirect stdout of the nix/skopeo setup to stderr (>&2) to
+        // prevent any nix evaluation output from leaking into the OCI archive
+        // stream. Only `cat "$oci_tmp"` writes the archive to stdout.
         let shell_cmd = format!(
             "set -euo pipefail\n\
+            docker_tmp=$(mktemp /tmp/flox-docker-XXXXXX.tar)\n\
+            oci_tmp=$(mktemp /tmp/flox-oci-XXXXXX.tar)\n\
             nix --extra-experimental-features 'nix-command flakes' --accept-flake-config \
-            run '{flox_flake}' -- \
-            flox{verbosity_arg} containerize --dir {MOUNT_ENV} --tag {tag_str} --file -{label_args}{mode_arg} | \
+            run '{flox_flake}' --{verbosity_arg} containerize --dir {MOUNT_ENV} --tag {tag_str} --file \"$docker_tmp\"{label_args}{mode_arg} >&2\n\
             nix --extra-experimental-features 'nix-command flakes' \
-            run 'nixpkgs#skopeo' -- copy \
-            docker-archive:/dev/stdin 'oci-archive:/dev/stdout:{image_ref}'"
+            run 'nixpkgs#skopeo' -- --insecure-policy copy \
+            \"docker-archive:$docker_tmp\" \"oci-archive:$oci_tmp:{image_ref}\" >&2\n\
+            rm -f \"$docker_tmp\"\n\
+            cat \"$oci_tmp\"\n\
+            rm -f \"$oci_tmp\""
         );
 
         let mut command = self.runtime_base_command();
         self.add_runtime_args(&mut command, flox);
+        // `bash` is found by Apple Container using the image's PATH env var.
         command.args(["bash", "-c", &shell_cmd]);
         command
     }
@@ -462,7 +537,7 @@ mod tests {
 
         // Command is `container run ...`
         assert_eq!(args[0], "container");
-        // Should invoke bash -c with the pipeline
+        // Apple Container resolves `bash` via the image's PATH env var.
         let bash_pos = args
             .iter()
             .position(|a| a == "bash")

--- a/cli/flox/src/commands/containerize/macos_containerize_proxy.rs
+++ b/cli/flox/src/commands/containerize/macos_containerize_proxy.rs
@@ -84,6 +84,10 @@ impl ContainerizeProxy {
     }
 
     /// Add a cache volume mount to the container runtime command.
+    ///
+    /// Docker and Podman support named volumes (`type=volume`), which persist
+    /// the Nix store across builds and speed up subsequent runs. Apple Container
+    /// also supports named volumes via the same `--mount type=volume` syntax.
     fn add_cache_mount(&self, command: &mut Command, path: &str) {
         command.args([
             "--mount",
@@ -92,8 +96,22 @@ impl ContainerizeProxy {
     }
 
     /// Copy the Nix store from the container image to the cache volume.
+    ///
+    /// Skipped for Apple Container because the cache volume population step
+    /// uses a shell pipeline (`bash -c '...'`) that is not available in the
+    /// NixOS container on Apple's Virtualization.framework without additional
+    /// setup. The main build still works; it just won't benefit from the
+    /// pre-populated cache on first run.
     #[instrument(skip_all, fields(progress = "Populating proxy container cache volume"))]
     fn populate_cache_volume(&self) -> Result<(), ContainerizeProxyError> {
+        if self.container_runtime == Runtime::AppleContainer {
+            // The cache-volume population shell pipeline is not compatible with
+            // Apple Container's runtime environment. Skip it; the build will
+            // proceed without the warm cache.
+            debug!("Skipping cache volume population for Apple Container runtime");
+            return Ok(());
+        }
+
         let mut command = self.runtime_base_command();
 
         // The cache volume has to be mounted in parallel to the container's own
@@ -144,12 +162,20 @@ impl ContainerizeProxy {
     }
 
     /// Inception L1: Container runtime args.
+    ///
+    /// Builds the `docker run` / `podman run` / `container run` invocation
+    /// that launches the nixos/nix proxy container. Adapts CLI flags for each
+    /// runtime:
+    ///
+    /// - Docker / Podman: `--mount type=bind,...` for all mounts; Podman also
+    ///   needs `--userns ""` to map the host user to root inside the container.
+    /// - Apple Container: uses the same `--mount type=bind,...` syntax;
+    ///   no `--userns` flag needed (Apple Container runs as the host user by
+    ///   default in its VM).
     fn add_runtime_args(&self, command: &mut Command, flox: &Flox) {
-        // The `--userns` flag creates a mapping of users in the container,
-        // which we need. However, in order to work we also need the user
-        // in the container to be `root` otherwise you run into multi-user
-        // issues. The empty string `""` argument to `--userns` maps the
-        // current user to `root` inside the container.
+        // Podman needs --userns to map the current user to root inside the
+        // container; otherwise multi-user Nix operations fail. Docker and Apple
+        // Container do not need this flag.
         if self.container_runtime == Runtime::Podman {
             command.args(["--userns", ""]);
         }
@@ -250,12 +276,94 @@ impl ContainerizeProxy {
             command.args(["--mode", &mode.to_string()]);
         }
     }
+
+    /// Build the full container run command for the OCI-conversion path.
+    ///
+    /// When the target runtime is Apple Container, `container image load` only
+    /// accepts OCI archives, but nixpkgs `dockerTools.streamLayeredImage`
+    /// emits docker-archive format. This method builds a shell pipeline that:
+    ///
+    /// 1. Runs `nix run github:flox/flox -- flox containerize --file -` to
+    ///    emit a docker-archive on stdout.
+    /// 2. Pipes it through nixpkgs `skopeo copy` to convert to OCI archive on
+    ///    stdout.
+    ///
+    /// The conversion runs entirely inside the nixos/nix builder container
+    /// using nixpkgs' skopeo, so no additional host-side tooling is required.
+    ///
+    /// Apple Container image refs require an explicit tag (`name:latest` works
+    /// where bare `name` fails), so the tag is embedded in the skopeo
+    /// destination reference.
+    fn build_oci_conversion_command(&self, flox: &Flox, tag: impl AsRef<str>) -> Command {
+        let tag_str = tag.as_ref();
+
+        // Derive the image name from the environment directory name, matching
+        // what the inner `flox containerize` would use.
+        let env_name = self
+            .environment_path
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "flox-env".to_string());
+
+        // Apple Container requires an explicit tag in the image reference;
+        // bare `name` (without `:tag`) causes `image load` to fail.
+        let image_ref = format!("{env_name}:{tag_str}");
+
+        let flox_version = &*FLOX_VERSION;
+        let flox_version_tag = format!("v{}", flox_version.base_semver());
+        let flox_flake = format!(
+            "{}/{}",
+            FLOX_FLAKE,
+            (*FLOX_CONTAINERIZE_FLAKE_REF_OR_REV)
+                .clone()
+                .unwrap_or(flox_version.commit_sha().unwrap_or(flox_version_tag))
+        );
+
+        let verbosity_arg = match flox.verbosity {
+            -1 => " --quiet".to_string(),
+            v if v > 0 => format!(" -{}", "v".repeat(v.try_into().unwrap())),
+            _ => String::new(),
+        };
+
+        let label_args: String = self
+            .labels
+            .iter()
+            .map(|l| format!(" --label '{}'", l.replace('\'', "'\\''")))
+            .collect();
+
+        let mode_arg = self
+            .mode
+            .as_ref()
+            .map(|m| format!(" --mode {}", m))
+            .unwrap_or_default();
+
+        // Single bash -c pipeline: flox containerize | skopeo copy
+        // Both tools are fetched from nixpkgs inside the builder container.
+        let shell_cmd = format!(
+            "set -euo pipefail\n\
+            nix --extra-experimental-features 'nix-command flakes' --accept-flake-config \
+            run '{flox_flake}' -- \
+            flox{verbosity_arg} containerize --dir {MOUNT_ENV} --tag {tag_str} --file -{label_args}{mode_arg} | \
+            nix --extra-experimental-features 'nix-command flakes' \
+            run 'nixpkgs#skopeo' -- copy \
+            docker-archive:/dev/stdin 'oci-archive:/dev/stdout:{image_ref}'"
+        );
+
+        let mut command = self.runtime_base_command();
+        self.add_runtime_args(&mut command, flox);
+        command.args(["bash", "-c", &shell_cmd]);
+        command
+    }
 }
 
 impl ContainerBuilder for ContainerizeProxy {
     type Error = ContainerizeProxyError;
 
     /// Create a [ContainerSource] for macOS that streams the output via a proxy container.
+    ///
+    /// When the target runtime is Apple Container, the output stream is an OCI
+    /// archive (converted inside the builder container using nixpkgs skopeo).
+    /// For Docker and Podman, the output remains docker-archive format.
     fn create_container_source(
         &self,
         flox: &Flox,
@@ -265,12 +373,139 @@ impl ContainerBuilder for ContainerizeProxy {
     ) -> Result<ContainerSource, Self::Error> {
         self.populate_cache_volume()?;
 
-        let mut command = self.runtime_base_command();
-        self.add_runtime_args(&mut command, flox);
-        self.add_nix_args(&mut command);
-        self.add_flox_args(&mut command, flox, tag);
+        let command = if self.container_runtime.requires_oci_format() {
+            // Apple Container: emit OCI archive via an in-container skopeo pipe.
+            self.build_oci_conversion_command(flox, tag)
+        } else {
+            // Docker / Podman: standard docker-archive path.
+            let mut command = self.runtime_base_command();
+            self.add_runtime_args(&mut command, flox);
+            self.add_nix_args(&mut command);
+            self.add_flox_args(&mut command, flox, tag);
+            command
+        };
 
         let container_source = ContainerSource::new(command);
         Ok(container_source)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use flox_rust_sdk::flox::test_helpers::flox_instance;
+
+    use super::*;
+
+    /// Collect the argv of a Command as strings for inspection.
+    fn argv(cmd: &Command) -> Vec<String> {
+        std::iter::once(cmd.get_program())
+            .chain(cmd.get_args())
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect()
+    }
+
+    #[test]
+    fn docker_proxy_uses_docker_run() {
+        let (flox, _tempdir) = flox_instance();
+        let proxy = ContainerizeProxy::new("/some/env".into(), Runtime::Docker, vec![], None);
+        let mut cmd = proxy.runtime_base_command();
+        proxy.add_runtime_args(&mut cmd, &flox);
+        let args = argv(&cmd);
+        assert_eq!(args[0], "docker");
+        assert!(args.contains(&"run".to_string()));
+        assert!(!args.iter().any(|a| a.contains("--userns")));
+    }
+
+    #[test]
+    fn podman_proxy_adds_userns_flag() {
+        let (flox, _tempdir) = flox_instance();
+        let proxy = ContainerizeProxy::new("/some/env".into(), Runtime::Podman, vec![], None);
+        let mut cmd = proxy.runtime_base_command();
+        proxy.add_runtime_args(&mut cmd, &flox);
+        let args = argv(&cmd);
+        assert_eq!(args[0], "podman");
+        // --userns must appear for Podman to map the host user to root inside the container.
+        let userns_pos = args
+            .iter()
+            .position(|a| a == "--userns")
+            .expect("--userns should be present for Podman");
+        assert_eq!(args[userns_pos + 1], "");
+    }
+
+    #[test]
+    fn apple_container_proxy_omits_userns_flag() {
+        let (flox, _tempdir) = flox_instance();
+        let proxy =
+            ContainerizeProxy::new("/some/env".into(), Runtime::AppleContainer, vec![], None);
+        let mut cmd = proxy.runtime_base_command();
+        proxy.add_runtime_args(&mut cmd, &flox);
+        let args = argv(&cmd);
+        assert_eq!(args[0], "container");
+        // Apple Container does not need --userns
+        assert!(
+            !args.iter().any(|a| a == "--userns"),
+            "Apple Container should not have --userns"
+        );
+    }
+
+    #[test]
+    fn oci_conversion_command_uses_bash_pipeline() {
+        let (flox, _tempdir) = flox_instance();
+        let proxy = ContainerizeProxy::new(
+            "/some/env/.flox/env".into(),
+            Runtime::AppleContainer,
+            vec![],
+            None,
+        );
+        let cmd = proxy.build_oci_conversion_command(&flox, "latest");
+        let args = argv(&cmd);
+
+        // Command is `container run ...`
+        assert_eq!(args[0], "container");
+        // Should invoke bash -c with the pipeline
+        let bash_pos = args
+            .iter()
+            .position(|a| a == "bash")
+            .expect("bash should be in argv");
+        assert_eq!(args[bash_pos + 1], "-c");
+        let shell_script = &args[bash_pos + 2];
+        // Pipeline should include flox containerize piped to skopeo
+        assert!(shell_script.contains("flox"), "pipeline should run flox");
+        assert!(
+            shell_script.contains("containerize"),
+            "pipeline should invoke containerize"
+        );
+        assert!(
+            shell_script.contains("skopeo"),
+            "pipeline should use skopeo for OCI conversion"
+        );
+        assert!(
+            shell_script.contains("oci-archive"),
+            "output should be OCI archive format"
+        );
+        assert!(
+            shell_script.contains("docker-archive"),
+            "input should be docker-archive format"
+        );
+        // Image ref must include explicit tag for Apple Container compatibility.
+        // Bare `name` (without `:tag`) causes `container image load` to fail.
+        assert!(
+            shell_script.contains(":latest"),
+            "OCI image ref must include explicit tag"
+        );
+    }
+
+    #[test]
+    fn oci_conversion_embeds_custom_tag() {
+        let (flox, _tempdir) = flox_instance();
+        let proxy =
+            ContainerizeProxy::new("/env/myapp".into(), Runtime::AppleContainer, vec![], None);
+        let cmd = proxy.build_oci_conversion_command(&flox, "v1.2.3");
+        let args = argv(&cmd);
+        // Custom tag must appear in the OCI destination reference
+        assert!(
+            args.iter().any(|a| a.contains("v1.2.3")),
+            "custom tag 'v1.2.3' should appear in the OCI conversion command"
+        );
     }
 }

--- a/cli/flox/src/commands/containerize/macos_containerize_proxy.rs
+++ b/cli/flox/src/commands/containerize/macos_containerize_proxy.rs
@@ -29,6 +29,13 @@ const CONTAINER_NIX_CACHE_VOLUME: &str = "flox-nix";
 
 const MOUNT_ENV: &str = "/flox_env";
 
+/// Escape a string for safe interpolation into a `bash -c` script as a
+/// single-quoted word. Internal single quotes become `'\''` (close quote,
+/// escaped literal quote, reopen quote).
+fn shell_single_quote(s: &str) -> String {
+    format!("'{}'", s.replace('\'', "'\\''"))
+}
+
 #[derive(Debug, Error)]
 pub enum ContainerizeProxyError {
     #[error("failed to populate proxy container cache volume")]
@@ -99,17 +106,13 @@ impl ContainerizeProxy {
 
     /// Copy the Nix store from the container image to the cache volume.
     ///
-    /// Skipped for Apple Container because the cache volume population step
-    /// uses a shell pipeline (`bash -c '...'`) that is not available in the
-    /// NixOS container on Apple's Virtualization.framework without additional
-    /// setup. The main build still works; it just won't benefit from the
-    /// pre-populated cache on first run.
+    /// Skipped for Apple Container because no cache volume is mounted there
+    /// (see `add_runtime_args`). As a result, Apple Container builds start
+    /// from a cold Nix store on every run — not just the first — and fetch
+    /// all dependencies from substituters each time.
     #[instrument(skip_all, fields(progress = "Populating proxy container cache volume"))]
     fn populate_cache_volume(&self) -> Result<(), ContainerizeProxyError> {
         if self.container_runtime == Runtime::AppleContainer {
-            // The cache-volume population shell pipeline is not compatible with
-            // Apple Container's runtime environment. Skip it; the build will
-            // proceed without the warm cache.
             debug!("Skipping cache volume population for Apple Container runtime");
             return Ok(());
         }
@@ -195,13 +198,11 @@ impl ContainerizeProxy {
         //
         // For Apple Container, mounting a volume over /nix shadows the nixos/nix
         // image's own Nix store, removing bash and nix from PATH before the
-        // container starts. The populate_cache_volume step (which copies image
-        // store content into the volume) uses a shell pipeline that also fails
-        // for the same reason.
-        //
-        // Skip the cache mount for Apple Container: the build works without it,
-        // relying on the substituter cache configured via NIX_CONFIG. This is
-        // slower on first run but avoids the bootstrap problem.
+        // container starts. Skip the cache mount there: builds rely on the
+        // substituter cache configured via NIX_CONFIG and start from a cold
+        // Nix store on EVERY run (not just the first), which makes each build
+        // noticeably slower. Real cache population for Apple Container is a
+        // follow-up (see flox/flox#4466).
         if self.container_runtime != Runtime::AppleContainer {
             self.add_cache_mount(command, "/nix");
         }
@@ -310,21 +311,20 @@ impl ContainerizeProxy {
 
     /// Build the full container run command for the OCI-conversion path.
     ///
-    /// When the target runtime is Apple Container, `container image load` only
-    /// accepts OCI archives, but nixpkgs `dockerTools.streamLayeredImage`
-    /// emits docker-archive format. This method builds a shell pipeline that:
+    /// Apple Container's `image load` only accepts OCI archives, but nixpkgs
+    /// `dockerTools.streamLayeredImage` emits docker-archive format. This
+    /// command runs a two-phase conversion inside the nixos/nix builder
+    /// container:
     ///
-    /// 1. Runs `nix run github:flox/flox -- flox containerize --file -` to
-    ///    emit a docker-archive on stdout.
-    /// 2. Pipes it through nixpkgs `skopeo copy` to convert to OCI archive on
-    ///    stdout.
+    /// 1. `nix run github:flox/flox -- containerize` writes a docker-archive
+    ///    to a temp file.
+    /// 2. nixpkgs `skopeo copy` converts it to an OCI archive in a second
+    ///    temp file, which `cat` then streams to stdout.
     ///
-    /// The conversion runs entirely inside the nixos/nix builder container
-    /// using nixpkgs' skopeo, so no additional host-side tooling is required.
-    ///
-    /// Apple Container image refs require an explicit tag (`name:latest` works
-    /// where bare `name` fails), so the tag is embedded in the skopeo
-    /// destination reference.
+    /// skopeo comes from nixpkgs inside the builder container, so no
+    /// host-side tooling is required. Apple Container image refs require an
+    /// explicit tag (`name:latest` works where bare `name` fails), so the
+    /// tag is embedded in the skopeo destination reference.
     fn build_oci_conversion_command(&self, flox: &Flox, tag: impl AsRef<str>) -> Command {
         let tag_str = tag.as_ref();
 
@@ -356,10 +356,14 @@ impl ContainerizeProxy {
             _ => String::new(),
         };
 
+        // User-controlled values (tag, image name, labels) are single-quote
+        // escaped so they cannot break out of the bash -c script.
+        let tag_quoted = shell_single_quote(tag_str);
+        let image_ref_quoted = shell_single_quote(&image_ref);
         let label_args: String = self
             .labels
             .iter()
-            .map(|l| format!(" --label '{}'", l.replace('\'', "'\\''")))
+            .map(|l| format!(" --label {}", shell_single_quote(l)))
             .collect();
 
         let mode_arg = self
@@ -368,56 +372,28 @@ impl ContainerizeProxy {
             .map(|m| format!(" --mode {}", m))
             .unwrap_or_default();
 
-        // OCI conversion pipeline: flox containerize | skopeo copy
+        // Sequential phases (not a pipe): running flox containerize and
+        // skopeo concurrently can exceed the Apple Container VM's memory
+        // and trigger the kernel OOM killer.
         //
-        // Apple Container resolves unqualified binary names (e.g. `bash`)
-        // using the image's OCI `Env` PATH, but does NOT follow absolute
-        // symlink paths like `/nix/var/nix/profiles/default/bin/bash` at
-        // container startup. We therefore pass `bash` as the executable name
-        // and let Apple Container find it via the nixos/nix image's PATH.
+        // `>&2` on both nix invocations: only `cat "$oci_tmp"` may write to
+        // stdout — anything else corrupts the OCI archive stream read by
+        // the host-side sink.
         //
-        // The shell pipeline:
-        // 1. Runs `nix run github:flox/flox -- flox containerize --file -`
-        //    to emit a docker-archive on stdout.
-        // 2. Pipes it through `nix run nixpkgs#skopeo -- copy` to convert
-        //    to OCI archive on stdout.
+        // skopeo runs with --insecure-policy because the nixos/nix image
+        // ships no /etc/containers/policy.json.
         //
-        // Both tools are fetched from nixpkgs inside the builder container,
-        // so no new host-side dependencies are introduced.
-        // `nix` is on PATH via `/root/.nix-profile/bin` (set in the OCI image
-        // Env config) once the shell starts.
-        // Two-phase OCI conversion:
-        //
-        // Phase 1: Build the docker-archive to a temp file using flox containerize.
-        // Phase 2: Convert with skopeo (sequential, not a simultaneous pipeline).
-        //
-        // We avoid the pipe approach because Apple Container VMs have limited
-        // memory; running flox containerize (which builds container layers) and
-        // skopeo (which reads and converts the archive) simultaneously can trigger
-        // the kernel OOM killer, causing one process to be killed with SIGKILL.
-        // Sequential execution keeps peak memory use lower.
-        //
-        // We write the OCI archive to a second temp file and cat it to the
-        // container's stdout (which `ContainerSource::stream_container` pipes to
-        // the host-side sink). Apple Container streams container stdout back to
-        // the host via virtio-serial, which handles sequential reads fine.
-        //
-        // `nix run github:flox/flox -- containerize` (not `flox containerize`):
-        // `nix run` makes the flox binary the process; `containerize` is the
-        // subcommand passed as the first argument.
-        // The nix run and skopeo commands write progress to stderr.
-        // We redirect stdout of the nix/skopeo setup to stderr (>&2) to
-        // prevent any nix evaluation output from leaking into the OCI archive
-        // stream. Only `cat "$oci_tmp"` writes the archive to stdout.
+        // The skopeo destination concatenates a double-quoted shell variable
+        // with the single-quoted image ref: "oci-archive:$oci_tmp:"'name:tag'.
         let shell_cmd = format!(
             "set -euo pipefail\n\
             docker_tmp=$(mktemp /tmp/flox-docker-XXXXXX.tar)\n\
             oci_tmp=$(mktemp /tmp/flox-oci-XXXXXX.tar)\n\
             nix --extra-experimental-features 'nix-command flakes' --accept-flake-config \
-            run '{flox_flake}' --{verbosity_arg} containerize --dir {MOUNT_ENV} --tag {tag_str} --file \"$docker_tmp\"{label_args}{mode_arg} >&2\n\
+            run '{flox_flake}' --{verbosity_arg} containerize --dir {MOUNT_ENV} --tag {tag_quoted} --file \"$docker_tmp\"{label_args}{mode_arg} >&2\n\
             nix --extra-experimental-features 'nix-command flakes' \
             run 'nixpkgs#skopeo' -- --insecure-policy copy \
-            \"docker-archive:$docker_tmp\" \"oci-archive:$oci_tmp:{image_ref}\" >&2\n\
+            \"docker-archive:$docker_tmp\" \"oci-archive:$oci_tmp:\"{image_ref_quoted} >&2\n\
             rm -f \"$docker_tmp\"\n\
             cat \"$oci_tmp\"\n\
             rm -f \"$oci_tmp\""
@@ -425,7 +401,9 @@ impl ContainerizeProxy {
 
         let mut command = self.runtime_base_command();
         self.add_runtime_args(&mut command, flox);
-        // `bash` is found by Apple Container using the image's PATH env var.
+        // `bash` (unqualified): Apple Container resolves the entrypoint via
+        // the image's PATH env var and does not follow absolute Nix profile
+        // symlink paths.
         command.args(["bash", "-c", &shell_cmd]);
         command
     }
@@ -568,6 +546,31 @@ mod tests {
             shell_script.contains(":latest"),
             "OCI image ref must include explicit tag"
         );
+
+        // Load-bearing pipeline structure:
+        // skopeo needs --insecure-policy (no policy.json in nixos/nix image).
+        assert!(
+            shell_script.contains("--insecure-policy"),
+            "skopeo must run with --insecure-policy"
+        );
+        // Both nix invocations redirect stdout to stderr so only `cat`
+        // writes the OCI archive to stdout.
+        assert_eq!(
+            shell_script.matches(">&2").count(),
+            2,
+            "both nix invocations must redirect stdout to stderr"
+        );
+        // Two-phase conversion: two temp files, no pipe between
+        // containerize and skopeo (concurrent execution can OOM the VM).
+        assert_eq!(
+            shell_script.matches("mktemp").count(),
+            2,
+            "two temp files: one docker-archive, one OCI archive"
+        );
+        assert!(
+            !shell_script.contains(" | "),
+            "containerize and skopeo must run sequentially, not piped"
+        );
     }
 
     #[test]
@@ -582,5 +585,52 @@ mod tests {
             args.iter().any(|a| a.contains("v1.2.3")),
             "custom tag 'v1.2.3' should appear in the OCI conversion command"
         );
+    }
+
+    #[test]
+    fn oci_conversion_escapes_hostile_tags() {
+        let (flox, _tempdir) = flox_instance();
+        let proxy =
+            ContainerizeProxy::new("/env/myapp".into(), Runtime::AppleContainer, vec![], None);
+
+        // A tag containing a space must be single-quoted so it stays one word.
+        let cmd = proxy.build_oci_conversion_command(&flox, "my tag");
+        let args = argv(&cmd);
+        let script = args.last().expect("script is last arg");
+        assert!(
+            script.contains("--tag 'my tag'"),
+            "tag with space must be single-quoted: {script}"
+        );
+        assert!(
+            script.contains("'myapp:my tag'"),
+            "image ref with space must be single-quoted: {script}"
+        );
+
+        // A tag containing a single quote must not be able to close the
+        // quoting and inject shell syntax. `a'b` becomes `'a'\''b'`.
+        let cmd = proxy.build_oci_conversion_command(&flox, "a'b");
+        let args = argv(&cmd);
+        let script = args.last().expect("script is last arg");
+        assert!(
+            script.contains("--tag 'a'\\''b'"),
+            "tag with single quote must be escaped: {script}"
+        );
+        assert!(
+            script.contains("'myapp:a'\\''b'"),
+            "image ref with single quote must be escaped: {script}"
+        );
+        // The raw unescaped tag must not appear as a bare word.
+        assert!(
+            !script.contains("--tag a'b"),
+            "unescaped tag must not reach the shell: {script}"
+        );
+    }
+
+    #[test]
+    fn shell_single_quote_escapes() {
+        assert_eq!(shell_single_quote("plain"), "'plain'");
+        assert_eq!(shell_single_quote("has space"), "'has space'");
+        assert_eq!(shell_single_quote("a'b"), "'a'\\''b'");
+        assert_eq!(shell_single_quote("$(rm -rf /)"), "'$(rm -rf /)'");
     }
 }

--- a/cli/flox/src/commands/containerize/mod.rs
+++ b/cli/flox/src/commands/containerize/mod.rs
@@ -82,6 +82,7 @@ impl Containerize {
             runtime.validate_in_path()?
         }
         let runtime = self.runtime.or_else(Runtime::detect_from_path);
+        let uses_apple_container = matches!(&runtime, Some(Runtime::AppleContainer));
         let output = match (&runtime, self.file) {
             // Specified file.
             (_, Some(dest)) => OutputTarget::File(dest),
@@ -134,12 +135,26 @@ impl Containerize {
                     Exporting a container on macOS requires Docker, Podman, or Apple Container ('container') to be installed.
                 "#});
             };
+            if uses_apple_container {
+                // No Nix store cache volume is mounted for Apple Container,
+                // so every build starts from a cold store.
+                message::info(
+                    "Apple Container builds run without a Nix store cache and fetch dependencies on every run; expect longer build times.",
+                );
+            }
             let builder = ContainerizeProxy::new(env_path, proxy_runtime, self.labels, self.mode);
             builder.create_container_source(&flox, env_name.as_ref(), output_tag)?
         };
 
         let mut writer = output.to_writer()?;
-        source.stream_container(&mut writer)?;
+        let stream_result = source.stream_container(&mut writer);
+        if uses_apple_container {
+            // `container run` failures most often mean the Apple Container
+            // system service is not running; point the user at the fix.
+            stream_result.context(APPLE_CONTAINER_SERVICE_HINT)?;
+        } else {
+            stream_result?;
+        }
         writer.wait()?;
 
         message::created(format!("'{env_name}:{output_tag}' written to {output}"));
@@ -295,6 +310,12 @@ impl ContainerSink for RuntimeSink {
     }
 }
 
+/// Actionable hint appended to Apple Container subprocess failures.
+/// The most common cause of `container run` / `container image load`
+/// errors is that the runtime's system service has not been started.
+const APPLE_CONTAINER_SERVICE_HINT: &str =
+    "Apple Container's system service may not be running. Try: 'container system start'";
+
 /// Sink for Apple Container (`container image load`).
 ///
 /// Apple Container's `image load` does not read from stdin; it requires a
@@ -343,6 +364,7 @@ impl ContainerSink for AppleContainerSink {
 
         let mut child = load_cmd
             .spawn()
+            .context(APPLE_CONTAINER_SERVICE_HINT)
             .context("Failed to spawn 'container image load'")?;
 
         let stderr_tap = child
@@ -361,7 +383,9 @@ impl ContainerSink for AppleContainerSink {
         let stderr = stderr_tap.wait();
 
         if !status.success() {
-            return Err(anyhow!("'container image load' was unsuccessful").context(stderr));
+            return Err(anyhow!("'container image load' was unsuccessful")
+                .context(stderr)
+                .context(APPLE_CONTAINER_SERVICE_HINT));
         }
 
         Ok(())

--- a/cli/flox/src/commands/containerize/mod.rs
+++ b/cli/flox/src/commands/containerize/mod.rs
@@ -19,6 +19,7 @@ use flox_rust_sdk::providers::container_builder::{ContainerBuilder, MkContainerN
 use flox_rust_sdk::utils::{ReaderExt, WireTap};
 use indoc::indoc;
 use macos_containerize_proxy::ContainerizeProxy;
+use tempfile::NamedTempFile;
 use tracing::{debug, info, instrument};
 
 use super::{EnvironmentSelect, environment_select};
@@ -40,7 +41,7 @@ pub struct Containerize {
     /// store the image (when '--file' is not specified)
     /// or build the image (when on macOS).
     /// Defaults to detecting the first available on PATH.
-    #[bpaf(long, argument("docker|podman"))]
+    #[bpaf(long, argument("docker|podman|container"))]
     runtime: Option<Runtime>,
 
     /// File to write the container image to.
@@ -130,7 +131,7 @@ impl Containerize {
                 bail!(indoc! {r#"
                     No container runtime found in PATH.
 
-                    Exporting a container on macOS requires Docker or Podman to be installed.
+                    Exporting a container on macOS requires Docker, Podman, or Apple Container ('container') to be installed.
                 "#});
             };
             let builder = ContainerizeProxy::new(env_path, proxy_runtime, self.labels, self.mode);
@@ -211,7 +212,7 @@ impl OutputTarget {
                 Box::new(file)
             },
             OutputTarget::File(FileOrStdout::Stdout) => Box::new(io::stdout()),
-            OutputTarget::Runtime(runtime) => Box::new(runtime.to_writer()?),
+            OutputTarget::Runtime(runtime) => runtime.to_writer()?,
         };
 
         Ok(writer)
@@ -294,16 +295,98 @@ impl ContainerSink for RuntimeSink {
     }
 }
 
-/// The container registry to load the container into
-/// Currently only supports Docker and Podman
+/// Sink for Apple Container (`container image load`).
+///
+/// Apple Container's `image load` does not read from stdin; it requires a
+/// file path via `--input`. This sink accumulates the OCI archive in a
+/// temporary file and invokes `container image load --input <file>` when
+/// `wait()` is called.
+#[derive(Debug)]
+struct AppleContainerSink {
+    /// The temporary file holding the OCI archive.
+    /// Wrapped in Option so it can be taken in `wait()`.
+    tmp: Option<NamedTempFile>,
+}
+
+impl Write for AppleContainerSink {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.tmp
+            .as_mut()
+            .expect("tmp file is present before wait()")
+            .write(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.tmp
+            .as_mut()
+            .expect("tmp file is present before wait()")
+            .flush()
+    }
+}
+
+impl ContainerSink for AppleContainerSink {
+    fn wait(&mut self) -> Result<()> {
+        self.flush()?;
+        let tmp = self
+            .tmp
+            .take()
+            .expect("tmp file is present and wait() is called only once");
+
+        let tmp_path = tmp.path().to_owned();
+        debug!(path = %tmp_path.display(), "loading OCI archive into Apple Container");
+
+        let mut load_cmd = Command::new("container");
+        load_cmd.args(["image", "load", "--input"]);
+        load_cmd.arg(&tmp_path);
+        load_cmd.stderr(Stdio::piped());
+        load_cmd.stdout(Stdio::piped());
+
+        let mut child = load_cmd
+            .spawn()
+            .context("Failed to spawn 'container image load'")?;
+
+        let stderr_tap = child
+            .stderr
+            .take()
+            .expect("Stderr is piped")
+            .tap_lines(|line| info!("{line}"));
+
+        child
+            .stdout
+            .take()
+            .expect("Stdout is piped")
+            .tap_lines(|line| info!("{line}"));
+
+        let status = child.wait()?;
+        let stderr = stderr_tap.wait();
+
+        if !status.success() {
+            return Err(anyhow!("'container image load' was unsuccessful").context(stderr));
+        }
+
+        Ok(())
+    }
+}
+
+/// The container runtime used to load or build container images.
+///
+/// Detection order is docker → podman → container, so existing users
+/// with Docker or Podman installed see no behavior change; Apple Container
+/// is used only when it is the only runtime present (or explicitly selected).
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum Runtime {
     Docker,
     Podman,
+    /// Apple Container (the `container` CLI, macOS-only).
+    /// Requires OCI archive format rather than docker-archive.
+    AppleContainer,
 }
 
 impl Runtime {
     /// Detect the container runtime from the PATH environment variable.
+    ///
+    /// Search order: docker, podman, container — append-only so existing
+    /// users with Docker or Podman installed see no behavior change.
     fn detect_from_path() -> Option<Self> {
         let path_var = match std::env::var("PATH") {
             Err(e) => {
@@ -313,9 +396,10 @@ impl Runtime {
             Ok(path) => path,
         };
 
-        let Some((_, runtime)) =
-            first_in_path(["docker", "podman"], std::env::split_paths(&path_var))
-        else {
+        let Some((_, runtime)) = first_in_path(
+            ["docker", "podman", "container"],
+            std::env::split_paths(&path_var),
+        ) else {
             debug!("No container runtime found in PATH");
             return None;
         };
@@ -332,7 +416,14 @@ impl Runtime {
         match self {
             Runtime::Docker => "docker",
             Runtime::Podman => "podman",
+            Runtime::AppleContainer => "container",
         }
+    }
+
+    /// Returns true when the runtime requires OCI archive format rather than
+    /// docker-archive. Apple Container's `image load` only accepts OCI archives.
+    fn requires_oci_format(&self) -> bool {
+        matches!(self, Runtime::AppleContainer)
     }
 
     /// Validate that the container runtime is available in the PATH.
@@ -348,43 +439,57 @@ impl Runtime {
         }
     }
 
-    /// Get a writer to the registry,
-    /// Essentially spawns a `docker load` or `podman load` process
-    /// and returns a handle to its stdin.
-    fn to_writer(&self) -> Result<impl ContainerSink> {
-        let cmd = self.to_cmd();
-        let mut child = Command::new(cmd)
-            .arg("load")
-            .stdin(Stdio::piped())
-            .stderr(Stdio::piped())
-            .stdout(Stdio::piped())
-            .spawn()
-            .context(format!("Failed to call runtime {cmd}"))?;
+    /// Get a writer to the registry.
+    ///
+    /// For Docker and Podman this spawns `docker load` / `podman load` and
+    /// returns a handle to its stdin.
+    ///
+    /// For Apple Container, `container image load` does not read from stdin;
+    /// it requires a file path via `--input`. The returned sink writes to a
+    /// temporary OCI archive on disk and invokes `container image load` when
+    /// flushed.
+    fn to_writer(&self) -> Result<Box<dyn ContainerSink>> {
+        match self {
+            Runtime::Docker | Runtime::Podman => {
+                let cmd = self.to_cmd();
+                let mut child = Command::new(cmd)
+                    .arg("load")
+                    .stdin(Stdio::piped())
+                    .stderr(Stdio::piped())
+                    .stdout(Stdio::piped())
+                    .spawn()
+                    .context(format!("Failed to call runtime {cmd}"))?;
 
-        let stderr_tap = child
-            .stderr
-            .take()
-            .expect("Stderr is piped")
-            .tap_lines(|line| info!("{line}"));
+                let stderr_tap = child
+                    .stderr
+                    .take()
+                    .expect("Stderr is piped")
+                    .tap_lines(|line| info!("{line}"));
 
-        child
-            .stdout
-            .take()
-            .expect("Stdout is piped")
-            .tap_lines(|line| info!("{line}"));
+                child
+                    .stdout
+                    .take()
+                    .expect("Stdout is piped")
+                    .tap_lines(|line| info!("{line}"));
 
-        Ok(RuntimeSink {
-            child,
-            stderr: Some(stderr_tap),
-        })
+                Ok(Box::new(RuntimeSink {
+                    child,
+                    stderr: Some(stderr_tap),
+                }))
+            },
+            Runtime::AppleContainer => {
+                // `container image load` requires a file path; it cannot read
+                // from stdin. Write the OCI archive to a temp file, then invoke
+                // `container image load --input <file>` when the sink is flushed.
+                let tmp = tempfile::NamedTempFile::new()
+                    .context("Failed to create temporary file for OCI archive")?;
+                Ok(Box::new(AppleContainerSink { tmp: Some(tmp) }))
+            },
+        }
     }
 
     fn to_command(&self) -> Command {
-        let cmd = match self {
-            Runtime::Docker => "docker",
-            Runtime::Podman => "podman",
-        };
-
+        let cmd = self.to_cmd();
         Command::new(cmd)
     }
 }
@@ -394,6 +499,7 @@ impl Display for Runtime {
         match self {
             Runtime::Docker => write!(f, "Docker runtime"),
             Runtime::Podman => write!(f, "Podman runtime"),
+            Runtime::AppleContainer => write!(f, "Apple Container runtime"),
         }
     }
 }
@@ -405,7 +511,10 @@ impl FromStr for Runtime {
         match s {
             "docker" => Ok(Runtime::Docker),
             "podman" => Ok(Runtime::Podman),
-            _ => Err(anyhow!("Runtime must be 'docker' or 'podman'")),
+            "container" => Ok(Runtime::AppleContainer),
+            _ => Err(anyhow!(
+                "Runtime must be 'docker', 'podman', or 'container'"
+            )),
         }
     }
 }
@@ -418,7 +527,19 @@ mod tests {
     fn runtime_parse() {
         "docker".parse::<Runtime>().unwrap();
         "podman".parse::<Runtime>().unwrap();
+        "container".parse::<Runtime>().unwrap();
         assert!("invalid".parse::<Runtime>().is_err());
+        assert_eq!(
+            "container".parse::<Runtime>().unwrap(),
+            Runtime::AppleContainer
+        );
+    }
+
+    #[test]
+    fn apple_container_requires_oci_format() {
+        assert!(Runtime::AppleContainer.requires_oci_format());
+        assert!(!Runtime::Docker.requires_oci_format());
+        assert!(!Runtime::Podman.requires_oci_format());
     }
 
     #[test]
@@ -427,21 +548,30 @@ mod tests {
 
         let docker_target = Runtime::Docker;
         let podman_target = Runtime::Podman;
+        let apple_container_target = Runtime::AppleContainer;
 
         let docker_bin = tempdir.path().join("docker-bin");
         let podman_bin = tempdir.path().join("podman-bin");
         let combined_bin = tempdir.path().join("combined-bin");
         let neither_bin = tempdir.path().join("neither-bin");
+        let apple_container_bin = tempdir.path().join("apple-container-bin");
+        let all_bin = tempdir.path().join("all-bin");
 
         fs::create_dir(&docker_bin).unwrap();
         fs::create_dir(&podman_bin).unwrap();
         fs::create_dir(&combined_bin).unwrap();
         fs::create_dir(&neither_bin).unwrap();
+        fs::create_dir(&apple_container_bin).unwrap();
+        fs::create_dir(&all_bin).unwrap();
 
         fs::write(docker_bin.join("docker"), "").unwrap();
         fs::write(podman_bin.join("podman"), "").unwrap();
         fs::write(combined_bin.join("docker"), "").unwrap();
         fs::write(combined_bin.join("podman"), "").unwrap();
+        fs::write(apple_container_bin.join("container"), "").unwrap();
+        fs::write(all_bin.join("docker"), "").unwrap();
+        fs::write(all_bin.join("podman"), "").unwrap();
+        fs::write(all_bin.join("container"), "").unwrap();
 
         let docker_first_path =
             Some(std::env::join_paths([&docker_bin, &podman_bin, &combined_bin]).unwrap());
@@ -449,7 +579,13 @@ mod tests {
             Some(std::env::join_paths([&podman_bin, &docker_bin, &combined_bin]).unwrap());
         let combined_path =
             Some(std::env::join_paths([&combined_bin, &podman_bin, &docker_bin]).unwrap());
-        let neither_path = Some(std::env::join_paths([neither_bin]).unwrap());
+        let neither_path = Some(std::env::join_paths([&neither_bin]).unwrap());
+        let apple_container_only_path = Some(std::env::join_paths([&apple_container_bin]).unwrap());
+        // When all three runtimes are present, docker takes precedence.
+        let all_runtimes_path = Some(std::env::join_paths([&all_bin]).unwrap());
+        // When only podman and container are present, podman takes precedence.
+        let podman_and_container_path =
+            Some(std::env::join_paths([&podman_bin, &apple_container_bin]).unwrap());
 
         // Check that a Runtime can be detected in PATH.
         let target = temp_env::with_var("PATH", docker_first_path.as_ref(), || {
@@ -472,6 +608,24 @@ mod tests {
         });
         assert_eq!(target, None);
 
+        // Apple Container is detected when it is the only runtime available.
+        let target = temp_env::with_var("PATH", apple_container_only_path.as_ref(), || {
+            Runtime::detect_from_path()
+        });
+        assert_eq!(target, Some(apple_container_target.clone()));
+
+        // Docker takes precedence over Apple Container when both are present.
+        let target = temp_env::with_var("PATH", all_runtimes_path.as_ref(), || {
+            Runtime::detect_from_path()
+        });
+        assert_eq!(target, Some(docker_target.clone()));
+
+        // Podman takes precedence over Apple Container when docker is absent.
+        let target = temp_env::with_var("PATH", podman_and_container_path.as_ref(), || {
+            Runtime::detect_from_path()
+        });
+        assert_eq!(target, Some(podman_target.clone()));
+
         // Check that a specified Runtime is in PATH.
         assert!(temp_env::with_var("PATH", docker_first_path, || {
             docker_target.validate_in_path().is_ok()
@@ -484,6 +638,14 @@ mod tests {
         }));
         assert!(temp_env::with_var("PATH", neither_path, || {
             docker_target.validate_in_path().is_err()
+        }));
+        assert!(temp_env::with_var(
+            "PATH",
+            apple_container_only_path,
+            || { apple_container_target.validate_in_path().is_ok() }
+        ));
+        assert!(temp_env::with_var("PATH", all_runtimes_path, || {
+            apple_container_target.validate_in_path().is_ok()
         }));
     }
 }


### PR DESCRIPTION
## Proposed Changes

Apple Container (the `container` CLI, Apple's open-source runtime on Virtualization.framework) is now a first-class runtime for `flox containerize`, removing the Docker/Podman requirement from the oci-backend image pipeline on macOS. This is the primary driver for making the sandboxed-activation prototype's oci-backend Docker-free: flox/forge#1104.

### Runtime detection and selection

- `container` (Apple Container) is added as a third runtime. Auto-detection order is `docker, podman, container` — append-only, so existing Docker/Podman users see no behavior change.
- The `--runtime` flag now accepts `docker|podman|container`.
- `Runtime::AppleContainer.requires_oci_format()` returns true; the other variants return false.

### Builder proxy adapter

- Podman's `--userns ""` flag is not added for Apple Container (not needed).
- Apple Container does NOT support file-level bind mounts. The config dir (`~/.config/flox`) is mounted instead of the individual `flox.toml` file.
- The Nix store cache volume (`flox-nix`) is NOT mounted for Apple Container. Mounting over `/nix` would shadow the nixos/nix image's Nix store and remove `bash` from PATH before the shell starts.
- Apple Container resolves unqualified binary names (e.g. `bash`) via the image's PATH env var; it does NOT follow absolute symlink paths. The proxy uses `bash` (unqualified) as the container entrypoint.

### OCI archive output

When the target runtime is Apple Container, the builder runs a two-phase conversion inside the nixos/nix VM:
1. `nix run github:flox/flox -- containerize --file <docker-tmp>` → docker-archive
2. `nix run nixpkgs#skopeo -- --insecure-policy copy docker-archive:<tmp> oci-archive:<oci-tmp>:<name:tag>` → OCI archive
3. `cat <oci-tmp>` → streamed to host stdout

The two-phase approach (sequential, not a simultaneous pipe) avoids OOM inside the Apple Container VM when both operations run concurrently. All setup output is redirected to stderr; only the OCI archive reaches the host-side sink. Skopeo is fetched from nixpkgs inside the builder container — no new host-side dependencies.

Apple Container requires explicit image tags (`name:latest` works; bare `name` fails). The skopeo destination embeds the tag. `container image load --input <file>` is used for loading (Apple Container does not support stdin for `image load`). The OCI archive is written to a host-side temp file first.

### Tests

New unit tests (no runtime needed in CI):
- `runtime_parse`: `container` parses to `Runtime::AppleContainer`
- `apple_container_requires_oci_format`: true for AppleContainer, false for others
- `detect_runtime_in_path`: all precedence cases (docker>podman>container)
- `docker_proxy_uses_docker_run`, `podman_proxy_adds_userns_flag`, `apple_container_proxy_omits_userns_flag`: argv adapter checks
- `oci_conversion_command_uses_bash_pipeline`: bash -c and OCI pipeline in argv
- `oci_conversion_embeds_custom_tag`: tag appears in OCI destination

### E2E validation on this host (Apple Container 1.1.0 + Docker Desktop)

Apple Container only path (`--runtime container`):

```
$ flox containerize --runtime container --file /tmp/test.oci.tar
⚡︎ 'flox-apple-container-test:latest' written to file '/tmp/test.oci.tar'

$ container image load --input /tmp/test.oci.tar
flox-apple-container-test:latest

$ container run --rm flox-apple-container-test:latest hello
Hello, world!
```

Load path (no `--file`):

```
$ flox containerize --runtime container
⚡︎ 'flox-apple-container-test:latest' written to Apple Container runtime

$ container run --rm flox-apple-container-test:latest hello
Hello, world!
```

Docker no-regression check:

```
$ flox containerize --runtime docker --file /tmp/test-docker.tar
⚡︎ 'flox-apple-container-test:latest' written to file '/tmp/test-docker.tar'

$ docker load -i /tmp/test-docker.tar
Loaded image: flox-apple-container-test:latest
```

### CLI incompatibilities adapted

- Apple Container requires bind-mount sources to be directories (not files) — fixed by mounting the parent config dir.
- Apple Container resolves entrypoint executables using the image's PATH, not by following Nix profile symlinks — fixed by using unqualified `bash`.
- The Nix store cache volume shadows `/nix` and removes image binaries from PATH — skipped for Apple Container; substituter caches compensate.
- Simultaneous `flox containerize | skopeo` pipeline exceeds Apple Container VM memory — fixed with two-phase sequential conversion.
- `container image load` requires `--input <file>` (no stdin) — OCI archive staged to host temp file before load.

## Follow-ups

- Real Nix store cache population for Apple Container: no cache volume is mounted over `/nix` (it would shadow the nixos/nix image's own store), so every Apple Container build starts from a cold Nix store and fetches all dependencies from substituters. A follow-up should pre-populate a cache volume without the shadowing bootstrap problem. Until then the CLI prints a note about longer build times on the Apple Container path.

## Release Notes

`flox containerize` now supports Apple Container (`container` CLI) as a third runtime option alongside Docker and Podman. On macOS systems where only Apple Container is installed, `flox containerize` works without Docker or Podman. Select it explicitly with `--runtime container`.

---
*Via Forge (implementation-worker) • 2f6d5497*
