### PR TITLE
fix(activate): source profile.d scripts from the environment, not the interpreter

### DIFF
--- a/assets/environment-interpreter/activate/activate
+++ b/assets/environment-interpreter/activate/activate
@@ -30,12 +30,8 @@ _flox_activations="@flox_activations@"
 
 set -euo pipefail
 
-# These all derive from the `flox-interpreter` package.
-# FIXME This is wrong; the profile.d scripts in particular should be
-#       sourced from the environment itself so that users can add pkgs
-#       which add additional scripts to the etc/profile.d directory.
+# The activation helper scripts derive from the `flox-interpreter` package.
 export _activate_d="__OUT__/activate.d"
-_profile_d="__OUT__/etc/profile.d"
 
 # shellcheck source-path=SCRIPTDIR/activate.d
 source "${_activate_d}/helpers.bash"
@@ -152,6 +148,12 @@ if [ -z "${_FLOX_ENV:-}" ]; then
   echo "$USAGE" >&2
   exit 1
 fi
+
+# Source profile.d scripts from the rendered environment rather than the
+# interpreter package so that scripts provided by installed packages are
+# processed in addition to the interpreter's own scripts, which are
+# symlinked into the environment as it is built.
+_profile_d="$_FLOX_ENV/etc/profile.d"
 
 # Convert the provided command string into an array of arguments in "$@".
 # Henceforth in the script it is assumed that these are the arguments to be

--- a/assets/environment-interpreter/wrapper/wrapper
+++ b/assets/environment-interpreter/wrapper/wrapper
@@ -30,12 +30,8 @@ _readlink="@coreutils@/bin/readlink"
 
 set -euo pipefail
 
-# These all derive from the `flox-interpreter` package.
-# FIXME This is wrong; the profile.d scripts in particular should be
-#       sourced from the environment itself so that users can add pkgs
-#       which add additional scripts to the etc/profile.d directory.
+# The activation helper scripts derive from the `flox-interpreter` package.
 _activate_d="__OUT__/activate.d"
-_profile_d="__OUT__/etc/profile.d"
 # shellcheck source-path=SCRIPTDIR/activate.d
 source "${_activate_d}/helpers.bash"
 
@@ -116,6 +112,12 @@ if [ -z "${FLOX_ENV-}" ]; then
   echo "$USAGE" >&2
   exit 1
 fi
+
+# Source profile.d scripts from the rendered environment rather than the
+# interpreter package so that scripts provided by installed packages are
+# processed in addition to the interpreter's own scripts, which are
+# symlinked into the environment as it is built.
+_profile_d="$FLOX_ENV/etc/profile.d"
 
 # prepend path
 export PATH="$FLOX_ENV/bin:$FLOX_ENV/sbin:$PATH"

--- a/cli/flox/doc/flox-activate.md
+++ b/cli/flox/doc/flox-activate.md
@@ -69,6 +69,17 @@ are set to the appropriate values for the environment in which the shell
 hook was defined.
 See [`manifest.toml(5)`](./manifest.toml.md) for more details on shell hooks.
 
+## Package-provided startup scripts
+
+Some packages ship startup scripts in their `etc/profile.d` directory.
+When such a package is installed to an environment,
+those scripts are linked into the environment's `etc/profile.d` directory,
+and activation sources every `*.sh` script found there in lexical order,
+alongside the startup scripts provided by Flox itself.
+These scripts run before the environment's `[hook]` and `[profile]` scripts.
+Activations in "run" mode source only the startup scripts provided by Flox,
+not those provided by packages.
+
 To reverse activation,
 run [`flox-deactivate(1)`](./flox-deactivate.md).
 Inside a `flox activate` subshell,

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -2695,6 +2695,39 @@ EOF
   assert_success
 }
 
