### PR TITLE
docs: add lifetimes guidance to Rust conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,6 +168,12 @@ Update your branch against `main` by rebasing — never a merge commit.
   - Follow existing style and Rust idioms
   - Use early returns from functions and functional programming style; don't use nested conditionals
   - Structs should derive `Clone` and `Debug`
+  - **Lifetimes: use sparingly.** Named lifetime parameters —
+    especially on structs, where they propagate to every use of
+    the type — are usually not worth the complexity. Prefer owned
+    fields and prioritize readability over micro-optimizations
+    like avoiding the clone of a short `&str`. Ordinary elided
+    borrows in function signatures (`&str` parameters) are fine.
   - Use structured log and tracing fields; don't interpolate variables into single strings
   - Use `assert_eq!` on entire structs in tests so that it's easier to debug failures and catch new fields; don't `assert!` or `assert_eq!` on individual fields
   - `use` guidelines


### PR DESCRIPTION
## What

Adds a bullet to the Rust style conventions in AGENTS.md: use named lifetime parameters sparingly, prefer owned fields, and prioritize readability over micro-optimizations like avoiding the clone of a short `&str`. Ordinary elided borrows in function signatures are explicitly carved out so coding agents don't over-rotate and start flagging every `&str` parameter.

## Why

Captures Matthew's suggestion from the review discussion on #4491 (thread: https://github.com/flox/flox/pull/4491#discussion_r3572864816), where the new `CheckBuildQuery<'a>` struct used borrowed fields: "Use lifetimes sparingly. Prioritize readability over micro-optimizations, like avoiding cloning a short &str." The wording here keeps those two sentences nearly verbatim and adds why struct lifetimes are the expensive case (they propagate to every use of the type) plus the elided-borrow carve-out.

That thread ended with "dunno what the rest of the team feels is on it" — so this PR is the discussion vehicle. Nothing here is settled until the team weighs in.

## Known tension: Forge review guidance currently pushes the other way

Forge's `rust-idioms` review skill lists "cloning because of poor API design instead of adjusting lifetimes" as a clone trap (flox/forge, `.claude/skills/rust-idioms/chapters/type-contracts.md`, section "Clone traps to avoid"). That guidance nudges reviewers toward lifetimes over clones — plausibly why the Forge convention pass on #4491 praised the borrowed fields as a positive. If the team adopts this convention, a follow-up PR in flox/forge will soften that line to match (e.g. scope it to large or hot-path data). If the team decides against it, this PR closes and no Forge change happens.

---
*Via Forge (interactive) • 7a5ffb43*