### PR TITLE
fix(install): suppress additional-outputs hint when user requested all outputs (CLI-107)

### DIFF
--- a/cli/flox/src/commands/install.rs
+++ b/cli/flox/src/commands/install.rs
@@ -1169,4 +1169,38 @@ mod tests {
             "expected no additional-outputs message when user requested all outputs, got: {output:?}"
         );
     }
+
+    /// When a package was installed with an explicit output selection
+    /// (`^out,man`), no additional-outputs hint should be shown — the user
+    /// already knows what they are and aren't selecting.
+    #[tokio::test]
+    async fn no_additional_outputs_message_when_user_requested_specific() {
+        // bash has additional outputs (default is a subset of all), so it normally
+        // triggers the hint. Use it to verify the explicit-selection suppression path.
+        let lockfile_contents =
+            std::fs::read_to_string(GENERATED_DATA.join("envs/bash/manifest.lock")).unwrap();
+        let lockfile: flox_manifest::lockfile::Lockfile = lockfile_contents.parse().unwrap();
+        let system = lockfile.packages[0].system().to_string();
+
+        // Package requested with an explicit output selection (^out)
+        let pkgs = [PackageToInstall::Catalog(CatalogPackage {
+            id: "bash".to_string(),
+            pkg_path: "bashNonInteractive".to_string(),
+            version: None,
+            systems: None,
+            outputs: Some(RawSelectedOutputs::Specific(vec!["out".to_string()])),
+        })];
+        let (subscriber, writer) = test_subscriber_message_only();
+        async {
+            message::packages_with_additional_outputs(&pkgs, &lockfile, &system);
+        }
+        .with_subscriber(subscriber)
+        .await;
+
+        let output = writer.to_string();
+        assert!(
+            output.is_empty(),
+            "expected no additional-outputs message when user selected outputs explicitly, got: {output:?}"
+        );
+    }
 }

