### PR TITLE
fix(activate): preserve default info(1) search path in INFOPATH

### DIFF
--- a/assets/environment-interpreter/common/etc/profile.d/0100_common-run-mode-paths.sh
+++ b/assets/environment-interpreter/common/etc/profile.d/0100_common-run-mode-paths.sh
@@ -6,10 +6,16 @@
 #
 # ---------------------------------------------------------------------------- #
 
-# A trailing ':' makes info(1) append its default (compiled-in) search path,
-# so system manuals remain visible. Unlike MANPATH, only a trailing colon is
-# special in INFOPATH; see "Other Info Directories" in the Texinfo manual.
-INFOPATH="$FLOX_ENV/share/info${INFOPATH:+:$INFOPATH}:"
+# A trailing ':' makes info(1) and emacs append the default (compiled-in)
+# search path, so system manuals remain visible. Unlike MANPATH, only a
+# trailing separator is special in INFOPATH ("Other Info Directories",
+# Texinfo manual). Don't append another ':' if a marker is already present,
+# so nested activations don't accumulate empty entries.
+case "${INFOPATH:-}" in
+  "") INFOPATH="$FLOX_ENV/share/info:" ;;
+  *:) INFOPATH="$FLOX_ENV/share/info:$INFOPATH" ;;
+  *) INFOPATH="$FLOX_ENV/share/info:$INFOPATH:" ;;
+esac
 XDG_DATA_DIRS="$FLOX_ENV/share${XDG_DATA_DIRS:+:$XDG_DATA_DIRS}"
 
 export INFOPATH XDG_DATA_DIRS

--- a/assets/environment-interpreter/common/etc/profile.d/0100_common-run-mode-paths.sh
+++ b/assets/environment-interpreter/common/etc/profile.d/0100_common-run-mode-paths.sh
@@ -7,15 +7,11 @@
 # ---------------------------------------------------------------------------- #
 
 # A trailing ':' makes info(1) and emacs append the default (compiled-in)
-# search path, so system manuals remain visible. Unlike MANPATH, only a
-# trailing separator is special in INFOPATH ("Other Info Directories",
-# Texinfo manual). Don't append another ':' if a marker is already present,
-# so nested activations don't accumulate empty entries.
-case "${INFOPATH:-}" in
-  "") INFOPATH="$FLOX_ENV/share/info:" ;;
-  *:) INFOPATH="$FLOX_ENV/share/info:$INFOPATH" ;;
-  *) INFOPATH="$FLOX_ENV/share/info:$INFOPATH:" ;;
-esac
+# search path, so system manuals remain visible ("Other Info Directories",
+# Texinfo manual). When INFOPATH is unset or empty, the expansion below
+# leaves exactly that trailing ':'. An existing value is preserved verbatim,
+# including the user's choice to include or exclude the default path.
+INFOPATH="$FLOX_ENV/share/info:${INFOPATH:-}"
 XDG_DATA_DIRS="$FLOX_ENV/share${XDG_DATA_DIRS:+:$XDG_DATA_DIRS}"
 
 export INFOPATH XDG_DATA_DIRS

--- a/assets/environment-interpreter/common/etc/profile.d/0100_common-run-mode-paths.sh
+++ b/assets/environment-interpreter/common/etc/profile.d/0100_common-run-mode-paths.sh
@@ -6,7 +6,10 @@
 #
 # ---------------------------------------------------------------------------- #
 
