### PR TITLE
feat(catalog): CLI-144 add _FLOX_RESOLVE_STABILITY for pinned mock recording

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1748,6 +1748,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "serde_yaml",
+ "temp-env",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/Justfile
+++ b/Justfile
@@ -158,20 +158,31 @@ gen-unit-data-no-publish force="":
 
     set -euo pipefail
 
-    # Pin resolve requests to the LTS stability channel so future force-regens
-    # are not subject to version drift across nixpkgs revisions.
-    # `FloxhubClientConfig::stability` (applied in resolve()) reads this var
-    # once at client construction and is symmetric between record and
-    # replay by construction, so it is NOT safe to add this export to any
-    # test-running recipe/CI path (unit-tests, ut, impure-tests) yet:
-    # every cassette committed today was recorded without a stability key,
-    # and replaying against them with this var set would break request
-    # matching (httpmock's playback matcher matches on the recorded `when`
-    # body — the same trap this var would hit in reverse). The flip to also
-    # set this var for test-running contexts happens atomically in the same
-    # future commit as the first LTS force-regen, gated on HUB-119
-    # (flox/floxhub#1908) reaching production.
-    export _FLOX_RESOLVE_STABILITY="lts"
+    # `_FLOX_RESOLVE_STABILITY` / `FloxhubClientConfig::stability` (this PR)
+    # is mechanism only — NOT pinned yet, deliberately no export here. There
+    # are two committed cassette stores (`test_data/unit_test_generated/`,
+    # replayed by `auto_recording_client_inner`; and
+    # `test_data/generated/resolve/`, replayed by `catalog_replay_client`),
+    # and neither was recorded with a stability key. httpmock's playback
+    # matcher matches on the recorded `when` body, so setting this var
+    # anywhere it reaches a record or replay path before both stores are
+    # regenerated together would strand cassette matches in one direction
+    # or the other.
+    #
+    # The first LTS pin lands as a single atomic future change, gated on
+    # HUB-119 (flox/floxhub#1908) reaching production:
+    #   1. Set _FLOX_RESOLVE_STABILITY=lts here, in
+    #      test_data/config.toml [vars], and in the test-running/replay
+    #      contexts (unit-tests, ut, impure-tests).
+    #   2. Flip `catalog_replay_client` (cli/flox-rust-sdk/src/providers/
+    #      catalog.rs) from hardcoded `stability: None` to
+    #      `FloxhubClientConfig::stability_from_env()`.
+    #      `auto_recording_client_inner` already reads the env var and
+    #      needs no change.
+    #   3. Force-regenerate both cassette stores: unit_test_generated via
+    #      `just gen-unit-data-no-publish force=true`, and the mk_data
+    #      store via `just md`.
+    #   4. Verify both replay suites are green.
 
     if [ "{{ force }}" = "true" ]; then
         export _FLOX_UNIT_TEST_RECORD="force"

--- a/Justfile
+++ b/Justfile
@@ -158,6 +158,11 @@ gen-unit-data-no-publish force="":
 
     set -euo pipefail
 
+    # Pin resolve requests to the LTS stability channel so recordings are not
+    # subject to version drift across nixpkgs revisions. Only active during
+    # record runs; existing cassettes and replay matching are unaffected.
+    export _FLOX_RESOLVE_STABILITY="lts"
+
     if [ "{{ force }}" = "true" ]; then
         export _FLOX_UNIT_TEST_RECORD="force"
 

--- a/Justfile
+++ b/Justfile
@@ -179,9 +179,14 @@ gen-unit-data-no-publish force="":
     #      `FloxhubClientConfig::stability_from_env()`.
     #      `auto_recording_client_inner` already reads the env var and
     #      needs no change.
-    #   3. Force-regenerate both cassette stores: unit_test_generated via
-    #      `just gen-unit-data-no-publish force=true`, and the mk_data
-    #      store via `just md`.
+    #   3. Force-regenerate the mk_data store first (`just md -f`), then
+    #      unit_test_generated (`just gen-unit-data-no-publish force=true`).
+    #      Order matters: gen-unit-data-no-publish's test suite replays the
+    #      mk_data store via `catalog_replay_client`, which after step 2
+    #      sends `lts` — those replays fail unless the mk_data store is
+    #      already regenerated with a matching stability key. `just md`
+    #      (no `-f`) skips any cassette whose output file already exists,
+    #      so it would leave the store unpinned; `-f` is required.
     #   4. Verify both replay suites are green.
 
     if [ "{{ force }}" = "true" ]; then

