### PR TITLE
build: remove the kerberos compile time feature flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ on:
           - "nix-plugins-dev"
           - "cli-unit"
           - "nix-build"
-          - "nix-build-kerberos"
           - "trigger-flox-installers-workflow"
           - "report-failure"
           - "nix-build-bats-tests"
@@ -285,77 +284,6 @@ jobs:
           FLOX_VERSION="${FLOX_VERSION:1}"
           echo "flox-version=$FLOX_VERSION" >> $GITHUB_OUTPUT
 
-  nix-build-kerberos:
-    name: "Verify Kerberos CLI build"
-    # Same as nix-build: fork PRs lack the secrets this job needs. The required
-    # "Verify Kerberos CLI build (*)" contexts come from the community-ci draft.
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
-    runs-on: "ubuntu-latest"
-    timeout-minutes: 60
-
-    permissions:
-      id-token: write # Needed for AWS Creds
-
-    strategy:
-      fail-fast: false
-      matrix:
-        system:
-          - "x86_64-linux"
-          - "aarch64-linux"
-
-    steps:
-      - name: "Checkout"
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          fetch-depth: 0
-
-      - name: "Setup upterm session"
-        if: ${{ (true == inputs.enableUpterm) && (inputs.breakOnJob == github.job) }}
-        uses: owenthereal/action-upterm@f26ebc11e22a09b8365f39d2cdafd06f63b42053 # v1
-        with:
-          limit-access-to-actor: true
-          limit-access-to-users: ${{ inputs.allowedUptermUsers }}
-          wait-timeout-minutes: 15
-
-      - name: "Setup"
-        uses: "./.github/actions/common-setup"
-        with:
-          GITHUB_ACCESS_TOKEN: "${{ secrets.MANAGED_FLOXBOT_GITHUB_ACCESS_TOKEN_REPO_SCOPE }}"
-          SUBSTITUTER: "${{ vars.MANAGED_CACHE_PUBLIC_S3_BUCKET }}"
-          SUBSTITUTER_KEY: "${{ secrets.MANAGED_CACHE_PUBLIC_SECRET_KEY }}"
-          AWS_ACCESS_KEY_ID: "${{ secrets.MANAGED_CACHE_PUBLIC_AWS_ACCESS_KEY_ID }}"
-          AWS_SECRET_ACCESS_KEY: "${{ secrets.MANAGED_CACHE_PUBLIC_AWS_SECRET_ACCESS_KEY }}"
-          SSH_KEY: "${{ secrets.MANAGED_FLOXBOT_SSH_KEY }}"
-          TAILSCALE_URL: "${{ vars.MANAGED_TAILSCALE_URL }}"
-          TAILSCALE_AUTH_KEY: "${{ secrets.MANAGED_TAILSCALE_AUTH_KEY }}"
-          REMOTE_BUILDERS: "${{ vars.MANAGED_REMOTE_BUILDERS }}"
-          SYSTEM: "${{ matrix.system }}"
-          SETUP_NIX: "false"
-
-      - name: "Configure AWS Credentials"
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6
-        with:
-          role-to-assume: "arn:aws:iam::759020684799:role/github-oidc-role-flox-cache-public"
-          role-session-name: "${{ github.run_id }}"
-          aws-region: "us-east-1"
-          output-env-credentials: true
-          unset-current-credentials: true
-
-      - name: "Build flox-cli-kerberos"
-        id: "build-kerberos"
-        env:
-          NIX_SUBSTITUTER: "${{ vars.MANAGED_CACHE_PUBLIC_S3_BUCKET }}"
-          NIX_SUBSTITUTER_KEY: "${{ secrets.MANAGED_CACHE_PUBLIC_SECRET_KEY }}"
-        run: |
-          export AWS_ACCESS_KEY_ID
-          export AWS_SECRET_ACCESS_KEY
-          export AWS_SESSION_TOKEN
-          export NIX_SUBSTITUTER_KEY
-
-          echo "::group::Building packages.${{ matrix.system }}.flox-cli-kerberos"
-          ./.github/scripts/remote-execute-nix-build.sh "packages.${{ matrix.system }}.flox-cli-kerberos" "$NIX_SUBSTITUTER"
-          echo "::endgroup::"
-
   trigger-flox-installers-workflow:
     name: "Build installers"
     if: ${{ (github.base_ref == 'refs/heads/main' || github.ref == 'refs/heads/main') && github.event_name == 'push' }}
@@ -419,7 +347,6 @@ jobs:
 
     needs:
       - "nix-build"
-      - "nix-build-kerberos"
       - "nix-plugins-dev"
       - "cli-unit"
       - "nix-build-bats-tests"

--- a/.github/workflows/nix-managed-lints.yml
+++ b/.github/workflows/nix-managed-lints.yml
@@ -106,6 +106,7 @@ jobs:
           nix develop -L --no-update-lock-file --command \
             pre-commit run \
               --verbose \
