### PR TITLE
restore env cache flag

### DIFF
--- a/assets/environment-interpreter/activate/activate
+++ b/assets/environment-interpreter/activate/activate
@@ -46,6 +46,7 @@ source "${_activate_d}/helpers.bash"
 OPTIONS="e:c:m:"
 LONGOPTS="command:,\
 env:,\
+env-cache:,\
 env-project:,\
 mode:,\
 start-state-dir:,\
@@ -53,6 +54,7 @@ skip-hook-on-activate,\
 cuda-detection"
 USAGE="Usage: $0 [-c \"<cmd> <args>\"] \
 [(-e|--env) <env>] \
+[--env-cache <path>] \
 [--env-project <path>] \
 [(-m|--mode) (dev|run|build)] \
 [--start-state-dir <path>] \
@@ -92,6 +94,16 @@ while true; do
         exit 1
       fi
       _FLOX_ENV="$1"
+      shift
+      ;;
+    --env-cache)
+      shift
+      if [ -z "${1:-}" ] || [ ! -d "$1" ]; then
+        echo "Option --env-cache requires a valid path as an argument." >&2
+        echo "$USAGE" >&2
+        exit 1
+      fi
+      _FLOX_ENV_CACHE="$1"
       shift
       ;;
     --env-project)
@@ -180,8 +192,7 @@ if [ "$_command_mode" = "true" ]; then
 
   # Propagate optional variables that are documented as exposed.
   # NB: `generate_*_start_commands()` performs the same logic except for zsh.
-  # shellcheck disable=SC2043
-  for var_key in FLOX_ENV_PROJECT; do
+  for var_key in FLOX_ENV_CACHE FLOX_ENV_PROJECT; do
     eval "var_val=\${_$var_key-}"
     if [ -n "$var_val" ]; then
       export $var_key="${var_val}"