--- a/Justfile
+++ b/Justfile
@@ -158,9 +158,19 @@ gen-unit-data-no-publish force="":
 
     set -euo pipefail
 
-    # Pin resolve requests to the LTS stability channel so recordings are not
-    # subject to version drift across nixpkgs revisions. Only active during
-    # record runs; existing cassettes and replay matching are unaffected.
+    # Pin resolve requests to the LTS stability channel so future force-regens
+    # are not subject to version drift across nixpkgs revisions.
+    # `FloxhubClientConfig::stability` (applied in resolve()) reads this var
+    # once at client construction and is symmetric between record and
+    # replay by construction, so it is NOT safe to add this export to any
+    # test-running recipe/CI path (unit-tests, ut, impure-tests) yet:
+    # every cassette committed today was recorded without a stability key,
+    # and replaying against them with this var set would break request
+    # matching (httpmock's playback matcher matches on the recorded `when`
+    # body — the same trap this var would hit in reverse). The flip to also
+    # set this var for test-running contexts happens atomically in the same
+    # future commit as the first LTS force-regen, gated on HUB-119
+    # (flox/floxhub#1908) reaching production.
     export _FLOX_RESOLVE_STABILITY="lts"
 
     if [ "{{ force }}" = "true" ]; then

--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -684,10 +684,11 @@ pub mod test_helpers {
             mock_mode: mock_mode.clone(),
             auth_context: AuthContext::from_mode(&AuthnMode::Auth0, auth.token().cloned()),
             user_agent: None,
-            // Read once here, symmetric with `init_floxhub_client`: whatever
-            // `_FLOX_RESOLVE_STABILITY` is set to at test-process start
-            // affects both the record and replay client built by this
-            // function identically.
+            // Read at each client construction, symmetric with
+            // `init_floxhub_client`. A single call builds only the record or
+            // the replay client (the mode comes from `_FLOX_UNIT_TEST_RECORD`);
+            // since nothing mutates `_FLOX_RESOLVE_STABILITY` mid-process, the
+            // record and replay runs read the same value.
             stability: FloxhubClientConfig::stability_from_env(),
         };
         let mut client =

--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -585,9 +585,13 @@ pub mod test_helpers {
             mock_mode: FloxhubMockMode::Replay(path.as_ref().to_path_buf()),
             auth_context: AuthContext::from_mode(&AuthnMode::Auth0, None),
             user_agent: None,
-            // Replay-only helper: never read `_FLOX_RESOLVE_STABILITY` here.
-            // Existing cassettes were recorded without a stability key, so
-            // setting it during replay would break every match today.
+            // Replays the mk_data-generated cassette store
+            // (test_data/generated/resolve/*.yaml), recorded without a
+            // stability key. Stays hardcoded `None` until that store's
+            // first LTS force-regen; flip to
+            // `FloxhubClientConfig::stability_from_env()` in that same
+            // change (see the Justfile `gen-unit-data-no-publish` comment
+            // for the full atomic flip checklist).
             stability: None,
         };
         FloxhubClient::new(catalog_config).expect("failed to create catalog client")

--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -585,6 +585,10 @@ pub mod test_helpers {
             mock_mode: FloxhubMockMode::Replay(path.as_ref().to_path_buf()),
             auth_context: AuthContext::from_mode(&AuthnMode::Auth0, None),
             user_agent: None,
+            // Replay-only helper: never read `_FLOX_RESOLVE_STABILITY` here.
+            // Existing cassettes were recorded without a stability key, so
+            // setting it during replay would break every match today.
+            stability: None,
         };
         FloxhubClient::new(catalog_config).expect("failed to create catalog client")
     }
