### PR TITLE
feat(auto-activate): drop auto activation feature flag

### DIFF
--- a/cli/flox-config/src/load.rs
+++ b/cli/flox-config/src/load.rs
@@ -178,7 +178,7 @@ fn raw_config_from_parts(
 /// The returned source splits on `#` (not `_`), so the config crate parses it,
 /// case insensitively, as `{ <prefix>: { something_nested: () } }`
 /// extracting one level of nesting, with the leaf key keeping its own underscores
-/// (`FLOX_FEATURES_AUTO_ACTIVATE` -> `features.auto_activate`).
+/// (`FLOX_FEATURES_SOME_FLAG` -> `features.some_flag`).
 fn mk_environment(envs: &mut Vec<(String, String)>, prefix: &str) -> Environment {
     let (prefixed_envs, flox_envs): (HashMap<String, String>, Vec<(String, String)>) = envs
         .iter()

--- a/cli/flox-core/src/features.rs
+++ b/cli/flox-core/src/features.rs
@@ -6,6 +6,4 @@ pub struct Features {
     pub qa: bool,
     #[serde(default)]
     pub beta: bool,
-    #[serde(default)]
-    pub auto_activate: bool,
 }

--- a/cli/flox/doc/flox-activate-allow.md
+++ b/cli/flox/doc/flox-activate-allow.md
@@ -18,10 +18,6 @@ flox [<general-options>] activate allow
 
 # DESCRIPTION
 
-```{.include}
-./include/auto-activate-experimental.md
-```
-
 Permits the selected environment to be auto-activated.
 
 Once an environment is allowed,

--- a/cli/flox/doc/flox-activate-deny.md
+++ b/cli/flox/doc/flox-activate-deny.md
@@ -18,10 +18,6 @@ flox [<general-options>] activate deny
 
 # DESCRIPTION
 
-```{.include}
-./include/auto-activate-experimental.md
-```
-
 Prevents the selected environment from being auto-activated.
 
 Once an environment is denied,

--- a/cli/flox/doc/flox-activate.md
+++ b/cli/flox/doc/flox-activate.md
@@ -87,10 +87,6 @@ Inside a `flox activate` subshell,
 
 # AUTO-ACTIVATION
 
-```{.include}
-./include/auto-activate-experimental.md
-```
-
 Auto-activation activates an environment automatically when you enter a
 directory that contains it,
 and deactivates it when you leave,
@@ -98,21 +94,19 @@ so you do not have to run `flox activate` or `flox deactivate` by hand.
 
 ## Enabling auto-activation
 
-Two things are required:
+Auto-activation is on by default and only requires the Flox prompt hook to be
+installed in your shell.
+The hook is installed by any in-place activation,
+so add a line such as `eval "$(flox activate -D)"` to your shell's startup
+file (for example `~/.bashrc`, `~/.zshrc`, `~/.config/fish/config.fish`, or
+`~/.tcshrc`).
+If you already activate a default or other environment in-place at startup,
+the hook is already installed.
 
-1. The Flox prompt hook must be installed in your shell.
-   The hook is installed by any in-place activation,
-   so add a line such as `eval "$(flox activate -D)"` to your shell's startup
-   file (for example `~/.bashrc`, `~/.zshrc`, `~/.config/fish/config.fish`, or
-   `~/.tcshrc`).
-   If you already activate a default or other environment in-place at startup,
-   the hook is already installed.
-   The hook ships with Flox and stays dormant until the feature flag below is
-   set.
-   Run `flox config --set disable_hook true` to opt out of the hook entirely.
-2. The `auto_activate` feature flag must be enabled,
-   either with `FLOX_FEATURES_AUTO_ACTIVATE=true` in your environment
-   or with `flox config --set features.auto_activate true`.
+Run `flox config --set disable_hook true` to opt out of the hook entirely,
+which both disables auto-activation and other features like `flox deactivate`.
+To keep the hook but stop auto-activating environments you have not explicitly
+allowed, set `auto_activate` to `allowlist`.
 
 ## How it works
 

--- a/cli/flox/doc/flox-config.md
+++ b/cli/flox/doc/flox-config.md
@@ -71,8 +71,7 @@ flox config --set 'trusted_environments."owner/name"' trust
 # SUPPORTED CONFIGURATION OPTIONS
 
 `auto_activate`
-:   How auto-activation treats environments you have not yet allowed or denied,
-    when the `auto_activate` feature flag is enabled.
+:   How auto-activation treats environments you have not yet allowed or denied.
     Possible values are `prompt` (default), `allowlist`, and `disabled`.
     `prompt` asks before auto-activating an environment the first time you enter
     its directory.
@@ -121,12 +120,6 @@ flox config --set 'trusted_environments."owner/name"' trust
 
 `disable_metrics`
 :   Disable collecting and sending usage metrics.
-
-`features.auto_activate`
-:   Feature flag to enable auto-activation, which is experimental
-    (default: false).
-    May also be set with `FLOX_FEATURES_AUTO_ACTIVATE=true`.
-    See the *AUTO-ACTIVATION* section of [`flox-activate(1)`](./flox-activate.md).
 
 `floxhub_token`
 :   Token to authenticate on FloxHub.
@@ -188,8 +181,3 @@ flox config --set 'trusted_environments."owner/name"' trust
 :   Variable for disabling the collection/sending of metrics data.
     If set to `true`, prevents Flox from submitting basic metrics information
     such as a unique token and the subcommand issued.
-
-`$FLOX_FEATURES_AUTO_ACTIVATE`
-:   Set to `true` to enable auto-activation, which is experimental.
-    Equivalent to setting `features.auto_activate = true`.
-    See the *AUTO-ACTIVATION* section of [`flox-activate(1)`](./flox-activate.md).

--- a/cli/flox/doc/include/auto-activate-experimental.md
+++ b/cli/flox/doc/include/auto-activate-experimental.md
@@ -1,6 +1,0 @@
-> **Experimental:**
-> Auto-activation is experimental and behind a feature flag, and its behavior is
-> subject to change.
-> Enable it by setting `FLOX_FEATURES_AUTO_ACTIVATE=true` in your environment,
-> or by running `flox config --set features.auto_activate true`.
-> See the *AUTO-ACTIVATION* section of *flox-activate(1)* for details.

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -326,17 +326,6 @@ impl Activate {
         config: Config,
         mut flox: Flox,
     ) -> Result<()> {
-        if !flox.features.auto_activate {
-            let cmd_name = match subcommand {
-                AutoActivate::Allow => "allow",
-                AutoActivate::Deny => "deny",
-            };
-            bail!(
-                "'{}' requires the auto_activate feature flag. Set FLOX_FEATURES_AUTO_ACTIVATE=true.",
-                cmd_name
-            );
-        }
-
         let concrete_environment = self
             .environment
             .to_concrete_environment(&mut flox, None)
@@ -360,6 +349,16 @@ impl Activate {
         message::updated(formatdoc! {"
             Auto-activation {verb} for {description}.
         "});
+
+        // The decision is recorded, but auto-activation relies on the prompt
+        // hook to act on it. Warn if the hook is disabled so the user isn't
+        // surprised that nothing auto-activates.
+        if config.flox.disable_hook.unwrap_or(false) {
+            message::warning(formatdoc! {"
+                The Flox prompt hook is disabled ('disable_hook = true'), so auto-activation will not run.
+                Re-enable it with 'flox config --delete disable_hook'.
+            "});
+        }
 
         Ok(())
     }

--- a/cli/flox/src/commands/hook_env.rs
+++ b/cli/flox/src/commands/hook_env.rs
@@ -136,20 +136,6 @@ impl HookEnv {
             }
         }
 
-        // The deactivate-action handling above runs unconditionally; the
-        // auto-activation logic below stays gated behind the auto_activate
-        // feature flag.
-        if !flox.features.auto_activate {
-            // Only record a metric when this run actually does something;
-            // `hook-env` runs on every shell prompt, and recording the common
-            // nothing-to-do case would be noise.
-            if !actions.is_empty() {
-                subcommand_metric!("hook-env");
-            }
-            writer.flush()?;
-            return Ok(());
-        }
-
         let ctx = gather_auto_activate_context(&config, !actions.is_empty())?;
         let plan = plan_auto_activation(&ctx);
 

--- a/cli/tests/deactivate.bats
+++ b/cli/tests/deactivate.bats
@@ -558,9 +558,6 @@ FLOX_COLD_START_UNSET=(
   # exported, but scrub both defensively.
   -u _FLOX_INVOCATION_TYPE
   -u _FLOX_INVOCATION_TYPES
-  # A leaked auto-activate flag makes the prompt hook auto-activate inside
-  # interactive test sessions, which also surfaces in the env diff.
-  -u FLOX_FEATURES_AUTO_ACTIVATE
   # State vars maintained by the prompt hook in any outer shell that
   # activated with auto-activate enabled (e.g. a developer's own terminal).
   # _FLOX_HOOK_FIRED is only set by older flox versions but can still leak

--- a/cli/tests/hook.bats
+++ b/cli/tests/hook.bats
@@ -116,6 +116,10 @@ setup_file() {
 
 setup() {
   common_test_setup
+  # This file exercises `prompt`-mode auto-activation (consent prompts and the
+  # default first-encounter behaviour), so override the suite-wide `allowlist`
+  # default back to `prompt` for every test here.
+  export FLOX_AUTO_ACTIVATE=prompt
   setup_isolated_flox
   export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/empty.yaml"
 }
@@ -137,23 +141,6 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------- #
-# hook-env: feature flag gating
-# ---------------------------------------------------------------------------- #
-
-# Deactivate-action handling in hook-env is not gated, but the auto-activation
-# logic still is: without the flag the hook emits nothing, even with a
-# discoverable environment in the working directory.
-# TODO: Remove this test when the auto_activate feature flag is removed.
-# bats test_tags=hook:hook-env
-@test "'flox hook-env' succeeds without auto_activate feature flag but doesn't auto-activate" {
-  project_setup
-  unset FLOX_FEATURES_AUTO_ACTIVATE
-  run --separate-stderr "$FLOX_BIN" hook-env --shell bash --shell-pid "$$"
-  assert_success
-  assert_output ""
-}
-
-# ---------------------------------------------------------------------------- #
 # hook-env / deactivate: advisory preamble output is suppressed
 # ---------------------------------------------------------------------------- #
 
@@ -169,8 +156,6 @@ EXPIRED_FLOXHUB_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3gu
 # would be eval'd by the shell.
 # bats test_tags=hook:hook-env
 @test "'flox hook-env' suppresses advisory preamble output" {
-  # With the flag set, hook-env legitimately emits an export to stdout.
-  unset FLOX_FEATURES_AUTO_ACTIVATE
   _FLOX_FLOXHUB_GIT_URL="https://git.example.invalid/" \
     FLOX_FLOXHUB_TOKEN="$EXPIRED_FLOXHUB_TOKEN" \
     run --separate-stderr "$FLOX_BIN" hook-env --shell bash --shell-pid "$$"
@@ -278,12 +263,10 @@ EXPIRED_FLOXHUB_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3gu
 @test "bash: hook auto-activates a discovered environment on cd" {
   project_setup
   project2_setup
-  export FLOX_FEATURES_AUTO_ACTIVATE=true
   # Auto-activation is opt-in; allow the target before entering it.
   "$FLOX_BIN" activate allow -d "$PROJECT2_DIR"
 
   run --separate-stderr bash -c "
-    export FLOX_FEATURES_AUTO_ACTIVATE=true
     export FLOX_SHELL=\$(which bash)
     eval \"\$($FLOX_BIN activate -d $PROJECT_DIR)\"
     cd $PROJECT2_DIR
@@ -300,12 +283,10 @@ EXPIRED_FLOXHUB_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3gu
 @test "zsh: hook auto-activates a discovered environment on cd" {
   project_setup
   project2_setup
-  export FLOX_FEATURES_AUTO_ACTIVATE=true
   # Auto-activation is opt-in; allow the target before entering it.
   "$FLOX_BIN" activate allow -d "$PROJECT2_DIR"
 
   run --separate-stderr zsh -c "
-    export FLOX_FEATURES_AUTO_ACTIVATE=true
     export FLOX_SHELL=\$(which zsh)
     eval \"\$($FLOX_BIN activate -d $PROJECT_DIR)\"
     cd $PROJECT2_DIR
@@ -322,12 +303,10 @@ EXPIRED_FLOXHUB_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3gu
 @test "fish: hook auto-activates a discovered environment on cd" {
   project_setup
   project2_setup
-  export FLOX_FEATURES_AUTO_ACTIVATE=true
   # Auto-activation is opt-in; allow the target before entering it.
   "$FLOX_BIN" activate allow -d "$PROJECT2_DIR"
 
   run --separate-stderr fish -c "
-    set -gx FLOX_FEATURES_AUTO_ACTIVATE true
     eval ($FLOX_BIN activate -d $PROJECT_DIR)
     cd $PROJECT2_DIR
     _flox_hook
@@ -343,7 +322,6 @@ EXPIRED_FLOXHUB_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3gu
 @test "fish: hook auto-activation sets the prompt" {
   project_setup
   project2_setup
-  export FLOX_FEATURES_AUTO_ACTIVATE=true
   # Mirror the reported scenario: the hook-registering outer activation is the
   # 'default' env, which is hidden from FLOX_PROMPT_ENVIRONMENTS, so the outer
   # activation defines no prompt variables at the top level. (An unscoped fish
@@ -359,7 +337,6 @@ EXPIRED_FLOXHUB_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3gu
   # A known fish_prompt is defined up front because non-interactive fish has
   # no prompt function for set-prompt.fish to save and wrap.
   run unbuffer fish -c '
-    set -gx FLOX_FEATURES_AUTO_ACTIVATE true
     set -gx NO_COLOR 1
     function fish_prompt; echo -n "knownPrompt> "; end
     eval ("$FLOX_BIN" activate -d "$PROJECT_DIR")
@@ -376,12 +353,10 @@ EXPIRED_FLOXHUB_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3gu
 @test "tcsh: hook auto-activates a discovered environment on cd" {
   project_setup
   project2_setup
-  export FLOX_FEATURES_AUTO_ACTIVATE=true
   # Auto-activation is opt-in; allow the target before entering it.
   "$FLOX_BIN" activate allow -d "$PROJECT2_DIR"
 
   run --separate-stderr tcsh -c "
-    setenv FLOX_FEATURES_AUTO_ACTIVATE true
     eval \"\`$FLOX_BIN activate -d $PROJECT_DIR\`\"
     cd $PROJECT2_DIR
     precmd
@@ -401,12 +376,10 @@ EXPIRED_FLOXHUB_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3gu
 @test "bash: auto-activated environment deactivates after leaving its directory" {
   project_setup
   project2_setup
-  export FLOX_FEATURES_AUTO_ACTIVATE=true
   # Auto-activation is opt-in; allow the target before entering it.
   "$FLOX_BIN" activate allow -d "$PROJECT2_DIR"
 
   run --separate-stderr bash -c "
-    export FLOX_FEATURES_AUTO_ACTIVATE=true
     export FLOX_SHELL=\$(which bash)
     eval \"\$($FLOX_BIN activate -d $PROJECT_DIR)\"
     cd $PROJECT2_DIR
@@ -426,11 +399,9 @@ EXPIRED_FLOXHUB_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3gu
 # bats test_tags=hook:auto-deactivate:manual
 @test "bash: manually activated environment is not deactivated on leaving" {
   project_setup
-  export FLOX_FEATURES_AUTO_ACTIVATE=true
   set_vars_manifest "$PROJECT_DIR" TEST_VAR manual
 
   run --separate-stderr bash -c "
-    export FLOX_FEATURES_AUTO_ACTIVATE=true
     export FLOX_SHELL=\$(which bash)
     eval \"\$($FLOX_BIN activate -d $PROJECT_DIR)\"
     cd $BATS_TEST_TMPDIR
@@ -445,12 +416,10 @@ EXPIRED_FLOXHUB_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3gu
 @test "bash: re-entering a project after leaving re-activates it" {
   project_setup
   project2_setup
-  export FLOX_FEATURES_AUTO_ACTIVATE=true
   # Auto-activation is opt-in; allow the target before entering it.
   "$FLOX_BIN" activate allow -d "$PROJECT2_DIR"
 
   run --separate-stderr bash -c "
-    export FLOX_FEATURES_AUTO_ACTIVATE=true
     export FLOX_SHELL=\$(which bash)
     eval \"\$($FLOX_BIN activate -d $PROJECT_DIR)\"
     cd $PROJECT2_DIR
@@ -477,13 +446,11 @@ EXPIRED_FLOXHUB_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3gu
   project_setup
   project2_setup
   project3_setup
-  export FLOX_FEATURES_AUTO_ACTIVATE=true
   # Auto-activation is opt-in; allow both layers of the nested stack.
   "$FLOX_BIN" activate allow -d "$PROJECT2_DIR"
   "$FLOX_BIN" activate allow -d "$PROJECT3_DIR"
 
   run --separate-stderr bash -c "
-    export FLOX_FEATURES_AUTO_ACTIVATE=true
     export FLOX_SHELL=\$(which bash)
     eval \"\$($FLOX_BIN activate -d $PROJECT_DIR)\"
     cd $PROJECT3_DIR
@@ -510,12 +477,10 @@ EXPIRED_FLOXHUB_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3gu
 @test "bash: 'flox deactivate' suppresses re-activation until the directory is left" {
   project_setup
   project2_setup
-  export FLOX_FEATURES_AUTO_ACTIVATE=true
   # Auto-activation is opt-in; allow the target before entering it.
   "$FLOX_BIN" activate allow -d "$PROJECT2_DIR"
 
   run --separate-stderr bash -c "
-    export FLOX_FEATURES_AUTO_ACTIVATE=true
     export FLOX_SHELL=\$(which bash)
     eval \"\$($FLOX_BIN activate -d $PROJECT_DIR)\"
     cd $PROJECT2_DIR
@@ -552,13 +517,11 @@ EXPIRED_FLOXHUB_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3gu
 @test "bash: hook does not auto-activate an environment denied via 'flox activate deny'" {
   project_setup
   project2_setup
-  export FLOX_FEATURES_AUTO_ACTIVATE=true
 
   # Record the deny preference for the second project before entering it.
   "$FLOX_BIN" activate deny -d "$PROJECT2_DIR"
 
   run --separate-stderr bash -c "
-    export FLOX_FEATURES_AUTO_ACTIVATE=true
     export FLOX_SHELL=\$(which bash)
     eval \"\$($FLOX_BIN activate -d $PROJECT_DIR)\"
     cd $PROJECT2_DIR
@@ -580,13 +543,11 @@ EXPIRED_FLOXHUB_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3gu
 @test "bash: unregistered environment is not auto-activated without consent" {
   project_setup
   project2_setup
-  export FLOX_FEATURES_AUTO_ACTIVATE=true
   # No allow/deny recorded, so the default 'prompt' mode applies. This run is
   # non-interactive (no controlling terminal), so the hook cannot prompt and
   # must leave the environment unregistered rather than auto-activating it.
 
   run --separate-stderr bash -c "
-    export FLOX_FEATURES_AUTO_ACTIVATE=true
     export FLOX_SHELL=\$(which bash)
     eval \"\$($FLOX_BIN activate -d $PROJECT_DIR)\"
     cd $PROJECT2_DIR
@@ -603,7 +564,6 @@ EXPIRED_FLOXHUB_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3gu
 @test "bash: answering the consent prompt with 'y' auto-activates the environment" {
   project_setup
   project2_setup
-  export FLOX_FEATURES_AUTO_ACTIVATE=true
 
   # Set up a .bashrc so the interactive shell has a known prompt
   export KNOWN_PROMPT="hooktest> "
@@ -622,7 +582,6 @@ EOF
 @test "bash: declining the consent prompt does not auto-activate the environment" {
   project_setup
   project2_setup
-  export FLOX_FEATURES_AUTO_ACTIVATE=true
 
   # Set up a .bashrc so the interactive shell has a known prompt
   export KNOWN_PROMPT="hooktest> "
@@ -642,7 +601,6 @@ EOF
   project_setup
   project2_setup
   project3_setup
-  export FLOX_FEATURES_AUTO_ACTIVATE=true
 
   # Set up a .bashrc so the interactive shell has a known prompt
   export KNOWN_PROMPT="hooktest> "
@@ -666,7 +624,6 @@ EOF
   project_setup
   project2_setup
   project3_setup
-  export FLOX_FEATURES_AUTO_ACTIVATE=true
 
   # Set up a .bashrc so the interactive shell has a known prompt
   export KNOWN_PROMPT="hooktest> "
@@ -694,7 +651,6 @@ EOF
 @test "bash: hook auto-activates via PROMPT_COMMAND in interactive shell" {
   project_setup
   project2_setup
-  export FLOX_FEATURES_AUTO_ACTIVATE=true
   # Auto-activation is opt-in; allow the target so the hook activates it
   # without prompting.
   "$FLOX_BIN" activate allow -d "$PROJECT2_DIR"
@@ -718,7 +674,6 @@ EOF
   project2_setup
   project3_setup
   projectz_setup
-  export FLOX_FEATURES_AUTO_ACTIVATE=true
   # Auto-activation is opt-in; allow every environment the run activates so the
   # hook does not prompt.
   "$FLOX_BIN" activate allow -d "$PROJECT2_DIR"
@@ -984,14 +939,12 @@ EOF
 # bats test_tags=hook:reinsert:bash
 @test "bash: re-allowing a denied mid-stack env re-inserts it in ancestor order" {
   nested_chain_setup
-  export FLOX_FEATURES_AUTO_ACTIVATE=true
   # Allow outer and inner; deny the middle so the initial stack skips it.
   "$FLOX_BIN" activate allow -d "$NEST_OUTER_DIR"
   "$FLOX_BIN" activate allow -d "$NEST_INNER_DIR"
   "$FLOX_BIN" activate deny -d "$NEST_MID_DIR"
 
   run --separate-stderr bash -c "
-    export FLOX_FEATURES_AUTO_ACTIVATE=true
     export FLOX_SHELL=\$(which bash)
     cd $NEST_INNER_DIR
     eval \"\$($FLOX_BIN activate -d $NEST_OUTER_DIR)\"
@@ -1017,13 +970,11 @@ EOF
 # bats test_tags=hook:reinsert:fish
 @test "fish: re-allowing a denied mid-stack env re-inserts it in ancestor order" {
   nested_chain_setup
-  export FLOX_FEATURES_AUTO_ACTIVATE=true
   "$FLOX_BIN" activate allow -d "$NEST_OUTER_DIR"
   "$FLOX_BIN" activate allow -d "$NEST_INNER_DIR"
   "$FLOX_BIN" activate deny -d "$NEST_MID_DIR"
 
   run --separate-stderr fish -c "
-    set -gx FLOX_FEATURES_AUTO_ACTIVATE true
     set -gx FLOX_SHELL (which fish)
     cd $NEST_INNER_DIR
     eval \"\$($FLOX_BIN activate -d $NEST_OUTER_DIR)\"
@@ -1041,14 +992,12 @@ EOF
 # bats test_tags=hook:reinsert:manual-fallback
 @test "bash: re-allow activates on top when a manual env is layered above the target" {
   nested_chain_setup
-  export FLOX_FEATURES_AUTO_ACTIVATE=true
   # Allow only outer; deny the middle. Inner is manually activated (never
   # allowed), so it sits above the middle as a non-poppable layer.
   "$FLOX_BIN" activate allow -d "$NEST_OUTER_DIR"
   "$FLOX_BIN" activate deny -d "$NEST_MID_DIR"
 
   run --separate-stderr bash -c "
-    export FLOX_FEATURES_AUTO_ACTIVATE=true
     export FLOX_SHELL=\$(which bash)
     cd $NEST_INNER_DIR
     eval \"\$($FLOX_BIN activate -d $NEST_OUTER_DIR)\"

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -1712,7 +1712,6 @@ EOF
 @test "services stop after auto-activated environment is deactivated" {
   setup_sleeping_services
 
-  export FLOX_FEATURES_AUTO_ACTIVATE=true
   "$FLOX_BIN" activate allow -d "$PROJECT_DIR"
 
   # Minimal outer project to register _flox_hook without services.
@@ -1722,7 +1721,6 @@ EOF
 
   run --separate-stderr bash -c "
     set -euo pipefail
-    export FLOX_FEATURES_AUTO_ACTIVATE=true
     export FLOX_SHELL=\$(which bash)
 
     # Manually activate the outer project to get _flox_hook defined.

--- a/cli/tests/shell-state-restoration/dump.bash
+++ b/cli/tests/shell-state-restoration/dump.bash
@@ -20,7 +20,6 @@
 # can't silently rot.
 
 set +e
-export FLOX_FEATURES_AUTO_ACTIVATE=true
 export FLOX_SHELL=$(command -v bash)
 
 # Stable ordering across platforms — macOS's default locale and Linux's

--- a/cli/tests/shell-state-restoration/dump.fish
+++ b/cli/tests/shell-state-restoration/dump.fish
@@ -17,7 +17,6 @@
 #   dump.fish <pre.txt> <post.txt>
 
 set --export LC_ALL C
-set --export FLOX_FEATURES_AUTO_ACTIVATE true
 set --export FLOX_SHELL (command -v fish)
 
 # fish-internal volatile names plus our own dump helpers, filtered

--- a/cli/tests/shell-state-restoration/dump.tcsh
+++ b/cli/tests/shell-state-restoration/dump.tcsh
@@ -23,7 +23,6 @@
 # helper.
 
 setenv LC_ALL C
-setenv FLOX_FEATURES_AUTO_ACTIVATE true
 setenv FLOX_SHELL `which tcsh`
 
 # tcsh-internal volatiles and this script's own helpers, filtered from

--- a/cli/tests/shell-state-restoration/dump.zsh
+++ b/cli/tests/shell-state-restoration/dump.zsh
@@ -20,7 +20,6 @@ emulate -L zsh
 unsetopt verbose xtrace
 set -u
 export LC_ALL=C
-export FLOX_FEATURES_AUTO_ACTIVATE=true
 export FLOX_SHELL=$(command -v zsh)
 
 # Pre-initialize compinit so the pre snapshot already contains the

--- a/cli/tests/test_support.bash
+++ b/cli/tests/test_support.bash
@@ -158,7 +158,14 @@ common_file_setup() {
 setup_file() { common_file_setup; }
 
 # Added for consistency with `teardown' routines.
-common_test_setup() { :; }
+common_test_setup() {
+  # Auto-activation is on by default. Default the whole suite to `allowlist`
+  # mode so that walking past a discovered `.flox` never auto-activates or
+  # prompts unless a test explicitly allows it. This keeps tests hermetic and
+  # independent of the developer's own shell/config leaking in. Files that
+  # exercise `prompt`-mode behaviour override this to `prompt` file-wide.
+  export FLOX_AUTO_ACTIVATE=allowlist
+}
 setup() { common_test_setup; }
 
 # ---------------------------------------------------------------------------- #


### PR DESCRIPTION
Drop the `auto_activate` feature flag so auto-activation is on by
default, controlled entirely by the existing `auto_activate` config
option (`prompt` default, or `allowed`). To auto-activate nothing, set
`allowed` and don't allow any environments.

- Remove `Features::auto_activate` and its two gates, in `hook-env` and
  in `flox activate allow`/`deny`.
- Warn from `flox activate allow`/`deny` when `disable_hook = true`,
  since the recorded decision can't take effect without the prompt hook.
- Graduate the docs from experimental: drop the feature-flag config and
  environment-variable entries and the shared experimental notice.
- Drop the now-redundant `FLOX_FEATURES_AUTO_ACTIVATE=true` from tests;
  force `allowed` mode in the deactivate cold-start harness so it stays
  hermetic now that auto-activation defaults on.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
