### PR TITLE
fix(nef): NEF lockless review follow-ups

### DIFF
--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -129,8 +129,8 @@ pub struct BuildResult {
     /// The direct catalog inputs the build locked, keyed by locked-input
     /// reference. Emitted by NEF builds; absent (and so empty) for build modes
     /// that resolve no catalog inputs.
-    #[serde(rename = "catalogLockfile", default)]
-    pub catalog_lockfile: HashMap<String, LockedInputEntry>,
+    #[serde(rename = "direct_catalog_inputs", default)]
+    pub direct_catalog_inputs: HashMap<String, LockedInputEntry>,
     // TODO: factor out and use buildenv::BuiltStorePath (?)
     #[serde(rename = "resultLinks")]
     pub result_links: BTreeMap<PathBuf, PathBuf>,

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -866,7 +866,7 @@ fn convert_build_result_to_build_metadata(
             PublishError::UnsupportedEnvironmentState("Invalid system".to_string())
         })?,
         version: Some(build_result.version.clone()),
-        direct_catalog_inputs: build_result.catalog_lockfile.clone(),
+        direct_catalog_inputs: build_result.direct_catalog_inputs.clone(),
         _private: (),
     })
 }

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -666,7 +666,9 @@ where
                 version: build_metadata.version.clone(),
             },
             locked_base_catalog_url: Some(self.package_metadata.base_catalog_ref.to_string()),
-            // Record the build's direct catalog inputs.
+            // Record the build's direct catalog inputs. Always sent: an empty
+            // map when the build resolved none. Older CLIs that omit the field
+            // are coalesced to empty server-side (floxhub#1791).
             locked_inputs: Some(build_metadata.direct_catalog_inputs.clone()),
             base_catalog_rev_count: None,
             base_catalog_rev_date: None,