@@ -676,6 +680,11 @@ pub mod test_helpers {
             mock_mode: mock_mode.clone(),
             auth_context: AuthContext::from_mode(&AuthnMode::Auth0, auth.token().cloned()),
             user_agent: None,
+            // Read once here, symmetric with `init_floxhub_client`: whatever
+            // `_FLOX_RESOLVE_STABILITY` is set to at test-process start
+            // affects both the record and replay client built by this
+            // function identically.
+            stability: FloxhubClientConfig::stability_from_env(),
         };
         let mut client =
             FloxhubClient::new(catalog_config).expect("failed to create catalog client");

--- a/cli/flox/src/utils/init/floxhub_client.rs
+++ b/cli/flox/src/utils/init/floxhub_client.rs
@@ -11,6 +11,8 @@ use uuid::Uuid;
 /// - Reads the catalog URL from config (defaults to the production catalog URL)
 /// - Configures mock replay mode if `_FLOX_USE_CATALOG_MOCK` is set
 /// - Includes device UUID and invocation-source headers when available
+/// - Pins `resolve()` requests to a stability channel if
+///   `_FLOX_RESOLVE_STABILITY` is set (test/regen-only, not user-facing)
 ///
 /// `base_url` is the API base the generated client joins request paths onto
 /// (e.g. `<base>/api/v1/catalog/...`); pass [`flox_core::floxhub::Floxhub::api_url_str`]
@@ -41,6 +43,7 @@ pub fn init_floxhub_client(
         mock_mode,
         auth_context,
         user_agent: Some(format!("flox-cli/{}", &*FLOX_VERSION)),
+        stability: FloxhubClientConfig::stability_from_env(),
     };
 
     debug!("using catalog client with url: {}", client_config.base_url);

--- a/cli/floxhub-client/Cargo.toml
+++ b/cli/floxhub-client/Cargo.toml
@@ -35,6 +35,7 @@ proptest.workspace = true
 sentry.workspace = true
 tempfile.workspace = true
 tracing-subscriber.workspace = true
+temp-env.workspace = true
 
 [features]
 default = []

--- a/cli/floxhub-client/src/client.rs
+++ b/cli/floxhub-client/src/client.rs
@@ -292,7 +292,16 @@ impl CatalogClientTrait for FloxhubClient {
             items: package_groups
                 .into_iter()
                 .map(TryInto::try_into)
-                .collect::<Result<Vec<_>, _>>()?,
+                .collect::<Result<Vec<api_types::PackageGroup>, _>>()?
+                .into_iter()
+                .map(|mut group| {
+                    // Apply the client's stability pin to every outgoing
+                    // group. Test/regen-only — see
+                    // `FloxhubClientConfig::stability`.
+                    group.stability = self.config.stability.clone();
+                    group
+                })
+                .collect(),
         };
 
         let response = self
@@ -852,6 +861,7 @@ pub mod test_helpers {
             mock_mode: Default::default(),
             auth_context: AuthContext::from_mode(&Default::default(), None),
             user_agent: None,
+            stability: None,
         }
     }
 
@@ -925,6 +935,67 @@ pub mod tests {
                 panic!();
             },
         };
+        mock.assert();
+    }
+
+    /// `resolve()` applies `FloxhubClientConfig::stability` to every
+    /// outgoing group, regardless of what (if anything) `TryFrom` set.
+    #[tokio::test]
+    async fn resolve_applies_config_stability_to_each_group() {
+        let server = MockServer::start_async().await;
+        let mock = server.mock(|when, then| {
+            when.method("POST")
+                .path("/api/v1/catalog/resolve")
+                .json_body(json!({
+                    "items": [{
+                        "descriptors": [],
+                        "name": "group",
+                        "stability": "lts",
+                    }]
+                }));
+            then.status(200).json_body(json!({"items": []}));
+        });
+
+        let config = FloxhubClientConfig {
+            stability: Some("lts".to_string()),
+            ..client_config(&server.base_url())
+        };
+        let client = FloxhubClient::new(config).unwrap();
+        client
+            .resolve(vec![PackageGroup {
+                name: "group".to_string(),
+                descriptors: vec![],
+            }])
+            .await
+            .unwrap();
+        mock.assert();
+    }
+
+    /// When `FloxhubClientConfig::stability` is `None`, the outgoing group
+    /// carries no `stability` key at all (not a `null`).
+    #[tokio::test]
+    async fn resolve_omits_stability_when_config_unset() {
+        let server = MockServer::start_async().await;
+        let mock = server.mock(|when, then| {
+            when.method("POST")
+                .path("/api/v1/catalog/resolve")
+                .json_body(json!({
+                    "items": [{
+                        "descriptors": [],
+                        "name": "group",
+                    }]
+                }));
+            then.status(200).json_body(json!({"items": []}));
+        });
+
+        let client = FloxhubClient::new(client_config(server.base_url().as_str())).unwrap();
+        client
+            .resolve(vec![PackageGroup {
+                name: "group".to_string(),
+                descriptors: vec![],
+            }])
+            .await
+            .unwrap();
         mock.assert();
     }
 