--- a/assets/environment-interpreter/common/etc/profile.d/profile.d.functions
+++ b/assets/environment-interpreter/common/etc/profile.d/profile.d.functions
@@ -43,9 +43,8 @@ function setup_python {
   # Only run if `pip' is in `PATH' for non-containerize activations.
   # FLOX_ENV_PROJECT is unset in `containerize`, but *is* set for builds and
   # other activations. We don't need a virtual environment inside a container.
-  # Write pip.ini to FLOX_ENV_CACHE rather than FLOX_ENV_PROJECT: for remote
-  # environments FLOX_ENV_PROJECT is the invocation directory, which may not
-  # contain a `.flox` directory to write into.
+  # pip.ini is written to the environment's cache directory, which exists
+  # for every environment type (path, managed, and remote).
   if [[ (-x "$FLOX_ENV/bin/pip3") && (-n "${FLOX_ENV_PROJECT:-}") && (-n "${FLOX_ENV_CACHE:-}") ]]; then
     "$_mkdir" -p "$FLOX_ENV_CACHE"
     PIP_CONFIG_FILE="$FLOX_ENV_CACHE/pip.ini"

--- a/assets/environment-interpreter/common/etc/profile.d/profile.d.functions
+++ b/assets/environment-interpreter/common/etc/profile.d/profile.d.functions
@@ -1,5 +1,6 @@
 # shellcheck shell=bash
 _cat="@coreutils@/bin/cat"
+_mkdir="@coreutils@/bin/mkdir"
 _flox_activations="@flox_activations@"
 
 # Setup Python3
@@ -42,8 +43,12 @@ function setup_python {
   # Only run if `pip' is in `PATH' for non-containerize activations.
   # FLOX_ENV_PROJECT is unset in `containerize`, but *is* set for builds and
   # other activations. We don't need a virtual environment inside a container.
-  if [[ (-x "$FLOX_ENV/bin/pip3") && (-n "${FLOX_ENV_PROJECT:-}") ]]; then
-    PIP_CONFIG_FILE="$FLOX_ENV_PROJECT/.flox/pip.ini"
+  # Write pip.ini to FLOX_ENV_CACHE rather than FLOX_ENV_PROJECT: for remote
+  # environments FLOX_ENV_PROJECT is the invocation directory, which may not
+  # contain a `.flox` directory to write into.
+  if [[ (-x "$FLOX_ENV/bin/pip3") && (-n "${FLOX_ENV_PROJECT:-}") && (-n "${FLOX_ENV_CACHE:-}") ]]; then
+    "$_mkdir" -p "$FLOX_ENV_CACHE"
+    PIP_CONFIG_FILE="$FLOX_ENV_CACHE/pip.ini"
     export PIP_CONFIG_FILE
     "$_cat" > "$PIP_CONFIG_FILE" << EOF
   [global]

--- a/assets/environment-interpreter/common/etc/profile.d/profile.d.functions
+++ b/assets/environment-interpreter/common/etc/profile.d/profile.d.functions
@@ -1,6 +1,5 @@
 # shellcheck shell=bash
 _cat="@coreutils@/bin/cat"
-_mkdir="@coreutils@/bin/mkdir"
 _flox_activations="@flox_activations@"
 
 # Setup Python3
@@ -46,7 +45,6 @@ function setup_python {
   # pip.ini is written to the environment's cache directory, which exists
   # for every environment type (path, managed, and remote).
   if [[ (-x "$FLOX_ENV/bin/pip3") && (-n "${FLOX_ENV_PROJECT:-}") && (-n "${FLOX_ENV_CACHE:-}") ]]; then
-    "$_mkdir" -p "$FLOX_ENV_CACHE"
     PIP_CONFIG_FILE="$FLOX_ENV_CACHE/pip.ini"
     export PIP_CONFIG_FILE
     "$_cat" > "$PIP_CONFIG_FILE" << EOF

--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -355,10 +355,7 @@ impl ManifestBuilder for FloxBuildMk<'_> {
             "FLOX_ENV_OUTPUTS={}",
             serde_json::json!(self.built_environments)
         ));
-        command.arg(format!(
-            "FLOX_ENV_CACHE={}",
-            self.flox_env_cache.display()
-        ));
+        command.arg(format!("FLOX_ENV_CACHE={}", self.flox_env_cache.display()));
 
         // TODO: modify flox-build.mk to allow missing expression dirs
         let expression_ref = self.expression_ref.as_url();

--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -224,6 +224,7 @@ pub struct FloxBuildMk<'args> {
     // common build components for manifest builds
     base_dir: &'args Path,
     built_environments: &'args BuildEnvOutputs,
+    flox_env_cache: &'args Path,
 
     // fetchable ref for nix expression builds
     expression_ref: &'args NixFlakeref,
@@ -240,6 +241,7 @@ impl FloxBuildMk<'_> {
         base_dir: &'args Path,
         expression_ref: &'args NixFlakeref,
         built_environments: &'args BuildEnvOutputs,
+        flox_env_cache: &'args Path,
     ) -> FloxBuildMk<'args> {
         FloxBuildMk {
             verbosity: flox.verbosity,
@@ -247,6 +249,7 @@ impl FloxBuildMk<'_> {
             base_dir,
             expression_ref,
             built_environments,
+            flox_env_cache,
             stdout_buffer: None,
             stderr_buffer: None,
         }
@@ -261,6 +264,7 @@ impl FloxBuildMk<'_> {
         base_dir: &'args Path,
         expression_ref: &'args NixFlakeref,
         built_environments: &'args BuildEnvOutputs,
+        flox_env_cache: &'args Path,
         stdout: &'args mut String,
         stderr: &'args mut String,
     ) -> FloxBuildMk<'args> {
@@ -270,6 +274,7 @@ impl FloxBuildMk<'_> {
             base_dir,
             expression_ref,
             built_environments,
+            flox_env_cache,
             stdout_buffer: Some(stdout),
             stderr_buffer: Some(stderr),
         }