+# Packages installed to an environment may provide their own etc/profile.d
+# scripts, which are linked into the rendered environment and must be sourced
+# from $FLOX_ENV on activation, not just the scripts provided by the
+# interpreter package.
+@test "profile: package-provided profile.d scripts are sourced from FLOX_ENV" {
+  project_setup
+
+  # Fabricate a package that provides an etc/profile.d script and install it
+  # to the environment as a store path.
+  mkdir -p "$BATS_TEST_TMPDIR/pkg/etc/profile.d"
+  cat > "$BATS_TEST_TMPDIR/pkg/etc/profile.d/0900_from-package.sh" <<'EOF'
+export _FLOX_PROFILE_D_TEST_VAR="from-package-profile.d"
+EOF
+  pkg_store_path="$(nix --extra-experimental-features nix-command \
+    store add --name profile-d-test-pkg "$BATS_TEST_TMPDIR/pkg")"
+  run "$FLOX_BIN" install "$pkg_store_path"
+  assert_success
+
+  SCRIPT="$(cat <<'EOF'
+    if ! [ -e "$FLOX_ENV/etc/profile.d/0900_from-package.sh" ]; then
+      echo "package profile.d script was not linked into the environment" >&3
+      exit 1
+    fi
+    if [ "$_FLOX_PROFILE_D_TEST_VAR" != "from-package-profile.d" ]; then
+      echo "package profile.d script was not sourced" >&3
+      exit 1
+    fi
+EOF
+  )"
+  FLOX_SHELL=bash run "$FLOX_BIN" activate -c "$SCRIPT"
+  assert_success
+}
+
 @test "activate works with fish 3.2.2" {
   if [ "$NIX_SYSTEM" == aarch64-linux ]; then
     # running fish at all on aarch64-linux throws:

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -2726,6 +2726,30 @@ EOF
   )"
   FLOX_SHELL=bash run "$FLOX_BIN" activate -c "$SCRIPT"
   assert_success
+
+  # Run mode sources only the interpreter's run-mode paths script from
+  # $FLOX_ENV; package-provided scripts are linked into the run environment
+  # but deliberately not sourced.
+  RUN_SCRIPT="$(cat <<'EOF'
+    if ! [ -e "$FLOX_ENV/etc/profile.d/0900_from-package.sh" ]; then
+      echo "package profile.d script was not linked into the run environment" >&3
+      exit 1
+    fi
+    case "$XDG_DATA_DIRS" in
+      *"$FLOX_ENV/share"*) : ;;
+      *)
+        echo "run-mode paths script was not sourced" >&3
+        exit 1
+        ;;
+    esac
+    if [ -n "${_FLOX_PROFILE_D_TEST_VAR:-}" ]; then
+      echo "package profile.d script was unexpectedly sourced in run mode" >&3
+      exit 1
+    fi
+EOF
+  )"
+  FLOX_SHELL=bash run "$FLOX_BIN" activate -m run -c "$RUN_SCRIPT"
+  assert_success
 }
 
 @test "activate works with fish 3.2.2" {

--- a/cli/tests/build-wrapper.bats
+++ b/cli/tests/build-wrapper.bats
@@ -119,3 +119,30 @@ EOF
 }
 
 # ---------------------------------------------------------------------------- #
+
+# The build wrapper must source profile.d scripts from the environment given
+# via --env, not just the scripts provided by the interpreter package.
+#
+# Packages installed by store path aren't part of the `toplevel` package
+# group, and no mocked catalog package ships an etc/profile.d script, so
+# invoke the wrapper directly against a fabricated environment instead of
+# driving it through `flox build`.
+@test "Build wrapper sources package-provided profile.d scripts" {
+  _wrapper="${FLOX_INTERPRETER?}-build_executable_wrapper"
+
+  # Fabricate a rendered environment the way buildenv would: the wrapper
+  # package's own profile.d contents merged with a package-provided script.
+  fake_env="$BATS_TEST_TMPDIR/env"
+  mkdir -p "$fake_env/etc/profile.d"
+  cp -RL "$_wrapper/etc/profile.d/." "$fake_env/etc/profile.d/"
+  cat > "$fake_env/etc/profile.d/0900_from-package.sh" <<'EOF'
+export _FLOX_PROFILE_D_TEST_VAR="from-package-profile.d"
+EOF
+
+  run "$_wrapper/wrapper" --env "$fake_env" -- \
+    bash -c 'echo "VAR: ${_FLOX_PROFILE_D_TEST_VAR:-unset}"'
+  assert_success
+  assert_output "VAR: from-package-profile.d"
+}
+
+# ---------------------------------------------------------------------------- #