--- a/cli/flox/src/commands/install.rs
+++ b/cli/flox/src/commands/install.rs
@@ -277,13 +277,9 @@ impl Install {
         let partitioned = Self::partition_installed_packages(&installed, &installation);
 
         // Print status messages for the installation attempt
-        let install_ids = partitioned
-            .successes
-            .iter()
-            .map(|pkg| pkg.id().to_string())
-            .collect::<Vec<_>>();
+        let successes_ref: Vec<&PackageToInstall> = partitioned.successes.iter().collect();
         message::packages_successfully_installed(&partitioned.successes, &description);
-        message::packages_with_additional_outputs(&install_ids, &lockfile, &flox.system);
+        message::packages_with_additional_outputs(&successes_ref, &lockfile, &flox.system);
         message::packages_installed_with_system_subsets(&partitioned.system_subsets);
         message::packages_already_installed(&partitioned.already_installed, &description);
         message::packages_outputs_updated(&partitioned.outputs_updated, &description);
@@ -819,7 +815,7 @@ fn add_activation_to_rc_file(
 mod tests {
     use flox_manifest::lockfile::test_helpers::fake_catalog_package_lock;
     use flox_manifest::lockfile::{LockedPackage, LockedPackageCatalog, Lockfile};
-    use flox_manifest::raw::{CatalogPackage, PackageToInstall};
+    use flox_manifest::raw::{CatalogPackage, PackageToInstall, RawSelectedOutputs};
     use flox_rust_sdk::flox::test_helpers::flox_instance;
     use flox_rust_sdk::models::environment::path_environment::test_helpers::new_path_environment_in;
     use flox_rust_sdk::providers::catalog::SystemEnum;
@@ -1053,10 +1049,17 @@ mod tests {
         // Pick the first system present in the lockfile for the check.
         let system = lockfile.packages[0].system().to_string();
 
-        let install_ids = vec!["bash".to_string()];
+        let pkgs = [PackageToInstall::Catalog(CatalogPackage {
+            id: "bash".to_string(),
+            pkg_path: "bashNonInteractive".to_string(),
+            version: None,
+            systems: None,
+            outputs: None,
+        })];
+        let pkgs_ref: Vec<&PackageToInstall> = pkgs.iter().collect();
         let (subscriber, writer) = test_subscriber_message_only();
         async {
-            message::packages_with_additional_outputs(&install_ids, &lockfile, &system);
+            message::packages_with_additional_outputs(&pkgs_ref, &lockfile, &system);
         }
         .with_subscriber(subscriber)
         .await;
@@ -1077,10 +1080,17 @@ mod tests {
         let lockfile: flox_manifest::lockfile::Lockfile = lockfile_contents.parse().unwrap();
         let system = lockfile.packages[0].system().to_string();
 
-        let install_ids = vec!["hello".to_string()];
+        let pkgs = [PackageToInstall::Catalog(CatalogPackage {
+            id: "hello".to_string(),
+            pkg_path: "hello".to_string(),
+            version: None,
+            systems: None,
+            outputs: None,
+        })];
+        let pkgs_ref: Vec<&PackageToInstall> = pkgs.iter().collect();
         let (subscriber, writer) = test_subscriber_message_only();
         async {
-            message::packages_with_additional_outputs(&install_ids, &lockfile, &system);
+            message::packages_with_additional_outputs(&pkgs_ref, &lockfile, &system);
         }
         .with_subscriber(subscriber)
         .await;
@@ -1109,10 +1119,17 @@ mod tests {
                 LockedPackage::StorePath(_) => {},
             });
 
-        let install_ids = vec!["hello".to_string()];
+        let pkgs = [PackageToInstall::Catalog(CatalogPackage {
+            id: "hello".to_string(),
+            pkg_path: "hello".to_string(),
+            version: None,
+            systems: None,
+            outputs: None,
+        })];
+        let pkgs_ref: Vec<&PackageToInstall> = pkgs.iter().collect();
         let (subscriber, writer) = test_subscriber_message_only();
         async {
-            message::packages_with_additional_outputs(&install_ids, &lockfile, &system);
+            message::packages_with_additional_outputs(&pkgs_ref, &lockfile, &system);
         }
         .with_subscriber(subscriber)
         .await;
@@ -1121,6 +1138,40 @@ mod tests {
         assert!(
             output.is_empty(),
             "expected no message for hello, got: {output:?}"
+        );
+    }
+
+    /// When a package was installed with `^..` (all outputs), no additional-outputs
+    /// hint should be shown — the user already opted in to everything.
+    #[tokio::test]
+    async fn no_additional_outputs_message_when_user_requested_all() {
+        // bash has additional outputs (default is a subset of all), so it normally
+        // triggers the hint. Use it to verify the All-outputs suppression path.
+        let lockfile_contents =
+            std::fs::read_to_string(GENERATED_DATA.join("envs/bash/manifest.lock")).unwrap();
+        let lockfile: flox_manifest::lockfile::Lockfile = lockfile_contents.parse().unwrap();
+        let system = lockfile.packages[0].system().to_string();
+
+        // Package requested with outputs = All (^..)
+        let pkgs = [PackageToInstall::Catalog(CatalogPackage {
+            id: "bash".to_string(),
+            pkg_path: "bashNonInteractive".to_string(),
+            version: None,
+            systems: None,
+            outputs: Some(RawSelectedOutputs::All),
+        })];
+        let pkgs_ref: Vec<&PackageToInstall> = pkgs.iter().collect();
+        let (subscriber, writer) = test_subscriber_message_only();
+        async {
+            message::packages_with_additional_outputs(&pkgs_ref, &lockfile, &system);
+        }
+        .with_subscriber(subscriber)
+        .await;
+
+        let output = writer.to_string();
+        assert!(
+            output.is_empty(),
+            "expected no additional-outputs message when user requested all outputs, got: {output:?}"
         );
     }
 }

--- a/cli/flox/src/commands/install.rs
+++ b/cli/flox/src/commands/install.rs
@@ -277,9 +277,8 @@ impl Install {
         let partitioned = Self::partition_installed_packages(&installed, &installation);
 
         // Print status messages for the installation attempt
-        let successes_ref: Vec<&PackageToInstall> = partitioned.successes.iter().collect();
         message::packages_successfully_installed(&partitioned.successes, &description);
-        message::packages_with_additional_outputs(&successes_ref, &lockfile, &flox.system);
+        message::packages_with_additional_outputs(&partitioned.successes, &lockfile, &flox.system);
         message::packages_installed_with_system_subsets(&partitioned.system_subsets);
         message::packages_already_installed(&partitioned.already_installed, &description);
         message::packages_outputs_updated(&partitioned.outputs_updated, &description);
@@ -1056,10 +1055,9 @@ mod tests {
             systems: None,
             outputs: None,
         })];
-        let pkgs_ref: Vec<&PackageToInstall> = pkgs.iter().collect();
         let (subscriber, writer) = test_subscriber_message_only();
         async {
-            message::packages_with_additional_outputs(&pkgs_ref, &lockfile, &system);
+            message::packages_with_additional_outputs(&pkgs, &lockfile, &system);
         }
         .with_subscriber(subscriber)
         .await;
@@ -1087,10 +1085,9 @@ mod tests {
             systems: None,
             outputs: None,
         })];
