### PR TITLE
ci(claude-review): Pass explicit PR number

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -39,4 +39,4 @@ jobs:
           plugin_marketplaces: https://github.com/anthropics/claude-plugins-official.git
           claude_args: '--dangerously-skip-permissions'
           plugins: 'code-review@claude-plugins-official'
-          prompt: '/code-review:code-review'
+          prompt: '/code-review:code-review PR #${{ github.event.pull_request.number }} in ${{ github.repository }}'


### PR DESCRIPTION
## Proposed Changes

Reviews were sometimes posted to the wrong PR. The workflow invoked the code-review plugin with a bare '/code-review:code-review' prompt, and in agent mode the action does not inject the PR number into the prompt. The checkout is a detached HEAD on 'refs/pull/N/merge', so the model had to infer which PR it was reviewing, typically via 'gh pr list'. Under concurrent bursts of runs it guessed wrong, usually picking the newest open PR.

All six misrouted comments observed on Jul 8 correlate 1:1 with a run for a different PR finishing seconds later (posting the comment is the run's last act before it wraps up):

- 09:48:51 comment on #4467 <- run 28932637327 for #4456, finished 09:49:02 https://github.com/flox/flox/pull/4467#issuecomment-4913529939 https://github.com/flox/flox/actions/runs/28932637327
- 10:36:30 comment on #4467 <- run 28935783871 for #4409, finished 10:36:43 https://github.com/flox/flox/pull/4467#issuecomment-4913912530 https://github.com/flox/flox/actions/runs/28935783871
- 10:36:39 comment on #4467 <- run 28935784889 for #4450, finished 10:36:54 https://github.com/flox/flox/pull/4467#issuecomment-4913913593 https://github.com/flox/flox/actions/runs/28935784889
- 10:38:45 comment on #4465 <- run 28935783795 for #4271, finished 10:39:02 https://github.com/flox/flox/pull/4465#issuecomment-4913929159 https://github.com/flox/flox/actions/runs/28935783795
- 10:42:01 comment on #4426 <- run 28935782808 for #4375, finished 10:43:10 https://github.com/flox/flox/pull/4426#issuecomment-4913956917 https://github.com/flox/flox/actions/runs/28935782808
- 10:48:20 comment on #4467 <- run 28935784327 for #4401, finished 10:48:35 https://github.com/flox/flox/pull/4467#issuecomment-4914006317 https://github.com/flox/flox/actions/runs/28935784327

Control cases confirm the correlation: runs that reviewed their own PR show the same ~13-second comment-to-finish gap:

- 10:44:26 comment on #4450 <- run 28935784554 for #4450, finished 10:44:39 https://github.com/flox/flox/pull/4450#issuecomment-4913976979 https://github.com/flox/flox/actions/runs/28935784554
- 10:57:00 comment on #4291 <- run 28935784053 for #4291, finished 10:57:11 https://github.com/flox/flox/pull/4291#issuecomment-4914071409 https://github.com/flox/flox/actions/runs/28935784053

Pass the PR number and repository explicitly as arguments to the slash command so the model never has to guess. The slash command must stay at the start of the prompt; trailing text is passed to it as arguments. Both expressions are injection-safe (a numeric PR number and the GitHub-controlled repository slug).

I've filed [CLI-125](https://linear.app/floxdotdev/issue/CLI-125/improve-automated-claude-reviews-on-floxflox-prs) to improve the actual content of the reviews.

## Release Notes

N/A