### PR TITLE
feat(activate): tolerate expired token when activating default environment

### DIFF
--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -1277,7 +1277,7 @@ impl EnvironmentSelect {
                 ConcreteEnvironment::Remote(env)
             },
             EnvironmentSelect::Default => {
-                let user_handle = ensure_auth(flox).await?;
+                let user_handle = ensure_auth_allowing_expired(flox).await?;
 
                 debug!(
                     user = %user_handle,
@@ -1679,6 +1679,22 @@ pub(super) async fn ensure_auth(flox: &mut Flox) -> Result<String> {
             };
             bail!("{message}");
         },
+    }
+}
+
+/// Validate authentication for the default-environment activate path and return
+/// the user's handle.
+///
+/// Unlike [`ensure_auth`], an expired Auth0 token is not a hard failure: the
+/// handle is still readable from the token, and [`FloxArgs::resolve_floxhub_token`]
+/// has already warned about the expiry, so activation proceeds with the handle
+/// rather than blocking. FloxHub still validates the token on the actual
+/// request. Missing credentials (not logged in / no Kerberos ticket) fall back
+/// to [`ensure_auth`] and its recovery flow.
+async fn ensure_auth_allowing_expired(flox: &mut Flox) -> Result<String> {
+    match flox.auth_context.authenticated_handle_allowing_expired() {
+        Ok(handle) => Ok(handle.to_string()),
+        Err(_) => ensure_auth(flox).await,
     }
 }
 

--- a/cli/floxhub-client/src/auth/auth_context.rs
+++ b/cli/floxhub-client/src/auth/auth_context.rs
@@ -99,6 +99,17 @@ impl AuthContext {
         }
     }
 
+    /// Return the user's handle if authenticated, allowing expired auth0 tokens,
+    /// or an [`AuthFailure`] describing why authentication failed.
+    pub fn authenticated_handle_allowing_expired(&self) -> Result<&str, AuthFailure> {
+        match self {
+            AuthContext::Auth0(Some(token)) => Ok(token.handle()),
+            AuthContext::Auth0(None) => Err(AuthFailure::NotLoggedIn),
+            AuthContext::Kerberos(Some(material)) => Ok(&material.principal),
+            AuthContext::Kerberos(None) => Err(AuthFailure::NoKerberosTicket),
+        }
+    }
+
     /// Produce the value for an HTTP Authorization header targeting the given URL.
     pub fn authorization_header(&self, url: &Url) -> Option<Result<String, AuthHeaderError>> {
         match self {

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -5436,6 +5436,32 @@ success"
   assert_output --partial "activated"
 }
 
+# bats test_tags=activate,activate:default-flag
+@test "activate -D warns but does not block with an expired token" {
+  project_setup
+  floxhub_setup "test"
+
+  # Create a directory for the default environment
+  DEFAULT_ENV_DIR="$PROJECT_DIR/default-env"
+  mkdir "$DEFAULT_ENV_DIR"
+
+  # Create and push test/default environment while the token is still valid
+  run "$FLOX_BIN" init -d "$DEFAULT_ENV_DIR" --name default
+  assert_success
+  run "$FLOX_BIN" push -d "$DEFAULT_ENV_DIR" --owner test
+  assert_success
+
+  # Swap in an expired token (exp: 2024-01-01T00:00:00+00:00, handle: "test").
+  # The handle is still readable from the expired token, so activation should
+  # proceed with a warning rather than blocking on the auth check.
+  export FLOX_FLOXHUB_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3guZGV2L2hhbmRsZSI6InRlc3QiLCJleHAiOjE3MDQwNjM2MDB9.-5VCofPtmYQuvh21EV1nEJhTFV_URkRP0WFu4QDPFxY"
+
+  run "$FLOX_BIN" activate -D -- echo "activated"
+  assert_success
+  assert_output --partial "activated"
+  assert_output --partial "Your FloxHub token has expired."
+}
+
 # bats test_tags=activate,activate:idempotent
 @test "activate is idempotent for an already-locked already-built environment" {
   # Ensure flox activate does not re-lock or re-build when the lockfile is


### PR DESCRIPTION
- **feat(activate): tolerate expired token when activating default environment**
  `flox activate -D` resolves the user's default remote environment from the
  handle in the FloxHub token. An expired token still carries a valid handle,
  and the once-per-session advisory from `resolve_floxhub_token` already warns
  about the expiry, so blocking activation added no information and forced a
  re-login the user may not need (for example when the environment is already
  cached locally).
  
  Add `ensure_auth_allowing_expired` for the default-environment activate path:
  an expired Auth0 token now proceeds with its handle instead of erroring, and
  FloxHub still validates the token on the actual request. The not-logged-in
  and missing-Kerberos-ticket cases keep the existing `ensure_auth` recovery
  flow, and the other `ensure_auth` call sites (push, publish, install, etc.)
  are unchanged.
  
  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

Fixes DEV-175
  