### PR TITLE
fix(gc): don't fetch from FloxHub when pruning the env registry

### DIFF
--- a/cli/flox-rust-sdk/src/models/env_registry.rs
+++ b/cli/flox-rust-sdk/src/models/env_registry.rs
@@ -4,7 +4,7 @@ use std::time::SystemTime;
 use flox_core::{Version, WriteError, serialize_atomically, traceable_path};
 use fslock::LockFile;
 use serde::{Deserialize, Serialize};
-use tracing::{debug, instrument};
+use tracing::{debug, instrument, warn};
 
 use super::environment::{EnvironmentPointer, path_hash};
 use super::floxmeta::{FloxMeta, FloxMetaError};
@@ -31,8 +31,6 @@ pub enum EnvRegistryError {
     WriteEnvironmentRegistry(#[source] WriteError),
     #[error("no registry found")]
     NoEnvRegistry,
-    #[error(transparent)]
-    FloxMeta(#[from] FloxMetaError),
 }
 
 /// A local registry of environments on the system.
@@ -121,31 +119,41 @@ impl EnvRegistry {
     }
 
     /// Prunes environments that no longer exist on disk from the Registry and FloxMeta.
-    fn prune_nonexistent(&mut self, flox: &Flox) -> Result<(), EnvRegistryError> {
-        self.entries
-            .iter()
-            .filter(|entry| !entry.exists())
-            .try_for_each(|entry| {
-                for env in entry.envs.iter() {
-                    // Prune floxmeta branches for managed environments
-                    if let EnvironmentPointer::Managed(ref pointer) = env.pointer {
-                        // Previously canonicalized path that we know no longer exists.
-                        let path = CanonicalPath::new_unchecked(&entry.path);
-                        let mut floxmeta = FloxMeta::open(flox, pointer)?;
-                        prune_branches_from_floxmeta_by_pointer(&mut floxmeta, pointer, &path)?;
-                    }
+    ///
+    /// Pruning floxmeta branches is best-effort and entirely local: the remote
+    /// is never contacted (the backing environment may no longer exist on
+    /// FloxHub), and a failure to prune branches for one entry doesn't prevent
+    /// other entries from being pruned.
+    fn prune_nonexistent(&mut self, flox: &Flox) {
+        for entry in self.entries.iter().filter(|entry| !entry.exists()) {
+            for env in entry.envs.iter() {
+                // Prune floxmeta branches for managed environments
+                let EnvironmentPointer::Managed(ref pointer) = env.pointer else {
+                    continue;
+                };
+                // Previously canonicalized path that we know no longer exists.
+                let path = CanonicalPath::new_unchecked(&entry.path);
+                let res = FloxMeta::open_local(flox, pointer).and_then(|mut floxmeta| {
+                    prune_branches_from_floxmeta_by_pointer(&mut floxmeta, pointer, &path)
+                });
+                match res {
+                    Ok(()) => {},
+                    // No floxmeta repository for this owner means there are no branches to prune.
+                    Err(FloxMetaError::NotFound(_)) => {},
+                    Err(err) => warn!(
+                        %err,
+                        owner = %pointer.owner,
+                        name = %pointer.name,
+                        "failed to prune floxmeta branches for deleted environment"
+                    ),
                 }
-
-                Ok(())
-            })
-            .map_err(EnvRegistryError::FloxMeta)?;
+            }
+        }
 
         // The environment registry is the only method we have of determining
         // whether a branch in floxmeta should be garbage collected, so only
         // remove entries after pruning floxmeta
         self.entries.retain(|entry| entry.exists());
-
-        Ok(())
     }
 }
 
@@ -338,7 +346,7 @@ pub fn garbage_collect(flox: &Flox) -> Result<EnvRegistry, EnvRegistryError> {
     let reg_path = env_registry_path(flox);
     let lock = acquire_env_registry_lock(&reg_path)?;
     let mut reg = read_environment_registry(&reg_path)?.ok_or(EnvRegistryError::NoEnvRegistry)?;
-    reg.prune_nonexistent(flox)?;
+    reg.prune_nonexistent(flox);
     write_environment_registry(&reg, &reg_path, lock)?;
     Ok(reg)
 }
@@ -357,6 +365,7 @@ mod test {
 
     use super::*;
     use crate::flox::test_helpers::flox_instance;
+    use crate::models::environment::ManagedPointer;
     use crate::models::environment::path_environment::test_helpers::new_path_environment;
 
     impl Arbitrary for RegistryEntry {
@@ -511,6 +520,35 @@ mod test {
             // Empty entries should be removed
             prop_assert!(reg.entry_for_hash(&hash).is_none());
         }
+    }
+
+    #[test]
+    fn prunes_stale_managed_env_without_contacting_floxhub() {
+        let (flox, _temp_dir) = flox_instance();
+
+        // A registered managed environment whose `.flox` directory no longer
+        // exists and whose floxmeta was never cloned locally. Pruning must not
+        // try to fetch the environment from FloxHub (the backing environment
+        // may have been deleted upstream) and must still remove the entry.
+        let pointer = ManagedPointer::new(
+            "owner".parse().unwrap(),
+            "name".parse().unwrap(),
+            &flox.floxhub,
+        );
+        let path = flox.temp_dir.join("deleted").join(".flox");
+        let mut reg = EnvRegistry::default();
+        reg.entries.push(RegistryEntry {
+            path_hash: path_hash(&path),
+            path,
+            envs: vec![RegisteredEnv {
+                created_at: 0,
+                pointer: EnvironmentPointer::Managed(pointer),
+            }],
+        });
+
+        reg.prune_nonexistent(&flox);
+
+        assert_eq!(reg.entries, vec![]);
     }
 
     #[test]

--- a/cli/flox-rust-sdk/src/models/floxmeta.rs
+++ b/cli/flox-rust-sdk/src/models/floxmeta.rs
@@ -126,6 +126,28 @@ impl FloxMeta {
         flox: &Flox,
         pointer: &ManagedPointer,
     ) -> Result<Self, FloxMetaError> {
+        let git = Self::open_git(user_floxmeta_dir, flox, pointer)?;
+        let branch: String = remote_branch_name(pointer);
+        if !git
+            .has_branch(&branch)
+            .map_err(FloxMetaError::CheckForBranch)?
+        {
+            git.fetch_branch("dynamicorigin", &branch)
+                .map_err(FloxMetaError::FetchBranch)?;
+        }
+
+        Ok(FloxMeta { git })
+    }
+
+    /// Open the git repository backing a user's floxmeta.
+    ///
+    /// This performs no remote interaction and does not guarantee that a
+    /// branch exists for the environment identified by `pointer`.
+    fn open_git(
+        user_floxmeta_dir: impl AsRef<Path>,
+        flox: &Flox,
+        pointer: &ManagedPointer,
+    ) -> Result<GitCommandProvider, FloxMetaError> {
         let floxhub = Floxhub::new(
             pointer.floxhub_base_url.to_owned(),
             None,
@@ -146,18 +168,7 @@ impl FloxMeta {
             Err(FloxMetaError::NotFound(pointer.owner.to_string()))?
         }
 
-        let git = GitCommandProvider::open_with(git_options, user_floxmeta_dir)
-            .map_err(FloxMetaError::Open)?;
-        let branch: String = remote_branch_name(pointer);
-        if !git
-            .has_branch(&branch)
-            .map_err(FloxMetaError::CheckForBranch)?
-        {
-            git.fetch_branch("dynamicorigin", &branch)
-                .map_err(FloxMetaError::FetchBranch)?;
-        }
-
-        Ok(FloxMeta { git })
+        GitCommandProvider::open_with(git_options, user_floxmeta_dir).map_err(FloxMetaError::Open)
     }
 
     /// Open a floxmeta repository for a given user
@@ -167,6 +178,17 @@ impl FloxMeta {
     pub fn open(flox: &Flox, pointer: &ManagedPointer) -> Result<Self, FloxMetaError> {
         let user_floxmeta_dir = floxmeta_dir(flox, &pointer.owner);
         Self::open_at(user_floxmeta_dir, flox, pointer)
+    }
+
+    /// Open a floxmeta repository for a given user without contacting FloxHub.
+    ///
+    /// Unlike [`FloxMeta::open`], the environment's branch is not fetched
+    /// when it is absent locally. Use this for operations that only need
+    /// local state, such as pruning branches during garbage collection.
+    pub fn open_local(flox: &Flox, pointer: &ManagedPointer) -> Result<Self, FloxMetaError> {
+        let user_floxmeta_dir = floxmeta_dir(flox, &pointer.owner);
+        let git = Self::open_git(user_floxmeta_dir, flox, pointer)?;
+        Ok(FloxMeta { git })
     }
 
     pub fn new_in(


### PR DESCRIPTION
Fixes [CLI-115](https://linear.app/floxdotdev/issue/CLI-115/flox-gc-crashes-fetching-a-deleted-remote-ref-while-pruning-the-env) (investigated in [CLI-28](https://linear.app/floxdotdev/issue/CLI-28/investigate-unreliable-env-registryjson-cleanup)).

## Problem

`flox gc` and `flox envs` crashed with `Failed to fetch environment: ref not found` when the environment registry contained a stale managed entry whose upstream environment had been deleted on FloxHub.

Registry pruning selects entries by a purely local check (the `.flox` directory no longer exists) and only deletes local floxmeta branches — but it obtained its floxmeta handle via `FloxMeta::open`, which fetches the environment's branch from the remote when it is absent locally. That fetch only fires when the branch is missing locally, which is exactly the case where pruning has nothing to delete — so it never did useful work, and it failed with `RefNotFound` when the upstream branch was gone.

Because the error aborted `prune_nonexistent` before the retain sweep, a single such entry blocked cleanup of **all** stale registry entries and made `flox envs` fail outright. The only workaround was hand-editing `~/.local/share/flox/env-registry.json`.

## Solution

- Add `FloxMeta::open_local`, which opens a user's floxmeta repository without contacting FloxHub (no fetch-on-missing-branch). The fetching behavior of `FloxMeta::open`/`open_at` is unchanged for callers that actually need the branch.
- Use it in `prune_nonexistent`, and make branch pruning best-effort and per-entry:
  - a missing floxmeta repo means there is nothing to prune,
  - any other per-entry failure logs a warning naming the environment instead of aborting the sweep,
  - the registry retain sweep now always runs.
- `prune_nonexistent` becomes infallible; the now-unused `EnvRegistryError::FloxMeta` variant is removed.

## Testing

Added `prunes_stale_managed_env_without_contacting_floxhub`: a registry entry for a managed environment whose `.flox` directory is gone and whose floxmeta was never cloned locally is pruned cleanly (offline). On the previous code this exact scenario made `garbage_collect` return an error.

## Release Notes

- Fixed `flox gc` and `flox envs` failing with `Failed to fetch environment: ref not found` when a deleted environment was still referenced by the local environment registry. Garbage collection no longer contacts FloxHub and cleans up stale registry entries even when one of them cannot be fully pruned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)