### PR TITLE
fix: set fish prompt variable in global scope

### DIFF
--- a/assets/environment-interpreter/activate/activate.d/set-prompt.fish
+++ b/assets/environment-interpreter/activate/activate.d/set-prompt.fish
@@ -11,14 +11,17 @@ if set -q FLOX_PROMPT_ENVIRONMENTS && test -n "$FLOX_PROMPT_ENVIRONMENTS"
         set FLOX_PROMPT flox
     end
 
+    # _flox must be global: fish_prompt reads it on every prompt, and this
+    # script may be sourced inside a function (the auto-activate hook), where
+    # an unscoped set on a new variable would vanish when the function returns.
     if set -q NO_COLOR
-        set _flox "flox [$FLOX_PROMPT_ENVIRONMENTS]"
+        set -g _flox "flox [$FLOX_PROMPT_ENVIRONMENTS]"
     else
         set colorPrompt1 \e\[38\;5\;$FLOX_PROMPT_COLOR_1""m
         set colorPrompt2 \e\[38\;5\;$FLOX_PROMPT_COLOR_2""m
         set _floxPrompt1 $colorPrompt1$FLOX_PROMPT
         set _floxPrompt2 $colorPrompt2"["$FLOX_PROMPT_ENVIRONMENTS"]"
-        set _flox (set_color --bold)$_floxPrompt1" "$_floxPrompt2
+        set -g _flox (set_color --bold)$_floxPrompt1" "$_floxPrompt2
     end
 
     if not functions -q flox_saved_fish_prompt
@@ -34,6 +37,7 @@ else if functions -q flox_saved_fish_prompt
     functions --erase fish_prompt
     functions --copy flox_saved_fish_prompt fish_prompt
     functions --erase flox_saved_fish_prompt
+    set -eg _flox
 end
 
 "$_flox_activate_tracer" "$_activate_d/set-prompt.fish" END

--- a/cli/tests/hook.bats
+++ b/cli/tests/hook.bats
@@ -339,6 +339,39 @@ EXPIRED_FLOXHUB_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3gu
   assert_output --partial "$(realpath "$PROJECT2_DIR")"
 }
 
+# bats test_tags=hook:auto-activate:fish
+@test "fish: hook auto-activation sets the prompt" {
+  project_setup
+  project2_setup
+  export FLOX_FEATURES_AUTO_ACTIVATE=true
+  # Mirror the reported scenario: the hook-registering outer activation is the
+  # 'default' env, which is hidden from FLOX_PROMPT_ENVIRONMENTS, so the outer
+  # activation defines no prompt variables at the top level. (An unscoped fish
+  # `set` reuses an existing variable's scope, so a visible outer env would
+  # mask scoping bugs when the hook later sets prompt variables inside a
+  # function.)
+  "$FLOX_BIN" edit -d "$PROJECT_DIR" --name default
+  # Auto-activation is opt-in; allow the target before entering it.
+  "$FLOX_BIN" activate allow -d "$PROJECT2_DIR"
+
+  # unbuffer provides a pty so that `isatty 1` holds and set-prompt.fish is
+  # sourced. NO_COLOR keeps the prompt prefix a plain "flox [<envs>]" string.
+  # A known fish_prompt is defined up front because non-interactive fish has
+  # no prompt function for set-prompt.fish to save and wrap.
+  run unbuffer fish -c '
+    set -gx FLOX_FEATURES_AUTO_ACTIVATE true
+    set -gx NO_COLOR 1
+    function fish_prompt; echo -n "knownPrompt> "; end
+    eval ("$FLOX_BIN" activate -d "$PROJECT_DIR")
+    cd "$PROJECT2_DIR"
+    _flox_hook
+    echo "<prompt>"(fish_prompt)"</prompt>"
+  '
+  assert_success
+  assert_output --partial "<prompt>flox [project2-"
+  assert_output --partial "knownPrompt>"
+}
+
 # bats test_tags=hook:auto-activate:tcsh
 @test "tcsh: hook auto-activates a discovered environment on cd" {
   project_setup


### PR DESCRIPTION
Fixes DEV-158.

An interactive `flox activate` in Fish shell showed the `flox [env]` prompt prefix, but auto-activation (cd-triggered via `_flox_hook`) did not.

**Root cause:** `set-prompt.fish` used an unscoped `set _flox`. In Fish, an unscoped `set` on a *new* variable is scoped to the enclosing function. During auto-activation the script is sourced inside `_flox_hook`, so `_flox` vanished when the hook returned — but the installed `fish_prompt` function persisted and rendered an empty prefix. Interactive activation spawns a subshell and sources the script at top level, where unscoped `set` is global, so it was unaffected.

**Fix:** `set -g _flox` in both code paths (NO_COLOR and colored), and `set -eg _flox` on the deactivation restore path to clean up the global when the env is left.

This is a cherry-pick of the fix commit from matthew's WIP branch (`matthew/dev-158-fish-prompt-not-set-when-auto-activating`), reviewed and manually verified before opening.

## Testing

New regression test: `fish: hook auto-activation sets the prompt` in `cli/tests/hook.bats`. Uses `unbuffer` to provide a pty (so `isatty 1` holds and `set-prompt.fish` is sourced). The outer activation is named `default` — `hide_default_prompt` filters it from `FLOX_PROMPT_ENVIRONMENTS`, ensuring no top-level `_flox` global exists when the hook runs, which is the exact condition that exposes the scoping bug.

Manual verification also performed: reproduced the bug and confirmed the fix using both a pure Fish scoping test and by sourcing both versions of `set-prompt.fish` inside a simulated hook function.

## Release Notes

Fish shell users using auto-activation (cd-triggered) will now see the `flox [env]` prompt prefix, matching the behavior of interactive `flox activate`.

---
*Via Forge (interactive) • 6e94836e*