@@ -349,6 +354,10 @@ impl ManifestBuilder for FloxBuildMk<'_> {
         command.arg(format!(
             "FLOX_ENV_OUTPUTS={}",
             serde_json::json!(self.built_environments)
+        ));
+        command.arg(format!(
+            "FLOX_ENV_CACHE={}",
+            self.flox_env_cache.display()
         ));
 
         // TODO: modify flox-build.mk to allow missing expression dirs
@@ -875,6 +884,7 @@ pub mod test_helpers {
             &env.parent_path().unwrap(),
             expression_ref,
             &env.build(flox).unwrap(),
+            &env.cache_path().unwrap(),
             &mut output_stdout,
             &mut output_stderr,
         )
@@ -934,6 +944,7 @@ pub mod test_helpers {
             &env.parent_path().unwrap(),
             &NixFlakeref::from_path(env.dot_flox_path()).unwrap(),
             &env.build(flox).unwrap(),
+            &env.cache_path().unwrap(),
             &mut String::new(),
             &mut String::new(),
         )

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -47,7 +47,7 @@ use super::git::{GitCommandError, GitCommandGetOriginError, GitCommandProvider, 
 use super::nix_auth::{AuthError, AuthProvider, CatalogAuth, NixCopyAuth};
 use crate::data::CanonicalPath;
 use crate::flox::Flox;
-use crate::models::environment::{Environment, EnvironmentError, open_path};
+use crate::models::environment::{CACHE_DIR_NAME, DOT_FLOX, Environment, EnvironmentError, open_path};
 use crate::providers::git::GitProvider;
 use crate::providers::nix::nix_base_command;
 use crate::providers::nix_auth::catalog_auth_to_envs;
@@ -906,7 +906,17 @@ pub fn check_build_metadata(
     };
     let (expression_ref, base_dir, built_environments) = build_source(flox, env_metadata, workdir)?;
 
-    let builder = FloxBuildMk::new(flox, &base_dir, &expression_ref, &built_environments);
+    // The build may run in a shared clone rather than the original checkout,
+    // so the environment cache is derived from the build working directory
+    // instead of the environment's own cache path.
+    let flox_env_cache = base_dir.join(DOT_FLOX).join(CACHE_DIR_NAME);
+    let builder = FloxBuildMk::new(
+        flox,
+        &base_dir,
+        &expression_ref,
+        &built_environments,
+        &flox_env_cache,
+    );
 
     let build_results = builder.build(
         &base_nixpkgs_url.as_flake_ref()?,

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -47,7 +47,13 @@ use super::git::{GitCommandError, GitCommandGetOriginError, GitCommandProvider, 
 use super::nix_auth::{AuthError, AuthProvider, CatalogAuth, NixCopyAuth};
 use crate::data::CanonicalPath;
 use crate::flox::Flox;
-use crate::models::environment::{CACHE_DIR_NAME, DOT_FLOX, Environment, EnvironmentError, open_path};
+use crate::models::environment::{
+    CACHE_DIR_NAME,
+    DOT_FLOX,
+    Environment,
+    EnvironmentError,
+    open_path,
+};
 use crate::providers::git::GitProvider;
 use crate::providers::nix::nix_base_command;
 use crate::providers::nix_auth::catalog_auth_to_envs;

--- a/cli/flox/src/commands/build.rs
+++ b/cli/flox/src/commands/build.rs
@@ -226,7 +226,14 @@ impl Build {
             .map(|target| target.name())
             .collect::<Vec<_>>();
 
-        let builder = FloxBuildMk::new(&flox, &base_dir, &expression_ref, &flox_env_build_outputs);
+        let cache_path = env.cache_path()?;
+        let builder = FloxBuildMk::new(
+            &flox,
+            &base_dir,
+            &expression_ref,
+            &flox_env_build_outputs,
+            &cache_path,
+        );
         builder.clean(&target_names)?;
 
         message::updated(format!(
@@ -320,7 +327,14 @@ impl Build {
             debug!(error = %err, "Failed to record v2 event");
         }
 
-        let builder = FloxBuildMk::new(&flox, &base_dir, &expression_ref, &built_environments);
+        let cache_path = env.cache_path()?;
+        let builder = FloxBuildMk::new(
+            &flox,
+            &base_dir,
+            &expression_ref,
+            &built_environments,
+            &cache_path,
+        );
         let results = builder.build(
             &base_nixpkgs_url,
             &FLOX_INTERPRETER,

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -1468,7 +1468,7 @@ EOF
 
   run -- "$FLOX_BIN" activate -c 'echo PIP_CONFIG_FILE is "$PIP_CONFIG_FILE"'
   assert_success
-  assert_line "PIP_CONFIG_FILE is $(realpath $PROJECT_DIR)/.flox/pip.ini"
+  assert_line "PIP_CONFIG_FILE is $(realpath $PROJECT_DIR)/.flox/cache/pip.ini"
 }
 
 # ---------------------------------------------------------------------------- #

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -1466,9 +1466,9 @@ EOF
   assert_success
   assert_line "PYTHONPATH is $(realpath $PROJECT_DIR)/.flox/run/$NIX_SYSTEM.$PROJECT_NAME-dev/lib/python3.11/site-packages"
 
-  run -- "$FLOX_BIN" activate -c 'echo PIP_CONFIG_FILE is "$PIP_CONFIG_FILE"'
+  run -- "$FLOX_BIN" activate -c 'if [ "$PIP_CONFIG_FILE" = "$FLOX_ENV_CACHE/pip.ini" ]; then echo "PIP_CONFIG_FILE is in FLOX_ENV_CACHE"; fi'
   assert_success
-  assert_line "PIP_CONFIG_FILE is $(realpath $PROJECT_DIR)/.flox/cache/pip.ini"
+  assert_line "PIP_CONFIG_FILE is in FLOX_ENV_CACHE"
 }
 
 # ---------------------------------------------------------------------------- #

--- a/cli/tests/environment-remote.bats
+++ b/cli/tests/environment-remote.bats
@@ -198,10 +198,9 @@ EOF
   make_empty_remote_env
   "$FLOX_BIN" install python311Packages.pip --reference "$OWNER/test"
 
-  export FLOX_CACHE_DIR="$(realpath $FLOX_CACHE_DIR)"
-  run "$FLOX_BIN" activate --trust --reference "$OWNER/test" -c 'echo PIP_CONFIG_FILE is "$PIP_CONFIG_FILE"'
+  run "$FLOX_BIN" activate --trust --reference "$OWNER/test" -c 'if [ "$PIP_CONFIG_FILE" = "$FLOX_ENV_CACHE/pip.ini" ]; then echo "PIP_CONFIG_FILE is in FLOX_ENV_CACHE"; fi'
   assert_success
-  assert_line "PIP_CONFIG_FILE is $FLOX_CACHE_DIR/remote/$OWNER/test/.flox/cache/pip.ini"
+  assert_line "PIP_CONFIG_FILE is in FLOX_ENV_CACHE"
 }
 
 # We need to trust the remote environment before we can activate it.

--- a/cli/tests/environment-remote.bats
+++ b/cli/tests/environment-remote.bats
@@ -189,6 +189,21 @@ EOF
   assert_output --partial "$FLOX_CACHE_DIR/remote/$OWNER/test/.flox/run/$NIX_SYSTEM.test-dev/bin/hello"
 }
 
+# Activating a pip-providing remote environment must not fail (or write
+# anything) when the working directory has no `.flox` directory; pip.ini is
+# written to the environment's own cache instead.
+# bats test_tags=remote,activate,remote:activate:pip
+@test "m9.1: 'activate --reference' works with pip when cwd has no .flox" {
+  export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/python311Packages.pip.yaml"
+  make_empty_remote_env
+  "$FLOX_BIN" install python311Packages.pip --reference "$OWNER/test"
+
+  export FLOX_CACHE_DIR="$(realpath $FLOX_CACHE_DIR)"
+  run "$FLOX_BIN" activate --trust --reference "$OWNER/test" -c 'echo PIP_CONFIG_FILE is "$PIP_CONFIG_FILE"'
+  assert_success
+  assert_line "PIP_CONFIG_FILE is $FLOX_CACHE_DIR/remote/$OWNER/test/.flox/cache/pip.ini"
+}
+
 # We need to trust the remote environment before we can activate it.
 # bats test_tags=remote,activate,trust,remote:activate:trust-required
 @test "m10.0: 'activate --reference' fails if remote environment is not trusted" {

--- a/package-builder/build-manifest.nix
+++ b/package-builder/build-manifest.nix
@@ -191,11 +191,13 @@ pkgs.runCommand name
 
                 # N.B. not using t3 --forcecolor option because Nix sandbox
                 # strips color codes from output anyway.
-                # FLOX_ENV_CACHE points into the sandbox's build directory so
+                # --env-cache points into the sandbox's build directory so
                 # the interpreter's profile.d scripts have a writable cache
                 # for generated state (e.g. pip.ini).
-                FLOX_SRC_DIR=$(pwd) FLOX_ENV_CACHE="$(pwd)/.flox/cache" \
+                mkdir -p "$(pwd)/.flox/cache"
+                FLOX_SRC_DIR=$(pwd) \
                   ${develop-copy-env-package}/activate --env ${develop-copy-env-package} \
+                    --env-cache "$(pwd)/.flox/cache" \
                     --mode build --skip-hook-on-activate --env-project $(pwd) -- \
                       t3 --relative $log -- bash -e ${buildScript-contents}
               ''
@@ -207,11 +209,13 @@ pkgs.runCommand name
 
                 # See flox-build.mk for a detailed explanation of why we use a nested
                 # activation when performing builds.
-                # FLOX_ENV_CACHE points into the sandbox's build directory so
+                # --env-cache points into the sandbox's build directory so
                 # the interpreter's profile.d scripts have a writable cache
                 # for generated state (e.g. pip.ini).
-                FLOX_SRC_DIR=$(pwd) FLOX_ENV_CACHE="$(pwd)/.flox/cache" \
+                mkdir -p "$(pwd)/.flox/cache"
+                FLOX_SRC_DIR=$(pwd) \
                   ${develop-copy-env-package}/activate --env ${develop-copy-env-package} \
+                    --env-cache "$(pwd)/.flox/cache" \
                     --mode build --skip-hook-on-activate --env-project $(pwd) -- \
                       t3 --relative $log -- bash -e ${buildScript-contents} || \
                 ( find $out -type d -exec chmod +w {} \; && rm -rf $out && echo "flox build failed (caching build dir)" | tee $out 1>&2 )

--- a/package-builder/build-manifest.nix
+++ b/package-builder/build-manifest.nix
@@ -191,7 +191,10 @@ pkgs.runCommand name
 
                 # N.B. not using t3 --forcecolor option because Nix sandbox
                 # strips color codes from output anyway.
-                FLOX_SRC_DIR=$(pwd) \
+                # FLOX_ENV_CACHE points into the sandbox's build directory so
+                # the interpreter's profile.d scripts have a writable cache
+                # for generated state (e.g. pip.ini).
+                FLOX_SRC_DIR=$(pwd) FLOX_ENV_CACHE="$(pwd)/.flox/cache" \
                   ${develop-copy-env-package}/activate --env ${develop-copy-env-package} \
                     --mode build --skip-hook-on-activate --env-project $(pwd) -- \
                       t3 --relative $log -- bash -e ${buildScript-contents}
@@ -204,7 +207,10 @@ pkgs.runCommand name
 
                 # See flox-build.mk for a detailed explanation of why we use a nested
                 # activation when performing builds.
-                FLOX_SRC_DIR=$(pwd) \
+                # FLOX_ENV_CACHE points into the sandbox's build directory so
+                # the interpreter's profile.d scripts have a writable cache
+                # for generated state (e.g. pip.ini).
+                FLOX_SRC_DIR=$(pwd) FLOX_ENV_CACHE="$(pwd)/.flox/cache" \
                   ${develop-copy-env-package}/activate --env ${develop-copy-env-package} \
                     --mode build --skip-hook-on-activate --env-project $(pwd) -- \
                       t3 --relative $log -- bash -e ${buildScript-contents} || \

--- a/package-builder/flox-build.mk
+++ b/package-builder/flox-build.mk
@@ -217,8 +217,10 @@ $(PROJECT_TMPDIR)/check-build-prerequisites:
 	@# Check that the BUILDTIME_NIXPKGS_URL and EXPRESSION_BUILD_NIXPKGS_URL are defined.
 	$(if $(BUILDTIME_NIXPKGS_URL),,$(error BUILDTIME_NIXPKGS_URL not defined))
 	$(if $(EXPRESSION_BUILD_NIXPKGS_URL),,$(error EXPRESSION_BUILD_NIXPKGS_URL not defined))
-	@# Check that the FLOX_ENV_CACHE is defined.
+	@# Check that the FLOX_ENV_CACHE is defined, and create it because the
+	@# activate script requires --env-cache to be an existing directory.
 	$(if $(FLOX_ENV_CACHE),,$(error FLOX_ENV_CACHE not defined))
+	@$(_mkdir) -p $(FLOX_ENV_CACHE)
 	@$(_mkdir) -p $(@D)
 	@$(_touch) $@
 
@@ -485,13 +487,12 @@ define BUILD_local_template =
 	@# As a result of the space delimiter, individual patterns cannot contain
 	@# spaces; this is documented for the `sandbox-allow` manifest field.
 	@#
-	@# FLOX_ENV_CACHE is provided by the CLI and set explicitly on the
-	@# activation (rather than inherited from any enclosing activation) so
-	@# that the interpreter's profile.d scripts write generated state
-	@# (e.g. pip.ini) to this build's environment cache deterministically.
+	@# --env-cache is provided by the CLI so that the interpreter's
+	@# profile.d scripts write generated state (e.g. pip.ini) to this
+	@# build's environment cache.
 	$(_V_) $(_env) $$(QUOTED_ENV_DISALLOW_ARGS) out=$($(_pvarname)_out) \
-	  FLOX_ENV_CACHE=$(FLOX_ENV_CACHE) \
 	  $(FLOX_INTERPRETER)/activate --env $$($(_pvarname)_develop_copy_env) \
+	    --env-cache $(FLOX_ENV_CACHE) \
 	    --mode build --skip-hook-on-activate --env-project $(PWD) -- \
 	    $(_t3) $($(_pvarname)_logfile) -- \
 	    $(if $(_virtualSandbox),$(_env) $(PRELOAD_VARS) FLOX_SRC_DIR=$(PWD) FLOX_SANDBOX_ALLOW_DIRS="$(__bash) $$($(_pvarname)_buildDeps)" FLOX_SANDBOX_ALLOW=$(_sandbox_allow) FLOX_VIRTUAL_SANDBOX=$(_sandbox)) \

--- a/package-builder/flox-build.mk
+++ b/package-builder/flox-build.mk
@@ -482,7 +482,13 @@ define BUILD_local_template =
 	@# expanding ~ or globbing *, leaving libsandbox to interpret the patterns).
 	@# As a result of the space delimiter, individual patterns cannot contain
 	@# spaces; this is documented for the `sandbox-allow` manifest field.
+	@#
+	@# FLOX_ENV_CACHE is set explicitly (rather than inherited from any
+	@# enclosing activation) so that the interpreter's profile.d scripts
+	@# write generated state (e.g. pip.ini) to this build's environment
+	@# cache deterministically.
 	$(_V_) $(_env) $$(QUOTED_ENV_DISALLOW_ARGS) out=$($(_pvarname)_out) \
+	  FLOX_ENV_CACHE=$(PWD)/.flox/cache \
 	  $(FLOX_INTERPRETER)/activate --env $$($(_pvarname)_develop_copy_env) \
 	    --mode build --skip-hook-on-activate --env-project $(PWD) -- \
 	    $(_t3) $($(_pvarname)_logfile) -- \

--- a/package-builder/flox-build.mk
+++ b/package-builder/flox-build.mk
@@ -217,6 +217,8 @@ $(PROJECT_TMPDIR)/check-build-prerequisites:
 	@# Check that the BUILDTIME_NIXPKGS_URL and EXPRESSION_BUILD_NIXPKGS_URL are defined.
 	$(if $(BUILDTIME_NIXPKGS_URL),,$(error BUILDTIME_NIXPKGS_URL not defined))
 	$(if $(EXPRESSION_BUILD_NIXPKGS_URL),,$(error EXPRESSION_BUILD_NIXPKGS_URL not defined))
+	@# Check that the FLOX_ENV_CACHE is defined.
+	$(if $(FLOX_ENV_CACHE),,$(error FLOX_ENV_CACHE not defined))
 	@$(_mkdir) -p $(@D)
 	@$(_touch) $@
 
@@ -483,12 +485,12 @@ define BUILD_local_template =
 	@# As a result of the space delimiter, individual patterns cannot contain
 	@# spaces; this is documented for the `sandbox-allow` manifest field.
 	@#
-	@# FLOX_ENV_CACHE is set explicitly (rather than inherited from any
-	@# enclosing activation) so that the interpreter's profile.d scripts
-	@# write generated state (e.g. pip.ini) to this build's environment
-	@# cache deterministically.
+	@# FLOX_ENV_CACHE is provided by the CLI and set explicitly on the
+	@# activation (rather than inherited from any enclosing activation) so
+	@# that the interpreter's profile.d scripts write generated state
+	@# (e.g. pip.ini) to this build's environment cache deterministically.
 	$(_V_) $(_env) $$(QUOTED_ENV_DISALLOW_ARGS) out=$($(_pvarname)_out) \
-	  FLOX_ENV_CACHE=$(PWD)/.flox/cache \
+	  FLOX_ENV_CACHE=$(FLOX_ENV_CACHE) \
 	  $(FLOX_INTERPRETER)/activate --env $$($(_pvarname)_develop_copy_env) \
 	    --mode build --skip-hook-on-activate --env-project $(PWD) -- \
 	    $(_t3) $($(_pvarname)_logfile) -- \


### PR DESCRIPTION
- **feat(activate): restore --env-cache option**
  Partially reverts commit 7268cf56e, which dropped --env-cache and
  --env-description because no caller passed them. Manifest builds now
  need to provide FLOX_ENV_CACHE to the interpreter so that profile.d
  scripts write generated state (e.g. pip.ini) to the environment cache,
  and a command-line option is the channel build invocations already use
  for this kind of input (--env-project).
  
  The option is parsed into _FLOX_ENV_CACHE and exported as
  FLOX_ENV_CACHE in the command-mode propagation loop alongside
  FLOX_ENV_PROJECT. When the option is not passed, the loop unsets
  FLOX_ENV_CACHE, so a value leaked from an enclosing activation cannot
  redirect where a nested command-mode activation writes its state.
  
  Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
  

- **refactor(build): pass FLOX_ENV_CACHE to activate as --env-cache**
  Build invocations of the activate script pass per-activation inputs as
  options (--env, --env-project, --mode), so pass the environment cache
  the same way instead of as an ambient environment variable. The
  propagation loop in the activate script exports the option's value in
  command mode and unsets FLOX_ENV_CACHE otherwise, which makes values
  leaked from an enclosing activation harmless without needing an
  explicit assignment on the invocation.
  
  Because --env-cache must be an existing directory,
  check-build-prerequisites creates it ('flox publish' derives it from
  the build working directory, which starts without one), and
  build-manifest.nix creates it inside the sandbox before activating.
  This also makes the defensive mkdir in setup_python unnecessary.
  
  Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
  