### PR TITLE
feat(sandbox): SL-002 restructure manifest sandbox to [options.sandbox] table

### DIFF
--- a/cli/flox-manifest/src/compose/shallow.rs
+++ b/cli/flox-manifest/src/compose/shallow.rs
@@ -22,8 +22,8 @@ use crate::parsed::common::{
 };
 use crate::parsed::latest::{Install, ManifestLatest, MinimumCliVersion};
 // merge_build and merge_options operate on the latest schema's Build and
-// Options (which carry `sandbox-allow` and `sandbox` respectively), so
-// composing environments preserves those fields.
+// Options (which carry `sandbox-allow` and `[options.sandbox]` table
+// respectively), so composing environments preserves those fields.
 use crate::parsed::v1_13_0::{Build, Options, Profile, ProfileDeactivate, Services};
 
 /// Merges two manifests by applying `manifest2` on top of `manifest1` and
@@ -224,14 +224,8 @@ impl ShallowMerger {
 
         let (merged_sandbox, sandbox_warning) = shallow_merge_options(
             root_key.push("sandbox"),
-            low_priority.sandbox,
-            high_priority.sandbox,
-        );
-
-        let (merged_sandbox_backend, sandbox_backend_warning) = shallow_merge_options(
-            root_key.push("sandbox-backend"),
-            low_priority.sandbox_backend,
-            high_priority.sandbox_backend,
+            low_priority.sandbox.clone(),
+            high_priority.sandbox.clone(),
         );
 
         let merged = Options {
@@ -246,7 +240,6 @@ impl ShallowMerger {
             },
             cuda_detection: merged_cuda_detection,
             sandbox: merged_sandbox,
-            sandbox_backend: merged_sandbox_backend,
             activate: ActivateOptions {
                 mode: merged_activate_mode,
             },
@@ -261,7 +254,6 @@ impl ShallowMerger {
                 allow_pre_releases_warning,
                 cuda_detection_warning,
                 sandbox_warning,
-                sandbox_backend_warning,
                 systems_warning,
             ]
             .into_iter()
@@ -413,6 +405,7 @@ impl ManifestMergeTrait for ShallowMerger {
 #[cfg(test)]
 mod tests {
 
+    use flox_core::activate::sandbox_backend::SandboxBackend;
     use flox_core::activate::sandbox_mode::SandboxMode;
     use flox_test_utils::proptest::btree_maps_overlapping_keys;
     use pretty_assertions::assert_eq;
@@ -422,7 +415,7 @@ mod tests {
     use crate::parsed::common::{Allows, ContainerizeConfig, SemverOptions, ServiceDescriptor};
     use crate::parsed::latest::ManifestPackageDescriptor;
     // Build merging operates on the latest schema's BuildDescriptor.
-    use crate::parsed::v1_13_0::BuildDescriptor;
+    use crate::parsed::v1_13_0::{BuildDescriptor, SandboxOptions};
 
     proptest! {
         // Ensures that the vars unique to each manifest are present in the merged output,
@@ -562,11 +555,10 @@ mod tests {
             let semver = SemverOptions { allow_pre_releases: options2.semver.allow_pre_releases.or(options1.semver.allow_pre_releases) };
             let cuda_detection = options2.cuda_detection.or(options1.cuda_detection);
             let sandbox = options2.sandbox.or(options1.sandbox);
-            let sandbox_backend = options2.sandbox_backend.or(options1.sandbox_backend);
             let activate = ActivateOptions {
                 mode: options2.activate.mode.or(options1.activate.mode),
             };
-            let expected = Options { systems, allow, semver, cuda_detection, sandbox, sandbox_backend, activate };
+            let expected = Options { systems, allow, semver, cuda_detection, sandbox, activate };
             prop_assert_eq!(merged, expected);
         }
 
@@ -969,16 +961,23 @@ mod tests {
         assert_eq!(ShallowMerger::merge_profile(None, None).unwrap(), None);
     }
 
-    /// `options.sandbox` shallow merges with the higher priority manifest
-    /// winning, just like `options.activate.mode`, and warns on override.
+    /// `options.sandbox` table shallow merges with the higher priority manifest
+    /// winning (the whole table), just like `options.activate.mode`, and warns
+    /// on override.
     #[test]
     fn merges_options_sandbox_high_priority_wins() {
         let low_priority = Options {
-            sandbox: Some(SandboxMode::Warn),
+            sandbox: Some(SandboxOptions {
+                mode: Some(SandboxMode::Warn),
+                backend: None,
+            }),
             ..Default::default()
         };
         let high_priority = Options {
-            sandbox: Some(SandboxMode::Enforce),
+            sandbox: Some(SandboxOptions {
+                mode: Some(SandboxMode::Enforce),
+                backend: Some(SandboxBackend::Oci),
+            }),
             ..Default::default()
         };
 
@@ -986,7 +985,10 @@ mod tests {
             ShallowMerger::merge_options(&low_priority, &high_priority).unwrap();
 
         assert_eq!(merged, Options {
-            sandbox: Some(SandboxMode::Enforce),
+            sandbox: Some(SandboxOptions {
+                mode: Some(SandboxMode::Enforce),
+                backend: Some(SandboxBackend::Oci),
+            }),
             ..Default::default()
         });
         assert!(
@@ -997,12 +999,15 @@ mod tests {
         );
     }
 
-    /// A low-priority `options.sandbox` is preserved when the higher priority
-    /// manifest doesn't set one.
+    /// A low-priority `[options.sandbox]` table is preserved when the higher
+    /// priority manifest doesn't set one.
     #[test]
     fn merges_options_sandbox_falls_back_to_low_priority() {
         let low_priority = Options {
-            sandbox: Some(SandboxMode::Prompt),
+            sandbox: Some(SandboxOptions {
+                mode: Some(SandboxMode::Prompt),
+                backend: None,
+            }),
             ..Default::default()
         };
         let high_priority = Options::default();
@@ -1011,7 +1016,10 @@ mod tests {
             ShallowMerger::merge_options(&low_priority, &high_priority).unwrap();
 
         assert_eq!(merged, Options {
-            sandbox: Some(SandboxMode::Prompt),
+            sandbox: Some(SandboxOptions {
+                mode: Some(SandboxMode::Prompt),
+                backend: None,
+            }),
             ..Default::default()
         });
         assert!(warnings.is_empty(), "unexpected warnings: {warnings:?}");

--- a/cli/flox-manifest/src/parsed/latest.rs
+++ b/cli/flox-manifest/src/parsed/latest.rs
@@ -125,9 +125,16 @@ mod tests {
         PackageDescriptorStorePath,
     };
     // ManifestLatest's build and options sections are the version-specific
-    // types (with `sandbox-allow` and `sandbox`), so assertions on them use
-    // the latest schema's types.
-    use crate::parsed::v1_13_0::{Build, BuildDescriptor, Options, Profile, ProfileDeactivate};
+    // types (with `sandbox-allow` and `[options.sandbox]` table), so assertions
+    // on them use the latest schema's types.
+    use crate::parsed::v1_13_0::{
+        Build,
+        BuildDescriptor,
+        Options,
+        Profile,
+        ProfileDeactivate,
+        SandboxOptions,
+    };
     use crate::test_helpers::{with_latest_schema, with_schema};
 
     #[test]
@@ -218,42 +225,182 @@ mod tests {
     }
 
     #[test]
-    fn options_sandbox_parses_with_latest_schema() {
+    fn options_sandbox_table_with_both_fields_parses() {
+        let manifest = with_latest_schema(indoc! {r#"
+            [options.sandbox]
+            backend = "oci"
+            mode = "enforce"
+        "#});
+
+        let parsed = toml_edit::de::from_str::<ManifestLatest>(&manifest).unwrap();
+
+        assert_eq!(parsed.options, Options {
+            sandbox: Some(SandboxOptions {
+                backend: Some(SandboxBackend::Oci),
+                mode: Some(SandboxMode::Enforce),
+            }),
+            ..Default::default()
+        });
+    }
+
+    #[test]
+    fn options_sandbox_table_backend_only_parses() {
+        let manifest = with_latest_schema(indoc! {r#"
+            [options.sandbox]
+            backend = "host-native"
+        "#});
+
+        let parsed = toml_edit::de::from_str::<ManifestLatest>(&manifest).unwrap();
+
+        assert_eq!(parsed.options, Options {
+            sandbox: Some(SandboxOptions {
+                backend: Some(SandboxBackend::HostNative),
+                mode: None,
+            }),
+            ..Default::default()
+        });
+    }
+
+    #[test]
+    fn options_sandbox_table_mode_only_parses() {
+        let manifest = with_latest_schema(indoc! {r#"
+            [options.sandbox]
+            mode = "warn"
+        "#});
+
+        let parsed = toml_edit::de::from_str::<ManifestLatest>(&manifest).unwrap();
+
+        assert_eq!(parsed.options, Options {
+            sandbox: Some(SandboxOptions {
+                backend: None,
+                mode: Some(SandboxMode::Warn),
+            }),
+            ..Default::default()
+        });
+    }
+
+    #[test]
+    fn options_sandbox_table_mode_off_parses() {
+        let manifest = with_latest_schema(indoc! {r#"
+            [options.sandbox]
+            mode = "off"
+        "#});
+
+        let parsed = toml_edit::de::from_str::<ManifestLatest>(&manifest).unwrap();
+
+        assert_eq!(parsed.options, Options {
+            sandbox: Some(SandboxOptions {
+                backend: None,
+                mode: Some(SandboxMode::Off),
+            }),
+            ..Default::default()
+        });
+    }
+
+    #[test]
+    fn options_sandbox_empty_table_parses() {
+        let manifest = with_latest_schema(indoc! {r#"
+            [options.sandbox]
+        "#});
+
+        let parsed = toml_edit::de::from_str::<ManifestLatest>(&manifest).unwrap();
+
+        assert_eq!(parsed.options, Options {
+            sandbox: Some(SandboxOptions {
+                backend: None,
+                mode: None,
+            }),
+            ..Default::default()
+        });
+    }
+
+    #[test]
+    fn options_flat_sandbox_key_rejected() {
+        // The old flat `sandbox = "warn"` key is no longer valid; the new form
+        // requires `[options.sandbox]` as a table.
         let manifest = with_latest_schema(indoc! {r#"
             [options]
             sandbox = "warn"
         "#});
 
-        let parsed = toml_edit::de::from_str::<ManifestLatest>(&manifest).unwrap();
+        let err = toml_edit::de::from_str::<ManifestLatest>(&manifest)
+            .expect_err("flat 'options.sandbox = string' should be rejected");
 
-        assert_eq!(parsed.options, Options {
-            sandbox: Some(SandboxMode::Warn),
-            ..Default::default()
-        });
+        // The error may mention type mismatch (expected a table, found string)
+        // or an unknown field; either is acceptable.
+        assert!(
+            err.message().contains("invalid type")
+                || err.message().contains("expected")
+                || err.message().contains("unknown"),
+            "unexpected error message: {err}",
+        );
     }
 
     #[test]
-    fn options_sandbox_backend_parses_with_latest_schema() {
+    fn options_flat_sandbox_backend_key_rejected() {
+        // The old flat `sandbox-backend` key is removed; it is now an unknown
+        // field at the `[options]` level (deny_unknown_fields).
         let manifest = with_latest_schema(indoc! {r#"
             [options]
-            sandbox-backend = "host-native"
+            sandbox-backend = "oci"
         "#});
 
-        let parsed = toml_edit::de::from_str::<ManifestLatest>(&manifest).unwrap();
+        let err = toml_edit::de::from_str::<ManifestLatest>(&manifest)
+            .expect_err("flat 'options.sandbox-backend' should be rejected");
 
-        assert_eq!(parsed.options, Options {
-            sandbox_backend: Some(SandboxBackend::HostNative),
-            ..Default::default()
-        });
+        assert!(
+            err.message()
+                .starts_with("unknown field `sandbox-backend`, expected one of"),
+            "unexpected error message: {err}",
+        );
     }
 
     #[test]
-    fn stays_latest_schema_when_sandbox_backend_set() {
-        // A set `options.sandbox-backend` cannot be represented in v1.12.0, so
+    fn options_sandbox_table_rejects_unknown_backend() {
+        let manifest = with_latest_schema(indoc! {r#"
+            [options.sandbox]
+            backend = "bogus"
+        "#});
+
+        let err = toml_edit::de::from_str::<ManifestLatest>(&manifest)
+            .expect_err("'bogus' should not be a valid sandbox backend");
+
+        assert!(
+            err.message().starts_with("unknown variant `bogus`"),
+            "unexpected error message: {err}",
+        );
+    }
+
+    #[test]
+    fn options_sandbox_table_rejected_by_v1_12_0_schema() {
+        let manifest = with_schema(KnownSchemaVersion::V1_12_0, indoc! {r#"
+            [options.sandbox]
+            backend = "oci"
+        "#});
+
+        let err = Manifest::parse_toml_typed(&manifest)
+            .expect_err("'[options.sandbox]' table should be rejected by the v1.12.0 schema");
+
+        let ManifestError::Invalid(err) = err else {
+            panic!("expected ManifestError::Invalid, got: {err:?}");
+        };
+        assert!(
+            err.message()
+                .starts_with("unknown field `sandbox`, expected one of"),
+            "unexpected error message: {err}",
+        );
+    }
+
+    #[test]
+    fn stays_latest_schema_when_sandbox_table_set() {
+        // A set `[options.sandbox]` table cannot be represented in v1.12.0, so
         // the manifest must stay on the latest schema rather than downgrade.
         let manifest = ManifestLatest {
             options: Options {
-                sandbox_backend: Some(SandboxBackend::HostNative),
+                sandbox: Some(SandboxOptions {
+                    backend: Some(SandboxBackend::Oci),
+                    mode: None,
+                }),
                 ..Default::default()
             },
             ..Default::default()
@@ -264,42 +411,6 @@ mod tests {
             .unwrap();
 
         assert_eq!(compat.get_schema_version(), KnownSchemaVersion::V1_13_0);
-    }
-
-    #[test]
-    fn options_sandbox_rejects_unknown_value() {
-        let manifest = with_latest_schema(indoc! {r#"
-            [options]
-            sandbox = "bogus"
-        "#});
-
-        let err = toml_edit::de::from_str::<ManifestLatest>(&manifest)
-            .expect_err("'bogus' should not be a valid sandbox mode");
-
-        assert!(
-            err.message().starts_with("unknown variant `bogus`"),
-            "unexpected error message: {err}",
-        );
-    }
-
-    #[test]
-    fn options_sandbox_rejected_by_v1_12_0_schema() {
-        let manifest = with_schema(KnownSchemaVersion::V1_12_0, indoc! {r#"
-            [options]
-            sandbox = "warn"
-        "#});
-
-        let err = Manifest::parse_toml_typed(&manifest)
-            .expect_err("'options.sandbox' should be rejected by the v1.12.0 schema");
-
-        let ManifestError::Invalid(err) = err else {
-            panic!("expected ManifestError::Invalid, got: {err:?}");
-        };
-        assert!(
-            err.message()
-                .starts_with("unknown field `sandbox`, expected one of"),
-            "unexpected error message: {err}",
-        );
     }
 
     #[test]
@@ -317,7 +428,10 @@ mod tests {
     fn stays_latest_schema_when_sandbox_set() {
         let manifest = ManifestLatest {
             options: Options {
-                sandbox: Some(SandboxMode::Prompt),
+                sandbox: Some(SandboxOptions {
+                    mode: Some(SandboxMode::Prompt),
+                    ..Default::default()
+                }),
                 ..Default::default()
             },
             ..Default::default()

--- a/cli/flox-manifest/src/parsed/v1_13_0/mod.rs
+++ b/cli/flox-manifest/src/parsed/v1_13_0/mod.rs
@@ -222,7 +222,7 @@ pub struct ProfileDeactivate {
 /// Options for V1_13_0.
 ///
 /// This is a version-specific copy of `common::Options` because V1_13_0 adds
-/// the `sandbox` field; the other fields (and their leaf types) are identical
+/// the `sandbox` table; the other fields (and their leaf types) are identical
 /// and continue to live in `parsed::common`.
 #[skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash, JsonSchema)]
@@ -247,25 +247,54 @@ pub struct Options {
     /// Whether to detect CUDA devices and libs during activation.
     // TODO: Migrate to `ActivateOptions`.
     pub cuda_detection: Option<bool>,
-    /// The sandbox mode applied when the environment is activated
-    /// (`off`, `warn`, `enforce`, or `prompt`). An explicit `--sandbox` flag
-    /// on `flox activate` takes precedence over this setting.
-    pub sandbox: Option<SandboxMode>,
-    /// The sandbox enforcement backend used when the environment is activated
-    /// (`libsandbox`, `nix`, `host-native`, `srt`, `oci`, or `libkrun`). The
-    /// `--sandbox-backend` flag on `flox activate` and the
-    /// `FLOX_SANDBOX_BACKEND` environment variable take precedence over this
-    /// setting.
-    pub sandbox_backend: Option<SandboxBackend>,
+    /// The sandbox table. When present, selects the sandbox backend and/or
+    /// mode for activations. An explicit `--sandbox` flag on `flox activate`
+    /// takes precedence over the table's `mode` field; `--sandbox-backend`,
+    /// `FLOX_SANDBOX_BACKEND`, and the table's `backend` field follow the
+    /// same flag > env > manifest precedence.
+    ///
+    /// ```toml
+    /// [options.sandbox]
+    /// backend = "oci"          # enforce-only backend; mode defaults to enforce
+    ///
+    /// [options.sandbox]
+    /// mode = "off"             # master switch: disables sandbox regardless
+    ///
+    /// [options.sandbox]
+    /// backend = "libsandbox"
+    /// mode    = "warn"
+    /// ```
+    pub sandbox: Option<SandboxOptions>,
     /// Options that control the behavior of activations.
     #[serde(default)]
     #[serde(skip_serializing_if = "ActivateOptions::skip_serializing")]
     pub activate: ActivateOptions,
 }
 
+/// The `[options.sandbox]` table.
+///
+/// Both fields are optional: an empty table (or a table with just `backend`)
+/// enables the sandbox with backend-appropriate defaults. `mode = "off"` is
+/// the master switch and disables the sandbox regardless of `backend`.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash, JsonSchema)]
+#[cfg_attr(any(test, feature = "tests"), derive(proptest_derive::Arbitrary))]
+#[serde(rename_all = "kebab-case")]
+#[serde(deny_unknown_fields)]
+pub struct SandboxOptions {
+    /// The enforcement backend. Defaults per backend when omitted: `enforce`
+    /// for enforcing backends (`capabilities().enforces == true`), `prompt`
+    /// for `libsandbox` (matching the bare `--sandbox` flag default).
+    pub backend: Option<SandboxBackend>,
+    /// The sandbox mode. When omitted the default is derived from the
+    /// backend's capabilities (see above). `mode = "off"` is the master
+    /// switch: it disables the sandbox regardless of `backend`.
+    pub mode: Option<SandboxMode>,
+}
+
 // Conversion from the common Options, used by the V1_12_0 -> V1_13_0
-// migration. The new `sandbox` field defaults to None, which is what makes
-// the migration lossless.
+// migration. The new `sandbox` table defaults to None, preserving
+// all pre-V1_13_0 manifests as-is.
 impl From<crate::parsed::common::Options> for Options {
     fn from(options: crate::parsed::common::Options) -> Self {
         let crate::parsed::common::Options {
@@ -281,7 +310,6 @@ impl From<crate::parsed::common::Options> for Options {
             semver,
             cuda_detection,
             sandbox: None,
-            sandbox_backend: None,
             activate,
         }
     }

--- a/cli/flox/doc/flox-activate.md
+++ b/cli/flox/doc/flox-activate.md
@@ -211,9 +211,10 @@ options.
    enforcing backends selected with `--sandbox-backend` isolate
    differently — see [`flox-sandbox(1)`](./flox-sandbox.md).
    A bare `--sandbox` with no value is shorthand for `--sandbox prompt`.
-   Environments can request a mode with the `options.sandbox` manifest
-   setting (see [`manifest.toml(5)`](./manifest.toml.md)); the
-   command-line flag takes precedence over the manifest.
+   Environments can declare a sandbox in the manifest via
+   `[options.sandbox]` (see [`manifest.toml(5)`](./manifest.toml.md));
+   the command-line flag takes precedence over the manifest's `mode`
+   field.
    `warn` reports out-of-policy access without blocking it,
    `enforce` denies it, and `prompt` denies it and queues it for approval.
    File reads outside the environment closure and TCP connections to hosts
@@ -291,8 +292,8 @@ options.
    backends (`host-native`, `srt`, `oci`) support `enforce` only and
    reject `warn`/`prompt`. `nix` and `libkrun` are not yet wired into
    activation and error if selected. Precedence: this flag, then the
-   `FLOX_SANDBOX_BACKEND` environment variable, then the
-   `options.sandbox-backend` manifest setting.
+   `FLOX_SANDBOX_BACKEND` environment variable, then the manifest's
+   `[options.sandbox].backend` field.
    See [`flox-sandbox(1)`](./flox-sandbox.md) for the full backend
    documentation, including OCI image baking and its operational valves.
 

--- a/cli/flox/doc/flox-sandbox.md
+++ b/cli/flox/doc/flox-sandbox.md
@@ -50,9 +50,9 @@ Sandboxing is requested per environment in the manifest, or per
 invocation on the command line:
 
 ```toml
-[options]
-sandbox = "enforce"
-sandbox-backend = "oci"
+[options.sandbox]
+backend = "oci"
+# mode defaults to "enforce" for enforcing backends
 ```
 
 ```console
@@ -61,8 +61,9 @@ $ flox activate --sandbox enforce --sandbox-backend oci -- <command>
 
 The command-line flags take precedence over the manifest; the
 `FLOX_SANDBOX_BACKEND` environment variable sits between them (flag,
-then environment variable, then manifest, then the default
-`libsandbox`).
+then environment variable, then manifest `backend`, then the default
+`libsandbox`). The manifest's `mode` field follows the same
+precedence relative to the `--sandbox` flag.
 
 When a manifest declares a sandbox, interactive auto-activation shows
 a consent prompt before entering a sandboxed session
@@ -160,8 +161,8 @@ current image and the `latest` alias only.
   manifest (`[vars]`), the project directory, or an in-session login.
 * Nothing credential-bearing is baked into the image: it carries the
   environment closure and activation context only, and the
-  prototype-only `options.sandbox*` keys are stripped from the view
-  the builder sees.
+  the prototype-only `[options.sandbox]` table is stripped from the
+  view the builder sees.
 
 **Network is not restricted.** The guest has the container runtime's
 default outbound network access. The isolation story for this

--- a/cli/flox/doc/manifest.toml.md
+++ b/cli/flox/doc/manifest.toml.md
@@ -772,8 +772,12 @@ Options ::= {
 , allow                     = null | Allows
 , semver                    = null | Semver
 , cuda-detection            = null | <BOOL>
-, sandbox                   = null | 'off' | 'warn' | 'enforce' | 'prompt'
-, sandbox-backend           = null | 'libsandbox' | 'nix' | 'host-native' | 'srt' | 'oci' | 'libkrun'
+, sandbox                   = null | SandboxTable
+}
+
+SandboxTable ::= {
+  backend = null | 'libsandbox' | 'nix' | 'host-native' | 'srt' | 'oci' | 'libkrun'
+, mode    = null | 'off' | 'warn' | 'enforce' | 'prompt'
 }
 
 Activate ::= {
@@ -844,24 +848,41 @@ Semver ::= {
     locate `libcuda` in well-known paths.
 
 `sandbox`
-:   The sandbox mode applied when the environment is activated:
-    `off` (default), `warn`, `enforce`, or `prompt`.
-    An explicit `flox activate --sandbox` flag takes precedence over this
-    setting.
-    See [`flox-activate(1)`](./flox-activate.md) for the mode semantics.
+:   An optional table that declares a sandbox for the environment's
+    activations. Both fields are optional:
+
+    ```toml
+    [options.sandbox]
+    backend = "oci"          # enforce-only; mode defaults to "enforce"
+
+    [options.sandbox]
+    mode = "off"             # master switch: disables any sandbox
+
+    [options.sandbox]
+    backend = "libsandbox"
+    mode    = "warn"
+    ```
+
+    `sandbox.backend`
+    :   The enforcement backend: `libsandbox` (default), `nix`,
+        `host-native`, `srt`, `oci`, or `libkrun`. The
+        `flox activate --sandbox-backend` flag and the
+        `FLOX_SANDBOX_BACKEND` environment variable take precedence.
+        See [`flox-sandbox(1)`](./flox-sandbox.md) for the available
+        backends.
+
+    `sandbox.mode`
+    :   The sandbox mode: `off`, `warn`, `enforce`, or `prompt`. When
+        omitted the default is derived from `backend`: `enforce` for
+        enforcing backends (`host-native`, `srt`, `oci`, `nix`,
+        `libkrun`), `prompt` for `libsandbox`. `mode = "off"` is the
+        master switch and disables the sandbox regardless of `backend`.
+        An explicit `flox activate --sandbox` flag takes precedence.
+
     Requires the `sandbox_activate` feature flag
     (set `FLOX_FEATURES_SANDBOX_ACTIVATE=true`);
-    without it the setting is ignored with a warning.
+    without it the table is ignored with a warning.
     Ignored for the ephemeral activations used by service startup.
-    This is an experimental prototype and may change or be removed.
-
-`sandbox-backend`
-:   The enforcement backend that applies the sandbox policy when the
-    environment is activated: `libsandbox` (default), `nix`, `host-native`,
-    `srt`, `oci`, or `libkrun`. The `flox activate --sandbox-backend` flag and
-    the `FLOX_SANDBOX_BACKEND` environment variable take precedence over this
-    setting. Only takes effect with an active `sandbox` mode.
-    See [`flox-sandbox(1)`](./flox-sandbox.md) for the available backends.
     This is an experimental prototype and may change or be removed.
 
 # SEE ALSO

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -2757,14 +2757,14 @@ mod tests {
     #[test]
     fn resolve_sandbox_mode_cli_flag_wins_over_manifest() {
         let manifest = sandbox_opts_with_mode(SandboxMode::Enforce);
-        let mode = resolve_sandbox_mode(Some(SandboxMode::Warn), Some(&manifest), true, false)
-            .unwrap();
+        let mode =
+            resolve_sandbox_mode(Some(SandboxMode::Warn), Some(&manifest), true, false).unwrap();
         assert_eq!(mode, SandboxMode::Warn);
 
         // An explicit `--sandbox off` overrides a manifest-set mode.
         let manifest = sandbox_opts_with_mode(SandboxMode::Prompt);
-        let mode = resolve_sandbox_mode(Some(SandboxMode::Off), Some(&manifest), true, false)
-            .unwrap();
+        let mode =
+            resolve_sandbox_mode(Some(SandboxMode::Off), Some(&manifest), true, false).unwrap();
         assert_eq!(mode, SandboxMode::Off);
     }
 
@@ -3671,10 +3671,7 @@ mode = "warn"
                 .expect("fixture has manifest.options");
             // The sandbox value is now an object (the table) rather than two
             // flat keys.
-            options.insert(
-                "sandbox".into(),
-                serde_json::json!({"backend": "oci"}),
-            );
+            options.insert("sandbox".into(), serde_json::json!({"backend": "oci"}));
             serde_json::to_string_pretty(&value).unwrap()
         }
 

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -26,6 +26,7 @@ use flox_events::EventsHub;
 use flox_manifest::interfaces::{AsLatestSchema, AsWritableManifest, WriteManifest};
 use flox_manifest::parsed::Inner;
 use flox_manifest::parsed::common::IncludeDescriptor;
+use flox_manifest::parsed::v1_13_0::SandboxOptions;
 use flox_manifest::{Manifest, MigratedTypedOnly};
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::floxmeta_branch::BranchOrd;
@@ -443,9 +444,10 @@ impl ActivateOptions {
 
         let is_ephemeral = !services_for_ephemeral_activation.is_empty();
 
+        let manifest_sandbox = manifest.as_latest_schema().options.sandbox.as_ref();
         let sandbox_mode = resolve_sandbox_mode(
             self.sandbox,
-            manifest.as_latest_schema().options.sandbox,
+            manifest_sandbox,
             flox.features.sandbox_activate,
             is_ephemeral,
         )?;
@@ -453,8 +455,8 @@ impl ActivateOptions {
         // A manifest-sourced mode first becomes visible here, after the
         // handle-level in-place guard (which only sees the CLI flag) has
         // already run, so re-check the rejection with the resolved mode.
-        // Otherwise `options.sandbox = "prompt"` piped to `tee` would activate
-        // in-place unsandboxed.
+        // Otherwise `[options.sandbox]\nmode = "prompt"` piped to `tee` would
+        // activate in-place unsandboxed.
         ensure_sandbox_not_in_place(sandbox_mode, &invocation_type)?;
 
         // Apply the selected enforcement backend. `libsandbox` (the default) is
@@ -475,7 +477,7 @@ impl ActivateOptions {
         } else {
             match resolve_sandbox_backend(
                 self.sandbox_backend,
-                manifest.as_latest_schema().options.sandbox_backend,
+                manifest_sandbox.and_then(|s| s.backend),
             )? {
                 SandboxBackend::Libsandbox => sandbox_mode,
                 SandboxBackend::HostNative => {
@@ -1171,7 +1173,7 @@ const WRAPPED_MARKER_VAR: &str = "_FLOX_SANDBOX_WRAPPED";
 
 /// Resolve the sandbox backend, in precedence order: the `--sandbox-backend`
 /// flag, the `FLOX_SANDBOX_BACKEND` environment variable, the manifest
-/// `options.sandbox-backend`, then the default (`libsandbox`).
+/// `[options.sandbox].backend`, then the default (`libsandbox`).
 fn resolve_sandbox_backend(
     flag: Option<SandboxBackend>,
     manifest: Option<SandboxBackend>,
@@ -1893,22 +1895,22 @@ fn ensure_latest_alias(runtime: &str, env_name: &str, hash12: &str) {
     }
 }
 
-/// Prototype-only `[options]` manifest keys that mainline flox does not
-/// know about. They configure the host-side activation sandbox; the baked
-/// image is the *inside* of that boundary, so they must not propagate
+/// Prototype-only `[options]` manifest key that mainline flox does not
+/// know about. It configures the host-side activation sandbox; the baked
+/// image is the *inside* of that boundary, so it must not propagate
 /// into the builder's view of the environment. Mainline flox parses
-/// manifest options with `deny_unknown_fields` and hard-fails on them --
+/// manifest options with `deny_unknown_fields` and hard-fails on it --
 /// both the in-container builder and any mainline flox inside the guest.
-const PROTOTYPE_ONLY_OPTION_KEYS: [&str; 2] = ["sandbox", "sandbox-backend"];
+const PROTOTYPE_ONLY_OPTION_KEYS: [&str; 1] = ["sandbox"];
 
-/// Strip prototype-only keys from `[options]` in manifest TOML text.
+/// Strip the prototype-only `sandbox` key from `[options]` in manifest TOML text.
 ///
-/// Returns `Some(sanitized)` when at least one key was removed, `None`
-/// when the manifest declares none of them (callers can skip building a
-/// temp view entirely). Formatting of untouched content is preserved via
-/// `toml_edit`, though only parsed values matter: the builder's
-/// freshness check is a typed equality between the parsed manifest and
-/// the lockfile's embedded manifest (see
+/// Returns `Some(sanitized)` when the key was removed, `None` when the
+/// manifest declares none of them (callers can skip building a temp view
+/// entirely). Formatting of untouched content is preserved via `toml_edit`,
+/// though only parsed values matter: the builder's freshness check is a
+/// typed equality between the parsed manifest and the lockfile's embedded
+/// manifest (see
 /// `flox-manifest/src/lockfile/mod.rs::is_up_to_date_with_serialized_manifest`).
 fn sanitize_manifest_toml(toml_text: &str) -> Result<Option<String>> {
     let mut doc = toml_text
@@ -1925,8 +1927,8 @@ fn sanitize_manifest_toml(toml_text: &str) -> Result<Option<String>> {
     Ok(changed.then(|| doc.to_string()))
 }
 
-/// Strip prototype-only keys from the embedded manifest(s) in lockfile
-/// JSON text: `manifest.options` and, for composed environments,
+/// Strip the prototype-only `sandbox` key from the embedded manifest(s) in
+/// lockfile JSON text: `manifest.options` and, for composed environments,
 /// `compose.composer.options` (the freshness check compares against
 /// `compose.composer` when present). Everything else is preserved
 /// verbatim at the JSON value level.
@@ -2484,7 +2486,13 @@ fn stale_ref_for_state(state: &OciImageState) -> &str {
 
 /// Resolve the effective sandbox mode for an activation.
 ///
-/// Precedence: CLI flag > manifest `options.sandbox` > off.
+/// Precedence: CLI flag > manifest `[options.sandbox].mode` > backend
+/// default > off.
+///
+/// When the `[options.sandbox]` table is present but `mode` is omitted,
+/// the backend's capabilities drive the default: `enforce` for enforcing
+/// backends, `prompt` for `libsandbox` (matching the bare `--sandbox`
+/// flag default). When the table is absent entirely, the default is `off`.
 ///
 /// An explicit CLI flag without the sandbox_activate feature flag is a hard
 /// error so the user knows the flag did not take effect. A manifest-sourced
@@ -2493,7 +2501,7 @@ fn stale_ref_for_state(state: &OciImageState) -> &str {
 /// downgraded to off with a warning when the feature flag is absent.
 fn resolve_sandbox_mode(
     cli_mode: Option<SandboxMode>,
-    manifest_mode: Option<SandboxMode>,
+    manifest_sandbox: Option<&SandboxOptions>,
     sandbox_feature_enabled: bool,
     is_ephemeral: bool,
 ) -> Result<SandboxMode> {
@@ -2509,23 +2517,43 @@ fn resolve_sandbox_mode(
         return Ok(mode);
     }
 
-    let Some(mode) = manifest_mode else {
+    // No `[options.sandbox]` table → no manifest-declared sandbox.
+    let Some(sandbox_opts) = manifest_sandbox else {
         return Ok(SandboxMode::Off);
     };
 
+    // `mode = "off"` is the master switch regardless of backend.
+    if sandbox_opts.mode == Some(SandboxMode::Off) {
+        return Ok(SandboxMode::Off);
+    }
+
     if is_ephemeral {
-        debug!("ignoring manifest 'options.sandbox' for an ephemeral (service) activation");
+        debug!("ignoring manifest '[options.sandbox]' for an ephemeral (service) activation");
         return Ok(SandboxMode::Off);
     }
 
     if !sandbox_feature_enabled {
         message::warning(
-            "Ignoring 'options.sandbox' from the manifest; sandboxing requires the sandbox_activate feature flag. Set FLOX_FEATURES_SANDBOX_ACTIVATE=true.",
+            "Ignoring '[options.sandbox]' from the manifest; sandboxing requires the sandbox_activate feature flag. Set FLOX_FEATURES_SANDBOX_ACTIVATE=true.",
         );
         return Ok(SandboxMode::Off);
     }
 
-    Ok(mode)
+    // When mode is explicit, use it; otherwise derive from backend capabilities.
+    if let Some(mode) = sandbox_opts.mode {
+        return Ok(mode);
+    }
+
+    // Mode omitted: default per backend. We resolve the backend here purely
+    // for the mode default — `resolve_sandbox_backend` is called again later
+    // to select the enforcement mechanism; both reads are cheap.
+    let backend = sandbox_opts.backend.unwrap_or_default();
+    if backend.capabilities().enforces {
+        Ok(SandboxMode::Enforce)
+    } else {
+        // libsandbox (the advisory default): mirror the bare `--sandbox` default.
+        Ok(SandboxMode::Prompt)
+    }
 }
 
 /// Reject a sandboxed in-place activation.
@@ -2717,36 +2745,39 @@ mod tests {
         assert!(parse_activate_options(&["--sandbox", "bogus"]).is_err());
     }
 
+    /// Build a `SandboxOptions` with an explicit mode for tests that
+    /// mirror the old flat-key API (mode only, no backend).
+    fn sandbox_opts_with_mode(mode: SandboxMode) -> SandboxOptions {
+        SandboxOptions {
+            mode: Some(mode),
+            backend: None,
+        }
+    }
+
     #[test]
     fn resolve_sandbox_mode_cli_flag_wins_over_manifest() {
-        let mode = resolve_sandbox_mode(
-            Some(SandboxMode::Warn),
-            Some(SandboxMode::Enforce),
-            true,
-            false,
-        )
-        .unwrap();
+        let manifest = sandbox_opts_with_mode(SandboxMode::Enforce);
+        let mode = resolve_sandbox_mode(Some(SandboxMode::Warn), Some(&manifest), true, false)
+            .unwrap();
         assert_eq!(mode, SandboxMode::Warn);
 
         // An explicit `--sandbox off` overrides a manifest-set mode.
-        let mode = resolve_sandbox_mode(
-            Some(SandboxMode::Off),
-            Some(SandboxMode::Prompt),
-            true,
-            false,
-        )
-        .unwrap();
+        let manifest = sandbox_opts_with_mode(SandboxMode::Prompt);
+        let mode = resolve_sandbox_mode(Some(SandboxMode::Off), Some(&manifest), true, false)
+            .unwrap();
         assert_eq!(mode, SandboxMode::Off);
     }
 
     #[test]
     fn resolve_sandbox_mode_manifest_applies_without_cli_flag() {
-        let mode = resolve_sandbox_mode(None, Some(SandboxMode::Warn), true, false).unwrap();
+        let manifest = sandbox_opts_with_mode(SandboxMode::Warn);
+        let mode = resolve_sandbox_mode(None, Some(&manifest), true, false).unwrap();
         assert_eq!(mode, SandboxMode::Warn);
     }
 
     #[test]
     fn resolve_sandbox_mode_defaults_to_off() {
+        // No table → off.
         let mode = resolve_sandbox_mode(None, None, true, false).unwrap();
         assert_eq!(mode, SandboxMode::Off);
 
@@ -2756,8 +2787,53 @@ mod tests {
 
     #[test]
     fn resolve_sandbox_mode_ignores_manifest_for_ephemeral_activation() {
-        let mode = resolve_sandbox_mode(None, Some(SandboxMode::Enforce), true, true).unwrap();
+        let manifest = sandbox_opts_with_mode(SandboxMode::Enforce);
+        let mode = resolve_sandbox_mode(None, Some(&manifest), true, true).unwrap();
         assert_eq!(mode, SandboxMode::Off);
+    }
+
+    #[test]
+    fn resolve_sandbox_mode_off_in_table_is_master_switch() {
+        // `mode = "off"` in the table disables the sandbox regardless of backend.
+        let manifest = SandboxOptions {
+            mode: Some(SandboxMode::Off),
+            backend: Some(SandboxBackend::Oci),
+        };
+        let mode = resolve_sandbox_mode(None, Some(&manifest), true, false).unwrap();
+        assert_eq!(mode, SandboxMode::Off);
+    }
+
+    #[test]
+    fn resolve_sandbox_mode_enforcing_backend_defaults_to_enforce() {
+        // Backend present, mode absent: enforcing backend → enforce.
+        let manifest = SandboxOptions {
+            mode: None,
+            backend: Some(SandboxBackend::Oci),
+        };
+        let mode = resolve_sandbox_mode(None, Some(&manifest), true, false).unwrap();
+        assert_eq!(mode, SandboxMode::Enforce);
+    }
+
+    #[test]
+    fn resolve_sandbox_mode_libsandbox_backend_defaults_to_prompt() {
+        // Backend present, mode absent: libsandbox → prompt (matches bare --sandbox).
+        let manifest = SandboxOptions {
+            mode: None,
+            backend: Some(SandboxBackend::Libsandbox),
+        };
+        let mode = resolve_sandbox_mode(None, Some(&manifest), true, false).unwrap();
+        assert_eq!(mode, SandboxMode::Prompt);
+    }
+
+    #[test]
+    fn resolve_sandbox_mode_empty_table_defaults_to_prompt() {
+        // Table present but both fields absent: default backend (libsandbox) → prompt.
+        let manifest = SandboxOptions {
+            mode: None,
+            backend: None,
+        };
+        let mode = resolve_sandbox_mode(None, Some(&manifest), true, false).unwrap();
+        assert_eq!(mode, SandboxMode::Prompt);
     }
 
     #[test]
@@ -2810,15 +2886,16 @@ mod tests {
     #[test]
     fn resolve_sandbox_mode_manifest_downgraded_without_feature_flag() {
         let (subscriber, writer) = test_subscriber_message_only();
+        let manifest = sandbox_opts_with_mode(SandboxMode::Prompt);
 
         let mode = tracing::subscriber::with_default(subscriber, || {
-            resolve_sandbox_mode(None, Some(SandboxMode::Prompt), false, false).unwrap()
+            resolve_sandbox_mode(None, Some(&manifest), false, false).unwrap()
         });
 
         assert_eq!(mode, SandboxMode::Off);
         let printed = writer.to_string();
         assert!(
-            printed.contains("Ignoring 'options.sandbox' from the manifest"),
+            printed.contains("Ignoring '[options.sandbox]' from the manifest"),
             "printed: {printed}"
         );
     }
@@ -3520,6 +3597,8 @@ mod upgrade_notification_tests {
 
         use super::*;
 
+        // New `[options.sandbox]` table syntax: a single `sandbox` key whose
+        // value is an object rather than two flat keys.
         const MANIFEST_WITH_SANDBOX: &str = r#"version = 1
 
 [install]
@@ -3527,8 +3606,9 @@ hello.pkg-path = "hello"
 
 [options]
 systems = ["aarch64-darwin"]
-sandbox = "enforce"
-sandbox-backend = "oci"
+
+[options.sandbox]
+backend = "oci"
 "#;
 
         const MANIFEST_WITHOUT_SANDBOX: &str = r#"version = 1
@@ -3544,7 +3624,7 @@ systems = ["aarch64-darwin"]
         fn toml_removes_exactly_the_prototype_keys() {
             let sanitized = sanitize_manifest_toml(MANIFEST_WITH_SANDBOX)
                 .unwrap()
-                .expect("sandbox keys present; must sanitize");
+                .expect("sandbox table present; must sanitize");
             assert!(
                 !sanitized.contains("sandbox"),
                 "no sandbox key may survive: {sanitized}"
@@ -3565,11 +3645,11 @@ systems = ["aarch64-darwin"]
         }
 
         #[test]
-        fn toml_removes_a_single_prototype_key() {
+        fn toml_removes_sandbox_table() {
             let manifest = r#"version = 1
 
-[options]
-sandbox = "warn"
+[options.sandbox]
+mode = "warn"
 "#;
             let sanitized = sanitize_manifest_toml(manifest).unwrap().unwrap();
             assert!(!sanitized.contains("sandbox"));
@@ -3579,7 +3659,7 @@ sandbox = "warn"
             let fixture = GENERATED_DATA.join("envs/hello/manifest.lock");
             let text = std::fs::read_to_string(&fixture).unwrap();
             let mut value: serde_json::Value = serde_json::from_str(&text).unwrap();
-            // The prototype sandbox fields exist only in schema 1.13.0;
+            // The prototype sandbox table exists only in schema 1.13.0;
             // bump the fixture's embedded manifest to match, as a real
             // sandbox-declaring environment would be.
             if let Some(v) = value.pointer_mut("/manifest/schema-version") {
@@ -3589,8 +3669,12 @@ sandbox = "warn"
                 .pointer_mut("/manifest/options")
                 .and_then(|v| v.as_object_mut())
                 .expect("fixture has manifest.options");
-            options.insert("sandbox".into(), "enforce".into());
-            options.insert("sandbox-backend".into(), "oci".into());
+            // The sandbox value is now an object (the table) rather than two
+            // flat keys.
+            options.insert(
+                "sandbox".into(),
+                serde_json::json!({"backend": "oci"}),
+            );
             serde_json::to_string_pretty(&value).unwrap()
         }
 
@@ -3599,13 +3683,12 @@ sandbox = "warn"
             let with_sandbox = lockfile_json_with_sandbox();
             let sanitized = sanitize_lockfile_json(&with_sandbox)
                 .unwrap()
-                .expect("sandbox keys present; must sanitize");
+                .expect("sandbox table present; must sanitize");
             let value: serde_json::Value = serde_json::from_str(&sanitized).unwrap();
             let options = value.pointer("/manifest/options").unwrap();
-            assert!(options.get("sandbox").is_none());
-            assert!(options.get("sandbox-backend").is_none());
+            assert!(options.get("sandbox").is_none(), "sandbox key must be gone");
             // Untouched structure survives: compare against the original
-            // fixture value with only the two keys absent.
+            // fixture value with only the sandbox key absent.
             let original: serde_json::Value = serde_json::from_str(&with_sandbox).unwrap();
             let mut expected = original.clone();
             if let Some(o) = expected
@@ -3613,7 +3696,6 @@ sandbox = "warn"
                 .and_then(|v| v.as_object_mut())
             {
                 o.remove("sandbox");
-                o.remove("sandbox-backend");
             }
             assert_eq!(value, expected);
         }
@@ -3629,18 +3711,13 @@ sandbox = "warn"
         fn lockfile_strips_composer_options_when_composed() {
             let json = r#"{
                 "lockfile-version": 1,
-                "manifest": {"version": 1, "options": {"sandbox": "enforce"}},
+                "manifest": {"version": 1, "options": {"sandbox": {"mode": "enforce"}}},
                 "packages": [],
-                "compose": {"composer": {"version": 1, "options": {"sandbox": "enforce", "sandbox-backend": "oci"}}}
+                "compose": {"composer": {"version": 1, "options": {"sandbox": {"backend": "oci"}}}}
             }"#;
             let sanitized = sanitize_lockfile_json(json).unwrap().unwrap();
             let value: serde_json::Value = serde_json::from_str(&sanitized).unwrap();
             assert!(value.pointer("/compose/composer/options/sandbox").is_none());
-            assert!(
-                value
-                    .pointer("/compose/composer/options/sandbox-backend")
-                    .is_none()
-            );
             assert!(value.pointer("/manifest/options/sandbox").is_none());
         }
 

--- a/cli/flox/src/commands/hook_env.rs
+++ b/cli/flox/src/commands/hook_env.rs
@@ -970,14 +970,18 @@ fn read_sandbox_class(project_dir: &Path) -> SandboxClass {
     };
 
     let opts = &manifest.as_latest_schema().options;
-    let mode = opts.sandbox;
-    let backend = opts.sandbox_backend.unwrap_or_default();
+    let Some(sandbox_table) = opts.sandbox.as_ref() else {
+        // No `[options.sandbox]` table → no sandbox declared.
+        return SandboxClass::None;
+    };
 
-    // Absent mode or explicit `off` → no sandbox.
-    match mode {
-        None | Some(SandboxMode::Off) => SandboxClass::None,
-        Some(_) if backend.capabilities().enforces => SandboxClass::Wrapping(backend),
-        Some(_) => SandboxClass::Libsandbox,
+    let backend = sandbox_table.backend.unwrap_or_default();
+
+    // `mode = "off"` is the master switch; absent mode activates the sandbox.
+    match sandbox_table.mode {
+        Some(SandboxMode::Off) => SandboxClass::None,
+        _ if backend.capabilities().enforces => SandboxClass::Wrapping(backend),
+        _ => SandboxClass::Libsandbox,
     }
 }
 

--- a/cli/schemas/lockfile-v1.schema.json
+++ b/cli/schemas/lockfile-v1.schema.json
@@ -1334,7 +1334,7 @@
         },
         "Options2": {
           "additionalProperties": false,
-          "description": "Options for V1_13_0.\n\nThis is a version-specific copy of `common::Options` because V1_13_0 adds\nthe `sandbox` field; the other fields (and their leaf types) are identical\nand continue to live in `parsed::common`.",
+          "description": "Options for V1_13_0.\n\nThis is a version-specific copy of `common::Options` because V1_13_0 adds\nthe `sandbox` table; the other fields (and their leaf types) are identical\nand continue to live in `parsed::common`.",
           "properties": {
             "activate": {
               "$ref": "#/$defs/ActivateOptions",
@@ -1354,24 +1354,13 @@
             "sandbox": {
               "anyOf": [
                 {
-                  "$ref": "#/$defs/SandboxMode"
+                  "$ref": "#/$defs/SandboxOptions"
                 },
                 {
                   "type": "null"
                 }
               ],
-              "description": "The sandbox mode applied when the environment is activated\n(`off`, `warn`, `enforce`, or `prompt`). An explicit `--sandbox` flag\non `flox activate` takes precedence over this setting."
-            },
-            "sandbox-backend": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/SandboxBackend"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "The sandbox enforcement backend used when the environment is activated\n(`libsandbox`, `nix`, `host-native`, `srt`, `oci`, or `libkrun`). The\n`--sandbox-backend` flag on `flox activate` and the\n`FLOX_SANDBOX_BACKEND` environment variable take precedence over this\nsetting."
+              "description": "The sandbox table. When present, selects the sandbox backend and/or\nmode for activations. An explicit `--sandbox` flag on `flox activate`\ntakes precedence over the table's `mode` field; `--sandbox-backend`,\n`FLOX_SANDBOX_BACKEND`, and the table's `backend` field follow the\nsame flag > env > manifest precedence.\n\n```toml\n[options.sandbox]\nbackend = \"oci\"          # enforce-only backend; mode defaults to enforce\n\n[options.sandbox]\nmode = \"off\"             # master switch: disables sandbox regardless\n\n[options.sandbox]\nbackend = \"libsandbox\"\nmode    = \"warn\"\n```"
             },
             "semver": {
               "$ref": "#/$defs/SemverOptions",
@@ -1844,6 +1833,35 @@
               "type": "string"
             }
           ]
+        },
+        "SandboxOptions": {
+          "additionalProperties": false,
+          "description": "The `[options.sandbox]` table.\n\nBoth fields are optional: an empty table (or a table with just `backend`)\nenables the sandbox with backend-appropriate defaults. `mode = \"off\"` is\nthe master switch and disables the sandbox regardless of `backend`.",
+          "properties": {
+            "backend": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/SandboxBackend"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The enforcement backend. Defaults per backend when omitted: `enforce`\nfor enforcing backends (`capabilities().enforces == true`), `prompt`\nfor `libsandbox` (matching the bare `--sandbox` flag default)."
+            },
+            "mode": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/SandboxMode"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The sandbox mode. When omitted the default is derived from the\nbackend's capabilities (see above). `mode = \"off\"` is the master\nswitch: it disables the sandbox regardless of `backend`."
+            }
+          },
+          "type": "object"
         },
         "SelectedOutputs": {
           "anyOf": [

--- a/cli/schemas/manifest-v1.schema.json
+++ b/cli/schemas/manifest-v1.schema.json
@@ -937,7 +937,7 @@
     },
     "Options2": {
       "additionalProperties": false,
-      "description": "Options for V1_13_0.\n\nThis is a version-specific copy of `common::Options` because V1_13_0 adds\nthe `sandbox` field; the other fields (and their leaf types) are identical\nand continue to live in `parsed::common`.",
+      "description": "Options for V1_13_0.\n\nThis is a version-specific copy of `common::Options` because V1_13_0 adds\nthe `sandbox` table; the other fields (and their leaf types) are identical\nand continue to live in `parsed::common`.",
       "properties": {
         "activate": {
           "$ref": "#/$defs/ActivateOptions",
@@ -957,24 +957,13 @@
         "sandbox": {
           "anyOf": [
             {
-              "$ref": "#/$defs/SandboxMode"
+              "$ref": "#/$defs/SandboxOptions"
             },
             {
               "type": "null"
             }
           ],
-          "description": "The sandbox mode applied when the environment is activated\n(`off`, `warn`, `enforce`, or `prompt`). An explicit `--sandbox` flag\non `flox activate` takes precedence over this setting."
-        },
-        "sandbox-backend": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/SandboxBackend"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "The sandbox enforcement backend used when the environment is activated\n(`libsandbox`, `nix`, `host-native`, `srt`, `oci`, or `libkrun`). The\n`--sandbox-backend` flag on `flox activate` and the\n`FLOX_SANDBOX_BACKEND` environment variable take precedence over this\nsetting."
+          "description": "The sandbox table. When present, selects the sandbox backend and/or\nmode for activations. An explicit `--sandbox` flag on `flox activate`\ntakes precedence over the table's `mode` field; `--sandbox-backend`,\n`FLOX_SANDBOX_BACKEND`, and the table's `backend` field follow the\nsame flag > env > manifest precedence.\n\n```toml\n[options.sandbox]\nbackend = \"oci\"          # enforce-only backend; mode defaults to enforce\n\n[options.sandbox]\nmode = \"off\"             # master switch: disables sandbox regardless\n\n[options.sandbox]\nbackend = \"libsandbox\"\nmode    = \"warn\"\n```"
         },
         "semver": {
           "$ref": "#/$defs/SemverOptions",
@@ -1447,6 +1436,35 @@
           "type": "string"
         }
       ]
+    },
+    "SandboxOptions": {
+      "additionalProperties": false,
+      "description": "The `[options.sandbox]` table.\n\nBoth fields are optional: an empty table (or a table with just `backend`)\nenables the sandbox with backend-appropriate defaults. `mode = \"off\"` is\nthe master switch and disables the sandbox regardless of `backend`.",
+      "properties": {
+        "backend": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SandboxBackend"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The enforcement backend. Defaults per backend when omitted: `enforce`\nfor enforcing backends (`capabilities().enforces == true`), `prompt`\nfor `libsandbox` (matching the bare `--sandbox` flag default)."
+        },
+        "mode": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SandboxMode"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The sandbox mode. When omitted the default is derived from the\nbackend's capabilities (see above). `mode = \"off\"` is the master\nswitch: it disables the sandbox regardless of `backend`."
+        }
+      },
+      "type": "object"
     },
     "SelectedOutputs": {
       "anyOf": [

--- a/demo/SCRIPT.md
+++ b/demo/SCRIPT.md
@@ -43,19 +43,18 @@ eval "$(flox hook-env --shell bash --shell-pid $$)"
 > requiring PATH manipulation.
 
 **Pre-bake off-camera.** The first bake takes ~2–5 min. Do it before
-the demo: add the two `[options]` lines from §0 to the manifest,
+the demo: add the `[options.sandbox]` table from §0 to the manifest,
 then:
 
 ```bash
 FLOX_SANDBOX_OCI_AUTOBAKE=true flox activate -- true
 ```
 
-Then remove the two lines again (`flox edit`) so §0 can add them
-live — the re-add produces the identical lockfile, so the cached
-image stays fresh and §0's `cd` drops into the sandbox in about a
-second. Also complete §2's one-time agent login off-camera unless
-you want to show it (it is a good beat, but it costs ~40s of
-URL-and-paste).
+Then remove the table again (`flox edit`) so §0 can add it live —
+the re-add produces the identical lockfile, so the cached image stays
+fresh and §0's `cd` drops into the sandbox in about a second. Also
+complete §2's one-time agent login off-camera unless you want to show
+it (it is a good beat, but it costs ~40s of URL-and-paste).
 
 ---
 
@@ -83,13 +82,11 @@ cd ~/sandbox-demo
 flox edit
 ```
 
-In the editor, add these two lines to the `[options]` section and
-save:
+In the editor, add the `[options.sandbox]` table and save:
 
 ```toml
-[options]
-sandbox = "enforce"
-sandbox-backend = "oci"
+[options.sandbox]
+backend = "oci"
 ```
 
 **"Now, just `cd` away and back."**


### PR DESCRIPTION
## Proposed Changes

The old flat-key syntax declared the activation sandbox via two independent top-level keys under `[options]`: `sandbox = "enforce"` and `sandbox-backend = "oci"`. This implied a mode choice that doesn't exist for single-mode backends — OCI is enforce-only, so `sandbox = "enforce"` is redundant at best and misleading at worst.

Product direction (SL-002) restructures to a table where single-mode backends read cleanly with only a `backend` field:

```toml
[options.sandbox]
backend = "oci"
# mode defaults to "enforce" for enforcing backends
```

### Changes

- Replace `Options.sandbox: Option<SandboxMode>` and `Options.sandbox_backend: Option<SandboxBackend>` with a single `Options.sandbox: Option<SandboxOptions>` table field (`v1_13_0`)
- Add `SandboxOptions { backend, mode }` struct with serde, JsonSchema, and `deny_unknown_fields`; the old flat `sandbox-backend` key now errors on unknown field (acceptable: pre-ship, no manifests in the wild)
- Update `resolve_sandbox_mode` to accept `Option<&SandboxOptions>` and derive mode defaults from backend capabilities when `mode` is omitted: enforcing backends (`oci`, `host-native`, `srt`, `nix`, `libkrun`) → `enforce`; `libsandbox` → `prompt` (matches bare `--sandbox` default)
- `mode = "off"` remains the master switch and disables the sandbox regardless of `backend`
- CLI flag precedence unchanged: `--sandbox` flag > manifest mode; `--sandbox-backend` flag > `FLOX_SANDBOX_BACKEND` env > manifest backend > libsandbox default
- Update `read_sandbox_class` in `hook_env.rs` to read the new table
- Shrink `PROTOTYPE_ONLY_OPTION_KEYS` from two entries to one (single `"sandbox"` key)
- Regenerate `manifest-v1.schema.json` and `lockfile-v1.schema.json`
- Update tests: new table-syntax parse tests, per-backend mode default tests, sanitizer tests with new fixture format
- Update docs: `flox-sandbox.md`, `flox-activate.md`, `manifest.toml.md`, `demo/SCRIPT.md`

## Release Notes

N/A — this is a prototype-only change behind `FLOX_FEATURES_SANDBOX_ACTIVATE`.

Refs: SL-002

---
*Via Forge (implementation-worker) • 2f6d5497*