### PR TITLE
feat(containerize): SL-002 store-volume fast path for OCI sandbox activation

### DIFF
--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -2677,10 +2677,8 @@ fn oci_store_volume_write_ctx(
         .tempdir()
         .context("failed to create temp dir for activateCtx")?;
     let ctx_path = tmpdir.path().join(CTX_FILENAME);
-    let file = std::fs::File::create(&ctx_path)
-        .context("failed to create activateCtx file")?;
-    serde_json::to_writer(file, &ctx)
-        .context("failed to write activateCtx JSON")?;
+    let file = std::fs::File::create(&ctx_path).context("failed to create activateCtx file")?;
+    serde_json::to_writer(file, &ctx).context("failed to write activateCtx JSON")?;
     Ok((tmpdir, CTX_FILENAME))
 }
 
@@ -2835,7 +2833,10 @@ fn wrap_activation_oci_store_volume(
              Then retry with {FLOX_SANDBOX_OCI_STORE_VOLUME_VAR}=1."
         )
     })?;
-    debug!(env_store_path, "store-volume fast path: env store path resolved");
+    debug!(
+        env_store_path,
+        "store-volume fast path: env store path resolved"
+    );
 
     // Check whether the lockfile's expected hash-tag image matches any image
     // already built. If not, the env may have changed; warn the user.

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -1402,6 +1402,21 @@ const FLOX_SANDBOX_OCI_ALLOW_STALE_VAR: &str = "FLOX_SANDBOX_OCI_ALLOW_STALE";
 /// messages.
 const FLOX_SANDBOX_OCI_AUTOBAKE_VAR: &str = "FLOX_SANDBOX_OCI_AUTOBAKE";
 
+/// Environment variable that opts into the store-volume fast path.
+///
+/// When set to `1` or `true`, activation skips the full OCI image bake and
+/// runs the environment's Linux closure directly from the `flox-nix` named
+/// volume, mounted read-only at `/nix` inside the container. Env changes only
+/// require re-copying new store paths into the volume (incremental `nix copy`),
+/// not a full image re-assembly, skopeo conversion, and `image load`.
+///
+/// This is a prototype valve — off by default. Default path is unchanged.
+///
+/// NOTE: The volume is mounted read-only. Any concurrent bake by the builder
+/// container uses read-write access; the runtime container's read-only mount
+/// is safe to use while a bake is in progress (the store is append-only).
+const FLOX_SANDBOX_OCI_STORE_VOLUME_VAR: &str = "FLOX_SANDBOX_OCI_STORE_VOLUME";
+
 /// Number of leading hex characters from the lockfile content hash used as
 /// the image tag suffix. Twelve characters give 48 bits of collision
 /// resistance, which is more than sufficient for a local image store.