--- a/cli/floxhub-client/src/client.rs
+++ b/cli/floxhub-client/src/client.rs
@@ -950,7 +950,11 @@ pub mod tests {
                 .json_body(json!({
                     "items": [{
                         "descriptors": [],
-                        "name": "group",
+                        "name": "group-one",
+                        "stability": "lts",
+                    }, {
+                        "descriptors": [],
+                        "name": "group-two",
                         "stability": "lts",
                     }]
                 }));
@@ -963,10 +967,16 @@ pub mod tests {
         };
         let client = FloxhubClient::new(config).unwrap();
         client
-            .resolve(vec![PackageGroup {
-                name: "group".to_string(),
-                descriptors: vec![],
-            }])
+            .resolve(vec![
+                PackageGroup {
+                    name: "group-one".to_string(),
+                    descriptors: vec![],
+                },
+                PackageGroup {
+                    name: "group-two".to_string(),
+                    descriptors: vec![],
+                },
+            ])
             .await
             .unwrap();
         mock.assert();

--- a/cli/floxhub-client/src/client.rs
+++ b/cli/floxhub-client/src/client.rs
@@ -295,10 +295,11 @@ impl CatalogClientTrait for FloxhubClient {
                 .collect::<Result<Vec<api_types::PackageGroup>, _>>()?
                 .into_iter()
                 .map(|mut group| {
-                    // Apply the client's stability pin to every outgoing
-                    // group. Test/regen-only — see
-                    // `FloxhubClientConfig::stability`.
-                    group.stability = self.config.stability.clone();
+                    // Fall back to the client's stability pin when a group
+                    // doesn't carry its own value. A per-group value (once
+                    // plumbed in) always wins over the config default.
+                    // Test/regen-only — see `FloxhubClientConfig::stability`.
+                    group.stability = group.stability.or_else(|| self.config.stability.clone());
                     group
                 })
                 .collect(),

--- a/cli/floxhub-client/src/config.rs
+++ b/cli/floxhub-client/src/config.rs
@@ -29,7 +29,7 @@ pub struct FloxhubClientConfig {
 impl FloxhubClientConfig {
     /// Read the test/regen-only stability pin from
     /// [`crate::FLOX_RESOLVE_STABILITY_VAR`]. Empty string is treated as
-    /// unset, matching [`FloxhubMockMode::default_from_env`].
+    /// unset.
     ///
     /// Call this once at client construction time and store the result on
     /// the config's `stability` field; `resolve()` applies it to every

--- a/cli/floxhub-client/src/config.rs
+++ b/cli/floxhub-client/src/config.rs
@@ -20,6 +20,25 @@ pub struct FloxhubClientConfig {
     pub mock_mode: FloxhubMockMode,
     pub auth_context: AuthContext,
     pub user_agent: Option<String>,
+    /// Stability pin applied to every outgoing `PackageGroup` in
+    /// `resolve()`. Test/regen-only — not a user-facing interface. See
+    /// [`crate::FLOX_RESOLVE_STABILITY_VAR`] and [`Self::stability_from_env`].
+    pub stability: Option<String>,
+}
+
+impl FloxhubClientConfig {
+    /// Read the test/regen-only stability pin from
+    /// [`crate::FLOX_RESOLVE_STABILITY_VAR`]. Empty string is treated as
+    /// unset, matching [`FloxhubMockMode::default_from_env`].
+    ///
+    /// Call this once at client construction time and store the result on
+    /// the config's `stability` field; `resolve()` applies it to every
+    /// outgoing package group.
+    pub fn stability_from_env() -> Option<String> {
+        std::env::var(crate::FLOX_RESOLVE_STABILITY_VAR)
+            .ok()
+            .filter(|s| !s.is_empty())
+    }
 }
 
 /// Mock recording/replay mode for integration testing.
@@ -45,5 +64,34 @@ impl FloxhubMockMode {
         } else {
             FloxhubMockMode::None
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stability_from_env_unset_gives_none() {
+        temp_env::with_var(crate::FLOX_RESOLVE_STABILITY_VAR, None::<&str>, || {
+            assert_eq!(FloxhubClientConfig::stability_from_env(), None);
+        });
+    }
+
+    #[test]
+    fn stability_from_env_empty_gives_none() {
+        temp_env::with_var(crate::FLOX_RESOLVE_STABILITY_VAR, Some(""), || {
+            assert_eq!(FloxhubClientConfig::stability_from_env(), None);
+        });
+    }
+
+    #[test]
+    fn stability_from_env_set_gives_some() {
+        temp_env::with_var(crate::FLOX_RESOLVE_STABILITY_VAR, Some("lts"), || {
+            assert_eq!(
+                FloxhubClientConfig::stability_from_env(),
+                Some("lts".to_string())
+            );
+        });
     }
 }

--- a/cli/floxhub-client/src/lib.rs
+++ b/cli/floxhub-client/src/lib.rs
@@ -47,7 +47,7 @@ pub const FLOX_CATALOG_MOCK_DATA_VAR: &str = "_FLOX_USE_CATALOG_MOCK";
 pub const FLOX_CATALOG_DUMP_DATA_VAR: &str = "_FLOX_CATALOG_DUMP_RESPONSE_FILE";
 /// Sets `PackageGroup.stability` on the wire during mock recording runs.
 /// Test/regen-only — not a user-facing interface. See Justfile
-/// `gen-unit-data-no-publish` and `test_data/config.toml` for usage.
+/// `gen-unit-data-no-publish` for usage.
 pub const FLOX_RESOLVE_STABILITY_VAR: &str = "_FLOX_RESOLVE_STABILITY";
 
 // Re-export catalog-api-v1 types for consumers.

--- a/cli/floxhub-client/src/lib.rs
+++ b/cli/floxhub-client/src/lib.rs
@@ -44,6 +44,10 @@ pub(crate) mod mock;
 pub const DEFAULT_CATALOG_URL: &str = "https://api.flox.dev";
 pub const FLOX_CATALOG_MOCK_DATA_VAR: &str = "_FLOX_USE_CATALOG_MOCK";
 pub const FLOX_CATALOG_DUMP_DATA_VAR: &str = "_FLOX_CATALOG_DUMP_RESPONSE_FILE";
+/// Sets `PackageGroup.stability` on the wire during mock recording runs.
+/// Test/regen-only — not a user-facing interface. See Justfile
+/// `gen-unit-data-no-publish` and `test_data/config.toml` for usage.
+pub const FLOX_RESOLVE_STABILITY_VAR: &str = "_FLOX_RESOLVE_STABILITY";
 
 // Re-export catalog-api-v1 types for consumers.
 // This allows consumers to depend only on floxhub-client, not directly on catalog-api-v1.

--- a/cli/floxhub-client/src/lib.rs
+++ b/cli/floxhub-client/src/lib.rs
@@ -24,6 +24,7 @@
 //!     mock_mode: FloxhubMockMode::None,
 //!     auth_context: AuthContext::from_mode(&Default::default(), floxhub_token),
 //!     user_agent: Some("flox-cli/1.0".to_string()),
+//!     stability: FloxhubClientConfig::stability_from_env(),
 //! };
 //!
 //! let client = FloxhubClient::new(config)?;

--- a/cli/floxhub-client/src/types.rs
+++ b/cli/floxhub-client/src/types.rs
@@ -71,13 +71,13 @@ impl TryFrom<PackageGroup> for api_types::PackageGroup {
     type Error = FloxhubClientError;
 
     fn try_from(package_group: PackageGroup) -> Result<Self, FloxhubClientError> {
-        let stability = std::env::var(crate::FLOX_RESOLVE_STABILITY_VAR)
-            .ok()
-            .filter(|s| !s.is_empty());
+        // `stability` defaults to `None` here; the client-level pin lives on
+        // `FloxhubClientConfig` and is applied by `resolve()`, which also
+        // leaves room for a future per-group value to override it.
         Ok(Self {
             descriptors: package_group.descriptors,
             name: package_group.name,
-            stability,
+            stability: None,
         })
     }
 }
@@ -694,25 +694,21 @@ mod tests {
         }
     }
 
+    /// `TryFrom` always defaults `stability` to `None` — the client-level pin
+    /// is applied later by `resolve()` from `FloxhubClientConfig::stability`,
+    /// not read here. Direct construction, no env involved.
     #[test]
-    fn package_group_convert_stability_unset_gives_none() {
-        temp_env::with_var(crate::FLOX_RESOLVE_STABILITY_VAR, None::<&str>, || {
-            let api_group: api_types::PackageGroup = make_package_group().try_into().unwrap();
-            assert_eq!(api_group.stability, None);
-        });
+    fn package_group_convert_defaults_stability_to_none() {
+        let api_group: api_types::PackageGroup = make_package_group().try_into().unwrap();
+        assert_eq!(api_group.stability, None);
     }
 
+    /// Regression guard: `TryFrom` must not read
+    /// `_FLOX_RESOLVE_STABILITY` even when it is set, now that the read
+    /// site lives on `FloxhubClientConfig`.
     #[test]
-    fn package_group_convert_stability_set_gives_some() {
+    fn package_group_convert_ignores_stability_env_var() {
         temp_env::with_var(crate::FLOX_RESOLVE_STABILITY_VAR, Some("lts"), || {
-            let api_group: api_types::PackageGroup = make_package_group().try_into().unwrap();
-            assert_eq!(api_group.stability, Some("lts".to_string()));
-        });
-    }
-
-    #[test]
-    fn package_group_convert_stability_empty_gives_none() {
-        temp_env::with_var(crate::FLOX_RESOLVE_STABILITY_VAR, Some(""), || {
             let api_group: api_types::PackageGroup = make_package_group().try_into().unwrap();
             assert_eq!(api_group.stability, None);
         });

--- a/cli/floxhub-client/src/types.rs
+++ b/cli/floxhub-client/src/types.rs
@@ -700,7 +700,11 @@ mod tests {
     #[test]
     fn package_group_convert_defaults_stability_to_none() {
         let api_group: api_types::PackageGroup = make_package_group().try_into().unwrap();
-        assert_eq!(api_group.stability, None);
+        assert_eq!(api_group, api_types::PackageGroup {
+            descriptors: vec![],
+            name: "toplevel".to_string(),
+            stability: None,
+        });
     }
 
     /// Regression guard: `TryFrom` must not read
@@ -710,7 +714,11 @@ mod tests {
     fn package_group_convert_ignores_stability_env_var() {
         temp_env::with_var(crate::FLOX_RESOLVE_STABILITY_VAR, Some("lts"), || {
             let api_group: api_types::PackageGroup = make_package_group().try_into().unwrap();
-            assert_eq!(api_group.stability, None);
+            assert_eq!(api_group, api_types::PackageGroup {
+                descriptors: vec![],
+                name: "toplevel".to_string(),
+                stability: None,
+            });
         });
     }
 }

--- a/cli/floxhub-client/src/types.rs
+++ b/cli/floxhub-client/src/types.rs
@@ -71,10 +71,13 @@ impl TryFrom<PackageGroup> for api_types::PackageGroup {
     type Error = FloxhubClientError;
 
     fn try_from(package_group: PackageGroup) -> Result<Self, FloxhubClientError> {
+        let stability = std::env::var(crate::FLOX_RESOLVE_STABILITY_VAR)
+            .ok()
+            .filter(|s| !s.is_empty());
         Ok(Self {
             descriptors: package_group.descriptors,
             name: package_group.name,
-            stability: None,
+            stability,
         })
     }
 }
@@ -682,5 +685,36 @@ mod tests {
             flake_ref.as_str(),
             "git+https://github.com/NixOS/nixpkgs?shallow=1"
         );
+    }
+
+    fn make_package_group() -> PackageGroup {
+        PackageGroup {
+            name: "toplevel".to_string(),
+            descriptors: vec![],
+        }
+    }
+
+    #[test]
+    fn package_group_convert_stability_unset_gives_none() {
+        temp_env::with_var(crate::FLOX_RESOLVE_STABILITY_VAR, None::<&str>, || {
+            let api_group: api_types::PackageGroup = make_package_group().try_into().unwrap();
+            assert_eq!(api_group.stability, None);
+        });
+    }
+
+    #[test]
+    fn package_group_convert_stability_set_gives_some() {
+        temp_env::with_var(crate::FLOX_RESOLVE_STABILITY_VAR, Some("lts"), || {
+            let api_group: api_types::PackageGroup = make_package_group().try_into().unwrap();
+            assert_eq!(api_group.stability, Some("lts".to_string()));
+        });
+    }
+
+    #[test]
+    fn package_group_convert_stability_empty_gives_none() {
+        temp_env::with_var(crate::FLOX_RESOLVE_STABILITY_VAR, Some(""), || {
+            let api_group: api_types::PackageGroup = make_package_group().try_into().unwrap();
+            assert_eq!(api_group.stability, None);
+        });
     }
 }

--- a/cli/nef-lock-catalog/src/bin/lock.rs
+++ b/cli/nef-lock-catalog/src/bin/lock.rs
@@ -207,6 +207,10 @@ fn build_client(config: &Config, floxhub_token: Option<String>) -> Result<Floxhu
         mock_mode,
         auth_context,
         user_agent: None,
+        // This binary uses `build_inputs_lookup`, not `resolve()`; its own
+        // `--stability` flag targets a different endpoint entirely, so it
+        // does not participate in the `_FLOX_RESOLVE_STABILITY` mechanism.
+        stability: None,
     };
 
     Ok(FloxhubClient::new(config)?)

--- a/test_data/config.toml
+++ b/test_data/config.toml
@@ -1,6 +1,3 @@
-[vars]
-_FLOX_RESOLVE_STABILITY = "lts"
-
 [resolve.empty]
 # Not actually a resolve response, just have to put it somewhere
 skip_if_output_exists = "empty.yaml"

--- a/test_data/config.toml
+++ b/test_data/config.toml
@@ -1,4 +1,6 @@
 [vars]
+_FLOX_RESOLVE_STABILITY = "lts"
+
 [resolve.empty]
 # Not actually a resolve response, just have to put it somewhere
 skip_if_output_exists = "empty.yaml"


### PR DESCRIPTION
## Why

Our catalog mock cassettes drift with every regeneration. The two non-publish recorders — `gen-unit-data-no-publish`, which fills the `test_data/unit_test_generated` store, and `mk_data`, which fills `test_data/generated` — record real resolve responses from api.flox.dev against whatever nixpkgs revision is current at recording time. Nothing pins the catalog page they resolve against, so each force-regeneration sweeps in whatever package versions happen to be live that day, and the fixtures churn on every cycle. That churn makes regenerated cassettes noisy to review and their diffs hard to attribute to any real change.

Catalog resolution can now filter by stability — lts, stable, staging, unstable — as of HUB-119. Recording against `lts` turns the moving target into a slow one: lts pages advance roughly every six months, so regenerations between transitions are deterministic and version churn is bounded to the lts cadence rather than arriving on every regen. Getting there is the point of this change.

## What it does

This is the mechanism only, and it ships zero live pins. It adds a test- and regen-only environment variable, `_FLOX_RESOLVE_STABILITY`, that will let the recorders pin the stability sent on the wire — but nothing in this PR sets it, so existing cassettes and their replay matching stay byte-identical to today. The first lts-pinned regeneration is a separate, deliberately atomic change, described below.

The wire already supports this: the generated `PackageGroup` type in `catalog-api-v1` carries a `stability` field, and the only code zeroing it was the `TryFrom<PackageGroup>` conversion. The mechanism gives that field a home on the client. `FloxhubClientConfig` gains a `stability` field, read once at client construction from the environment through a new `stability_from_env()`, and `resolve()` applies it as a fallback for any package group that does not already carry its own value: `group.stability.or_else(|| self.config.stability.clone())`. A per-group value always wins, which leaves room for package groups to set their own stability later; the config value only fills the gap. `TryFrom<PackageGroup>` returns to always setting `None`.

Reading the variable at client construction rather than inside `TryFrom` is what makes record and replay symmetric, and that symmetry is the whole game. httpmock's playback matches an incoming request against the recorded `when` body, so the stability a client sends on replay must match the stability baked into the cassette when it was recorded. Both the real CLI client (`init_floxhub_client`) and the unit-test record/replay helper (`auto_recording_client_inner`) now build through the same `FloxhubClientConfig` path, so whatever `_FLOX_RESOLVE_STABILITY` holds at process start shapes both modes identically — one side cannot send a stability the other omits.

That symmetry has to hold across two independent stores, which is the subtlety an earlier revision of this PR got wrong. The `unit_test_generated` store is recorded by `gen-unit-data-no-publish` and replayed by `auto_recording_client_inner`, now reading `stability_from_env()`. The `generated` store is recorded by `mk_data` and replayed by a different helper, `catalog_replay_client`, which this PR leaves hardcoded to `None`. Neither store was ever recorded with a stability key, so pinning the variable for one store or one replay helper while leaving the other alone would strand the untouched store on its next regeneration. To avoid planting that trap, this PR carries no live pin in either the `gen-unit-data-no-publish` recipe or `test_data/config.toml` — both were removed from an earlier revision — and `catalog_replay_client` stays on `None` until its store is regenerated. (A few unrelated construction sites, such as the `nef-lock-catalog` lock binary, simply set `None` to satisfy the new field; that binary talks to a different endpoint and never resolves.)

## Turning it on later

The first lts pin lands as one atomic change, gated on HUB-119 (flox/floxhub#1908) reaching production — recording before then would capture unfiltered responses that diverge from what lts filtering returns. That change sets `_FLOX_RESOLVE_STABILITY=lts` in the recording recipes and the test-running contexts, flips `catalog_replay_client` from `None` to `stability_from_env()` (the other replay helper already reads it), and force-regenerates both stores. Order matters inside that step: the mk_data store has to be regenerated first, with `just md -f`, because `gen-unit-data-no-publish`'s own test suite replays the mk_data store through `catalog_replay_client`, which by then sends `lts` — those replays fail unless the mk_data cassettes already carry a matching key. Plain `just md` will not do it, since it skips any cassette whose file already exists; the `-f` forces the rewrite. With both stores regenerated, both replay suites should come back green. Each of these moves depends on the others, which is why they land together rather than piecemeal.

## Scope and verification

Cassette regeneration is intentionally excluded, and so is setting the variable anywhere. Verified locally with the variable unset, its state throughout this PR: `cargo test -p floxhub-client` passes 69/69, and a targeted `cargo nextest` run across the catalog, lock, resolve, manifest, and install replay suites passes 313/314 — the one failure is the known pre-existing flake `manifest_builds_of_filenames_with_special_characters_sandbox_off`, tracked as CLI-146.

One adjacent path stays deliberately separate. `latest_prod_versions.json` (`get_prod_package_version`) does not use resolve and should not be converted to it; its value is cross-confirming recorded versions through a different mechanism. If its versions diverge from lts-pinned resolves once HUB-119 is deployed, the follow-up is to filter its entries client-side by the stabilities metadata already present in the versions payload.

Fixes CLI-144

## Release Notes

N/A — internal test/regen tooling only; no user-facing behavior change.

---
*Via Forge (interactive) • 798bbb29*