### PR TITLE
feat(sandbox): CF-7b — enable services inside the OCI container guest

### DIFF
--- a/cli/flox-activations/src/cli/activate.rs
+++ b/cli/flox-activations/src/cli/activate.rs
@@ -101,10 +101,23 @@ impl ActivateArgs {
         if context.project_ctx.is_none()
             && !context.flox_bin.is_empty()
             && let Ok(cwd) = std::env::current_dir()
-            && let Some(active_json) =
-                crate::container_active_env::container_active_environments_json(&cwd)
         {
-            context.attach_ctx.flox_active_environments = active_json;
+            if let Some(active_json) =
+                crate::container_active_env::container_active_environments_json(&cwd)
+            {
+                context.attach_ctx.flox_active_environments = active_json;
+            }
+
+            // Populate the project context at runtime so the guest env gets
+            // a running process-compose supervisor and `flox services` works.
+            // The baked context has `project_ctx = null`; filling it in here
+            // mirrors how `flox_active_environments` stays "[]" baked and is
+            // overwritten above. When `_FLOX_SERVICES_SOCKET_OVERRIDE` or
+            // `PROCESS_COMPOSE_BIN` are not set, this returns None and the
+            // activation proceeds without services (safe degradation).
+            if let Some(project_ctx) = crate::container_project_ctx::container_project_ctx(&cwd) {
+                context.project_ctx = Some(project_ctx);
+            }
         }
 
         if let Ok(shell_force) = std::env::var("_FLOX_SHELL_FORCE") {

--- a/cli/flox-activations/src/container_project_ctx.rs
+++ b/cli/flox-activations/src/container_project_ctx.rs
@@ -1,0 +1,574 @@
+//! Builds the `project_ctx` for a container guest activation.
+//!
+//! The baked container context ships `project_ctx = null` (no project), so
+//! service startup is skipped and `flox services` cannot connect to a socket.
+//! At activation time this module constructs an [`AttachProjectCtx`] from the
+//! bind-mounted project directory, enabling:
+//!
+//! - Auto-start: the guard at `activate.rs` starts process-compose when
+//!   `services_to_start` is non-empty.
+//! - In-guest `flox services status/start/stop/logs`: the populated project
+//!   context routes these commands to the running supervisor via the pinned
+//!   socket path.
+//!
+//! The socket path is read from `_FLOX_SERVICES_SOCKET_OVERRIDE` (set in the
+//! container Env block by mkContainer.nix) so the activation entrypoint and
+//! in-guest `flox services` always agree on a single path without needing to
+//! re-derive a path_hash inside the guest.
+//!
+//! Log files are written to `/run/flox/log` rather than the bind-mounted
+//! `.flox/log` because the host owns the `.flox` directory and the guest
+//! (uid 10000) may lack write access to it.
+//!
+//! A round-trip test using [`flox_core::activate::context::AttachProjectCtx`]
+//! guards the struct shape against serde drift (this crate cannot depend on
+//! flox-rust-sdk, but can depend on flox-core).
+
+use std::path::{Path, PathBuf};
+
+use flox_core::activate::context::AttachProjectCtx;
+use serde::Deserialize;
+
+/// The environment pointer file inside a `.flox` directory.
+const ENV_POINTER_FILENAME: &str = "env.json";
+/// The `.flox` directory name.
+const DOT_FLOX: &str = ".flox";
+/// Path to the lockfile within `.flox/env/`.
+const LOCKFILE_PATH: &str = "env/manifest.lock";
+
+/// The env var that pins the services socket to a fixed guest path.
+/// Set in the container image's Env block; both the activation entrypoint
+/// and in-guest `flox services` read this override before deriving a
+/// path_hash-based path, so they cannot diverge.
+const SERVICES_SOCKET_OVERRIDE_VAR: &str = "_FLOX_SERVICES_SOCKET_OVERRIDE";
+
+/// The env var that points to the process-compose binary. Set in the
+/// container image's Env block so this crate does not need to bake it in
+/// at compile time.
+const PROCESS_COMPOSE_BIN_VAR: &str = "PROCESS_COMPOSE_BIN";
+
+/// Writable guest log directory. The bind-mounted `.flox/log` is owned by the
+/// host uid; the guest (uid 10000) cannot write to it. Route log files here
+/// instead — `/run/flox` is chowned to the guest user in mkContainer.nix.
+const GUEST_LOG_DIR: &str = "/run/flox/log";
+
+/// Minimal env-pointer shape used only to detect managed environments
+/// (those with an `owner` field).
+#[derive(Debug, Deserialize)]
+struct EnvPointerFile {
+    #[serde(default)]
+    owner: Option<String>,
+}
+
+/// Minimal lockfile shape: only the fields needed to extract service names.
+///
+/// The full `Lockfile` type lives in flox-manifest (which this crate cannot
+/// depend on), so we deserialize only what we need using serde_json's
+/// `Value`-backed field access.
+#[derive(Debug, Deserialize)]
+struct MinimalLockfile {
+    manifest: serde_json::Value,
+}
+
+/// Build the `AttachProjectCtx` for a container guest, or `None` when the
+/// project cannot be resolved.
+///
+/// Returns `None` for managed environments, when no `.flox` is found, when
+/// the lockfile is missing or unreadable, or when neither auto-start is
+/// enabled nor any services are defined.
+pub fn container_project_ctx(start_dir: &Path) -> Option<AttachProjectCtx> {
+    let dot_flox = find_dot_flox(start_dir)?;
+
+    // Skip managed environments: they have an `owner` field in env.json.
+    let pointer_path = dot_flox.join(ENV_POINTER_FILENAME);
+    let pointer_contents = std::fs::read_to_string(&pointer_path).ok()?;
+    let pointer: EnvPointerFile = serde_json::from_str(&pointer_contents).ok()?;
+    if pointer.owner.is_some() {
+        return None;
+    }
+
+    let lockfile_path = dot_flox.join(LOCKFILE_PATH);
+    let lockfile_contents = std::fs::read_to_string(&lockfile_path).ok()?;
+    let lockfile: MinimalLockfile = serde_json::from_str(&lockfile_contents).ok()?;
+
+    let services_to_start = services_to_start_from_lockfile(&lockfile.manifest);
+
+    // Only provide a project context when there are services to start.
+    // When the services list is empty the startup gate in activate.rs is a
+    // no-op, and routing through the executive for an environment with no
+    // services would add overhead with no benefit.
+    if services_to_start.is_empty() {
+        return None;
+    }
+
+    let process_compose_bin = std::env::var(PROCESS_COMPOSE_BIN_VAR)
+        .map(PathBuf::from)
+        .ok()?;
+
+    let flox_services_socket = std::env::var(SERVICES_SOCKET_OVERRIDE_VAR)
+        .map(PathBuf::from)
+        .ok()?;
+
+    let env_project = dot_flox.parent().unwrap_or(Path::new("/")).to_path_buf();
+
+    let flox_env_log_dir = PathBuf::from(GUEST_LOG_DIR);
+
+    Some(AttachProjectCtx {
+        env_project,
+        dot_flox_path: dot_flox,
+        flox_env_log_dir,
+        process_compose_bin,
+        flox_services_socket,
+        services_to_start,
+    })
+}
+
+/// Extract service names to start from the manifest embedded in the lockfile.
+///
+/// Returns service names that are:
+/// - listed under `manifest.services` (excluding the `auto-start` key), and
+/// - either have no `systems` filter, or include `aarch64-linux` (the guest
+///   container system).
+///
+/// Returns an empty list when `auto-start` is not `true` or when no services
+/// are defined for the guest system.
+fn services_to_start_from_lockfile(manifest_value: &serde_json::Value) -> Vec<String> {
+    let services = match manifest_value.get("services") {
+        Some(serde_json::Value::Object(map)) => map,
+        _ => return Vec::new(),
+    };
+
+    // Only auto-start when the manifest opts in.
+    let auto_start = services
+        .get("auto-start")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    if !auto_start {
+        return Vec::new();
+    }
+
+    // The container always runs aarch64-linux.
+    let guest_system = "aarch64-linux";
+
+    let mut names: Vec<String> = services
+        .iter()
+        .filter(|(key, _)| *key != "auto-start")
+        .filter_map(|(name, descriptor)| {
+            // A descriptor without a `systems` field runs on all systems.
+            // A descriptor with a `systems` array runs only on listed systems.
+            let systems = descriptor.get("systems");
+            let system_matches = match systems {
+                None => true,
+                Some(serde_json::Value::Array(arr)) => arr
+                    .iter()
+                    .filter_map(|v| v.as_str())
+                    .any(|s| s == guest_system),
+                _ => false,
+            };
+            system_matches.then_some(name.clone())
+        })
+        .collect();
+
+    // Sort for deterministic ordering (BTreeMap iteration is ordered, but
+    // serde_json::Map preserves insertion order; sort here to be safe).
+    names.sort();
+    names
+}
+
+/// Ascend from `start_dir` looking for a `.flox` directory.
+/// Mirrors the same function in `container_active_env`.
+pub fn find_dot_flox(start_dir: &Path) -> Option<PathBuf> {
+    let mut dir = Some(start_dir);
+    while let Some(current) = dir {
+        let candidate = current.join(DOT_FLOX);
+        if candidate.is_dir() {
+            return std::fs::canonicalize(&candidate).ok();
+        }
+        dir = current.parent();
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use flox_core::activate::context::AttachProjectCtx;
+    use tempfile::TempDir;
+
+    use super::*;
+
+    /// Create a minimal `.flox` directory with the given env.json and
+    /// manifest.lock contents. Returns the canonical path to `.flox`.
+    fn write_dot_flox(dir: &Path, env_json: &str, lockfile_json: &str) -> PathBuf {
+        let dot_flox = dir.join(DOT_FLOX);
+        let env_dir = dot_flox.join("env");
+        fs::create_dir_all(&env_dir).unwrap();
+        fs::write(dot_flox.join(ENV_POINTER_FILENAME), env_json).unwrap();
+        fs::write(env_dir.join("manifest.lock"), lockfile_json).unwrap();
+        std::fs::canonicalize(&dot_flox).unwrap()
+    }
+
+    /// Minimal lockfile JSON with one service that has auto-start enabled.
+    fn lockfile_with_autostart_service(service_name: &str) -> String {
+        serde_json::json!({
+            "lockfile-version": 1,
+            "manifest": {
+                "version": 1,
+                "services": {
+                    "auto-start": true,
+                    service_name: {
+                        "command": "my-daemon"
+                    }
+                }
+            },
+            "packages": []
+        })
+        .to_string()
+    }
+
+    /// Minimal lockfile JSON with a service restricted to aarch64-linux.
+    fn lockfile_with_system_filtered_service() -> String {
+        serde_json::json!({
+            "lockfile-version": 1,
+            "manifest": {
+                "version": 1,
+                "services": {
+                    "auto-start": true,
+                    "linux-only": {
+                        "command": "linux-daemon",
+                        "systems": ["aarch64-linux"]
+                    },
+                    "mac-only": {
+                        "command": "mac-daemon",
+                        "systems": ["aarch64-darwin"]
+                    }
+                }
+            },
+            "packages": []
+        })
+        .to_string()
+    }
+
+    /// Minimal lockfile JSON with no services.
+    fn lockfile_no_services() -> String {
+        serde_json::json!({
+            "lockfile-version": 1,
+            "manifest": {
+                "version": 1
+            },
+            "packages": []
+        })
+        .to_string()
+    }
+
+    /// Minimal lockfile JSON with services but auto-start = false.
+    fn lockfile_autostart_false() -> String {
+        serde_json::json!({
+            "lockfile-version": 1,
+            "manifest": {
+                "version": 1,
+                "services": {
+                    "auto-start": false,
+                    "my-service": {
+                        "command": "daemon"
+                    }
+                }
+            },
+            "packages": []
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn builds_project_ctx_for_path_env_with_autostart() {
+        let tmp = TempDir::new().unwrap();
+        write_dot_flox(
+            tmp.path(),
+            r#"{"name":"sandbox-demo","version":1}"#,
+            &lockfile_with_autostart_service("postgres"),
+        );
+
+        temp_env::with_vars(
+            [
+                (
+                    PROCESS_COMPOSE_BIN_VAR,
+                    Some("/nix/store/abc-pc/bin/process-compose"),
+                ),
+                (
+                    SERVICES_SOCKET_OVERRIDE_VAR,
+                    Some("/run/flox/runtime/services.sock"),
+                ),
+            ],
+            || {
+                let ctx = container_project_ctx(tmp.path())
+                    .expect("path env with autostart should yield a project ctx");
+
+                assert_eq!(
+                    ctx.flox_services_socket,
+                    PathBuf::from("/run/flox/runtime/services.sock")
+                );
+                assert_eq!(
+                    ctx.process_compose_bin,
+                    PathBuf::from("/nix/store/abc-pc/bin/process-compose")
+                );
+                assert_eq!(ctx.flox_env_log_dir, PathBuf::from(GUEST_LOG_DIR));
+                assert_eq!(ctx.services_to_start, vec!["postgres".to_string()]);
+            },
+        );
+    }
+
+    #[test]
+    fn filters_services_by_system() {
+        let tmp = TempDir::new().unwrap();
+        write_dot_flox(
+            tmp.path(),
+            r#"{"name":"proj","version":1}"#,
+            &lockfile_with_system_filtered_service(),
+        );
+
+        temp_env::with_vars(
+            [
+                (
+                    PROCESS_COMPOSE_BIN_VAR,
+                    Some("/nix/store/abc-pc/bin/process-compose"),
+                ),
+                (
+                    SERVICES_SOCKET_OVERRIDE_VAR,
+                    Some("/run/flox/runtime/services.sock"),
+                ),
+            ],
+            || {
+                let ctx = container_project_ctx(tmp.path())
+                    .expect("should have services for aarch64-linux");
+                // Only the linux-only service matches the guest system.
+                assert_eq!(ctx.services_to_start, vec!["linux-only".to_string()]);
+            },
+        );
+    }
+
+    #[test]
+    fn returns_none_when_no_services() {
+        let tmp = TempDir::new().unwrap();
+        write_dot_flox(
+            tmp.path(),
+            r#"{"name":"empty","version":1}"#,
+            &lockfile_no_services(),
+        );
+
+        temp_env::with_vars(
+            [
+                (
+                    PROCESS_COMPOSE_BIN_VAR,
+                    Some("/nix/store/abc-pc/bin/process-compose"),
+                ),
+                (
+                    SERVICES_SOCKET_OVERRIDE_VAR,
+                    Some("/run/flox/runtime/services.sock"),
+                ),
+            ],
+            || {
+                assert!(container_project_ctx(tmp.path()).is_none());
+            },
+        );
+    }
+
+    #[test]
+    fn returns_none_when_autostart_false() {
+        let tmp = TempDir::new().unwrap();
+        write_dot_flox(
+            tmp.path(),
+            r#"{"name":"no-auto","version":1}"#,
+            &lockfile_autostart_false(),
+        );
+
+        temp_env::with_vars(
+            [
+                (
+                    PROCESS_COMPOSE_BIN_VAR,
+                    Some("/nix/store/abc-pc/bin/process-compose"),
+                ),
+                (
+                    SERVICES_SOCKET_OVERRIDE_VAR,
+                    Some("/run/flox/runtime/services.sock"),
+                ),
+            ],
+            || {
+                assert!(container_project_ctx(tmp.path()).is_none());
+            },
+        );
+    }
+
+    #[test]
+    fn returns_none_for_managed_env() {
+        let tmp = TempDir::new().unwrap();
+        write_dot_flox(
+            tmp.path(),
+            r#"{"name":"prod","owner":"acme","version":1}"#,
+            &lockfile_with_autostart_service("web"),
+        );
+
+        temp_env::with_vars(
+            [
+                (
+                    PROCESS_COMPOSE_BIN_VAR,
+                    Some("/nix/store/abc-pc/bin/process-compose"),
+                ),
+                (
+                    SERVICES_SOCKET_OVERRIDE_VAR,
+                    Some("/run/flox/runtime/services.sock"),
+                ),
+            ],
+            || {
+                assert!(container_project_ctx(tmp.path()).is_none());
+            },
+        );
+    }
+
+    #[test]
+    fn returns_none_when_no_dot_flox() {
+        let tmp = TempDir::new().unwrap();
+
+        temp_env::with_vars(
+            [
+                (
+                    PROCESS_COMPOSE_BIN_VAR,
+                    Some("/nix/store/abc-pc/bin/process-compose"),
+                ),
+                (
+                    SERVICES_SOCKET_OVERRIDE_VAR,
+                    Some("/run/flox/runtime/services.sock"),
+                ),
+            ],
+            || {
+                assert!(container_project_ctx(tmp.path()).is_none());
+            },
+        );
+    }
+
+    #[test]
+    fn returns_none_when_socket_override_not_set() {
+        let tmp = TempDir::new().unwrap();
+        write_dot_flox(
+            tmp.path(),
+            r#"{"name":"proj","version":1}"#,
+            &lockfile_with_autostart_service("svc"),
+        );
+
+        temp_env::with_vars(
+            [
+                (
+                    PROCESS_COMPOSE_BIN_VAR,
+                    Some("/nix/store/abc-pc/bin/process-compose"),
+                ),
+                (SERVICES_SOCKET_OVERRIDE_VAR, None),
+            ],
+            || {
+                // Without the socket override, we can't build the project ctx.
+                assert!(container_project_ctx(tmp.path()).is_none());
+            },
+        );
+    }
+
+    /// Verify that the socket path produced by the container path and the
+    /// `_FLOX_SERVICES_SOCKET_OVERRIDE` env var agree. Both the entrypoint
+    /// (`container_project_ctx`) and in-guest `flox services` read the same
+    /// env var, so they cannot diverge.
+    #[test]
+    fn socket_override_env_var_is_read_by_container_project_ctx() {
+        let expected_socket = "/run/flox/runtime/services.sock";
+
+        let tmp = TempDir::new().unwrap();
+        write_dot_flox(
+            tmp.path(),
+            r#"{"name":"proj","version":1}"#,
+            &lockfile_with_autostart_service("svc"),
+        );
+
+        temp_env::with_vars(
+            [
+                (
+                    PROCESS_COMPOSE_BIN_VAR,
+                    Some("/nix/store/abc-pc/bin/process-compose"),
+                ),
+                (SERVICES_SOCKET_OVERRIDE_VAR, Some(expected_socket)),
+            ],
+            || {
+                let ctx = container_project_ctx(tmp.path()).expect("should build ctx");
+                assert_eq!(ctx.flox_services_socket, PathBuf::from(expected_socket));
+            },
+        );
+    }
+
+    /// The pinned socket path `/run/flox/runtime/services.sock` is well under
+    /// the Linux 108-char `sun_path` limit. This documents the constraint so it
+    /// won't be silently violated if the path changes.
+    #[test]
+    fn pinned_socket_path_is_within_sun_path_limit() {
+        let socket = "/run/flox/runtime/services.sock";
+        // 108 minus null terminator = 107 usable chars on Linux.
+        assert!(
+            socket.len() <= 107,
+            "socket path '{}' exceeds 107-char Linux sun_path limit (len={})",
+            socket,
+            socket.len()
+        );
+    }
+
+    /// Guard the [`AttachProjectCtx`] field names against serde drift.
+    /// `container_project_ctx` builds this struct in flox-activations and
+    /// `flox-activations activate` receives it as a serialised JSON value —
+    /// if the struct fields change in flox-core, the round-trip would silently
+    /// break without this test.
+    #[test]
+    fn attach_project_ctx_round_trip() {
+        let ctx = AttachProjectCtx {
+            env_project: PathBuf::from("/project"),
+            dot_flox_path: PathBuf::from("/project/.flox"),
+            flox_env_log_dir: PathBuf::from("/run/flox/log"),
+            process_compose_bin: PathBuf::from("/nix/store/abc-pc/bin/process-compose"),
+            flox_services_socket: PathBuf::from("/run/flox/runtime/services.sock"),
+            services_to_start: vec!["postgres".to_string(), "redis".to_string()],
+        };
+
+        let json = serde_json::to_string(&ctx).unwrap();
+        let decoded: AttachProjectCtx = serde_json::from_str(&json).unwrap();
+        assert_eq!(ctx.env_project, decoded.env_project);
+        assert_eq!(ctx.dot_flox_path, decoded.dot_flox_path);
+        assert_eq!(ctx.flox_env_log_dir, decoded.flox_env_log_dir);
+        assert_eq!(ctx.process_compose_bin, decoded.process_compose_bin);
+        assert_eq!(ctx.flox_services_socket, decoded.flox_services_socket);
+        assert_eq!(ctx.services_to_start, decoded.services_to_start);
+    }
+
+    #[test]
+    fn discovers_dot_flox_from_subdirectory() {
+        let tmp = TempDir::new().unwrap();
+        write_dot_flox(
+            tmp.path(),
+            r#"{"name":"proj","version":1}"#,
+            &lockfile_with_autostart_service("web"),
+        );
+        let subdir = tmp.path().join("src").join("deep");
+        fs::create_dir_all(&subdir).unwrap();
+
+        temp_env::with_vars(
+            [
+                (
+                    PROCESS_COMPOSE_BIN_VAR,
+                    Some("/nix/store/abc-pc/bin/process-compose"),
+                ),
+                (
+                    SERVICES_SOCKET_OVERRIDE_VAR,
+                    Some("/run/flox/runtime/services.sock"),
+                ),
+            ],
+            || {
+                let ctx =
+                    container_project_ctx(&subdir).expect("should ascend to the project .flox");
+                assert_eq!(ctx.services_to_start, vec!["web".to_string()]);
+            },
+        );
+    }
+}

--- a/cli/flox-activations/src/lib.rs
+++ b/cli/flox-activations/src/lib.rs
@@ -2,6 +2,7 @@ pub mod attach;
 pub mod attach_diff;
 pub mod cli;
 pub mod container_active_env;
+pub mod container_project_ctx;
 pub mod deactivate;
 pub mod env_diff;
 pub mod gen_rc;

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -1575,6 +1575,29 @@ mod test {
         ));
     }
 
+    /// The `_FLOX_SERVICES_SOCKET_OVERRIDE` env var bypasses path-length
+    /// validation and is returned verbatim. This is the mechanism used in
+    /// OCI container guests where the socket path is pinned at a fixed location
+    /// (`/run/flox/runtime/services.sock`, 34 chars) to avoid runtime
+    /// path_hash re-derivation inside the guest.
+    #[test]
+    fn services_socket_path_override_bypasses_length_check() {
+        let override_path = "/run/flox/runtime/services.sock";
+        let (mut flox, _temp_dir_handle) = flox_instance();
+        // Make the runtime_dir path absurdly long so the derived path would
+        // fail validation — but the override must win regardless.
+        flox.runtime_dir = flox.runtime_dir.join("X".repeat(100));
+
+        let result = temp_env::with_var(
+            FLOX_SERVICES_SOCKET_OVERRIDE_VAR,
+            Some(override_path),
+            || services_socket_path("1", &flox),
+        )
+        .unwrap();
+
+        assert_eq!(result, std::path::PathBuf::from(override_path));
+    }
+
     /// The dev and run links are the `--out-link` prefix with the nix output
     /// names appended, and `out_link_prefix()` returns that prefix verbatim
     /// rather than re-deriving it from the dev link.

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -2062,14 +2062,16 @@ fn bake_oci_image(
     // The frozen fallback rev: a known-good prototype-branch commit containing
     // the container-guest fixes (hook enable/disable, prompt label), the CF-7
     // guest-flox baking (real flox in the guest, active-env registration,
-    // deterministic marker), and the packaging fixes that let the branch build
-    // for aarch64-linux. Used when the host is a dev build. Not CI-cached: the
-    // builder compiles it in-VM against the persistent `flox-nix` cache volume,
-    // so only the first bake pays the compile.
+    // deterministic marker), the CF-7b in-guest services (project_ctx +
+    // process-compose auto-start + pinned socket), and the packaging fixes
+    // that let the branch build for aarch64-linux. Used when the host is a
+    // dev build. Not CI-cached: the builder compiles it in-VM against the
+    // persistent `flox-nix` cache volume, so only the first bake pays the
+    // compile.
     //
     // NOTE: Update this rev when builder-side behavior changes (mkContainer,
     // flox-activations, package-builder); host-side-only commits don't need it.
-    const FROZEN_FALLBACK_REV: &str = "bf9293273a665ab559aa807897a1722f17b98cbd";
+    const FROZEN_FALLBACK_REV: &str = "73b8a967bf73d354f2d25cf4637d460ff86e0697";
 
     let hash12 = lockfile_hash12(lockfile);
     let hash_tag = format!("{env_name}:{hash12}");

--- a/mkContainer/mkContainer.nix
+++ b/mkContainer/mkContainer.nix
@@ -192,11 +192,15 @@ let
       # /home/flox is a writable HOME for a real guest flox; XDG_CONFIG_HOME,
       # XDG_STATE_HOME, and XDG_CACHE_HOME route under it. XDG_RUNTIME_DIR
       # routes to /run/flox/runtime, created here so the runtime dir exists.
+      # /run/flox/log is writable by the guest user for process-compose logs;
+      # the bind-mounted .flox/log is owned by the host uid and may not be
+      # writable inside the container.
       extraCommands = ''
         mkdir -m 1777 tmp
         mkdir -m 1770 run
         mkdir -p -m 1770 run/flox
         mkdir -p -m 0700 run/flox/runtime
+        mkdir -p -m 0700 run/flox/log
         mkdir -p -m 0700 home/flox
       '';
 
@@ -243,12 +247,25 @@ let
           # /home/flox, and /run/flox/runtime are the writable locations
           # in the image. Append to any user-provided Env rather than
           # replacing it.
+          #
+          # _FLOX_SERVICES_SOCKET_OVERRIDE: pin the services socket to a fixed
+          # guest path so both the activation entrypoint and in-guest
+          # `flox services` always use the same socket without re-deriving a
+          # path_hash inside the guest. /run/flox/runtime is already writable.
+          # Path is 34 chars, well under the 107-char Linux sun_path limit.
+          #
+          # PROCESS_COMPOSE_BIN: flox-activations reads this at runtime to
+          # locate the process-compose supervisor. The flox-activations binary
+          # built for this image does not bake in PROCESS_COMPOSE_BIN at
+          # compile time (unlike the flox binary), so we inject it here.
           Env = (containerConfig.Env or [ ]) ++ [
             "HOME=/home/flox"
             "XDG_CONFIG_HOME=/home/flox/.config"
             "XDG_STATE_HOME=/home/flox/.local/state"
             "XDG_CACHE_HOME=/home/flox/.cache"
             "XDG_RUNTIME_DIR=/run/flox/runtime"
+            "_FLOX_SERVICES_SOCKET_OVERRIDE=/run/flox/runtime/services.sock"
+            "PROCESS_COMPOSE_BIN=${containerPkgs.process-compose}/bin/process-compose"
           ];
         };
 


### PR DESCRIPTION
## Proposed Changes

CF-7a made the guest environment ACTIVE so `guard_is_within_activation` passes and `flox deactivate` works. CF-7b adds the running supervisor: on guest entry the env's `[services]` with `auto-start = true` start automatically, and in-guest `flox services status/start/stop/logs` work against the running process-compose.

The root cause is the "T4 exclusion": the baked container context ships `project_ctx = null`, so the service-startup gate in `activate.rs` is skipped and process-compose never runs. This ticket fills `project_ctx` at runtime, exactly as CF-7a fills `flox_active_environments` from `[]` to a live entry.

### New: `cli/flox-activations/src/container_project_ctx.rs`

Builds `Option<AttachProjectCtx>` at activation time from the bind-mounted project directory. Reads the lockfile manifest to find services with `auto-start = true`, filtered for `aarch64-linux` (the guest system). Reads `PROCESS_COMPOSE_BIN` and `_FLOX_SERVICES_SOCKET_OVERRIDE` from the container Env block. Returns `None` for managed envs, no-`.flox`, no auto-start services, or missing env vars (safe fallback).

### Modified: `cli/flox-activations/src/cli/activate.rs`

Populate `context.project_ctx` at runtime for container guest activations (where `project_ctx` is None and `flox_bin` is non-empty). With the project context populated, `start()` routes through the executive-spawning arm which spawns the executive process. The executive signals readiness via SIGUSR1; the activate path then calls `start_services_with_new_process_compose` which sends SIGUSR1 to the executive to start process-compose. In-guest `flox services` uses the same socket path (pinned via `_FLOX_SERVICES_SOCKET_OVERRIDE`).

### Modified: `mkContainer/mkContainer.nix`

Bake into the guest Env block (alongside CF-7a's HOME/XDG vars): `_FLOX_SERVICES_SOCKET_OVERRIDE=/run/flox/runtime/services.sock` (pins the socket path so the activation entrypoint and in-guest `flox services` always agree without re-deriving a path_hash; 34 chars, well under the 107-char Linux sun_path limit) and `PROCESS_COMPOSE_BIN=${containerPkgs.process-compose}/bin/process-compose` (provides the binary path that `flox-activations` cannot bake in at compile time).

Also create `/run/flox/log` in `extraCommands` so process-compose logs are writable by the guest user (uid 10000). The bind-mounted `.flox/log` is host-owned and may not be writable inside the guest.

### Modified: `cli/flox-rust-sdk/src/models/environment/mod.rs`

Extended the socket-length test with a positive case verifying that `_FLOX_SERVICES_SOCKET_OVERRIDE` bypasses path-length validation and is returned verbatim.

### How the executive gets spawned in the guest

With `project_ctx` populated, `start()` routes through `Some(project) if !activations.executive_started() => spawn_executive(...)`. The executive spawns, sets up signal handlers, sends SIGUSR1 to the parent (activate), and enters the monitoring loop. The activate path then calls `start_services_with_new_process_compose`, which reads `executive_pid` from `state.json` and sends SIGUSR1 to it. The executive's `handle_start_services_signal` calls `start_process_compose_no_services`, and services start via the socket API.

### Test results

- 11 new unit tests in `container_project_ctx` — all pass
- 1 new test in `flox-rust-sdk` for socket override bypass — passes
- Full `flox-activations` suite: 200 passed, 0 failed
- Pre-push hooks: clippy, rustfmt, treefmt — all passed
- `just build-cli` — clean build

### E2E steps (for handoff owner)

E2E requires a FROZEN_FALLBACK_REV bump to the tip of `cf7b-services-in-guest` and an Apple Container bake against an env with a `[services]` block.

1. Bump `FROZEN_FALLBACK_REV` to this branch's HEAD SHA.
2. Build flox with `just build` and bake a container with an env that has `[services] auto-start = true` and at least one service definition.
3. Run `flox activate --sandbox oci` to enter the guest.
4. Verify services auto-started: `flox services status` shows the service running.
5. `flox services stop <svc>` then `flox services start <svc>` to verify manual control.
6. `flox services logs <svc>` to verify log output.

Note: do NOT bump FROZEN_FALLBACK_REV or merge to prototype before E2E bake.

Refs: CF-7b (sandboxed-activation-prototype SL-002)

---

Via Forge implementation-worker (2f6d5497)

## Release Notes

N/A — prototype branch, not yet behind a feature flag.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flox/codesmith/flox/pr/4482"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786227074&installation_id=145526267&pr_number=4482&repository=flox%2Fflox&return_to=https%3A%2F%2Fgithub.com%2Fflox%2Fflox%2Fpull%2F4482&signature=39cba535a94e404993afc9fa13f266bf23b2aacb9586b74275ada480c33ee6c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->