+              --show-diff-on-failure \
               --hook-stage manual \
               --from-ref "$( git rev-parse "target" )" \
               --to-ref   "$( git rev-parse "head" )";

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,7 +143,11 @@ signal-hook = "0.4.3"
 
 # build(.rs) dependencies
 openapiv3 = "2.2"
-prettyplease = "0.2"
+# libgssapi{-sys} -> bindgen enables prettyplease[verbatim].
+# Due to feature unification, when compiling flox crates using prettyplease
+# ({catalog,factory}-api-v1), the generated client code changes when built
+# together with another crate that depends on libgssapi.
+prettyplease = { version = "0.2", features = ["verbatim"] }
 progenitor = "0.11.2"
 syn = "2.0"
 

--- a/cli/catalog-api-v1/src/client.rs
+++ b/cli/catalog-api-v1/src/client.rs
@@ -5550,7 +5550,7 @@ Sends a `POST` request to `/api/v1/catalog/build-inputs/lookup`
         ResponseValue<types::BuildInputsLookupResponse>,
         Error<types::ErrorResponse>,
     > {
-        let url = format!("{}/api/v1/catalog/build-inputs/lookup", self.baseurl,);
+        let url = format!("{}/api/v1/catalog/build-inputs/lookup", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map
             .append(
@@ -5601,7 +5601,7 @@ Sends a `POST` request to `/api/v1/catalog/catalogs/`
         &'a self,
         name: &'a types::CatalogName,
     ) -> Result<ResponseValue<types::UserCatalog>, Error<types::ErrorResponse>> {
-        let url = format!("{}/api/v1/catalog/catalogs/", self.baseurl,);
+        let url = format!("{}/api/v1/catalog/catalogs/", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map
             .append(
@@ -5655,8 +5655,9 @@ Sends a `GET` request to `/api/v1/catalog/catalogs/{catalog_name}`
         catalog_name: &'a types::CatalogName,
     ) -> Result<ResponseValue<types::UserCatalog>, Error<types::ErrorResponse>> {
         let url = format!(
-            "{}/api/v1/catalog/catalogs/{}", self.baseurl, encode_path(& catalog_name
-            .to_string()),
+            "{}/api/v1/catalog/catalogs/{}",
+            self.baseurl,
+            encode_path(&catalog_name.to_string()),
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map
@@ -5712,8 +5713,9 @@ Sends a `DELETE` request to `/api/v1/catalog/catalogs/{catalog_name}`
         catalog_name: &'a types::CatalogName,
     ) -> Result<ResponseValue<::serde_json::Value>, Error<types::ErrorResponse>> {
         let url = format!(
-            "{}/api/v1/catalog/catalogs/{}", self.baseurl, encode_path(& catalog_name
-            .to_string()),
+            "{}/api/v1/catalog/catalogs/{}",
+            self.baseurl,
+            encode_path(&catalog_name.to_string()),
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map
@@ -5782,8 +5784,9 @@ Sends a `GET` request to `/api/v1/catalog/catalogs/{catalog_name}/locked-sources
         Error<types::ErrorResponse>,
     > {
         let url = format!(
-            "{}/api/v1/catalog/catalogs/{}/locked-sources", self.baseurl, encode_path(&
-            catalog_name.to_string()),
+            "{}/api/v1/catalog/catalogs/{}/locked-sources",
+            self.baseurl,
+            encode_path(&catalog_name.to_string()),
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map
@@ -5841,8 +5844,9 @@ Sends a `GET` request to `/api/v1/catalog/catalogs/{catalog_name}/packages`
         catalog_name: &'a types::CatalogName,
     ) -> Result<ResponseValue<types::UserPackageList>, Error<types::ErrorResponse>> {
         let url = format!(
-            "{}/api/v1/catalog/catalogs/{}/packages", self.baseurl, encode_path(&
-            catalog_name.to_string()),
+            "{}/api/v1/catalog/catalogs/{}/packages",
+            self.baseurl,
+            encode_path(&catalog_name.to_string()),
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map
@@ -5903,8 +5907,9 @@ Sends a `POST` request to `/api/v1/catalog/catalogs/{catalog_name}/packages`
         body: &'a types::UserPackageCreate,
     ) -> Result<ResponseValue<types::UserPackage>, Error<types::ErrorResponse>> {
         let url = format!(
-            "{}/api/v1/catalog/catalogs/{}/packages", self.baseurl, encode_path(&
-            catalog_name.to_string()),
+            "{}/api/v1/catalog/catalogs/{}/packages",
+            self.baseurl,
+            encode_path(&catalog_name.to_string()),
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map
@@ -5972,8 +5977,10 @@ Sends a `GET` request to `/api/v1/catalog/catalogs/{catalog_name}/packages/{pack
         package_name: &'a types::PackageName,
     ) -> Result<ResponseValue<types::UserPackage>, Error<types::ErrorResponse>> {
         let url = format!(
-            "{}/api/v1/catalog/catalogs/{}/packages/{}", self.baseurl, encode_path(&
-            catalog_name.to_string()), encode_path(& package_name.to_string()),
+            "{}/api/v1/catalog/catalogs/{}/packages/{}",
+            self.baseurl,
+            encode_path(&catalog_name.to_string()),
+            encode_path(&package_name.to_string()),
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map
@@ -6031,9 +6038,10 @@ Sends a `GET` request to `/api/v1/catalog/catalogs/{catalog_name}/packages/{pack
         package_name: &'a types::PackageName,
     ) -> Result<ResponseValue<types::PackageBuildList>, Error<types::ErrorResponse>> {
         let url = format!(
-            "{}/api/v1/catalog/catalogs/{}/packages/{}/builds", self.baseurl,
-            encode_path(& catalog_name.to_string()), encode_path(& package_name
-            .to_string()),
+            "{}/api/v1/catalog/catalogs/{}/packages/{}/builds",
+            self.baseurl,
+            encode_path(&catalog_name.to_string()),
+            encode_path(&package_name.to_string()),
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map
@@ -6097,9 +6105,10 @@ Sends a `PUT` request to `/api/v1/catalog/catalogs/{catalog_name}/packages/{pack
         Error<types::ErrorResponse>,
     > {
         let url = format!(
-            "{}/api/v1/catalog/catalogs/{}/packages/{}/builds", self.baseurl,
-            encode_path(& catalog_name.to_string()), encode_path(& package_name
-            .to_string()),
+            "{}/api/v1/catalog/catalogs/{}/packages/{}/builds",
+            self.baseurl,
+            encode_path(&catalog_name.to_string()),
+            encode_path(&package_name.to_string()),
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map
@@ -6168,9 +6177,10 @@ Sends a `POST` request to `/api/v1/catalog/catalogs/{catalog_name}/packages/{pac
         Error<types::ErrorResponse>,
     > {
         let url = format!(
-            "{}/api/v1/catalog/catalogs/{}/packages/{}/builds", self.baseurl,
-            encode_path(& catalog_name.to_string()), encode_path(& package_name
-            .to_string()),
+            "{}/api/v1/catalog/catalogs/{}/packages/{}/builds",
+            self.baseurl,
+            encode_path(&catalog_name.to_string()),
+            encode_path(&package_name.to_string()),
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map
@@ -6247,9 +6257,10 @@ Sends a `POST` request to `/api/v1/catalog/catalogs/{catalog_name}/packages/{pac
         body: &'a types::CheckBuildRequest,
     ) -> Result<ResponseValue<types::CheckBuildResponse>, Error<types::ErrorResponse>> {
         let url = format!(
-            "{}/api/v1/catalog/catalogs/{}/packages/{}/check-build", self.baseurl,
-            encode_path(& catalog_name.to_string()), encode_path(& package_name
-            .to_string()),
+            "{}/api/v1/catalog/catalogs/{}/packages/{}/check-build",
+            self.baseurl,
+            encode_path(&catalog_name.to_string()),
+            encode_path(&package_name.to_string()),
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map
@@ -6312,9 +6323,10 @@ Sends a `POST` request to `/api/v1/catalog/catalogs/{catalog_name}/packages/{pac
         Error<types::ErrorResponse>,
     > {
         let url = format!(
-            "{}/api/v1/catalog/catalogs/{}/packages/{}/publish/info", self.baseurl,
-            encode_path(& catalog_name.to_string()), encode_path(& package_name
-            .to_string()),
+            "{}/api/v1/catalog/catalogs/{}/packages/{}/publish/info",
+            self.baseurl,
+            encode_path(&catalog_name.to_string()),
+            encode_path(&package_name.to_string()),
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map
@@ -6378,8 +6390,9 @@ Sends a `GET` request to `/api/v1/catalog/catalogs/{catalog_name}/store/config`
         Error<types::ErrorResponse>,
     > {
         let url = format!(
-            "{}/api/v1/catalog/catalogs/{}/store/config", self.baseurl, encode_path(&
-            catalog_name.to_string()),
+            "{}/api/v1/catalog/catalogs/{}/store/config",
+            self.baseurl,
+            encode_path(&catalog_name.to_string()),
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map
@@ -6442,8 +6455,9 @@ Sends a `PUT` request to `/api/v1/catalog/catalogs/{catalog_name}/store/config`
         Error<types::ErrorResponse>,
     > {
         let url = format!(
-            "{}/api/v1/catalog/catalogs/{}/store/config", self.baseurl, encode_path(&
-            catalog_name.to_string()),
+            "{}/api/v1/catalog/catalogs/{}/store/config",
+            self.baseurl,
+            encode_path(&catalog_name.to_string()),
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map
@@ -6488,7 +6502,7 @@ Sends a `GET` request to `/api/v1/catalog/info/base-catalog`
     pub async fn get_base_catalog_api_v1_catalog_info_base_catalog_get<'a>(
         &'a self,
     ) -> Result<ResponseValue<types::BaseCatalogInfo>, Error<types::ErrorResponse>> {
-        let url = format!("{}/api/v1/catalog/info/base-catalog", self.baseurl,);
+        let url = format!("{}/api/v1/catalog/info/base-catalog", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map
             .append(
@@ -6544,8 +6558,9 @@ Sends a `GET` request to `/api/v1/catalog/packages/{attr_path}`
         page_size: Option<i64>,
     ) -> Result<ResponseValue<types::PackagesResult>, Error<types::ErrorResponse>> {
         let url = format!(
-            "{}/api/v1/catalog/packages/{}", self.baseurl, encode_path(& attr_path
-            .to_string()),
+            "{}/api/v1/catalog/packages/{}",
+            self.baseurl,
+            encode_path(&attr_path.to_string()),
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map
@@ -6639,7 +6654,7 @@ Sends a `POST` request to `/api/v1/catalog/resolve`
         ResponseValue<types::ResolvedPackageGroups>,
         Error<types::ErrorResponse>,
     > {
-        let url = format!("{}/api/v1/catalog/resolve", self.baseurl,);
+        let url = format!("{}/api/v1/catalog/resolve", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map
             .append(
@@ -6702,7 +6717,7 @@ Sends a `POST` request to `/api/v1/catalog/sbom/environment`
         ResponseValue<::serde_json::Map<::std::string::String, ::serde_json::Value>>,
         Error<types::ErrorResponse>,
     > {
-        let url = format!("{}/api/v1/catalog/sbom/environment", self.baseurl,);
+        let url = format!("{}/api/v1/catalog/sbom/environment", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map
             .append(
@@ -6773,8 +6788,9 @@ Arguments:
         Error<types::ErrorResponse>,
     > {
         let url = format!(
-            "{}/api/v1/catalog/sbom/package/{}", self.baseurl, encode_path(& derivation
-            .to_string()),
+            "{}/api/v1/catalog/sbom/package/{}",
+            self.baseurl,
+            encode_path(&derivation.to_string()),
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map
@@ -6837,7 +6853,7 @@ Sends a `GET` request to `/api/v1/catalog/search`
         search_term: Option<&'a types::SearchTerm>,
         system: types::PackageSystem,
     ) -> Result<ResponseValue<types::PackageSearchResult>, Error<types::ErrorResponse>> {
-        let url = format!("{}/api/v1/catalog/search", self.baseurl,);
+        let url = format!("{}/api/v1/catalog/search", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map
             .append(
@@ -6893,8 +6909,9 @@ Sends a `POST` request to `/api/v1/catalog/settings/{key}`
         value: &'a str,
     ) -> Result<ResponseValue<::serde_json::Value>, Error<types::ErrorResponse>> {
         let url = format!(
-            "{}/api/v1/catalog/settings/{}", self.baseurl, encode_path(& key
-            .to_string()),
+            "{}/api/v1/catalog/settings/{}",
+            self.baseurl,
+            encode_path(&key.to_string()),
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map
@@ -6947,7 +6964,7 @@ Sends a `POST` request to `/api/v1/catalog/store`
         &'a self,
         body: &'a types::StoreInfoRequest,
     ) -> Result<ResponseValue<types::StoreInfoResponse>, Error<types::ErrorResponse>> {
-        let url = format!("{}/api/v1/catalog/store", self.baseurl,);
+        let url = format!("{}/api/v1/catalog/store", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map
             .append(
@@ -7001,7 +7018,7 @@ Sends a `POST` request to `/api/v1/catalog/store/status`
         ResponseValue<types::StorepathStatusResponse>,
         Error<types::ErrorResponse>,
     > {
-        let url = format!("{}/api/v1/catalog/store/status", self.baseurl,);
+        let url = format!("{}/api/v1/catalog/store/status", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map
             .append(

--- a/cli/factory-api-v1/src/client.rs
+++ b/cli/factory-api-v1/src/client.rs
@@ -597,7 +597,7 @@ Sends a `GET` request to `/api/v1/factory/builds`
         page_size: Option<::std::num::NonZeroU64>,
         status: Option<&'a str>,
     ) -> Result<ResponseValue<types::BuildListResponse>, Error<types::ErrorResponse>> {
-        let url = format!("{}/api/v1/factory/builds", self.baseurl,);
+        let url = format!("{}/api/v1/factory/builds", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map
             .append(
@@ -644,8 +644,9 @@ Sends a `GET` request to `/api/v1/factory/builds/{build_id}`
         build_id: i64,
     ) -> Result<ResponseValue<types::BuildResponse>, Error<types::ErrorResponse>> {
         let url = format!(
-            "{}/api/v1/factory/builds/{}", self.baseurl, encode_path(& build_id
-            .to_string()),
+            "{}/api/v1/factory/builds/{}",
+            self.baseurl,
+            encode_path(&build_id.to_string()),
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map
@@ -727,8 +728,9 @@ Sends a `DELETE` request to `/api/v1/factory/builds/{build_id}`
         build_id: i64,
     ) -> Result<ResponseValue<types::BuildResponse>, Error<types::ErrorResponse>> {
         let url = format!(
-            "{}/api/v1/factory/builds/{}", self.baseurl, encode_path(& build_id
-            .to_string()),
+            "{}/api/v1/factory/builds/{}",
+            self.baseurl,
+            encode_path(&build_id.to_string()),
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map
@@ -795,8 +797,9 @@ Sends a `GET` request to `/api/v1/factory/builds/{build_id}/logs`
         build_id: i64,
     ) -> Result<ResponseValue<ByteStream>, Error<types::ErrorResponse>> {
         let url = format!(
-            "{}/api/v1/factory/builds/{}/logs", self.baseurl, encode_path(& build_id
-            .to_string()),
+            "{}/api/v1/factory/builds/{}/logs",
+            self.baseurl,
+            encode_path(&build_id.to_string()),
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map

--- a/cli/flox-config/src/config.rs
+++ b/cli/flox-config/src/config.rs
@@ -31,8 +31,8 @@ pub type SearchLimit = NonZeroU8;
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum AuthnMode {
-    /// Auth0 authentication
-    Auth0,
+    /// Token authentication
+    Token,
     /// Kerberos authentication
     Kerberos,
 }

--- a/cli/flox-rust-sdk/Cargo.toml
+++ b/cli/flox-rust-sdk/Cargo.toml
@@ -70,10 +70,6 @@ floxhub-client = { workspace = true, features = ["tests"] }
 
 
 [features]
-# Catalog authentication strategy
-# Kerberos authentication is available when this feature is enabled
-floxhub-authn-kerberos = ["floxhub-client/floxhub-authn-kerberos"]
-
 # allow exporting test helpers in dev mode only
 tests = [
     "dep:tracing-subscriber",

--- a/cli/flox/Cargo.toml
+++ b/cli/flox/Cargo.toml
@@ -85,4 +85,3 @@ flox-manifest = { workspace = true, features = [ "tests" ]}
 [features]
 extra-tests = ["impure-unit-tests"]
 impure-unit-tests = []
-floxhub-authn-kerberos = ["flox-rust-sdk/floxhub-authn-kerberos"]

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -571,7 +571,7 @@ impl FloxArgs {
 fn effective_authn_mode(config: &Config) -> AuthnMode {
     match config.flox.floxhub_authn_mode {
         None => AuthnMode::default(),
-        Some(flox_config::AuthnMode::Auth0) => AuthnMode::Auth0,
+        Some(flox_config::AuthnMode::Token) => AuthnMode::Auth0,
         Some(flox_config::AuthnMode::Kerberos) => AuthnMode::Kerberos,
     }
 }

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -327,7 +327,7 @@ impl FloxArgs {
 
         let floxhub = Floxhub::new(floxhub_url, api_url_override, git_url_override)?;
 
-        let authn_mode = effective_authn_mode(&config)?;
+        let authn_mode = effective_authn_mode(&config);
         let floxhub_token = self.resolve_floxhub_token(&config, &authn_mode);
 
         let metrics_device_uuid = (!config.flox.disable_metrics)
@@ -566,21 +566,13 @@ impl FloxArgs {
     }
 }
 
-/// Resolve the configured authn mode to the client's, applying the
-/// compiled-in default when unset.
-///
-/// The config enum always parses both modes; the client enum only carries the
-/// modes compiled into this build.
-fn effective_authn_mode(config: &Config) -> Result<AuthnMode> {
+/// Resolve the configured authn mode to the client's, applying the default
+/// when unset.
+fn effective_authn_mode(config: &Config) -> AuthnMode {
     match config.flox.floxhub_authn_mode {
-        None => Ok(AuthnMode::default()),
-        Some(flox_config::AuthnMode::Auth0) => Ok(AuthnMode::Auth0),
-        #[cfg(feature = "floxhub-authn-kerberos")]
-        Some(flox_config::AuthnMode::Kerberos) => Ok(AuthnMode::Kerberos),
-        #[cfg(not(feature = "floxhub-authn-kerberos"))]
-        Some(flox_config::AuthnMode::Kerberos) => Err(anyhow!(
-            "Kerberos authentication is not supported by this build."
-        )),
+        None => AuthnMode::default(),
+        Some(flox_config::AuthnMode::Auth0) => AuthnMode::Auth0,
+        Some(flox_config::AuthnMode::Kerberos) => AuthnMode::Kerberos,
     }
 }
 

--- a/cli/floxhub-client/Cargo.toml
+++ b/cli/floxhub-client/Cargo.toml
@@ -23,9 +23,9 @@ url.workspace = true
 httpmock.workspace = true
 serde_yaml.workspace = true
 
-# Optional dependencies for GSSAPI/Kerberos authentication
-libgssapi = { workspace = true, optional = true }
-base64 = { workspace = true, optional = true }
+# GSSAPI/Kerberos authentication
+libgssapi.workspace = true
+base64.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
@@ -39,6 +39,3 @@ tracing-subscriber.workspace = true
 [features]
 default = []
 tests = []
-# Catalog authentication strategy
-# Kerberos authentication is available when this feature is enabled
-floxhub-authn-kerberos = ["dep:libgssapi", "dep:base64"]

--- a/cli/floxhub-client/src/auth/auth_context_factory/mod.rs
+++ b/cli/floxhub-client/src/auth/auth_context_factory/mod.rs
@@ -3,8 +3,6 @@
 use crate::auth::{AuthContext, AuthnMode};
 use crate::token::FloxhubToken;
 
-// Conditionally include Kerberos
-#[cfg(feature = "floxhub-authn-kerberos")]
 mod kerberos;
 
 impl AuthContext {
@@ -14,13 +12,9 @@ impl AuthContext {
     /// - Kerberos: resolves the principal and embeds a SPNEGO token generator;
     ///   returns `Kerberos(None)` (with a warning log) if the ticket cannot be
     ///   resolved.
-    // TODO(ENT-101): surface a user-friendly error when the configured authn
-    // mode is not supported by this build (e.g. kerberos mode without the
-    // floxhub-authn-kerberos feature).
     pub fn from_mode(mode: &AuthnMode, floxhub_token: Option<FloxhubToken>) -> Self {
         match mode {
             AuthnMode::Auth0 => AuthContext::Auth0(floxhub_token),
-            #[cfg(feature = "floxhub-authn-kerberos")]
             AuthnMode::Kerberos => kerberos::kerberos_credential(),
         }
     }

--- a/cli/floxhub-client/src/auth/mod.rs
+++ b/cli/floxhub-client/src/auth/mod.rs
@@ -1,10 +1,9 @@
 //! Authentication for catalog client requests
 //!
-//! This module provides credential creation via compile-time selection of
-//! authentication method. The available methods are:
+//! The available methods are:
 //!
-//! - Default (no feature): Auth0 authentication only (no Kerberos dependencies)
-//! - `floxhub-authn-kerberos`: Kerberos authentication via GSSAPI
+//! - Auth0 authentication
+//! - Kerberos authentication via GSSAPI
 
 use serde::{Deserialize, Serialize};
 
@@ -14,7 +13,6 @@ mod auth_context_factory;
 pub use auth_context::{AuthContext, AuthFailure, AuthHeaderError, KerberosMaterial};
 
 /// Errors from authentication validation (internal, used by Kerberos credential acquisition).
-#[cfg(feature = "floxhub-authn-kerberos")]
 #[derive(Debug, Clone, thiserror::Error)]
 pub(crate) enum AuthError {
     #[error("{0}")]
@@ -22,28 +20,12 @@ pub(crate) enum AuthError {
 }
 
 /// Available authentication methods
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum AuthnMode {
     /// Auth0 authentication
+    #[default]
     Auth0,
     /// Kerberos authentication
-    #[cfg(feature = "floxhub-authn-kerberos")]
     Kerberos,
-}
-
-#[cfg(not(feature = "floxhub-authn-kerberos"))]
-#[allow(clippy::derivable_impls)]
-impl Default for AuthnMode {
-    fn default() -> Self {
-        AuthnMode::Auth0
-    }
-}
-
-#[cfg(feature = "floxhub-authn-kerberos")]
-#[allow(clippy::derivable_impls)]
-impl Default for AuthnMode {
-    fn default() -> Self {
-        AuthnMode::Kerberos
-    }
 }

--- a/cli/nef-lock-catalog/Cargo.toml
+++ b/cli/nef-lock-catalog/Cargo.toml
@@ -20,6 +20,3 @@ flox-core = {path = "../flox-core"}
 rnix.workspace = true
 rowan.workspace = true
 tokio.workspace = true
-
-[features]
-floxhub-authn-kerberos = ["floxhub-client/floxhub-authn-kerberos"]

--- a/cli/nef-lock-catalog/src/bin/lock.rs
+++ b/cli/nef-lock-catalog/src/bin/lock.rs
@@ -3,7 +3,7 @@ use std::io::IsTerminal;
 use std::path::PathBuf;
 use std::process::ExitCode;
 
-use anyhow::{Result, anyhow, bail};
+use anyhow::{Result, bail};
 use clap::Parser;
 use flox_config::Config;
 use flox_core::floxhub::{DEFAULT_FLOXHUB_URL, Floxhub};
@@ -197,7 +197,7 @@ fn build_client(config: &Config, floxhub_token: Option<String>) -> Result<Floxhu
 
     let floxhub_token = floxhub_token.map(|token| token.parse()).transpose()?;
     let auth_context = AuthContext::from_mode(
-        &effective_authn_mode(&config.flox.floxhub_authn_mode)?,
+        &effective_authn_mode(&config.flox.floxhub_authn_mode),
         floxhub_token,
     );
 
@@ -212,23 +212,13 @@ fn build_client(config: &Config, floxhub_token: Option<String>) -> Result<Floxhu
     Ok(FloxhubClient::new(config)?)
 }
 
-/// Resolve the configured authn mode to the client's, applying the
-/// compiled-in default when unset.
-///
-/// The config enum always parses both modes; the client enum only carries the
-/// modes compiled into this build.
-/// The config enum always parses both modes; the client enum only carries the
-/// modes compiled into this build.
-fn effective_authn_mode(mode: &Option<flox_config::AuthnMode>) -> Result<AuthnMode> {
+/// Resolve the configured authn mode to the client's, applying the default
+/// when unset.
+fn effective_authn_mode(mode: &Option<flox_config::AuthnMode>) -> AuthnMode {
     match mode {
-        None => Ok(AuthnMode::default()),
-        Some(flox_config::AuthnMode::Auth0) => Ok(AuthnMode::Auth0),
-        #[cfg(feature = "floxhub-authn-kerberos")]
-        Some(flox_config::AuthnMode::Kerberos) => Ok(AuthnMode::Kerberos),
-        #[cfg(not(feature = "floxhub-authn-kerberos"))]
-        Some(flox_config::AuthnMode::Kerberos) => Err(anyhow!(
-            "Kerberos authentication is not supported by this build."
-        )),
+        None => AuthnMode::default(),
+        Some(flox_config::AuthnMode::Auth0) => AuthnMode::Auth0,
+        Some(flox_config::AuthnMode::Kerberos) => AuthnMode::Kerberos,
     }
 }
 

--- a/cli/nef-lock-catalog/src/bin/lock.rs
+++ b/cli/nef-lock-catalog/src/bin/lock.rs
@@ -217,7 +217,7 @@ fn build_client(config: &Config, floxhub_token: Option<String>) -> Result<Floxhu
 fn effective_authn_mode(mode: &Option<flox_config::AuthnMode>) -> AuthnMode {
     match mode {
         None => AuthnMode::default(),
-        Some(flox_config::AuthnMode::Auth0) => AuthnMode::Auth0,
+        Some(flox_config::AuthnMode::Token) => AuthnMode::Auth0,
         Some(flox_config::AuthnMode::Kerberos) => AuthnMode::Kerberos,
     }
 }

--- a/flake.nix
+++ b/flake.nix
@@ -110,26 +110,6 @@
           nef-lock-catalog = callPackage ./pkgs/nef-lock-catalog { };
           flox-cli = callPackage ./pkgs/flox-cli { };
 
-          # Kerberos-enabled variant with GSSAPI authentication
-          flox-cli-kerberos = callPackage ./pkgs/flox-cli {
-            overrideCatalogAuth = "floxhub-authn-kerberos";
-            rust-internal-deps = final.rust-internal-deps.override {
-              overrideCatalogAuth = "floxhub-authn-kerberos";
-              rust-external-deps = final.rust-external-deps.override {
-                overrideCatalogAuth = "floxhub-authn-kerberos";
-              };
-              flox-package-builder = final.flox-package-builder.override {
-                nef-lock-catalog = final.nef-lock-catalog.override {
-                  overrideCatalogAuth = "floxhub-authn-kerberos";
-                  rust-external-deps = final.rust-external-deps.override {
-                    overrideCatalogAuth = "floxhub-authn-kerberos";
-                  };
-                };
-              };
-            };
-
-          };
-
           flox-manpages = callPackage ./pkgs/flox-manpages { }; # Flox Command Line Interface Manpages
           flox = callPackage ./pkgs/flox { }; # Flox Command Line Interface ( production build ).
 
@@ -216,7 +196,6 @@
           flox-activations
           nef-lock-catalog
           flox-cli
-          flox-cli-kerberos
           flox-cli-tests
           flox-manpages
           flox

--- a/pkgs/flox-cli/default.nix
+++ b/pkgs/flox-cli/default.nix
@@ -18,9 +18,6 @@
   rust-toolchain,
   rustfmt ? rust-toolchain.rustfmt,
   stdenv,
-  # Override catalog authentication strategy if needed
-  # Options: "floxhub-authn-kerberos"
-  overrideCatalogAuth ? null,
 }:
 let
   FLOX_VERSION = lib.fileContents ./../../VERSION;
@@ -84,11 +81,7 @@ craneLib.buildPackage (
 
     # Set up incremental compilation
     cargoArtifacts = rust-internal-deps;
-    cargoExtraArgs =
-      "--locked -p flox"
-      + lib.optionalString (
-        overrideCatalogAuth != null
-      ) " --features flox-rust-sdk/${overrideCatalogAuth}";
+    cargoExtraArgs = "--locked -p flox";
 
     # runtime dependencies
     buildInputs = rust-internal-deps.buildInputs ++ [ ];

--- a/pkgs/nef-lock-catalog/default.nix
+++ b/pkgs/nef-lock-catalog/default.nix
@@ -10,9 +10,6 @@
   flox-src,
   rust-external-deps,
   stdenv,
-  # Override catalog authentication strategy if needed
-  # Options: "floxhub-authn-kerberos"
-  overrideCatalogAuth ? null,
 }:
 let
   FLOX_VERSION = lib.fileContents ./../../VERSION;
@@ -51,9 +48,7 @@ craneLib.buildPackage (
     #
     # `nef-lock-catalog` is not a cargo default-member, so it must be built
     # explicitly with `-p`.
-    cargoExtraArgs =
-      "--locked -p nef-lock-catalog"
-      + lib.optionalString (overrideCatalogAuth != null) " --features ${overrideCatalogAuth}";
+    cargoExtraArgs = "--locked -p nef-lock-catalog";
 
     CARGO_PROFILE = "small";
 

--- a/pkgs/rust-external-deps/default.nix
+++ b/pkgs/rust-external-deps/default.nix
@@ -10,9 +10,6 @@
   stdenv,
   flox-src,
   llvmPackages,
-  # Override catalog authentication strategy
-  # Options: "floxhub-authn-kerberos"
-  overrideCatalogAuth ? null,
 }:
 let
   # crane (<https://crane.dev/>) library for building rust packages
@@ -39,22 +36,19 @@ let
 
       src = craneLib.cleanCargoSource (craneLib.path flox-src);
 
-      # Override catalog authentication strategy if needed
-      cargoExtraArgs =
-        if overrideCatalogAuth != null then "--features flox-rust-sdk/${overrideCatalogAuth}" else "";
-
       # runtime dependencies of the dependent crates
       buildInputs = [
         # reqwest -> hyper -> openssl-sys
         openssl.dev
-      ]
-      # Conditionally include Kerberos dependencies for GSSAPI
-      ++ lib.optional (overrideCatalogAuth == "floxhub-authn-kerberos") krb5.dev;
+        # Kerberos dependency for GSSAPI
+        krb5.dev
+      ];
 
       nativeBuildInputs = [
         pkg-config
+        # required to build libgssapi bindings
+        rustPlatform.bindgenHook
       ]
-      ++ lib.optional (overrideCatalogAuth == "floxhub-authn-kerberos") rustPlatform.bindgenHook
       ++ lib.optional (stdenv.hostPlatform.system == "x86_64-linux") llvmPackages.bintools;
       passthru = {
         inherit envs;

--- a/pkgs/rust-internal-deps/default.nix
+++ b/pkgs/rust-internal-deps/default.nix
@@ -20,9 +20,6 @@
   rust-external-deps,
   rust-toolchain,
   stdenv,
-  # Override catalog authentication strategy if needed
-  # Options: "floxhub-authn-kerberos"
-  overrideCatalogAuth ? null,
 }:
 let
   FLOX_VERSION = lib.fileContents ./../../VERSION;
@@ -95,11 +92,7 @@ in
     # In this case we do want to build some of the crates in the workspace,
     # i.e. flox-rust-sdk, catalog-api-v1, and shared as dependencies of flox.
     # To achieve this, we copy the source of these crates back into the workspace.
-    cargoExtraArgs =
-      "--locked -p flox"
-      + lib.optionalString (
-        overrideCatalogAuth != null
-      ) " --features flox-rust-sdk/${overrideCatalogAuth}";
+    cargoExtraArgs = "--locked -p flox";
     postPatch = ''
       cp -rf --no-preserve=mode ${flox-src}/cli/flox-rust-sdk/* ./cli/flox-rust-sdk
       cp -rf --no-preserve=mode ${flox-src}/cli/flox-manifest/* ./cli/flox-manifest

--- a/shells/default/default.nix
+++ b/shells/default/default.nix
@@ -85,7 +85,7 @@ mkShell (
       flox-activations
     ];
 
-    # Include krb5 for development to enable building with GSSAPI feature
+    # krb5 is required to build the GSSAPI/Kerberos authentication support
     buildInputs = [ krb5.dev ];
     nativeBuildInputs = [ rustPlatform.bindgenHook ];
 


### PR DESCRIPTION
Remove the `floxhub-authn-kerberos` cargo feature and compile Kerberos (GSSAPI) authentication support unconditionally.
Kerberos becomes a runtime-selectable alternative authentication strategy in every build, chosen via the `floxhub_authn_mode` config setting. 

Changes:

* `floxhub-client`: `libgssapi` and `base64` become regular dependencies; all `#[cfg(feature = "floxhub-authn-kerberos")]` gates are removed. `AuthnMode::default()` is `Auth0`.

* The feature forwarding in `flox-rust-sdk`, `flox`, and `nef-lock-catalog` is removed, and the `effective_authn_mode` helpers no longer need an "unsupported in this build" error path.

Nix packaging: the `flox-cli-kerberos` package and the `overrideCatalogAuth` plumbing in `pkgs/rust-external-deps`, `pkgs/rust-internal-deps`, `pkgs/flox-cli`, and `pkgs/nef-lock-catalog` are removed. `krb5.dev` and `bindgenHook` become unconditional build inputs.
