### PR TITLE
feat(publish): ECO-143 send closure to closure-aware check-build

### DIFF
--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -401,7 +401,7 @@ impl CatalogClientTrait for MockClient {
         _source_rev: &str,
         _nixpkgs_rev: &str,
         _system: PackageSystem,
-        _locked_inputs: Option<std::collections::HashMap<String, floxhub_client::LockedInputEntry>>,
+        _locked_inputs: std::collections::HashMap<String, floxhub_client::LockedInputEntry>,
     ) -> Result<CheckBuildResponse, FloxhubClientError> {
         unimplemented!("check_build_already_recorded is not supported in MockClient")
     }

--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -392,6 +392,7 @@ impl CatalogClientTrait for MockClient {
         unimplemented!("build_inputs_lookup is not supported in MockClient")
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn check_build_already_recorded(
         &self,
         _catalog_name: impl AsRef<str> + Send + Sync,
@@ -400,6 +401,7 @@ impl CatalogClientTrait for MockClient {
         _source_rev: &str,
         _nixpkgs_rev: &str,
         _system: PackageSystem,
+        _locked_inputs: Option<std::collections::HashMap<String, floxhub_client::LockedInputEntry>>,
     ) -> Result<CheckBuildResponse, FloxhubClientError> {
         unimplemented!("check_build_already_recorded is not supported in MockClient")
     }

--- a/cli/flox/src/commands/publish.rs
+++ b/cli/flox/src/commands/publish.rs
@@ -8,7 +8,6 @@ use flox_manifest::{Manifest, MigratedTypedOnly};
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::{ConcreteEnvironment, Environment};
 use flox_rust_sdk::providers::build::{COMMON_NIXPKGS_URL, PackageTarget};
-use flox_rust_sdk::providers::catalog::SystemEnum;
 use flox_rust_sdk::providers::nix_auth::NixAuth;
 use flox_rust_sdk::providers::publish::{
     PublishProvider,
@@ -258,9 +257,23 @@ impl Publish {
             debug!(error = %err, "Failed to record v2 event");
         }
 
-        // Pre-check: ask the catalog server if this exact build already exists
-        // before spending time on the build. If the check fails, warn the
-        // user and continue — the dedup feature must never block publishes.
+        let system_override_inner = publish_config.system_override.into_inner();
+
+        let build_metadata = check_build_metadata(
+            &flox,
+            &selected_base_nixpkgs_url,
+            system_override_inner,
+            &publish_provider.env_metadata,
+            &publish_provider.package_metadata.package,
+            nef_stability,
+        )?;
+
+        // Dedup check: ask the catalog server if this exact build has already
+        // been published before spending time on the upload. The closure
+        // identity (direct_catalog_inputs) is now available after
+        // check_build_metadata, so we can send it to the server for a
+        // closure-aware match. If the check fails, warn and continue —
+        // the pre-check must never block a publish.
         let nixpkgs_rev = publish_provider.package_metadata.base_catalog_ref.rev();
         let nixpkgs_rev = nixpkgs_rev.as_deref().unwrap_or_else(|| {
             warn!(
@@ -270,15 +283,6 @@ impl Publish {
             );
             ""
         });
-        let system_override_inner = publish_config.system_override.into_inner();
-        let system = {
-            let system_str = system_override_inner
-                .as_deref()
-                .unwrap_or(flox.system.as_str());
-            system_str
-                .parse::<SystemEnum>()
-                .context("invalid system value for dedup pre-check")?
-        };
         let catalog = &flox.floxhub_client;
         let check_result = catalog
             .check_build_already_recorded(
@@ -287,7 +291,8 @@ impl Publish {
                 &publish_provider.env_metadata.build_repo_meta.url,
                 &publish_provider.env_metadata.build_repo_meta.rev,
                 nixpkgs_rev,
-                system,
+                build_metadata.system,
+                Some(build_metadata.direct_catalog_inputs.clone()),
             )
             .await;
 
@@ -307,29 +312,20 @@ impl Publish {
                 return Ok(());
             },
             Ok(_) => {
-                // Not a duplicate, proceed with build.
+                // Not a duplicate, proceed with upload and publish.
             },
             Err(e) => {
                 // Pre-check failed; show user-visible warning and proceed
-                // with build (graceful degradation per D3).
+                // (graceful degradation — the check must never block a publish).
                 message::warning(
                     "Unable to check if already published — continuing with build and publish.",
                 );
                 warn!(
                     error = %e,
-                    "Dedup pre-check failed, proceeding with build"
+                    "Dedup pre-check failed, proceeding with publish"
                 );
             },
         }
-
-        let build_metadata = check_build_metadata(
-            &flox,
-            &selected_base_nixpkgs_url,
-            system_override_inner,
-            &publish_provider.env_metadata,
-            &publish_provider.package_metadata.package,
-            nef_stability,
-        )?;
 
         // CLI args take precedence over config
         let key_file = publish_config.cache_args.signing_private_key.or(config

--- a/cli/flox/src/commands/publish.rs
+++ b/cli/flox/src/commands/publish.rs
@@ -17,7 +17,7 @@ use flox_rust_sdk::providers::publish::{
     check_environment_metadata,
     check_package_metadata,
 };
-use floxhub_client::CatalogClientTrait;
+use floxhub_client::{CatalogClientTrait, CheckBuildResponse, FloxhubClientError};
 use indoc::formatdoc;
 use nef_lock_catalog::NixFlakeref;
 use tracing::{debug, info_span, instrument, warn};
@@ -43,6 +43,29 @@ use crate::{environment_subcommand_metric, subcommand_metric};
 
 const PUBLISH_COMPLETION_POLL_INTERVAL_MILLIS: u64 = 2_000; // 1s
 const PUBLISH_COMPLETION_TIMEOUT_MILLIS: u64 = 30 * 60 * 1_000; // 30 min
+
+/// Outcome of the dedup pre-check against the catalog.
+#[derive(Debug)]
+enum DedupOutcome {
+    /// The server confirmed this exact build (by closure identity) was already
+    /// published. The caller should display provenance and skip the upload.
+    AlreadyPublished(CheckBuildResponse),
+    /// The build is new or the check could not be completed (graceful
+    /// degradation — a check failure must never block a publish).
+    Proceed,
+}
+
+/// Map the raw check-build result to a [`DedupOutcome`].
+///
+/// An `Err` result (network failure, server error, etc.) is treated as
+/// `Proceed` rather than a fatal error: the dedup check is a best-effort
+/// optimisation and must never prevent a legitimate publish.
+fn dedup_outcome(result: Result<CheckBuildResponse, FloxhubClientError>) -> DedupOutcome {
+    match result {
+        Ok(resp) if resp.already_published => DedupOutcome::AlreadyPublished(resp),
+        _ => DedupOutcome::Proceed,
+    }
+}
 
 #[derive(Bpaf, Clone)]
 pub struct Publish {
@@ -296,8 +319,18 @@ impl Publish {
             )
             .await;
 
-        match check_result {
-            Ok(resp) if resp.already_published => {
+        // Emit a user-visible warning if the pre-check itself failed before
+        // handing the result to the pure helper (which consumes it).
+        if let Err(ref e) = check_result {
+            message::warning("Unable to check if already published — continuing with publish.");
+            warn!(
+                error = %e,
+                "Dedup pre-check failed, proceeding with publish"
+            );
+        }
+
+        match dedup_outcome(check_result) {
+            DedupOutcome::AlreadyPublished(resp) => {
                 message::updated(formatdoc! {"
                     Package already published.
 
@@ -311,19 +344,8 @@ impl Publish {
                 });
                 return Ok(());
             },
-            Ok(_) => {
-                // Not a duplicate, proceed with upload and publish.
-            },
-            Err(e) => {
-                // Pre-check failed; show user-visible warning and proceed
-                // (graceful degradation — the check must never block a publish).
-                message::warning(
-                    "Unable to check if already published — continuing with build and publish.",
-                );
-                warn!(
-                    error = %e,
-                    "Dedup pre-check failed, proceeding with publish"
-                );
+            DedupOutcome::Proceed => {
+                // Not a duplicate (or check failed, already warned above).
             },
         }
 
@@ -522,5 +544,40 @@ mod tests {
                 flox_rust_sdk::providers::build::PackageTargetKind::ManifestBuild { sandbox: None }
             )
         );
+    }
+
+    // --- dedup_outcome unit tests ---
+
+    fn make_check_response(already_published: bool) -> CheckBuildResponse {
+        CheckBuildResponse {
+            already_published,
+            published_at: None,
+            source_rev: None,
+            source_rev_date: None,
+        }
+    }
+
+    #[test]
+    fn dedup_outcome_already_published_maps_to_already_published() {
+        let resp = make_check_response(true);
+        let result = Ok(resp);
+        assert!(matches!(
+            dedup_outcome(result),
+            DedupOutcome::AlreadyPublished(_)
+        ));
+    }
+
+    #[test]
+    fn dedup_outcome_not_published_maps_to_proceed() {
+        let resp = make_check_response(false);
+        let result = Ok(resp);
+        assert!(matches!(dedup_outcome(result), DedupOutcome::Proceed));
+    }
+
+    #[test]
+    fn dedup_outcome_err_maps_to_proceed() {
+        let result: Result<CheckBuildResponse, FloxhubClientError> =
+            Err(FloxhubClientError::Other("network error".to_string()));
+        assert!(matches!(dedup_outcome(result), DedupOutcome::Proceed));
     }
 }

--- a/cli/flox/src/commands/publish.rs
+++ b/cli/flox/src/commands/publish.rs
@@ -50,20 +50,24 @@ enum DedupOutcome {
     /// The server confirmed this exact build (by closure identity) was already
     /// published. The caller should display provenance and skip the upload.
     AlreadyPublished(CheckBuildResponse),
-    /// The build is new or the check could not be completed (graceful
-    /// degradation — a check failure must never block a publish).
-    Proceed,
+    /// The build is new; proceed with the publish.
+    New,
+    /// The check request itself failed (network error, server error, etc.).
+    /// A failed check must never block a publish — it is a best-effort
+    /// optimisation only.
+    CheckFailed(FloxhubClientError),
 }
 
 /// Map the raw check-build result to a [`DedupOutcome`].
 ///
-/// An `Err` result (network failure, server error, etc.) is treated as
-/// `Proceed` rather than a fatal error: the dedup check is a best-effort
-/// optimisation and must never prevent a legitimate publish.
+/// An `Err` result (network failure, server error, etc.) maps to
+/// `CheckFailed` rather than propagating: the dedup pre-check must never
+/// prevent a legitimate publish.
 fn dedup_outcome(result: Result<CheckBuildResponse, FloxhubClientError>) -> DedupOutcome {
     match result {
         Ok(resp) if resp.already_published => DedupOutcome::AlreadyPublished(resp),
-        _ => DedupOutcome::Proceed,
+        Ok(_) => DedupOutcome::New,
+        Err(e) => DedupOutcome::CheckFailed(e),
     }
 }
 
@@ -293,10 +297,8 @@ impl Publish {
 
         // Dedup check: ask the catalog server if this exact build has already
         // been published before spending time on the upload. The closure
-        // identity (direct_catalog_inputs) is now available after
-        // check_build_metadata, so we can send it to the server for a
-        // closure-aware match. If the check fails, warn and continue —
-        // the pre-check must never block a publish.
+        // identity (direct_catalog_inputs) is available after
+        // check_build_metadata, enabling a closure-aware match on the server.
         let nixpkgs_rev = publish_provider.package_metadata.base_catalog_ref.rev();
         let nixpkgs_rev = nixpkgs_rev.as_deref().unwrap_or_else(|| {
             warn!(
@@ -319,16 +321,6 @@ impl Publish {
             )
             .await;
 
-        // Emit a user-visible warning if the pre-check itself failed before
-        // handing the result to the pure helper (which consumes it).
-        if let Err(ref e) = check_result {
-            message::warning("Unable to check if already published — continuing with publish.");
-            warn!(
-                error = %e,
-                "Dedup pre-check failed, proceeding with publish"
-            );
-        }
-
         match dedup_outcome(check_result) {
             DedupOutcome::AlreadyPublished(resp) => {
                 message::updated(formatdoc! {"
@@ -344,8 +336,14 @@ impl Publish {
                 });
                 return Ok(());
             },
-            DedupOutcome::Proceed => {
-                // Not a duplicate (or check failed, already warned above).
+            DedupOutcome::New => {},
+            DedupOutcome::CheckFailed(e) => {
+                // A failed check must never block a publish; warn and continue.
+                message::warning("Unable to check if already published — continuing with publish.");
+                warn!(
+                    error = %e,
+                    "Dedup pre-check failed, proceeding with publish"
+                );
             },
         }
 
@@ -558,26 +556,28 @@ mod tests {
     }
 
     #[test]
-    fn dedup_outcome_already_published_maps_to_already_published() {
-        let resp = make_check_response(true);
-        let result = Ok(resp);
-        assert!(matches!(
-            dedup_outcome(result),
-            DedupOutcome::AlreadyPublished(_)
-        ));
+    fn dedup_outcome_already_published_passes_response_through() {
+        let input = make_check_response(true);
+        let expected = input.clone();
+        let DedupOutcome::AlreadyPublished(got) = dedup_outcome(Ok(input)) else {
+            panic!("expected AlreadyPublished variant");
+        };
+        assert_eq!(got, expected);
     }
 
     #[test]
-    fn dedup_outcome_not_published_maps_to_proceed() {
+    fn dedup_outcome_not_published_maps_to_new() {
         let resp = make_check_response(false);
-        let result = Ok(resp);
-        assert!(matches!(dedup_outcome(result), DedupOutcome::Proceed));
+        assert!(matches!(dedup_outcome(Ok(resp)), DedupOutcome::New));
     }
 
     #[test]
-    fn dedup_outcome_err_maps_to_proceed() {
+    fn dedup_outcome_err_maps_to_check_failed() {
         let result: Result<CheckBuildResponse, FloxhubClientError> =
             Err(FloxhubClientError::Other("network error".to_string()));
-        assert!(matches!(dedup_outcome(result), DedupOutcome::Proceed));
+        assert!(matches!(
+            dedup_outcome(result),
+            DedupOutcome::CheckFailed(_)
+        ));
     }
 }

--- a/cli/flox/src/commands/publish.rs
+++ b/cli/flox/src/commands/publish.rs
@@ -317,7 +317,7 @@ impl Publish {
                 &publish_provider.env_metadata.build_repo_meta.rev,
                 nixpkgs_rev,
                 build_metadata.system,
-                Some(build_metadata.direct_catalog_inputs.clone()),
+                build_metadata.direct_catalog_inputs.clone(),
             )
             .await;
 

--- a/cli/floxhub-client/src/client.rs
+++ b/cli/floxhub-client/src/client.rs
@@ -241,12 +241,20 @@ pub trait CatalogClientTrait {
     async fn get_base_catalog_info(&self) -> Result<BaseCatalogInfo, FloxhubClientError>;
 
     /// Query the catalog to check whether a build matching the given source
-    /// tuple (source URL, source rev, nixpkgs rev, system, package name) has
-    /// already been recorded/published.
+    /// tuple (source URL, source rev, nixpkgs rev, system, package name, and
+    /// direct closure inputs) has already been recorded/published.
+    ///
+    /// `locked_inputs` is the build's direct catalog inputs. Passing
+    /// `Some(map)` (including an empty map for builds with no catalog
+    /// dependencies) lets the server match on closure identity; `None` falls
+    /// back to source-tuple matching only. The CLI always passes
+    /// `Some(direct_catalog_inputs)` so the server can distinguish
+    /// re-publishes that differ only in transitive dependencies.
     ///
     /// Returns provenance data (source rev date, rev) in `CheckBuildResponse`
     /// when `already_published` is true. Used for dedup pre-check before
-    /// running the build.
+    /// uploading/publishing.
+    #[allow(clippy::too_many_arguments)]
     async fn check_build_already_recorded(
         &self,
         catalog_name: impl AsRef<str> + Send + Sync,
@@ -255,6 +263,7 @@ pub trait CatalogClientTrait {
         source_rev: &str,
         nixpkgs_rev: &str,
         system: api_types::PackageSystem,
+        locked_inputs: Option<std::collections::HashMap<String, api_types::LockedInputEntry>>,
     ) -> Result<CheckBuildResponse, FloxhubClientError>;
 }
 
@@ -561,6 +570,7 @@ impl CatalogClientTrait for FloxhubClient {
             .map(|res| res.into_inner().into())
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn check_build_already_recorded(
         &self,
         catalog_name: impl AsRef<str> + Send + Sync,
@@ -569,6 +579,7 @@ impl CatalogClientTrait for FloxhubClient {
         source_rev: &str,
         nixpkgs_rev: &str,
         system: api_types::PackageSystem,
+        locked_inputs: Option<std::collections::HashMap<String, api_types::LockedInputEntry>>,
     ) -> Result<CheckBuildResponse, FloxhubClientError> {
         let catalog = str_to_catalog_name(catalog_name)?;
         let package = str_to_package_name(package_name)?;
@@ -577,12 +588,7 @@ impl CatalogClientTrait for FloxhubClient {
             source_rev: source_rev.to_string(),
             nixpkgs_rev: nixpkgs_rev.to_string(),
             system,
-            // The pre-check runs before the build, so direct catalog inputs
-            // are not yet known.  None canonicalizes to H(∅) server-side
-            // (AI-410), which is correct: if the stored build had a non-empty
-            // closure it will not match, and the publish call will resolve
-            // the actual duplicate via the full closure hash.
-            locked_inputs: None,
+            locked_inputs,
         };
         self.catalog
             .check_build_api_v1_catalog_catalogs_catalog_name_packages_package_name_check_build_post(
@@ -1231,5 +1237,174 @@ pub mod tests {
             };
             prop_assert_eq!(expected_results, collected_results);
         }
+    }
+
+    // ---------------------------------------------------------------------------
+    // check_build_already_recorded — closure-aware dedup pre-check
+    // ---------------------------------------------------------------------------
+
+    const CHECK_BUILD_PATH: &str = "/api/v1/catalog/catalogs/myorg/packages/mypkg/check-build";
+
+    /// locked_inputs (non-empty map) is serialised into the check-build request
+    /// body so the server can perform a closure-aware dedup match.
+    #[tokio::test]
+    async fn check_build_sends_locked_inputs() {
+        use catalog_api_v1::types as api_types;
+
+        let server = MockServer::start_async().await;
+        let mock = server.mock(|when, then| {
+            // Verify key fields are present; inputs=null is omitted by
+            // skip_serializing_if so we don't assert on it here.
+            when.method("POST")
+                .path(CHECK_BUILD_PATH)
+                .json_body_includes(
+                    json!({
+                        "locked_inputs": {
+                            "dep-key": {
+                                "catalog": "nixpkgs",
+                                "attr_path": ["hello"],
+                                "build_type": "manifest",
+                                "locked_inputs_hash": "sha256:aabbcc"
+                            }
+                        }
+                    })
+                    .to_string(),
+                );
+            then.status(200).json_body(json!({
+                "already_published": false
+            }));
+        });
+
+        let client = FloxhubClient::new(client_config(server.base_url().as_str())).unwrap();
+
+        let entry = api_types::LockedInputEntry {
+            catalog: "nixpkgs".to_string(),
+            attr_path: vec!["hello".to_string()],
+            build_type: api_types::BuildType::Manifest,
+            source: api_types::LockedGitSource {
+                type_: "git".to_string(),
+                url: "https://github.com/NixOS/nixpkgs".to_string(),
+                rev: "abc123".to_string(),
+                ref_: "main".to_string(),
+                dir: ".".to_string(),
+            },
+            inputs: None,
+            locked_inputs_hash: "sha256:aabbcc".to_string(),
+        };
+        let mut locked_inputs = std::collections::HashMap::new();
+        locked_inputs.insert("dep-key".to_string(), entry);
+
+        let result = client
+            .check_build_already_recorded(
+                "myorg",
+                "mypkg",
+                &"https://example.com/repo".parse().unwrap(),
+                "deadbeef",
+                "cafebabe",
+                api_types::PackageSystem::X8664Linux,
+                Some(locked_inputs),
+            )
+            .await;
+
+        mock.assert();
+        let resp = result.expect("expected Ok");
+        assert!(!resp.already_published);
+    }
+
+    /// An empty locked_inputs map serialises as `{}` (not omitted).
+    #[tokio::test]
+    async fn check_build_sends_empty_locked_inputs_as_object() {
+        use catalog_api_v1::types as api_types;
+
+        let server = MockServer::start_async().await;
+        let mock = server.mock(|when, then| {
+            when.method("POST")
+                .path(CHECK_BUILD_PATH)
+                .json_body_includes(json!({ "locked_inputs": {} }).to_string());
+            then.status(200).json_body(json!({
+                "already_published": false
+            }));
+        });
+
+        let client = FloxhubClient::new(client_config(server.base_url().as_str())).unwrap();
+
+        let result = client
+            .check_build_already_recorded(
+                "myorg",
+                "mypkg",
+                &"https://example.com/repo".parse().unwrap(),
+                "deadbeef",
+                "cafebabe",
+                api_types::PackageSystem::X8664Linux,
+                Some(std::collections::HashMap::new()),
+            )
+            .await;
+
+        mock.assert();
+        assert!(!result.unwrap().already_published);
+    }
+
+    /// already_published=true → Ok with already_published flag set.
+    #[tokio::test]
+    async fn check_build_returns_already_published_true() {
+        use catalog_api_v1::types as api_types;
+
+        let server = MockServer::start_async().await;
+        let mock = server.mock(|when, then| {
+            when.method("POST").path(CHECK_BUILD_PATH);
+            then.status(200).json_body(json!({
+                "already_published": true,
+                "source_rev": "deadbeef",
+                "published_at": "2024-01-01T00:00:00Z"
+            }));
+        });
+
+        let client = FloxhubClient::new(client_config(server.base_url().as_str())).unwrap();
+
+        let result = client
+            .check_build_already_recorded(
+                "myorg",
+                "mypkg",
+                &"https://example.com/repo".parse().unwrap(),
+                "deadbeef",
+                "cafebabe",
+                api_types::PackageSystem::X8664Linux,
+                Some(std::collections::HashMap::new()),
+            )
+            .await;
+
+        mock.assert();
+        let resp = result.expect("expected Ok");
+        assert!(resp.already_published);
+        assert_eq!(resp.source_rev.as_deref(), Some("deadbeef"));
+    }
+
+    /// A 5xx error from the server is returned as Err, not panicked or swallowed.
+    #[tokio::test]
+    async fn check_build_server_error_returns_err() {
+        use catalog_api_v1::types as api_types;
+
+        let server = MockServer::start_async().await;
+        let mock = server.mock(|when, then| {
+            when.method("POST").path(CHECK_BUILD_PATH);
+            then.status(500);
+        });
+
+        let client = FloxhubClient::new(client_config(server.base_url().as_str())).unwrap();
+
+        let result = client
+            .check_build_already_recorded(
+                "myorg",
+                "mypkg",
+                &"https://example.com/repo".parse().unwrap(),
+                "deadbeef",
+                "cafebabe",
+                api_types::PackageSystem::X8664Linux,
+                Some(std::collections::HashMap::new()),
+            )
+            .await;
+
+        mock.assert();
+        assert!(result.is_err(), "expected Err from 5xx, got: {result:?}");
     }
 }

--- a/cli/floxhub-client/src/client.rs
+++ b/cli/floxhub-client/src/client.rs
@@ -244,9 +244,10 @@ pub trait CatalogClientTrait {
     /// tuple (source URL, source rev, nixpkgs rev, system, package name, and
     /// direct closure inputs) has already been recorded/published.
     ///
-    /// The CLI always passes `Some(direct_catalog_inputs)`. An empty map
-    /// serialises as `{}`, signalling a build with no catalog dependencies.
-    /// Passing `None` is reserved for callers that lack closure information.
+    /// Callers must always provide the direct catalog inputs. An empty map
+    /// means the build has no catalog dependencies and serialises as `{}` on
+    /// the wire. Optionality at the generated request type level exists only
+    /// for old-CLI compatibility and does not apply here.
     ///
     /// Returns provenance data (source rev date, rev) in `CheckBuildResponse`
     /// when `already_published` is true. Used for dedup pre-check before
@@ -260,7 +261,7 @@ pub trait CatalogClientTrait {
         source_rev: &str,
         nixpkgs_rev: &str,
         system: api_types::PackageSystem,
-        locked_inputs: Option<std::collections::HashMap<String, api_types::LockedInputEntry>>,
+        locked_inputs: std::collections::HashMap<String, api_types::LockedInputEntry>,
     ) -> Result<CheckBuildResponse, FloxhubClientError>;
 }
 
@@ -576,7 +577,7 @@ impl CatalogClientTrait for FloxhubClient {
         source_rev: &str,
         nixpkgs_rev: &str,
         system: api_types::PackageSystem,
-        locked_inputs: Option<std::collections::HashMap<String, api_types::LockedInputEntry>>,
+        locked_inputs: std::collections::HashMap<String, api_types::LockedInputEntry>,
     ) -> Result<CheckBuildResponse, FloxhubClientError> {
         let catalog = str_to_catalog_name(catalog_name)?;
         let package = str_to_package_name(package_name)?;
@@ -585,7 +586,7 @@ impl CatalogClientTrait for FloxhubClient {
             source_rev: source_rev.to_string(),
             nixpkgs_rev: nixpkgs_rev.to_string(),
             system,
-            locked_inputs,
+            locked_inputs: Some(locked_inputs),
         };
         self.catalog
             .check_build_api_v1_catalog_catalogs_catalog_name_packages_package_name_check_build_post(
@@ -1299,7 +1300,7 @@ pub mod tests {
                 "deadbeef",
                 "cafebabe",
                 api_types::PackageSystem::X8664Linux,
-                Some(locked_inputs),
+                locked_inputs,
             )
             .await;
 
@@ -1337,7 +1338,7 @@ pub mod tests {
                 "deadbeef",
                 "cafebabe",
                 api_types::PackageSystem::X8664Linux,
-                Some(std::collections::HashMap::new()),
+                std::collections::HashMap::new(),
             )
             .await;
 
@@ -1375,7 +1376,7 @@ pub mod tests {
                 "deadbeef",
                 "cafebabe",
                 api_types::PackageSystem::X8664Linux,
-                Some(std::collections::HashMap::new()),
+                std::collections::HashMap::new(),
             )
             .await;
 
@@ -1410,7 +1411,7 @@ pub mod tests {
                 "deadbeef",
                 "cafebabe",
                 api_types::PackageSystem::X8664Linux,
-                Some(std::collections::HashMap::new()),
+                std::collections::HashMap::new(),
             )
             .await;
 

--- a/cli/floxhub-client/src/client.rs
+++ b/cli/floxhub-client/src/client.rs
@@ -244,12 +244,9 @@ pub trait CatalogClientTrait {
     /// tuple (source URL, source rev, nixpkgs rev, system, package name, and
     /// direct closure inputs) has already been recorded/published.
     ///
-    /// `locked_inputs` is the build's direct catalog inputs. Passing
-    /// `Some(map)` (including an empty map for builds with no catalog
-    /// dependencies) gives the server explicit closure identity; absent or
-    /// `None` is canonicalised server-side to the empty-closure hash H(∅).
-    /// The CLI always passes `Some(direct_catalog_inputs)` so the server can
-    /// distinguish re-publishes that differ only in transitive dependencies.
+    /// The CLI always passes `Some(direct_catalog_inputs)`. An empty map
+    /// serialises as `{}`, signalling a build with no catalog dependencies.
+    /// Passing `None` is reserved for callers that lack closure information.
     ///
     /// Returns provenance data (source rev date, rev) in `CheckBuildResponse`
     /// when `already_published` is true. Used for dedup pre-check before
@@ -1307,8 +1304,12 @@ pub mod tests {
             .await;
 
         mock.assert();
-        let resp = result.expect("expected Ok");
-        assert!(!resp.already_published);
+        assert_eq!(result.expect("expected Ok"), CheckBuildResponse {
+            already_published: false,
+            published_at: None,
+            source_rev: None,
+            source_rev_date: None,
+        });
     }
 
     /// An empty locked_inputs map serialises as `{}` (not omitted).
@@ -1341,10 +1342,15 @@ pub mod tests {
             .await;
 
         mock.assert();
-        assert!(!result.unwrap().already_published);
+        assert_eq!(result.expect("expected Ok"), CheckBuildResponse {
+            already_published: false,
+            published_at: None,
+            source_rev: None,
+            source_rev_date: None,
+        });
     }
 
-    /// already_published=true → Ok with already_published flag set.
+    /// already_published=true → Ok with all provenance fields populated.
     #[tokio::test]
     async fn check_build_returns_already_published_true() {
         use catalog_api_v1::types as api_types;
@@ -1374,9 +1380,13 @@ pub mod tests {
             .await;
 
         mock.assert();
-        let resp = result.expect("expected Ok");
-        assert!(resp.already_published);
-        assert_eq!(resp.source_rev.as_deref(), Some("deadbeef"));
+        let expected: CheckBuildResponse = serde_json::from_value(json!({
+            "already_published": true,
+            "source_rev": "deadbeef",
+            "published_at": "2024-01-01T00:00:00Z",
+        }))
+        .unwrap();
+        assert_eq!(result.expect("expected Ok"), expected);
     }
 
     /// A 5xx error from the server is returned as Err, not panicked or swallowed.

--- a/cli/floxhub-client/src/client.rs
+++ b/cli/floxhub-client/src/client.rs
@@ -246,10 +246,10 @@ pub trait CatalogClientTrait {
     ///
     /// `locked_inputs` is the build's direct catalog inputs. Passing
     /// `Some(map)` (including an empty map for builds with no catalog
-    /// dependencies) lets the server match on closure identity; `None` falls
-    /// back to source-tuple matching only. The CLI always passes
-    /// `Some(direct_catalog_inputs)` so the server can distinguish
-    /// re-publishes that differ only in transitive dependencies.
+    /// dependencies) gives the server explicit closure identity; absent or
+    /// `None` is canonicalised server-side to the empty-closure hash H(∅).
+    /// The CLI always passes `Some(direct_catalog_inputs)` so the server can
+    /// distinguish re-publishes that differ only in transitive dependencies.
     ///
     /// Returns provenance data (source rev date, rev) in `CheckBuildResponse`
     /// when `already_published` is true. Used for dedup pre-check before


### PR DESCRIPTION
## Proposed Changes

The catalog server's check-build endpoint gained closure-aware dedup matching in AI-410 (floxhub PR #1867): it now accepts an optional `locked_inputs` map on `CheckBuildRequest` and can reject re-publishes that differ only in transitive dependencies. The CLI was not sending this field, so the new closure-aware match had no effect.

This PR wires `direct_catalog_inputs` from `check_build_metadata` into the check-build request, and moves the dedup check to run after `check_build_metadata` so the closure is available.

**Stacked on #4487** — the schema re-vendor generated from the merged floxhub PR #1867. This PR carries no `cli/catalog-api-v1/` changes of its own; the generated `CheckBuildRequest.locked_inputs` comes from the base. Lands after #4487.

**cli/floxhub-client/src/client.rs:** add a required `locked_inputs` parameter (`HashMap<String, LockedInputEntry>`) to `CatalogClientTrait::check_build_already_recorded` and its `FloxhubClient` implementation. The parameter is deliberately non-optional: the CLI always knows its direct inputs, and an empty map (the empty closure) serialises as `{}`; `Option` wrapping is confined to where the generated request is built. Adds four httpmock-based tests covering: non-empty map serialisation, empty map serialises as `{}` (not omitted), `already_published=true`, and server error → `Err`.

**cli/flox-rust-sdk/src/providers/catalog.rs:** propagate the new parameter to `MockClient` (stub unchanged, still `unimplemented!`).

**cli/flox/src/commands/publish.rs:** move the dedup check block to after `check_build_metadata`; pass `build_metadata.direct_catalog_inputs.clone()` as `locked_inputs`; use `build_metadata.system` directly (avoids use-after-move of `system_override_inner`). Extract `fn dedup_outcome(Result<…>) -> DedupOutcome` with `enum DedupOutcome { AlreadyPublished(…), New, CheckFailed(…) }` — the decision is a pure, exhaustively-matched function, and the caller warns and proceeds in the `CheckFailed` arm (a failed check must never block a publish). Unit tests cover all three variants.

Fixes ECO-143. Part of AI-410 (see also floxhub PR #1867 and follow-ups CLI-138, CLI-139, CLI-140).

## Behavior Change

Because `direct_catalog_inputs` is only available after `check_build_metadata` (which runs the Nix build), the dedup check now runs **after** the build completes. A duplicate publish will therefore complete the Nix build before reporting "already published" — only the upload and publish steps are skipped.

This is the intended AI-410 tradeoff: getting the correct closure hash is worth finishing the build. Pre-build short-circuit (dedup using only the source tuple, before building) is tracked in AI-411.

## Release Notes

The duplicate-publish detection is now closure-aware: re-publishes that differ only in transitive dependencies are correctly identified as new builds. A duplicate publish completes the Nix build before reporting "already published" (upload skipped); pre-build short-circuit returns in AI-411.

---
*Via Forge (implementation-worker) • 43b1cce9*