-        let pkgs_ref: Vec<&PackageToInstall> = pkgs.iter().collect();
         let (subscriber, writer) = test_subscriber_message_only();
         async {
-            message::packages_with_additional_outputs(&pkgs_ref, &lockfile, &system);
+            message::packages_with_additional_outputs(&pkgs, &lockfile, &system);
         }
         .with_subscriber(subscriber)
         .await;
@@ -1126,10 +1123,9 @@ mod tests {
             systems: None,
             outputs: None,
         })];
-        let pkgs_ref: Vec<&PackageToInstall> = pkgs.iter().collect();
         let (subscriber, writer) = test_subscriber_message_only();
         async {
-            message::packages_with_additional_outputs(&pkgs_ref, &lockfile, &system);
+            message::packages_with_additional_outputs(&pkgs, &lockfile, &system);
         }
         .with_subscriber(subscriber)
         .await;
@@ -1160,10 +1156,9 @@ mod tests {
             systems: None,
             outputs: Some(RawSelectedOutputs::All),
         })];
-        let pkgs_ref: Vec<&PackageToInstall> = pkgs.iter().collect();
         let (subscriber, writer) = test_subscriber_message_only();
         async {
-            message::packages_with_additional_outputs(&pkgs_ref, &lockfile, &system);
+            message::packages_with_additional_outputs(&pkgs, &lockfile, &system);
         }
         .with_subscriber(subscriber)
         .await;

--- a/cli/flox/src/utils/message.rs
+++ b/cli/flox/src/utils/message.rs
@@ -9,7 +9,7 @@ pub use flox_core::util::message::{stderr_supports_color, stdout_supports_color}
 use flox_manifest::compose::{COMPOSER_MANIFEST_ID, Warning};
 use flox_manifest::lockfile::{LockedPackage, Lockfile, PackageOutputs};
 use flox_manifest::parsed::latest::SelectedOutputs;
-use flox_manifest::raw::PackageToInstall;
+use flox_manifest::raw::{PackageToInstall, RawSelectedOutputs};
 use indoc::formatdoc;
 use minus::{ExitStrategy, Pager, page_all};
 use tracing::{debug, info};