--- a/cli/nef-lock-catalog/src/bin/lock.rs
+++ b/cli/nef-lock-catalog/src/bin/lock.rs
@@ -15,6 +15,7 @@ use floxhub_client::{
     FloxhubClientConfig,
     FloxhubClientError,
     FloxhubMockMode,
+    Stability,
 };
 use nef_lock_catalog::{
     CatalogRef,
@@ -54,7 +55,7 @@ struct Cli {
 
     /// Catalog stability channel.
     #[arg(long, default_value = BaseCatalogInfo::DEFAULT_STABILITY)]
-    stability: String,
+    stability: Stability,
 
     /// Explain each step: files read, catalog references found (with source
     /// locations), the resolved catalog endpoint, and the full lookup request
@@ -103,7 +104,7 @@ async fn main() -> ExitCode {
         base_dir = %cli.base_dir.display(),
         rel_paths = cli.rel_paths.len(),
         out = cli.out.as_deref().map(|out| out.display().to_string()).unwrap_or_else(|| "<stdout>".to_string()),
-        stability = cli.stability,
+        stability = cli.stability.as_str(),
     )
 )]
 async fn run(cli: Cli) -> Result<()> {
@@ -124,7 +125,7 @@ async fn run(cli: Cli) -> Result<()> {
 
     // Render each failure to its message body at the boundary, while the
     // structured data is still in hand; `main` adds the `✘ ERROR:` decoration.
-    let lock = match lock_references(&client, references, &cli.stability).await {
+    let lock = match lock_references(&client, references, cli.stability).await {
         Ok(lock) => lock,
         // REQ-013: surface the unresolvable dependency chains.
         Err(LockError::Unresolvable(entries)) => bail!(render_unresolvable(&entries)),

--- a/cli/nef-lock-catalog/src/bin/lock.rs
+++ b/cli/nef-lock-catalog/src/bin/lock.rs
@@ -10,6 +10,7 @@ use flox_core::util::message::format_error;
 use floxhub_client::{
     AuthContext,
     AuthnMode,
+    BaseCatalogInfo,
     FloxhubClient,
     FloxhubClientConfig,
     FloxhubClientError,
@@ -52,7 +53,7 @@ struct Cli {
     out: Option<PathBuf>,
 
     /// Catalog stability channel.
-    #[arg(long, default_value = "stable")]
+    #[arg(long, default_value = BaseCatalogInfo::DEFAULT_STABILITY)]
     stability: String,
 
     /// Explain each step: files read, catalog references found (with source

--- a/cli/nef-lock-catalog/src/lock/lookup.rs
+++ b/cli/nef-lock-catalog/src/lock/lookup.rs
@@ -217,10 +217,10 @@ mod tests {
         match err {
             LockError::Unresolvable(entries) => {
                 assert_eq!(entries.len(), 1);
-                assert_eq!(entries[0].reference, "catalogs.myorg.missing-dep");
+                assert_eq!(entries[0].reference, "myorg.missing-dep");
                 assert_eq!(entries[0].chain, vec![
-                    "catalogs.myorg.hello".to_string(),
-                    "catalogs.myorg.missing-dep".to_string(),
+                    "myorg.hello".to_string(),
+                    "myorg.missing-dep".to_string(),
                 ]);
             },
             other => panic!("expected LockError::Unresolvable, got {other:?}"),

--- a/cli/nef-lock-catalog/src/lock/lookup.rs
+++ b/cli/nef-lock-catalog/src/lock/lookup.rs
@@ -38,10 +38,6 @@ pub enum LockError {
     #[error("{} catalog reference(s) were unresolvable", .0.len())]
     Unresolvable(Vec<UnresolvableEntry>),
 
-    /// The requested stability is not a valid catalog stability string.
-    #[error("invalid stability: {0:?}")]
-    InvalidStability(String),
-
     /// The catalog lookup request itself failed.
     #[error(transparent)]
     Client(#[from] FloxhubClientError),
@@ -57,22 +53,17 @@ pub enum LockError {
 /// `/build-inputs/lookup` call, and maps the response to a [BuildLock].
 /// Returns [LockError::Unresolvable] if any reference is unresolvable.
 ///
-/// `stability` is the higher-level string input; it is parsed into the typed
-/// [Stability] required by the request contract, failing with
-/// [LockError::InvalidStability] if empty/invalid.
+/// `stability` is the typed [Stability] parsed at the CLI boundary, so this
+/// function cannot fail on an invalid stability string.
 #[instrument(
     skip(client, references),
-    fields(references = references.len(), stability = stability)
+    fields(references = references.len(), stability = stability.as_str())
 )]
 pub async fn lock_references(
     client: &(impl CatalogClientTrait + Send + Sync),
     references: BTreeSet<CatalogRef>,
-    stability: &str,
+    stability: Stability,
 ) -> Result<BuildLock, LockError> {
-    let stability: Stability = stability
-        .parse()
-        .map_err(|_| LockError::InvalidStability(stability.to_string()))?;
-
     let request = build_request(references, stability);
     // The exact JSON POSTed to `/build-inputs/lookup`, for `--verbose`. Guarded
     // so the request is only serialized when the level is enabled.

--- a/cli/nef-lock-catalog/test_data/build_inputs_lookup/partial.json
+++ b/cli/nef-lock-catalog/test_data/build_inputs_lookup/partial.json
@@ -5,9 +5,9 @@
       "matched": {},
       "unresolvable": [
         {
-          "chain": ["catalogs.myorg.hello", "catalogs.myorg.missing-dep"],
+          "chain": ["myorg.hello", "myorg.missing-dep"],
           "leaf": { "unresolvable": {} },
-          "reference": "catalogs.myorg.missing-dep"
+          "reference": "myorg.missing-dep"
         }
       ]
     }

--- a/cli/nef-lock-catalog/test_data/build_inputs_lookup/success.json
+++ b/cli/nef-lock-catalog/test_data/build_inputs_lookup/success.json
@@ -2,10 +2,11 @@
   "groups": {
     "default": {
       "lock": {
-        "myorg.hello": {
+        "myorg/hello": {
           "attr_path": ["hello"],
           "build_type": "nef",
           "catalog": "myorg",
+          "inputs": [],
           "locked_inputs_hash": "sha256-success-fixture",
           "source": {
             "type": "git",
@@ -17,7 +18,7 @@
         }
       },
       "matched": {
-        "myorg.hello": ["catalogs.myorg.hello"]
+        "myorg/hello": ["myorg.hello"]
       },
       "unresolvable": []
     }

--- a/package-builder/flox-build.mk
+++ b/package-builder/flox-build.mk
@@ -835,7 +835,7 @@ define NIX_EXPRESSION_BUILD_template =
 	  --argstr nixpkgs-url '$(EXPRESSION_BUILD_NIXPKGS_URL)' \
 	  --argstr system '$(NIX_SYSTEM)' \
 	  --argstr source-ref '$(NIX_EXPRESSION_REF)' \
-	  --argstr catalog-lockfile $$< \
+	  --argstr catalog-lockfile '$$<' \
 	  --json \
 	  --apply 'pkg: { \
 	    drvPath = pkg.drvPath; \

--- a/package-builder/flox-build.mk
+++ b/package-builder/flox-build.mk
@@ -888,7 +888,7 @@ define NIX_EXPRESSION_BUILD_template =
 	  --argjson resultLinks '$$($(_pvarname)_resultLinks_json)' \
 	  --slurpfile eval $($(_pvarname)_evalJSON) \
 	  --slurpfile build $($(_pvarname)_buildJSON) \
-	  '$$$$build[0][0] * $$$$eval[0] * { system:$$$$system, catalogLockfile:$$$$catalogLock[0].direct_catalog_inputs, log:$$$$logfile, resultLinks:$$$$resultLinks }' > $$@
+	  '$$$$build[0][0] * $$$$eval[0] * { system:$$$$system, direct_catalog_inputs:$$$$catalogLock[0].direct_catalog_inputs, log:$$$$logfile, resultLinks:$$$$resultLinks }' > $$@
 	@echo -e "Completed build of $$(_name) in Nix expression mode\n"
 
   # Create targets for cleaning up the result and log symlinks.

--- a/package-builder/flox-build.mk
+++ b/package-builder/flox-build.mk
@@ -826,7 +826,7 @@ define NIX_EXPRESSION_BUILD_template =
 	  --base-dir '$$(NIX_EXPRESSION_ABSDIRPATH_$(_pvarname))' \
 	  --rel-path '$$(NIX_EXPRESSION_RELFILEPATH_$(_pvarname))' \
 	  --stability '$(EXPRESSION_BUILD_STABILITY)' \
-	  --out $$@
+	  --out '$$@'
 
   # Continue by evaluating the build
   $($(_pvarname)_evalJSON): $($(_pvarname)_catalogLockfile)


### PR DESCRIPTION
Follow-ups to the merged NEF lockless-resolution stack (#4271, #4291,
#4375, #4401, #4409, #4450, #4456), addressing the code-actionable review
comments from @dcarley. One commit per comment.

## Changes

- **fix(flox-build.mk): quote the --out target expansion** — quote `$@` (#4450)
- **fix(flox-build.mk): quote the catalog-lockfile prerequisite expansion** — quote `$<` (#4450)
- **docs(publish): correct the locked_inputs comment** — always sent, empty
  when none; older CLIs coalesced server-side since floxhub#1791 (#4456)
- **refactor(build): rename catalogLockfile → direct_catalog_inputs** — the
  field is a map of inputs, not a file; internal rename incl. the makefile's
  emitted JSON key (#4456)
- **fix(nef-lock-catalog): default stability to BaseCatalogInfo::DEFAULT_STABILITY** (#4409)
- **fix(nef-lock-catalog): parse stability at the CLI boundary** — fail fast on
  invalid `--stability`; removes the now-dead `InvalidStability` variant (#4401)
- **test(nef-lock-catalog): align success lookup fixture with catalog-server** —
  slash canonical keys, unprefixed matched values, always-present `inputs` (#4401)
- **test(nef-lock-catalog): use wire-form refs in the partial lookup fixture** —
  unprefixed refs; `render.rs` restores the `catalogs.` root (#4401)

## Deferred to Linear

Non-code review follow-ups were filed rather than addressed here:
ECO-133 (scanner parse/IO errors), ECO-134 (scanner edge cases), ECO-135
(wide `catalog.*` warning), ECO-136/137 (NEF test coverage) + ECO-141
(interim fixture scaffolding), ECO-138 (stability semantics + makefile
default), ECO-139 (error-messaging UX), ECO-140 (superseded-locks docs).
Token propagation for the lock libexec is tracked in CLI-112.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