--- a/cli/tests/build-wrapper.bats
+++ b/cli/tests/build-wrapper.bats
@@ -128,7 +128,7 @@ EOF
 # invoke the wrapper directly against a fabricated environment instead of
 # driving it through `flox build`.
 @test "Build wrapper sources package-provided profile.d scripts" {
-  _wrapper="${FLOX_INTERPRETER?}-build_executable_wrapper"
+  _wrapper="${FLOX_INTERPRETER_WRAPPER?}"
 
   # Fabricate a rendered environment the way buildenv would: the wrapper
   # package's own profile.d contents merged with a package-provided script.

--- a/pkgs/flox-cli-tests/default.nix
+++ b/pkgs/flox-cli-tests/default.nix
@@ -204,6 +204,7 @@ writeShellScriptBin PROJECT_NAME ''
     export FLOX_ACTIVATIONS_BIN="${flox-activations}/libexec/flox-activations"
     export PROCESS_COMPOSE_BIN='${process-compose}/bin/process-compose'
     export FLOX_INTERPRETER='${flox-interpreter}'
+    export FLOX_INTERPRETER_WRAPPER='${flox-interpreter.build_executable_wrapper}'
   ''}
 
   # Default flag values

--- a/shells/default/default.nix
+++ b/shells/default/default.nix
@@ -132,6 +132,7 @@ mkShell (
 
       # Nix built subsystems
       define_dev_env_var FLOX_INTERPRETER "''${REPO_ROOT}/build/flox-interpreter";
+      define_dev_env_var FLOX_INTERPRETER_WRAPPER "''${REPO_ROOT}/build/flox-interpreter-build_executable_wrapper";
       define_dev_env_var FLOX_BUILDENV "''${REPO_ROOT}/build/flox-buildenv";
       define_dev_env_var FLOX_BUILDENV_NIX "''${FLOX_BUILDENV}/lib/buildenv.nix";
       define_dev_env_var FLOX_PACKAGE_BUILDER "''${REPO_ROOT}/build/flox-package-builder";


### PR DESCRIPTION
## Summary

The `etc/profile.d` directory was always intended to work like the classic SYSV `init.d` pattern: packages installed to an environment drop scripts into `etc/profile.d`, and activation sources everything found there in lexical order. The environment build has always merged package-provided `profile.d` scripts into the rendered environment, but the `activate` and `wrapper` scripts enumerated the flox-interpreter package's own `etc/profile.d` instead, so package-provided scripts were never sourced. Both scripts carried a `FIXME` describing exactly this bug.

- Set `_profile_d` to `$FLOX_ENV/etc/profile.d` in both the `activate` and `wrapper` scripts, once the environment path is known from argument parsing. The interpreter's own scripts continue to be sourced because they are symlinked into every rendered environment at build time (asserted by existing `buildenv` unit tests for both the `runtime` and `develop` outputs).
- Build mode is unaffected structurally: the develop-copy environment used by the package builder is a full copy of the environment's symlink tree, so it carries `etc/profile.d`.
- Run mode semantics are unchanged: it still sources only `0100_common-run-mode-paths.sh`, now resolved via `$FLOX_ENV`. Sourcing package-provided scripts in run mode is a follow-up design decision, since the interpreter's dev-only scripts are indistinguishable from package scripts once merged — tracked in #4514 along with documenting the reserved numeric prefix conventions.

## Testing

- New integration test in `activate.bats` fabricates a package providing an `etc/profile.d` script (via `nix store add`), installs it by store path, and asserts the script is linked into `$FLOX_ENV` and sourced on dev-mode activation. It also asserts run-mode behavior: the package script is linked into the run environment and the interpreter's run-mode paths script is sourced from `$FLOX_ENV`, but package-provided scripts are deliberately not sourced.
- New test in `build-wrapper.bats` asserts the wrapper sources package-provided profile.d scripts from the environment given via `--env`, invoked directly against a fabricated environment (a `flox build` e2e isn't currently possible because store-path packages aren't part of the `toplevel` group and no mocked catalog package ships `etc/profile.d` scripts).
- Both new tests verified to fail against the previous logic and pass with this change.
- All 75 profile-related tests in `activate.bats`, all 13 `activate-mode.bats` tests, and all `build-wrapper.bats` tests pass.
- `nix build .#flox-interpreter` passes, which runs shellcheck and shfmt over both modified scripts.

## Release Notes

- Packages installed to an environment that provide `etc/profile.d` scripts now have those scripts sourced on `flox activate`, in lexical order alongside the scripts provided by Flox itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
