### PR TITLE
feat(auth): support non-interactive login with --token-file

### DIFF
--- a/cli/flox-rust-sdk/src/flox.rs
+++ b/cli/flox-rust-sdk/src/flox.rs
@@ -242,37 +242,9 @@ pub mod test_helpers {
 
 #[cfg(test)]
 pub mod tests {
+    use floxhub_client::token_test_helpers::{FAKE_EXPIRED_TOKEN, FAKE_TOKEN};
+
     use super::*;
-
-    /// A fake FloxHub token
-    ///
-    /// {
-    ///  "typ": "JWT",
-    ///  "alg": "HS256"
-    /// }
-    /// .
-    /// {
-    ///   "https://flox.dev/handle": "test"
-    ///   "exp": 9999999999,                // 2286-11-20T17:46:39+00:00
-    /// }
-    /// .
-    /// AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
-    const FAKE_TOKEN: &str = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3guZGV2L2hhbmRsZSI6InRlc3QiLCJleHAiOjk5OTk5OTk5OTl9.6-nbzFzQEjEX7dfWZFLE-I_qW2N_-9W2HFzzfsquI74";
-
-    /// A fake floxhub token, that is expired
-    ///
-    /// {
-    ///  "typ": "JWT",
-    ///  "alg": "HS256"
-    /// }
-    /// .
-    /// {
-    ///   "https://flox.dev/handle": "test"
-    ///   "exp": 1704063600,                // 2024-01-01T00:00:00+00:00
-    /// }
-    /// .
-    /// AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
-    const FAKE_EXPIRED_TOKEN: &str = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3guZGV2L2hhbmRsZSI6InRlc3QiLCJleHAiOjE3MDQwNjM2MDB9.-5VCofPtmYQuvh21EV1nEJhTFV_URkRP0WFu4QDPFxY";
 
     #[tokio::test]
     async fn test_get_username() {

--- a/cli/flox-rust-sdk/src/providers/nix_auth.rs
+++ b/cli/flox-rust-sdk/src/providers/nix_auth.rs
@@ -170,13 +170,11 @@ pub(crate) fn store_needs_auth(url: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use floxhub_client::token_test_helpers::FAKE_TOKEN;
     use tempfile::tempdir;
 
     use super::*;
     use crate::flox::FloxhubToken;
-
-    // Unexpired JWT with handle "test" for use in tests.
-    const FAKE_TOKEN: &str = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3guZGV2L2hhbmRsZSI6InRlc3QiLCJleHAiOjk5OTk5OTk5OTl9.6-nbzFzQEjEX7dfWZFLE-I_qW2N_-9W2HFzzfsquI74";
 
     fn test_auth() -> NixAuth {
         let token = FloxhubToken::new(FAKE_TOKEN.to_string()).unwrap();

--- a/cli/flox/doc/flox-auth.md
+++ b/cli/flox/doc/flox-auth.md
@@ -13,7 +13,7 @@ flox-auth - FloxHub authentication commands
 
 ```text
 flox [<general-options>] auth
-     (login | logout | status | token)
+     (login [--token-file <path>] | logout | status | token)
 ```
 
 # DESCRIPTION
@@ -32,6 +32,13 @@ Authenticating also automatically trusts your personal environments.
 
 Prompts you to enter a one-time code at a specified URL.
 If called interactively it can open the browser for you if you press `<enter>`.
+
+With `--token-file <path>` the login is non-interactive:
+the FloxHub token is read from `<path>` instead
+(pass `-` to read the token from stdin).
+The token is validated and stored,
+and no browser, prompt, or network access is involved.
+Use this in CI, containers, and other scripted setups.
 
 See also: [`flox-push(1)`](./flox-push.md),
 [`flox-pull(1)`](./flox-pull.md),

--- a/cli/flox/src/commands/auth.rs
+++ b/cli/flox/src/commands/auth.rs
@@ -1,3 +1,6 @@
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
 use anyhow::{Context, Result, bail};
 use bpaf::Bpaf;
 use chrono::offset::Utc;
@@ -230,7 +233,11 @@ fn calculate_expiry(expires_in: i64) -> String {
 pub enum Auth {
     /// Login to FloxHub
     #[bpaf(command)]
-    Login,
+    Login {
+        /// Read a FloxHub token from PATH instead of logging in interactively (use '-' for stdin)
+        #[bpaf(long("token-file"), argument("PATH"))]
+        token_file: Option<PathBuf>,
+    },
 
     /// Logout from FloxHub
     #[bpaf(command)]
@@ -251,10 +258,17 @@ impl Auth {
         subcommand_metric!("auth2");
 
         match self {
-            Auth::Login => {
+            Auth::Login { token_file } => {
                 let span = tracing::info_span!("login");
                 let _guard = span.enter();
-                login_flox(&mut flox).await?;
+                match token_file {
+                    Some(path) => {
+                        login_with_token_file(&mut flox, &path)?;
+                    },
+                    None => {
+                        login_flox(&mut flox).await?;
+                    },
+                }
                 Ok(())
             },
             Auth::Logout => {
@@ -339,4 +353,125 @@ pub async fn login_flox(flox: &mut Flox) -> Result<String> {
     message::updated(format!("Logged in as {handle}"));
 
     Ok(handle)
+}
+
+/// Log in non-interactively with a token read from a file, or from stdin if
+/// the path is `-`.
+///
+/// * validates the token and rejects expired tokens
+/// * updates the config file with the token
+/// * updates the auth context of the [Flox] instance
+pub fn login_with_token_file(flox: &mut Flox, token_file: &Path) -> Result<String> {
+    let contents = if token_file == Path::new("-") {
+        let mut contents = String::new();
+        std::io::stdin()
+            .read_to_string(&mut contents)
+            .context("Could not read token from stdin.")?;
+        contents
+    } else {
+        std::fs::read_to_string(token_file)
+            .with_context(|| format!("Could not read token file {}.", token_file.display()))?
+    };
+
+    let token = FloxhubToken::new(contents.trim().to_string())
+        .context("The provided token is not a valid FloxHub token.")?;
+
+    if token.is_expired() {
+        bail!("The provided token is expired.\nObtain a fresh token from FloxHub and try again.");
+    }
+
+    let handle = token.handle().to_string();
+
+    update_config(&flox.config_dir, "floxhub_token", Some(token.clone()))
+        .context("Could not write token to config")?;
+
+    let auth_context = AuthContext::from_mode(&AuthnMode::Auth0, Some(token));
+    let _ = flox.set_auth_context(auth_context);
+
+    message::updated(format!("Logged in as {handle}"));
+
+    Ok(handle)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use flox_rust_sdk::flox::test_helpers::{create_test_token, flox_instance};
+
+    use super::*;
+    use crate::config::FLOX_CONFIG_FILE;
+
+    /// A fake expired FloxHub token
+    ///
+    /// {
+    ///   "https://flox.dev/handle": "test",
+    ///   "exp": 1704063600                 // 2024-01-01T00:00:00+00:00
+    /// }
+    const EXPIRED_TOKEN: &str = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3guZGV2L2hhbmRsZSI6InRlc3QiLCJleHAiOjE3MDQwNjM2MDB9.-5VCofPtmYQuvh21EV1nEJhTFV_URkRP0WFu4QDPFxY";
+
+    #[test]
+    fn login_with_token_file_stores_valid_token() {
+        let (mut flox, _temp_dir) = flox_instance();
+        let token = create_test_token("test-user");
+        let token_file = flox.temp_dir.join("token");
+        fs::write(&token_file, format!("{}\n", token.secret())).unwrap();
+
+        let handle = login_with_token_file(&mut flox, &token_file).unwrap();
+
+        assert_eq!(handle, "test-user");
+        let config_contents = fs::read_to_string(flox.config_dir.join(FLOX_CONFIG_FILE)).unwrap();
+        assert_eq!(
+            config_contents,
+            format!("floxhub_token = \"{}\"\n", token.secret())
+        );
+        let AuthContext::Auth0(Some(stored)) = &flox.auth_context else {
+            panic!("expected an Auth0 auth context with a token");
+        };
+        assert_eq!(stored.secret(), token.secret());
+    }
+
+    #[test]
+    fn login_with_token_file_rejects_missing_file() {
+        let (mut flox, _temp_dir) = flox_instance();
+        let missing = flox.temp_dir.join("nonexistent");
+
+        let err = login_with_token_file(&mut flox, &missing).unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            format!("Could not read token file {}.", missing.display())
+        );
+        assert!(!flox.config_dir.join(FLOX_CONFIG_FILE).exists());
+    }
+
+    #[test]
+    fn login_with_token_file_rejects_malformed_token() {
+        let (mut flox, _temp_dir) = flox_instance();
+        let token_file = flox.temp_dir.join("token");
+        fs::write(&token_file, "not-a-jwt").unwrap();
+
+        let err = login_with_token_file(&mut flox, &token_file).unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "The provided token is not a valid FloxHub token."
+        );
+        assert!(!flox.config_dir.join(FLOX_CONFIG_FILE).exists());
+    }
+
+    #[test]
+    fn login_with_token_file_rejects_expired_token() {
+        let (mut flox, _temp_dir) = flox_instance();
+        let token_file = flox.temp_dir.join("token");
+        fs::write(&token_file, EXPIRED_TOKEN).unwrap();
+
+        let err = login_with_token_file(&mut flox, &token_file).unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "The provided token is expired.\nObtain a fresh token from FloxHub and try again."
+        );
+        assert!(!flox.config_dir.join(FLOX_CONFIG_FILE).exists());
+    }
 }

--- a/cli/flox/src/commands/auth.rs
+++ b/cli/flox/src/commands/auth.rs
@@ -349,10 +349,15 @@ pub async fn login_flox(flox: &mut Flox) -> Result<String> {
     let auth_context = AuthContext::from_mode(&AuthnMode::Auth0, Some(token.clone()));
     let _ = flox.set_auth_context(auth_context);
 
-    message::updated("Authentication complete");
-    message::updated(format!("Logged in as {handle}"));
+    print_login_success(&handle);
 
     Ok(handle)
+}
+
+/// Print the success message shared by all login flows.
+fn print_login_success(handle: &str) {
+    message::updated("Authentication complete");
+    message::updated(format!("Logged in as {handle}"));
 }
 
 /// Log in non-interactively with a token read from a file, or from stdin if
@@ -388,7 +393,7 @@ pub fn login_with_token_file(flox: &mut Flox, token_file: &Path) -> Result<Strin
     let auth_context = AuthContext::from_mode(&AuthnMode::Auth0, Some(token));
     let _ = flox.set_auth_context(auth_context);
 
-    message::updated(format!("Logged in as {handle}"));
+    print_login_success(&handle);
 
     Ok(handle)
 }
@@ -398,17 +403,10 @@ mod tests {
     use std::fs;
 
     use flox_rust_sdk::flox::test_helpers::{create_test_token, flox_instance};
+    use floxhub_client::token_test_helpers::FAKE_EXPIRED_TOKEN;
 
     use super::*;
     use crate::config::FLOX_CONFIG_FILE;
-
-    /// A fake expired FloxHub token
-    ///
-    /// {
-    ///   "https://flox.dev/handle": "test",
-    ///   "exp": 1704063600                 // 2024-01-01T00:00:00+00:00
-    /// }
-    const EXPIRED_TOKEN: &str = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3guZGV2L2hhbmRsZSI6InRlc3QiLCJleHAiOjE3MDQwNjM2MDB9.-5VCofPtmYQuvh21EV1nEJhTFV_URkRP0WFu4QDPFxY";
 
     #[test]
     fn login_with_token_file_stores_valid_token() {
@@ -464,7 +462,7 @@ mod tests {
     fn login_with_token_file_rejects_expired_token() {
         let (mut flox, _temp_dir) = flox_instance();
         let token_file = flox.temp_dir.join("token");
-        fs::write(&token_file, EXPIRED_TOKEN).unwrap();
+        fs::write(&token_file, FAKE_EXPIRED_TOKEN).unwrap();
 
         let err = login_with_token_file(&mut flox, &token_file).unwrap_err();
 

--- a/cli/flox/src/commands/auth.rs
+++ b/cli/flox/src/commands/auth.rs
@@ -402,11 +402,11 @@ pub fn login_with_token_file(flox: &mut Flox, token_file: &Path) -> Result<Strin
 mod tests {
     use std::fs;
 
+    use flox_config::FLOX_CONFIG_FILE;
     use flox_rust_sdk::flox::test_helpers::{create_test_token, flox_instance};
     use floxhub_client::token_test_helpers::FAKE_EXPIRED_TOKEN;
 
     use super::*;
-    use crate::config::FLOX_CONFIG_FILE;
 
     #[test]
     fn login_with_token_file_stores_valid_token() {

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -548,7 +548,9 @@ impl FloxArgs {
             Ok(Some(token)) if token.is_expired() => {
                 let reauthenticating = matches!(
                     self.command,
-                    Some(Commands::Admin(AdminCommands::Auth(auth::Auth::Login)))
+                    Some(Commands::Admin(AdminCommands::Auth(
+                        auth::Auth::Login { .. }
+                    )))
                 );
                 // The token is account-global, so the reminder only needs to
                 // appear once per shell session. The outermost activation

--- a/cli/floxhub-client/src/lib.rs
+++ b/cli/floxhub-client/src/lib.rs
@@ -77,6 +77,6 @@ pub use factory_api_v1::{
     Error as FactoryApiError,
     ResponseValue as FactoryApiResponseValue,
 };
-pub use token::{FloxhubToken, FloxhubTokenError};
+pub use token::{FloxhubToken, FloxhubTokenError, test_helpers as token_test_helpers};
 // Types (re-exported from types module for convenience)
 pub use types::*;

--- a/cli/floxhub-client/src/token.rs
+++ b/cli/floxhub-client/src/token.rs
@@ -91,3 +91,40 @@ pub enum FloxhubTokenError {
     #[error("invalid token")]
     InvalidToken(#[source] jsonwebtoken::errors::Error),
 }
+
+/// Test fixtures for [FloxhubToken].
+///
+/// Intentionally not behind `#[cfg(test)]` so that other crates' (also
+/// non-gated) test helpers can use them without enabling a feature.
+/// Nothing here should be used in production code.
+pub mod test_helpers {
+    /// A fake FloxHub token
+    ///
+    /// {
+    ///  "typ": "JWT",
+    ///  "alg": "HS256"
+    /// }
+    /// .
+    /// {
+    ///   "https://flox.dev/handle": "test"
+    ///   "exp": 9999999999,                // 2286-11-20T17:46:39+00:00
+    /// }
+    /// .
+    /// AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+    pub const FAKE_TOKEN: &str = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3guZGV2L2hhbmRsZSI6InRlc3QiLCJleHAiOjk5OTk5OTk5OTl9.6-nbzFzQEjEX7dfWZFLE-I_qW2N_-9W2HFzzfsquI74";
+
+    /// A fake floxhub token, that is expired
+    ///
+    /// {
+    ///  "typ": "JWT",
+    ///  "alg": "HS256"
+    /// }
+    /// .
+    /// {
+    ///   "https://flox.dev/handle": "test"
+    ///   "exp": 1704063600,                // 2024-01-01T00:00:00+00:00
+    /// }
+    /// .
+    /// AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+    pub const FAKE_EXPIRED_TOKEN: &str = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3guZGV2L2hhbmRsZSI6InRlc3QiLCJleHAiOjE3MDQwNjM2MDB9.-5VCofPtmYQuvh21EV1nEJhTFV_URkRP0WFu4QDPFxY";
+}

--- a/cli/tests/auth.bats
+++ b/cli/tests/auth.bats
@@ -33,6 +33,11 @@ project_setup() {
   rm -rf "$PROJECT_DIR"
   mkdir -p "$PROJECT_DIR"
   pushd "$PROJECT_DIR" > /dev/null || return
+  # Tests in this file assert on login state persisted in FLOX_CONFIG_DIR.
+  # Bats runs tests within a file in parallel on CI, so each test needs its
+  # own config dir — otherwise a neighboring test's 'auth logout' (below)
+  # removes the token another test just stored.
+  setup_isolated_flox
   unset FLOX_FLOXHUB_TOKEN
   "$FLOX_BIN" auth logout
 }

--- a/cli/tests/auth.bats
+++ b/cli/tests/auth.bats
@@ -63,3 +63,70 @@ teardown() {
   run "$FLOX_BIN" auth login
   assert_failure
 }
+
+# ---------------------------------------------------------------------------- #
+
+# A valid dummy JWT with payload:
+#   { "https://flox.dev/handle": "test", "exp": 9999999999 }
+# (same token as floxhub_setup in test_support.bash)
+DUMMY_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3guZGV2L2hhbmRsZSI6InRlc3QiLCJleHAiOjk5OTk5OTk5OTl9.6-nbzFzQEjEX7dfWZFLE-I_qW2N_-9W2HFzzfsquI74"
+
+# An expired dummy JWT with payload:
+#   { "https://flox.dev/handle": "test", "exp": 1704063600 }
+EXPIRED_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3guZGV2L2hhbmRsZSI6InRlc3QiLCJleHAiOjE3MDQwNjM2MDB9.-5VCofPtmYQuvh21EV1nEJhTFV_URkRP0WFu4QDPFxY"
+
+# bats test_tags=auth,auth:login:token-file
+@test "auth login --token-file logs in with a token from a file" {
+  echo "$DUMMY_TOKEN" > "$PROJECT_DIR/token"
+
+  run "$FLOX_BIN" auth login --token-file "$PROJECT_DIR/token"
+  assert_success
+  assert_output --partial "Logged in as test"
+
+  run "$FLOX_BIN" auth status
+  assert_success
+  assert_output --partial "You are logged in as test"
+
+  run "$FLOX_BIN" auth token
+  assert_success
+  assert_output "$DUMMY_TOKEN"
+}
+
+# bats test_tags=auth,auth:login:token-file
+@test "auth login --token-file - reads the token from stdin" {
+  run sh -c "echo '$DUMMY_TOKEN' | '$FLOX_BIN' auth login --token-file -"
+  assert_success
+  assert_output --partial "Logged in as test"
+
+  run "$FLOX_BIN" auth token
+  assert_success
+  assert_output "$DUMMY_TOKEN"
+}
+
+# bats test_tags=auth,auth:login:token-file
+@test "auth login --token-file fails for a missing file" {
+  run "$FLOX_BIN" auth login --token-file "$PROJECT_DIR/does-not-exist"
+  assert_failure
+  assert_output --partial "Could not read token file"
+}
+
+# bats test_tags=auth,auth:login:token-file
+@test "auth login --token-file fails for a malformed token" {
+  echo "not-a-jwt" > "$PROJECT_DIR/token"
+
+  run "$FLOX_BIN" auth login --token-file "$PROJECT_DIR/token"
+  assert_failure
+  assert_output --partial "The provided token is not a valid FloxHub token."
+}
+
+# bats test_tags=auth,auth:login:token-file
+@test "auth login --token-file fails for an expired token" {
+  echo "$EXPIRED_TOKEN" > "$PROJECT_DIR/token"
+
+  run "$FLOX_BIN" auth login --token-file "$PROJECT_DIR/token"
+  assert_failure
+  assert_output --partial "The provided token is expired."
+
+  run "$FLOX_BIN" auth status
+  assert_failure
+}


### PR DESCRIPTION
closes [DEV-96](https://linear.app/floxdotdev/issue/DEV-96/allow-setting-floxhub-token-from-a-file)

## Summary

`flox auth login` today only supports the interactive OAuth device flow (browser + one-time code), which can't run in CI, containers, or scripted setups. Escape hatches exist (`FLOX_FLOXHUB_TOKEN`, `flox config --set floxhub_token …`), but neither is discoverable as an auth operation, and neither validates the token or confirms who you logged in as.

This adds a non-interactive path:

```
flox auth login --token-file <PATH>    # read a FloxHub token from a file
cat token | flox auth login --token-file -    # '-' reads from stdin

```

The token is trimmed, validated locally (JWT structure and expiry — no network), stored in the config exactly like interactive login, and the command confirms the identity with `✅  Logged in as <handle>`.

## Behavior

- `-` means stdin, following the existing convention from `flox edit`, `flox lock-manifest`, and `flox containerize`.
- Failure modes all exit non-zero and leave stored credentials untouched:
  - unreadable/missing file → `Could not read token file <PATH>.` with the underlying cause
  - malformed token → `The provided token is not a valid FloxHub token.`
  - expired token → `The provided token is expired.` with a hint to obtain a fresh one
- `flox auth login` without the flag keeps the interactive OAuth device flow, unchanged.

## Testing

- 4 new unit tests in `commands/auth.rs` (valid token stores config + auth context; missing file; malformed token; expired token — failure cases assert no config write).
- 5 new bats tests in `cli/tests/auth.bats` covering file login (verified via `auth status` / `auth token`), stdin via `-`, and the three failure modes.

## Release Notes

`flox auth login` now supports non-interactive authentication via `--token-file <PATH>`: read a FloxHub token from a file, validate it, and log in without a browser — for CI, containers, and scripted setups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)