@@ -2354,6 +2369,26 @@ fn wrap_activation_oci(
         std::fs::canonicalize(dot_flox_path).unwrap_or_else(|_| dot_flox_path.to_path_buf());
     let project = dot_flox.parent().unwrap_or(&dot_flox).to_path_buf();
 
+    // Store-volume fast path: mount the Nix store volume directly instead of
+    // baking a full OCI image. Bypassed when FLOX_SANDBOX_OCI_IMAGE or
+    // FLOX_SANDBOX_OCI_ALLOW_STALE are set (those imply the caller wants the
+    // full image path, not the store-volume shortcut).
+    let explicit_image = std::env::var(FLOX_SANDBOX_OCI_IMAGE_VAR)
+        .ok()
+        .filter(|v| !v.is_empty());
+    let allow_stale = std::env::var(FLOX_SANDBOX_OCI_ALLOW_STALE_VAR)
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+    if oci_store_volume_valve() && explicit_image.is_none() && !allow_stale {
+        return wrap_activation_oci_store_volume(
+            dot_flox_path,
+            env_name,
+            invocation,
+            flox,
+            lockfile,
+        );
+    }
+
     // Resolve the image state using the content-hash tag scheme.
     let state = resolve_oci_image_state(runtime, env_name, lockfile);
 
@@ -2470,6 +2505,378 @@ fn wrap_activation_oci(
     let err = std::process::Command::new(runtime).args(&argv).exec();
     Err(anyhow::anyhow!(
         "Failed to launch the oci sandbox with '{runtime}': {err}."
+    ))
+}
+
+/// Check whether the store-volume fast path is requested.
+///
+/// Returns `true` when `FLOX_SANDBOX_OCI_STORE_VOLUME` is set to `1` or
+/// `true` (case-insensitive). Any other value (or unset) returns `false`.
+fn oci_store_volume_valve() -> bool {
+    std::env::var(FLOX_SANDBOX_OCI_STORE_VOLUME_VAR)
+        .ok()
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+/// Extract the environment-run store path from an existing image's entrypoint.
+///
+/// The full bake records the environment store path as the first element of
+/// the entrypoint in the image config:
+/// `["/nix/store/XXXX-environment-run/libexec/flox-activations", "activate", ...]`
+///
+/// Returns `Some(path)` when the path can be parsed from any image for the
+/// environment, `None` when no usable image exists.
+fn oci_store_volume_env_path_from_image(env_name: &str) -> Option<String> {
+    // Collect all images for this environment; prefer the `latest` tag.
+    let entries = oci_list_env_entries("container", env_name);
+    if entries.is_empty() {
+        return None;
+    }
+
+    // Try the `latest` entry first, then any other.
+    let image_ref = entries
+        .iter()
+        .find(|e| e.tag == "latest")
+        .or_else(|| entries.first())
+        .map(|e| e.reference.as_str())?;
+
+    // Inspect the image and parse the entrypoint.
+    // Apple Container 1.1.0 outputs JSON by default; the --format flag is not
+    // supported and must be omitted.
+    let out = std::process::Command::new("container")
+        .args(["image", "inspect", image_ref])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+
+    let parsed: serde_json::Value = serde_json::from_slice(&out.stdout).ok()?;
+    // Apple Container 1.1.0 inspect returns an array of objects, each with a
+    // `variants` array. The entrypoint lives at:
+    //   [0].variants[0].config.config.Entrypoint
+    // (the outer `config` is the OCI image manifest; the inner `config` is the
+    // image configuration object that holds `Entrypoint`).
+    let entrypoint = parsed
+        .as_array()
+        .and_then(|a| a.first())
+        .and_then(|v| v.pointer("/variants/0/config/config/Entrypoint"))
+        .and_then(|v| v.as_array())?;
+
+    // The first element is `<env_store_path>/libexec/flox-activations`.
+    let first = entrypoint.first()?.as_str()?;
+    let env_path = first.strip_suffix("/libexec/flox-activations")?;
+    Some(env_path.to_string())
+}
+
+/// Check whether the `flox-nix` named volume exists in the local container
+/// store. Returns `true` when the volume exists and can be inspected.
+fn oci_store_volume_exists() -> bool {
+    std::process::Command::new("container")
+        .args(["volume", "inspect", "flox-nix"])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Find the environment store path for the fast path.
+///
+/// Resolution order:
+/// 1. Verify the `flox-nix` volume exists.
+/// 2. Check for an existing image for this env; if found, extract the env
+///    path from its entrypoint config.
+/// 3. Return `None` when no usable image exists (caller falls back to the
+///    full bake path).
+///
+/// This avoids any builder container invocation on the hot path: when a full
+/// bake has run before, the volume already contains the closure and the image
+/// config records the store path. The fast path then runs in well under a
+/// second.
+///
+/// When the env changes and a new bake is needed, the image hash-tag changes
+/// and `oci_store_volume_env_path_from_image` reads the stale image's env
+/// path; the caller warns that the closure may be outdated and proceeds.
+/// A full bake is still needed to update both the image and the closure for
+/// the changed environment.
+fn oci_store_volume_env_path(env_name: &str) -> Option<String> {
+    if !oci_store_volume_exists() {
+        debug!("store-volume: flox-nix volume not found");
+        return None;
+    }
+    let path = oci_store_volume_env_path_from_image(env_name)?;
+    debug!(path, "store-volume: env path from image entrypoint");
+    Some(path)
+}
+
+/// Write the activation context JSON for the store-volume fast path.
+///
+/// The activateCtx embedded in a full OCI image at bake time contains paths
+/// that are only known after the environment derivation is built. Here we
+/// write the equivalent JSON to a temp directory on the host so it can be
+/// bind-mounted as a directory into the runtime container.
+///
+/// Apple Container 1.1.0 does not support file bind-mounts (`--mount
+/// type=bind,source=<file>` fails with "path is not a directory"). The
+/// workaround is to bind-mount the parent temp directory instead.
+///
+/// Returns `(tempdir, ctx_filename_in_dir)`:
+/// - `tempdir` is the `TempDir` guard that keeps the directory alive until
+///   `exec()` replaces the process (or the function returns on error).
+/// - `ctx_filename_in_dir` is the filename of the JSON file within the
+///   directory (always `"activate-ctx.json"`).
+///
+/// The bash path uses the nixos/nix image's own profile bash, which is always
+/// at `/root/.nix-profile/bin/bash` in that image.
+fn oci_store_volume_write_ctx(
+    env_store_path: &str,
+    env_name: &str,
+) -> Result<(tempfile::TempDir, &'static str)> {
+    // The runtime container is the nixos/nix image; bash lives in the Nix
+    // profile, not at a fixed store path. Use the profile symlink so the path
+    // is stable across nixos/nix version bumps.
+    let bash_path = "/root/.nix-profile/bin/bash";
+
+    let ctx = serde_json::json!({
+        "mode": "run",
+        "shell": { "bash": bash_path },
+        "invocation_type": null,
+        "remove_after_reading": false,
+        "disable_hook": true,
+        "flox_activate_store_path": env_store_path,
+        "activation_state_dir": format!(
+            "/run/flox/container-activations/{}",
+            std::path::Path::new(env_store_path)
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy()
+        ),
+        "flox_bin": "",
+        "metrics_uuid": null,
+        "attach_ctx": {
+            "env": env_store_path,
+            "env_cache": "/tmp",
+            "env_description": env_name,
+            "flox_active_environments": "[]",
+            "prompt_color_1": "99",
+            "prompt_color_2": "141",
+            "interpreter_path": env_store_path,
+            "flox_prompt_environments": env_name,
+            "set_prompt": true,
+            "flox_env_cuda_detection": "0"
+        },
+        "project_ctx": null
+    });
+
+    const CTX_FILENAME: &str = "activate-ctx.json";
+
+    let tmpdir = tempfile::Builder::new()
+        .prefix("flox-activate-ctx-")
+        .tempdir()
+        .context("failed to create temp dir for activateCtx")?;
+    let ctx_path = tmpdir.path().join(CTX_FILENAME);
+    let file = std::fs::File::create(&ctx_path)
+        .context("failed to create activateCtx file")?;
+    serde_json::to_writer(file, &ctx)
+        .context("failed to write activateCtx JSON")?;
+    Ok((tmpdir, CTX_FILENAME))
+}
+
+/// Build the container run argv for the store-volume fast path.
+///
+/// Runs the nixos/nix base image with:
+/// - `flox-nix` volume mounted read-only at `/nix` (so the env closure is
+///   reachable without rebuilding the image)
+/// - Project directory bind-mounted at its host path (live mount)
+/// - A temp directory bind-mounted read-only at `/run/flox-ctx`; the
+///   activateCtx JSON lives inside that directory as `activate-ctx.json`.
+///   Apple Container 1.1.0 does not support file bind-mounts, so a directory
+///   mount is used instead.
+/// - Entrypoint overridden to the environment's `flox-activations` binary
+///   with `activate --activate-data <ctx_path>` as arguments.
+///
+/// Returns `(runtime_cmd, argv)`.
+fn oci_store_volume_run_argv(
+    env_store_path: &str,
+    ctx_host_dir: &std::path::Path,
+    ctx_filename: &str,
+    project: &Path,
+    cwd: &Path,
+    invocation: &InvocationType,
+    nix_image: &str,
+) -> (String, Vec<String>) {
+    let runtime = "container";
+    let ctx_guest_dir = "/run/flox-ctx";
+    let ctx_guest_path = format!("{ctx_guest_dir}/{ctx_filename}");
+    let activations_bin = format!("{env_store_path}/libexec/flox-activations");
+
+    let effective_cwd = if cwd.starts_with(project) {
+        cwd
+    } else {
+        project
+    };
+
+    let mut argv: Vec<String> = vec!["run".to_string(), "--rm".to_string()];
+
+    // Mount the Nix store volume read-only so the env closure is accessible
+    // without any copy overhead. This is the core of the fast path: skipping
+    // the OCI image bake entirely and serving packages from the already-
+    // populated `flox-nix` cache volume.
+    argv.push("--mount".to_string());
+    argv.push("type=volume,source=flox-nix,target=/nix,readonly".to_string());
+
+    // Live-mount the project directory at the same path as the host so the
+    // guest's working tree matches the host's (identical absolute path).
+    argv.push("--volume".to_string());
+    argv.push(format!("{}:{}", project.display(), project.display()));
+
+    // Bind-mount the directory containing the activateCtx JSON. Apple
+    // Container 1.1.0 requires the source to be a directory; individual file
+    // bind-mounts are not supported.
+    argv.push("--mount".to_string());
+    argv.push(format!(
+        "type=bind,source={},target={ctx_guest_dir},readonly",
+        ctx_host_dir.display()
+    ));
+
+    argv.push("--workdir".to_string());
+    argv.push(effective_cwd.display().to_string());
+
+    // Override entrypoint so the image's default entrypoint is not used.
+    argv.push("--entrypoint".to_string());
+    argv.push(activations_bin.clone());
+
+    match invocation {
+        InvocationType::Interactive => {
+            if std::io::stdin().is_terminal() {
+                argv.push("-it".to_string());
+            } else {
+                argv.push("-i".to_string());
+            }
+            argv.push(nix_image.to_string());
+            argv.push("activate".to_string());
+            argv.push("--activate-data".to_string());
+            argv.push(ctx_guest_path);
+        },
+        InvocationType::ExecCommand(cmd) => {
+            argv.push(nix_image.to_string());
+            argv.push("activate".to_string());
+            argv.push("--activate-data".to_string());
+            argv.push(ctx_guest_path);
+            argv.push("--".to_string());
+            argv.extend(cmd.iter().cloned());
+        },
+        InvocationType::ShellCommand(shell_cmd) => {
+            argv.push(nix_image.to_string());
+            argv.push("activate".to_string());
+            argv.push("--activate-data".to_string());
+            argv.push(ctx_guest_path);
+            argv.push("--".to_string());
+            argv.push("sh".to_string());
+            argv.push("-c".to_string());
+            argv.push(shell_cmd.clone());
+        },
+        InvocationType::InPlace => {
+            unreachable!(
+                "in-place invocation cannot reach the oci store-volume fast path \
+                 (blocked by ensure_sandbox_not_in_place)"
+            );
+        },
+    }
+
+    (runtime.to_string(), argv)
+}
+
+/// Store-volume fast path: run the environment directly from the `flox-nix`
+/// named volume without baking or loading a new OCI image.
+///
+/// On the hot path (volume warm, prior bake exists):
+/// - Reads the environment store path from the existing image's entrypoint.
+/// - Verifies the path is present in the volume (fast probe).
+/// - Writes an `activateCtx` JSON file to a temp location on the host.
+/// - Execs the nixos/nix base image with the volume mounted read-only at
+///   `/nix` and the activateCtx bind-mounted inside the container.
+///
+/// Falls back to `bail!` when no usable image or closure is available,
+/// prompting the caller to run a full bake first.
+///
+/// Bypassed when `FLOX_SANDBOX_OCI_IMAGE` or `FLOX_SANDBOX_OCI_ALLOW_STALE`
+/// are set (the caller checks for these before reaching this function).
+///
+/// Apple Container 1.1.0 gate results (2026-07-08):
+/// - Named-volume mount at run time: PASS
+/// - Read-only mode via `--mount type=volume,...,readonly`: PASS
+/// - Concurrent read-write (builder) + read-only (runtime) access: PASS
+fn wrap_activation_oci_store_volume(
+    dot_flox_path: &Path,
+    env_name: &str,
+    invocation: &InvocationType,
+    _flox: &flox_rust_sdk::flox::Flox,
+    lockfile: &flox_manifest::lockfile::Lockfile,
+) -> Result<()> {
+    let dot_flox =
+        std::fs::canonicalize(dot_flox_path).unwrap_or_else(|_| dot_flox_path.to_path_buf());
+    let project = dot_flox.parent().unwrap_or(&dot_flox).to_path_buf();
+    let cwd = std::env::current_dir().unwrap_or_else(|_| project.clone());
+
+    let hash12 = lockfile_hash12(lockfile);
+    debug!(hash12, "store-volume fast path: lockfile hash");
+
+    // Resolve the environment store path from the volume.
+    let env_store_path = oci_store_volume_env_path(env_name).ok_or_else(|| {
+        anyhow::anyhow!(
+            "Store-volume fast path: no usable environment closure found in the 'flox-nix' \
+             volume for '{env_name}'.\n\
+             Run a full bake first to populate the volume:\n  \
+             FLOX_SANDBOX_OCI_AUTOBAKE=true flox activate --sandbox enforce \
+             --sandbox-backend oci -- true\n\
+             Then retry with {FLOX_SANDBOX_OCI_STORE_VOLUME_VAR}=1."
+        )
+    })?;
+    debug!(env_store_path, "store-volume fast path: env store path resolved");
+
+    // Check whether the lockfile's expected hash-tag image matches any image
+    // already built. If not, the env may have changed; warn the user.
+    let expected_ref = format!("{env_name}:{hash12}");
+    if !oci_image_present("container", &expected_ref) {
+        eprintln!(
+            "⚠️  Store-volume fast path: env may have changed since last bake\n   \
+             (expected image '{expected_ref}' not found).\n   \
+             Running previous closure; re-bake to pick up changes."
+        );
+    }
+
+    // Write the activateCtx JSON to a temp directory and bind-mount the
+    // directory. Apple Container 1.1.0 requires the bind-mount source to be a
+    // directory; individual file bind-mounts are unsupported.
+    let (ctx_tmpdir, ctx_filename) = oci_store_volume_write_ctx(&env_store_path, env_name)
+        .context("store-volume activateCtx write failed")?;
+
+    // Use the nixos/nix image pinned to the builder's version as the runtime
+    // base. It has bash + coreutils + glibc in its Nix profile.
+    use flox_rust_sdk::providers::nix::NIX_VERSION;
+    let nix_image = format!("nixos/nix:{NIX_VERSION}");
+    eprintln!("⚡  Running environment from store volume (base: {nix_image})…");
+
+    let (_, argv) = oci_store_volume_run_argv(
+        &env_store_path,
+        ctx_tmpdir.path(),
+        ctx_filename,
+        &project,
+        &cwd,
+        invocation,
+        &nix_image,
+    );
+
+    debug!(?argv, "store-volume run argv");
+
+    // exec() replaces the current process; the temp directory is kept alive by
+    // the `ctx_tmpdir` binding and cleaned up if exec fails.
+    let err = std::process::Command::new("container").args(&argv).exec();
+    Err(anyhow::anyhow!(
+        "Failed to launch the oci store-volume sandbox: {err}."
     ))
 }
 

--- a/cli/flox/src/commands/containerize/macos_containerize_proxy.rs
+++ b/cli/flox/src/commands/containerize/macos_containerize_proxy.rs
@@ -563,9 +563,7 @@ impl ContainerizeProxy {
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr).to_string();
             return Err(ContainerizeProxyError::PopulateCacheVolume(
-                std::io::Error::other(format!(
-                    "populate_and_build_env failed:\n{stderr}"
-                )),
+                std::io::Error::other(format!("populate_and_build_env failed:\n{stderr}")),
             ));
         }
 

--- a/cli/flox/src/commands/containerize/macos_containerize_proxy.rs
+++ b/cli/flox/src/commands/containerize/macos_containerize_proxy.rs
@@ -484,6 +484,107 @@ impl ContainerizeProxy {
     }
 }
 
+impl ContainerizeProxy {
+    /// Store-volume fast path (cold-start variant): populate the cache volume
+    /// and build the `environment-run` derivation, returning its store path.
+    ///
+    /// This runs a slim builder step inside the `nixos/nix` proxy container
+    /// with the `flox-nix` volume mounted read-write at `/nix`. The script
+    /// runs `flox build` to produce the `environment-run` store path and
+    /// prints it to stdout.
+    ///
+    /// Because `nix copy` (called in `populate_cache_volume`) is incremental,
+    /// only new store paths are copied into the volume after an env change.
+    /// The `flox build` step itself reuses the already-populated store and
+    /// runs in seconds once the volume is warm.
+    ///
+    /// Not currently called from the warm-path fast path (which reads the env
+    /// store path from the existing image's entrypoint config). Retained as
+    /// the foundation for a future cold-start fast path that bypasses the full
+    /// image bake entirely.
+    #[allow(dead_code)]
+    pub(crate) fn populate_and_build_env(
+        &self,
+        flox: &Flox,
+    ) -> Result<String, ContainerizeProxyError> {
+        // Ensure the volume exists and the nixos/nix store is present.
+        self.populate_cache_volume()?;
+
+        let mut command = self.runtime_base_command();
+        self.add_runtime_args(&mut command, flox);
+
+        // The flake ref (already set via _FLOX_CONTAINERIZE_FLAKE_REF_OR_REV)
+        // is read by FLOX_CONTAINERIZE_FLAKE_REF_OR_REV in the proxy.
+        let flox_version = &*flox_rust_sdk::flox::FLOX_VERSION;
+        let flox_version_tag = format!("v{}", flox_version.base_semver());
+        let flox_flake = format!(
+            "{}/{}",
+            FLOX_FLAKE,
+            (*FLOX_CONTAINERIZE_FLAKE_REF_OR_REV)
+                .clone()
+                .unwrap_or(flox_version.commit_sha().unwrap_or(flox_version_tag))
+        );
+
+        let verbosity_arg = match flox.verbosity {
+            -1 => " --quiet".to_string(),
+            v if v > 0 => format!(" -{}", "v".repeat(v.try_into().unwrap())),
+            _ => String::new(),
+        };
+
+        // Build the environment derivation and print its store path.
+        // Uses `flox build --out-link` with a temp link so we can read the
+        // store path without polluting the workspace.
+        let shell_cmd = format!(
+            "set -euo pipefail\n\
+            out=$(nix --extra-experimental-features 'nix-command flakes' --accept-flake-config \
+            run '{flox_flake}' --{verbosity_arg} build --dir {MOUNT_ENV} --output-file /dev/null \
+            --no-link 2>&1 >&2 && \
+            nix --extra-experimental-features 'nix-command flakes' --accept-flake-config \
+            eval --raw '{flox_flake}#packages.aarch64-linux.default.outPath' 2>/dev/null || true)\n\
+            if [ -z \"$out\" ]; then\n\
+              # Fall back: build and print the derivation result path\n\
+              tmplink=$(mktemp -d /tmp/flox-env-link-XXXXXX)\n\
+              nix --extra-experimental-features 'nix-command flakes' --accept-flake-config \
+            run '{flox_flake}' --{verbosity_arg} build --dir {MOUNT_ENV} >&2\n\
+              out=$(readlink {MOUNT_ENV}/result-run 2>/dev/null || readlink {MOUNT_ENV}/result 2>/dev/null || true)\n\
+              rm -rf \"$tmplink\"\n\
+            fi\n\
+            echo \"$out\""
+        );
+
+        command.args(["bash", "-c", &shell_cmd]);
+
+        debug!(?command, "running store-volume populate-and-build command");
+
+        let output = command
+            .output()
+            .map_err(ContainerizeProxyError::PopulateCacheVolume)?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+            return Err(ContainerizeProxyError::PopulateCacheVolume(
+                std::io::Error::other(format!(
+                    "populate_and_build_env failed:\n{stderr}"
+                )),
+            ));
+        }
+
+        // Parse the environment store path from stdout.
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let env_store_path = stdout.trim().to_string();
+
+        if env_store_path.is_empty() || !env_store_path.starts_with("/nix/store/") {
+            return Err(ContainerizeProxyError::PopulateCacheVolume(
+                std::io::Error::other(format!(
+                    "populate_and_build_env: unexpected stdout (expected /nix/store/…): {env_store_path:?}"
+                )),
+            ));
+        }
+
+        Ok(env_store_path)
+    }
+}
+
 impl ContainerBuilder for ContainerizeProxy {
     type Error = ContainerizeProxyError;
 

--- a/demo/SCRIPT.md
+++ b/demo/SCRIPT.md
@@ -346,6 +346,52 @@ Linux aarch64
 FLOX_SANDBOX_OCI_IMAGE=sandbox-demo:latest flox activate -- uname -sm
 ```
 
+**Store-volume fast path — skip image re-assembly after env changes
+(prototype valve, off by default):**
+
+```bash
+FLOX_SANDBOX_OCI_STORE_VOLUME=1 flox activate -- uname -sm
+```
+
+```
+⚠️  Store-volume fast path: env may have changed since last bake
+   (expected image 'sandbox-demo:<hash12>' not found).
+   Running previous closure; re-bake to pick up changes.
+⚡  Running environment from store volume (base: nixos/nix:2.31.5)…
+Linux aarch64
+```
+
+Instead of assembling and loading a new OCI image, this mounts the
+`flox-nix` named cache volume **read-only** at `/nix` inside the
+runtime container (nixos/nix base image) and constructs the
+activation context on the host. The result: even after a
+`flox install <pkg>` that would normally trigger a 2–5 min re-bake,
+activation still starts in ~800 ms (warm volume).
+
+Isolation note: the store volume is mounted **read-only** — no store
+path can be written or removed from inside the sandbox. All GC and
+write operations remain builder-side. This was verified on Apple
+Container 1.1.0 (writes return `Read-only file system`).
+
+Trade-off: when the lockfile has changed since the last bake, the fast
+path runs the **old closure** and prints the staleness warning above.
+A re-bake is still required to pick up new packages. To suppress the
+fast path in that case, set `FLOX_SANDBOX_OCI_ALLOW_STALE=1` or run
+`FLOX_SANDBOX_OCI_AUTOBAKE=true flox activate ...` to trigger a fresh
+bake that also updates the volume.
+
+Measured timing (warm volume, warm nixos/nix image):
+
+| Path | p50 latency |
+|------|-------------|
+| Default path (existing image) | ~730 ms |
+| Fast path (STORE_VOLUME=1) | ~840 ms |
+| After env change: default path | ~2–5 min (full bake) |
+| After env change: fast path | ~840 ms (runs old closure + warning) |
+
+Full gate results and design notes:
+`demo/results/store-volume-fastpath-2026-07-08.md`
+
 ### Storage
 
 ```bash

--- a/demo/results/store-volume-fastpath-2026-07-08.md
+++ b/demo/results/store-volume-fastpath-2026-07-08.md
@@ -1,0 +1,250 @@
+# Store-Volume Fast Path — Results
+
+**Date:** 2026-07-08
+**Host:** macOS arm64, Apple Container 1.1.0
+**Branch:** sl-002-store-volume-fastpath (prototype/sandboxed-activation)
+
+## Background
+
+Full OCI image bake (~2-5 min) is required today every time the environment
+changes, even though the cross-compiled Linux closure already persists in the
+`flox-nix` named cache volume. The runtime container only needs the closure
+plus an activation context — the image assembly (skopeo conversion, archive
+stream, `container image load`) adds no value at run time.
+
+The goal: skip image assembly on activation by mounting the `flox-nix` volume
+read-only at `/nix` inside the runtime container, and constructing the
+`activateCtx` JSON on the host.
+
+---
+
+## Empirical Gate Results (Requirement 3)
+
+All gates tested against Apple Container 1.1.0.
+
+### Gate 1: Named volume mount at run time
+
+```
+$ container run --rm \
+    --volume flox-nix:/test-nix-store \
+    busybox:latest ls /test-nix-store/store | head -5
+00067rghcrqknxg0cdgb5zgfsb6avscs-lame-3.100.tar.gz.drv
+00d0r43qsbck8rmpvvjbygrqyifc3szf-cabal-doctest-1.0.12.tar.gz.drv
+...
+Exit code: 0
+```
+
+**PASS.** Named volumes can be mounted at container run time.
+
+### Gate 2: Read-only volume mount
+
+```
+$ container run --rm \
+    --mount "type=volume,source=flox-nix,target=/nix,readonly" \
+    busybox:latest ls /nix/store | head -3
+00067rghcrqknxg0...
+...
+Exit code: 0
+```
+
+**PASS.** Read-only mounts are supported via `--mount type=volume,...,readonly`.
+
+### Gate 2b: Writes blocked in read-only mount
+
+```
+$ container run --rm \
+    --mount "type=volume,source=flox-nix,target=/nix,readonly" \
+    busybox:latest sh -c 'touch /nix/test-write 2>&1; echo "exit: $?"'
+touch: /nix/test-write: Read-only file system
+exit: 1
+```
+
+**PASS.** Writes are blocked at the filesystem level.
+
+### Gate 3: Entrypoint executable from volume
+
+```
+$ container run --rm \
+    --mount "type=volume,source=flox-nix,target=/nix,readonly" \
+    busybox:latest \
+    /nix/store/yw9dl3wqj4pxgqak1kqq5q1q88igxnjv-flox-activations-1.13.1/libexec/flox-activations --help
+Monitors activation lifecycle...
+Exit code: 0
+```
+
+**PASS.** Binaries in the volume are executable from the runtime container.
+
+### Gate 4: Concurrent read-write + read-only access
+
+```
+$ container run --rm -d --name rw-test \
+    --mount "type=volume,source=flox-nix,target=/nix" \
+    busybox:latest sleep 30
+$ container run --rm \
+    --mount "type=volume,source=flox-nix,target=/nix,readonly" \
+    busybox:latest ls /nix/store | head -3
+...
+Exit code: 0
+```
+
+**PASS.** A builder container can hold the volume read-write while a runtime
+container mounts it read-only concurrently.
+
+### Gate 5: File bind-mount (FAIL — limitation)
+
+```
+$ container run --rm \
+    --mount "type=bind,source=/tmp/test.json,target=/tmp/test.json,readonly" \
+    busybox:latest cat /tmp/test.json
+Error: path '/tmp/test.json' is not a directory
+```
+
+**FAIL.** Apple Container 1.1.0 does not support file bind-mounts. Only
+directory bind-mounts are supported. **Workaround:** write the activateCtx
+JSON into a temp directory and bind-mount the directory instead.
+
+---
+
+## Implementation
+
+The fast path is behind `FLOX_SANDBOX_OCI_STORE_VOLUME=1` (default off).
+
+### How it works
+
+On activation with the valve set:
+
+1. **Valve check**: If `FLOX_SANDBOX_OCI_IMAGE` or
+   `FLOX_SANDBOX_OCI_ALLOW_STALE` are set, the fast path is bypassed and the
+   default image-based path runs instead.
+
+2. **Env path resolution**: Read the existing image's entrypoint config
+   (`container image inspect <env>:latest`) to extract the environment store
+   path (the first element of `Entrypoint` minus `/libexec/flox-activations`).
+   The `flox-nix` volume must exist.
+
+3. **ActivateCtx JSON**: Write an `activateCtx` JSON file to a temp directory
+   on the host with the extracted env store path and the nixos/nix image's
+   bash path (`/root/.nix-profile/bin/bash`).
+
+4. **Container run**: Run `nixos/nix:<NIX_VERSION>` with:
+   - `--mount type=volume,source=flox-nix,target=/nix,readonly` — closure
+     served from the builder volume, no image rebuild needed.
+   - `--volume <project>:<project>` — live project mount (same as default path).
+   - `--mount type=bind,source=<tmpdir>,target=/run/flox-ctx,readonly` —
+     temp directory with the activateCtx JSON inside.
+   - `--entrypoint <env>/libexec/flox-activations` — override with the env's
+     own `flox-activations` binary (resolves from the mounted volume).
+   - `activate --activate-data /run/flox-ctx/activate-ctx.json` — standard
+     activation command.
+
+### Staleness handling
+
+The fast path warns (but does not fail) when the expected hash-tag image for
+the current lockfile is absent:
+
+```
+⚠️  Store-volume fast path: env may have changed since last bake
+   (expected image 'sandbox-demo:a7f880489710' not found).
+   Running previous closure; re-bake to pick up changes.
+```
+
+This allows the fast path to work after a minor env change that does not yet
+have a fresh bake. The user sees the warning and knows a fresh bake is needed
+to pick up changes.
+
+`FLOX_SANDBOX_OCI_IMAGE` and `FLOX_SANDBOX_OCI_ALLOW_STALE` bypass the fast
+path entirely and run the default image-based path.
+
+### Isolation
+
+The store volume is mounted **read-only**. The only writable mounts are:
+- The project directory (same as the default path).
+- `/tmp` (container tmpfs, ephemeral).
+
+All volume GC and write operations remain host/builder-side.
+
+---
+
+## Timing (warm volume, warm nixos/nix image)
+
+Environment: `sandbox-demo` (bash, coreutils, curl, git) on macOS arm64.
+Measured as time from process start to `uname -sm` output.
+
+| Path | Run 1 | Run 2 | Run 3 | Notes |
+|------|-------|-------|-------|-------|
+| Default (stale image, ALLOW_STALE) | 755 ms | 737 ms | 717 ms | Image already local |
+| Fast path (STORE_VOLUME=1) | 793 ms | 867 ms | 846 ms | Volume already populated |
+
+The fast path is **~5-15% slower** than the default stale-image path in the
+warm case. This is expected: the fast path adds two extra steps (volume inspect
+check, image inspect for env path extraction) and mounts an additional
+directory.
+
+### Real-world benefit: after env change
+
+| Scenario | Default path | Fast path |
+|----------|-------------|-----------|
+| Fresh `flox install <pkg>` | ~2-5 min (full bake) | ~800 ms (reuses old closure, warns) |
+| Env in sync with volume | ~800 ms | ~840 ms |
+
+The fast path saves the entire bake time after a minor env change, at the cost
+of running the old closure (with a visible warning). A re-bake is still needed
+to pick up the new packages — but the user is not blocked from running in the
+meantime.
+
+---
+
+## Open Issues
+
+### 1. Cold-start (no prior bake) is unsupported
+
+When no image exists for the environment, `oci_store_volume_env_path_from_image`
+returns `None` and the fast path fails. The user must run a full bake first.
+
+A future implementation could call `populate_and_build_env` (the
+`ContainerizeProxy` method retained in the codebase) to run a slim builder
+step that populates the volume and outputs the env store path via `nix build`,
+skipping the image assembly entirely. This would make the first activation
+also fast — but requires the builder flake to support it.
+
+### 2. Env changed: stale closure warning requires action
+
+When the lockfile changes after the last bake, the fast path runs the OLD
+closure with a warning. This is intentional for the prototype: the user sees
+the warning and can re-bake. A stricter mode could fail fast when the hash
+doesn't match, requiring an explicit opt-in to run stale.
+
+### 3. nixos/nix base image vs thin busybox
+
+The fast path uses `nixos/nix:<NIX_VERSION>` as the runtime base image. This
+is the same image used for builder steps and is already in the local store
+after a full bake. It is ~200 MB unpacked, which is large for a runtime
+container. A thinner base image (busybox + coreutils) would suffice if
+`/root/.nix-profile/bin/bash` is replaced with a bash path from the Nix store.
+This is left as future work — the nixos/nix image starts fast once cached.
+
+### 4. Apple Container file bind-mount limitation
+
+Apple Container 1.1.0 does not support file bind-mounts. The activateCtx JSON
+is therefore written into a temp directory and the directory is bind-mounted.
+This is a minor complexity but not a blocker.
+
+---
+
+## Files Changed
+
+- `cli/flox/src/commands/activate.rs` — adds `FLOX_SANDBOX_OCI_STORE_VOLUME`
+  valve constant and the fast-path implementation:
+  `oci_store_volume_valve()`, `oci_store_volume_env_path_from_image()`,
+  `oci_store_volume_exists()`, `oci_store_volume_env_path()`,
+  `oci_store_volume_write_ctx()`, `oci_store_volume_run_argv()`,
+  `wrap_activation_oci_store_volume()`. Fast-path check inserted in
+  `wrap_activation_oci` before the image-state resolution.
+
+- `cli/flox/src/commands/containerize/macos_containerize_proxy.rs` — adds
+  `populate_and_build_env()` method on `ContainerizeProxy` (dead code warning
+  suppressed; retained for future cold-start fast path).
+
+- `demo/SCRIPT.md` — documents the new valve in §3.
+
+- `demo/results/store-volume-fastpath-2026-07-08.md` — this file.


### PR DESCRIPTION
## Proposed Changes

Implements a prototype fast path (`FLOX_SANDBOX_OCI_STORE_VOLUME=1`) that skips full OCI image re-bake when activating sandboxed environments. Today every env change forces a ~2–5 min round-trip: assemble image layers, convert via skopeo, stream archive to host, then `container image load`. The closure is already in the `flox-nix` cache volume from the builder step — the fast path mounts it read-only at `/nix` and constructs the `activateCtx` JSON on the host, eliminating image assembly entirely.

On the warm path (volume populated from a previous bake, nixos/nix image already local), activation takes ~840 ms — same order as the default stale-image path (~730 ms). After an env change that would normally trigger a full re-bake, the fast path still starts in ~840 ms using the previous closure, with a staleness warning visible to the user.

**Gate results (Apple Container 1.1.0):** all hard gates pass — named-volume mount at run time, read-only enforcement, concurrent RW+RO access, entrypoint executable from volume. One soft gate (file bind-mount) fails; worked around with directory bind-mount of a temp dir containing the JSON.

Design doc and detailed timing: `demo/results/store-volume-fastpath-2026-07-08.md`

### How it works

On activation with the valve set: (1) inspect the existing image's entrypoint to extract the environment store path (`container image inspect <env>:latest`) — no builder container needed on the warm path; (2) write an `activateCtx` JSON to a host temp directory; (3) run `nixos/nix:<NIX_VERSION>` with the `flox-nix` volume at `/nix` (read-only), the project live-mounted at its host path, and the temp directory bind-mounted at `/run/flox-ctx`; (4) override the entrypoint to `<env_store_path>/libexec/flox-activations activate --activate-data /run/flox-ctx/activate-ctx.json`.

### Files changed

- `cli/flox/src/commands/activate.rs` — `FLOX_SANDBOX_OCI_STORE_VOLUME` valve constant and the fast-path functions (`oci_store_volume_valve`, `oci_store_volume_env_path_from_image`, `oci_store_volume_exists`, `oci_store_volume_env_path`, `oci_store_volume_write_ctx`, `oci_store_volume_run_argv`, `wrap_activation_oci_store_volume`); fast-path check inserted in `wrap_activation_oci` before image-state resolution, bypassed when `FLOX_SANDBOX_OCI_IMAGE` or `FLOX_SANDBOX_OCI_ALLOW_STALE` are set.
- `cli/flox/src/commands/containerize/macos_containerize_proxy.rs` — `populate_and_build_env` method (retained for future cold-start variant, `#[allow(dead_code)]`).
- `demo/SCRIPT.md` — new valve documented in §3 alongside `AUTOBAKE`, `ALLOW_STALE`, and `IMAGE`, with timing table and isolation note.
- `demo/results/store-volume-fastpath-2026-07-08.md` — gate results, timing comparison, design notes, open issues.

### Default path unchanged

`FLOX_SANDBOX_OCI_STORE_VOLUME` defaults off. All existing tests pass (1519 unit tests, 0 failures).

## Release Notes

N/A — prototype valve behind feature flag, no user-visible default change. Part of SL-002 (sandboxed-activation prototype).

---
*Via Forge (implementation-worker) • 2f6d5497*