### PR TITLE
chore(dev): AI-420 add cargo-llvm-cov coverage recipe

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -345,6 +345,89 @@ test-all: test-nix-plugins impure-tests integ-tests nix-integ-tests
 
 # ---------------------------------------------------------------------------- #
 
+# Measure line/function coverage for a single crate (default: flox-core).
+#
+# The nix Rust toolchain ships llvm-tools and profiler builtins, but there
+# is no rustup, so cargo-llvm-cov's automatic tool discovery fails. We
+# therefore export LLVM_COV and LLVM_PROFDATA directly from the toolchain
+# sysroot before invoking cargo-llvm-cov.
+#
+# cargo-llvm-cov is provisioned non-invasively via nixpkgs — no global
+# install, no rustup, no toolchain file changes.
+#
+# Per-crate feature handling:
+#   flox-core        — needs --features tests  (enables proptest helpers)
+#   flox-rust-sdk    — needs --features tests  (enables test helpers)
+#   flox             — needs --features extra-tests  (impure unit tests)
+#   flox-manifest    — needs --features tests
+#   other crates     — no extra features required
+#
+# Usage:
+#   just coverage              # measure flox-core (default, ~50 s cold)
+#   just coverage flox-rust-sdk
+#   just coverage flox         # requires `just build` first (needs
+#                              #   built subsystems at build/)
+#   just coverage --workspace  # all crates; also requires `just build`
+#                              #   first; measured wall-clock: ~3 min
+coverage crate="flox-core":
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    CRATE="{{crate}}"
+
+    # --- Locate LLVM tools from the Rust toolchain sysroot ------------------
+    # The nix toolchain bundles llvm-cov and llvm-profdata alongside rustc,
+    # but cargo-llvm-cov's rustup-based discovery won't find them. Point it
+    # at the sysroot binaries directly.
+    SYSROOT="$(rustc --print sysroot)"
+    TARGET_TRIPLE="$(rustc -Vv | awk '/^host:/ { print $2 }')"
+    LLVM_BIN="${SYSROOT}/lib/rustlib/${TARGET_TRIPLE}/bin"
+
+    if [ ! -f "${LLVM_BIN}/llvm-cov" ]; then
+        echo "error: llvm-cov not found at ${LLVM_BIN}/llvm-cov" >&2
+        echo "       Is llvm-tools available in the Rust toolchain?" >&2
+        exit 1
+    fi
+
+    export LLVM_COV="${LLVM_BIN}/llvm-cov"
+    export LLVM_PROFDATA="${LLVM_BIN}/llvm-profdata"
+
+    # --- Build cargo-llvm-cov arguments -------------------------------------
+    ARGS=()
+
+    if [ "$CRATE" = "--workspace" ]; then
+        ARGS+=(--workspace)
+    else
+        ARGS+=(-p "$CRATE")
+
+        # Per-crate feature flags: enable test helpers that ship behind
+        # feature gates so they don't bloat production binaries.
+        case "$CRATE" in
+            flox-core | flox-rust-sdk | flox-manifest)
+                ARGS+=(--features tests)
+                ;;
+            flox)
+                ARGS+=(--features extra-tests)
+                ;;
+        esac
+    fi
+
+    echo "==> Coverage for: ${CRATE}"
+    echo "    LLVM_COV=${LLVM_COV}"
+    echo "    LLVM_PROFDATA=${LLVM_PROFDATA}"
+    echo
+
+    # cargo-llvm-cov is provisioned from nixpkgs — no install step needed.
+    # The '--' separator passes remaining flags to nextest.
+    nix run \
+        --extra-experimental-features 'nix-command flakes' \
+        nixpkgs#cargo-llvm-cov -- \
+        llvm-cov nextest \
+        "${ARGS[@]}" \
+        --summary-only
+
+# ---------------------------------------------------------------------------- #
+
 # Refresh the prior-release lockfile fixtures under
 #   test_data/manually_generated/prior_release_baselines/
 # used by the cross-release tests: a current Flox release must still honor

--- a/Justfile
+++ b/Justfile
@@ -361,6 +361,8 @@ test-all: test-nix-plugins impure-tests integ-tests nix-integ-tests
 #   flox             — needs --features extra-tests  (impure unit tests)
 #   flox-manifest    — needs --features tests
 #   other crates     — no extra features required
+#   --workspace      — enables all of the above via package-qualified
+#                      features (flox-core/tests, ..., flox/extra-tests)
 #
 # Usage:
 #   just coverage              # measure flox-core (default, ~50 s cold)
@@ -396,7 +398,10 @@ coverage crate="flox-core":
     ARGS=()
 
     if [ "$CRATE" = "--workspace" ]; then
+        # Package-qualified features mirror the per-crate flags below so
+        # workspace coverage measures the same test set as per-crate runs.
         ARGS+=(--workspace)
+        ARGS+=(--features flox-core/tests,flox-rust-sdk/tests,flox-manifest/tests,flox/extra-tests)
     else
         ARGS+=(-p "$CRATE")
 


### PR DESCRIPTION
## Proposed Changes

Adds a `just coverage [CRATE]` recipe to the Justfile so developers can measure line/function coverage for any Rust crate in the workspace without a global install or toolchain changes.

**The problem:** The nix Rust toolchain ships llvm-tools and profiler builtins, but has no rustup, so cargo-llvm-cov's automatic tool discovery fails. This recipe works around it by exporting `LLVM_COV` and `LLVM_PROFDATA` directly from the toolchain sysroot (`$(rustc --print sysroot)/lib/rustlib/$(host)/bin/`). cargo-llvm-cov is provisioned via `nix run nixpkgs#cargo-llvm-cov` — no global install, no toolchain file changes.

**Per-crate feature handling** is automatic: `flox-core`, `flox-rust-sdk`, `flox-manifest` get `--features tests`; `flox` gets `--features extra-tests`; other crates get no extra features.

**Usage:**

```
just coverage              # flox-core (default)
just coverage flox-rust-sdk
just coverage flox         # needs `just build` first (requires built subsystems)
just coverage --workspace  # all crates; also needs `just build` first
```

**Verification run on flox-core:**

- Line coverage: 70.49% (spike AI-417 reference: 67.9%; deviation attributed to `--features tests` enabling proptest-based tests not run in the spike, plus nixpkgs channel drift)
- Wall-clock cold: ~50 s (flox-core only)
- Full workspace wall-clock: ~3 min (before hitting `flox`-crate test failures that need `just build`)

Note: `--workspace` fails for `flox` crate tests requiring built subsystems under `build/` unless `just build` has been run first. Single-crate invocations for `flox-core`, `flox-rust-sdk`, and `flox-manifest` work without any prior build step.

Fixes AI-420

## Release Notes

N/A

---
*Via Forge (implementation-worker) • f939584c*

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/flox/codesmith/flox/pr/4490"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786386925&installation_id=145526267&pr_number=4490&repository=flox%2Fflox&return_to=https%3A%2F%2Fgithub.com%2Fflox%2Fflox%2Fpull%2F4490&signature=eb8803c79bac9debb680b7cf100b06bce41a6078d596472438e73887f98ca9a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->