-INFOPATH="$FLOX_ENV/share/info${INFOPATH:+:$INFOPATH}"
+# A trailing ':' makes info(1) append its default (compiled-in) search path,
+# so system manuals remain visible. Unlike MANPATH, only a trailing colon is
+# special in INFOPATH; see "Other Info Directories" in the Texinfo manual.
+INFOPATH="$FLOX_ENV/share/info${INFOPATH:+:$INFOPATH}:"
 XDG_DATA_DIRS="$FLOX_ENV/share${XDG_DATA_DIRS:+:$XDG_DATA_DIRS}"
 
 export INFOPATH XDG_DATA_DIRS

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -3476,13 +3476,31 @@ PIDs of the running activations: ${ACTIVATION_PID}"
 @test "INFOPATH keeps the default search path" {
   project_setup
 
-  # An unset INFOPATH must gain a trailing colon so info(1) appends its
-  # default (compiled-in) search path.
+  # Both info(1) and emacs treat a trailing separator in INFOPATH as "append
+  # the default (compiled-in) search path here". Asserting on that marker
+  # tests the exact mechanism that keeps system manuals (e.g. the built-in
+  # emacs manual) discoverable; neither tool is available in the sandbox to
+  # assert on directly.
+
+  # An unset INFOPATH must gain a trailing colon.
+  run env -u INFOPATH "$FLOX_BIN" activate -c "sh -c 'echo \$INFOPATH'"
+  assert_success
+  assert_output --regexp "/share/info:$"
+
+  # An empty INFOPATH behaves the same as unset.
   INFOPATH= run "$FLOX_BIN" activate -c "sh -c 'echo \$INFOPATH'"
   assert_success
   assert_output --regexp "/share/info:$"
 
-  # An existing INFOPATH is preserved and still ends with a colon.
+  # An INFOPATH that already ends with the marker is preserved without
+  # gaining an extra empty entry.
+  INFOPATH=/home/bob/info: run "$FLOX_BIN" activate -c "sh -c 'echo \$INFOPATH'"
+  assert_success
+  assert_output --regexp "/share/info:/home/bob/info:$"
+  refute_output --regexp "::"
+
+  # An INFOPATH without the marker is preserved and still gains a trailing
+  # colon so the default search path isn't lost (same policy as MANPATH).
   INFOPATH=/some/info run "$FLOX_BIN" activate -c "sh -c 'echo \$INFOPATH'"
   assert_success
   assert_output --regexp "/share/info:/some/info:$"

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -3472,7 +3472,7 @@ PIDs of the running activations: ${ACTIVATION_PID}"
 # ---------------------------------------------------------------------------- #
 
 
-# bats test_tags=activate,activate:paths
+# bats test_tags=activate,activate:path
 @test "INFOPATH keeps the default search path" {
   project_setup
 

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -3499,11 +3499,11 @@ PIDs of the running activations: ${ACTIVATION_PID}"
   assert_output --regexp "/share/info:/home/bob/info:$"
   refute_output --regexp "::"
 
-  # An INFOPATH without the marker is preserved and still gains a trailing
-  # colon so the default search path isn't lost (same policy as MANPATH).
+  # An INFOPATH without the marker deliberately excludes the default search
+  # path; that choice is preserved rather than forcing the marker back in.
   INFOPATH=/some/info run "$FLOX_BIN" activate -c "sh -c 'echo \$INFOPATH'"
   assert_success
-  assert_output --regexp "/share/info:/some/info:$"
+  assert_output --regexp "/share/info:/some/info$"
 }
 
 # bats test_tags=activate,activate:attach

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -3472,6 +3472,22 @@ PIDs of the running activations: ${ACTIVATION_PID}"
 # ---------------------------------------------------------------------------- #
 
 
+# bats test_tags=activate,activate:paths
+@test "INFOPATH keeps the default search path" {
+  project_setup
+
+  # An unset INFOPATH must gain a trailing colon so info(1) appends its
+  # default (compiled-in) search path.
+  INFOPATH= run "$FLOX_BIN" activate -c "sh -c 'echo \$INFOPATH'"
+  assert_success
+  assert_output --regexp "/share/info:$"
+
+  # An existing INFOPATH is preserved and still ends with a colon.
+  INFOPATH=/some/info run "$FLOX_BIN" activate -c "sh -c 'echo \$INFOPATH'"
+  assert_success
+  assert_output --regexp "/share/info:/some/info:$"
+}
+
 # bats test_tags=activate,activate:attach
 @test "attach doesn't break MANPATH" {
   project_setup


### PR DESCRIPTION
fixes https://github.com/flox/flox/issues/4458
[CLI-117](https://linear.app/floxdotdev/issue/CLI-117/activation-drops-the-default-search-path-from-infopath)
## Proposed Changes

A trailing ':' in INFOPATH expands to info's default (compiled-in) search path ("Other Info Directories" in the Texinfo manual; emacs's `info.el` implements the same rule). Activation previously set INFOPATH without one, so manuals installed outside the environment (e.g. the built-in emacs manual) disappeared from `info` and emacs's info browser.

Activation now prepends `$FLOX_ENV/share/info:` and preserves any existing INFOPATH verbatim:

- unset or empty INFOPATH becomes `$FLOX_ENV/share/info:` — the trailing ':' keeps the default search path visible (the bug fix)
- a value already ending in ':' keeps it without gaining a duplicate empty entry
- a value without a trailing ':' (a deliberate exclusion of the default path) is respected rather than overridden
- nested activations only prepend, so separators don't accumulate

Adds a regression test covering all four cases.

## Release Notes

- Fixed INFOPATH inside activated environments so info manuals installed outside the environment (e.g. the built-in emacs manual) remain discoverable.