@@ -182,17 +182,23 @@ pub(crate) fn packages_already_installed(pkgs: &[PackageToInstall], environment_
 }
 
 pub(crate) fn packages_with_additional_outputs(
-    install_ids_of_new_pkgs: &[String],
+    new_pkgs: &[&PackageToInstall],
     lockfile: &Lockfile,
     current_system: &System,
 ) {
     let mut pkgs_with_additional_outputs = vec![];
-    let pkgs = lockfile.packages.as_slice();
+    let locked_pkgs = lockfile.packages.as_slice();
     // Yes this is n^2, but n is small
-    for install_id in install_ids_of_new_pkgs.iter() {
-        for pkg in pkgs.iter() {
-            if (pkg.install_id() == install_id) && (pkg.system() == current_system) {
-                match pkg {
+    for pkg in new_pkgs.iter() {
+        // When the user explicitly asked for all outputs (^..) the hint is
+        // redundant — they already opted in to everything.
+        if pkg.outputs() == Some(&RawSelectedOutputs::All) {
+            continue;
+        }
+        let install_id = pkg.id();
+        for locked in locked_pkgs.iter() {
+            if (locked.install_id() == install_id) && (locked.system() == current_system) {
+                match locked {
                     LockedPackage::Catalog(locked) => {
                         let maybe_matched = locked.outputs_match_outputs_to_install();
                         if maybe_matched.is_some_and(|matched| !matched) {

--- a/cli/flox/src/utils/message.rs
+++ b/cli/flox/src/utils/message.rs
@@ -182,7 +182,7 @@ pub(crate) fn packages_already_installed(pkgs: &[PackageToInstall], environment_
 }
 
 pub(crate) fn packages_with_additional_outputs(
-    new_pkgs: &[&PackageToInstall],
+    new_pkgs: &[PackageToInstall],
     lockfile: &Lockfile,
     current_system: &System,
 ) {

--- a/cli/flox/src/utils/message.rs
+++ b/cli/flox/src/utils/message.rs
@@ -9,7 +9,7 @@ pub use flox_core::util::message::{stderr_supports_color, stdout_supports_color}
 use flox_manifest::compose::{COMPOSER_MANIFEST_ID, Warning};
 use flox_manifest::lockfile::{LockedPackage, Lockfile, PackageOutputs};
 use flox_manifest::parsed::latest::SelectedOutputs;
-use flox_manifest::raw::{PackageToInstall, RawSelectedOutputs};
+use flox_manifest::raw::PackageToInstall;
 use indoc::formatdoc;
 use minus::{ExitStrategy, Pager, page_all};
 use tracing::{debug, info};
@@ -190,9 +190,9 @@ pub(crate) fn packages_with_additional_outputs(
     let locked_pkgs = lockfile.packages.as_slice();
     // Yes this is n^2, but n is small
     for pkg in new_pkgs.iter() {
-        // When the user explicitly asked for all outputs (^..) the hint is
-        // redundant — they already opted in to everything.
-        if pkg.outputs() == Some(&RawSelectedOutputs::All) {
+        // When the user explicitly selected outputs (^.. or ^out,man) the hint
+        // is redundant — they already know what they are and aren't selecting.
+        if pkg.outputs().is_some() {
             continue;
         }
         let install_id = pkg.id();


### PR DESCRIPTION
## What

`flox install pkg^..` still printed the additional-outputs hint even though the user explicitly requested all outputs:

```
% flox install man^..
✔ 'man' installed to environment 'tmp'
ℹ 'man' has additional outputs, use 'flox list -a' to see more
```

## Why

`packages_with_additional_outputs` fired whenever a freshly installed package had more outputs than what was locked, without checking whether the user had already opted into all of them.

## How

Change `packages_with_additional_outputs` to accept `&[PackageToInstall]` instead of `&[String]` so it can inspect each package's requested outputs, and skip the hint for any package with an explicit output selection (`^..` or `^out,man`) — the user already knows what they are and aren't selecting.

Adds unit tests verifying that bash (which has additional outputs beyond its defaults) produces no hint when installed with `^..` or with an explicit output list.

Implementation started by Forge on `cli-39-output-cleanups`; cherry-picked onto current main and finalized.

Fixes CLI-107.

## Release Notes

- `flox install` no longer prints the "additional outputs" hint when the user explicitly selected outputs (`pkg^..` or `pkg^out,man`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
