### PR TITLE
feat(activate): replay profile.d PATH prepends across attachments

### DIFF
--- a/assets/environment-interpreter/activate/activate
+++ b/assets/environment-interpreter/activate/activate
@@ -195,7 +195,7 @@ if [ "$_command_mode" = "true" ]; then
   # shellcheck disable=SC1090
   source <("$_flox_activations" set-env-dirs --shell bash --flox-env "$_FLOX_ENV" --env-dirs "${FLOX_ENV_DIRS:-}")
   # shellcheck disable=SC1090
-  source <("$_flox_activations" fix-paths --shell bash --env-dirs "$FLOX_ENV_DIRS" --path "$PATH" --manpath "${MANPATH:-}")
+  source <("$_flox_activations" fix-paths --shell bash --env-dirs "$FLOX_ENV_DIRS" --path "$PATH" --manpath "${MANPATH:-}" --path-prepends "${_FLOX_ENV_PATH_PREPENDS:-}")
 fi
 
 if [ "$_command_mode" = "false" ]; then

--- a/assets/environment-interpreter/activate/activate.d/zsh
+++ b/assets/environment-interpreter/activate/activate.d/zsh
@@ -37,7 +37,7 @@ old_fpath="$FPATH"
 # shellcheck disable=SC1090
 source <("$_flox_activations" set-env-dirs --shell zsh --flox-env "$FLOX_ENV" --env-dirs "${FLOX_ENV_DIRS:-}")
 # shellcheck disable=SC1090
-source <("$_flox_activations" fix-paths --shell zsh --env-dirs "$FLOX_ENV_DIRS" --path "$PATH" --manpath "${MANPATH:-}")
+source <("$_flox_activations" fix-paths --shell zsh --env-dirs "$FLOX_ENV_DIRS" --path "$PATH" --manpath "${MANPATH:-}" --path-prepends "${_FLOX_ENV_PATH_PREPENDS:-}")
 
 # We use `FPATH` as input here so we can re-use machinery for rearranging
 # PATH-like variables, but we actually output code to set `fpath` instead.

--- a/assets/environment-interpreter/common/activate.d/helpers.bash
+++ b/assets/environment-interpreter/common/activate.d/helpers.bash
@@ -35,17 +35,20 @@ function source_profile_d {
   unset -f setup_cmake
 }
 
-# flox_prepend_path <dir> [<flox_env>]
+# flox_prepend_path <dir>
 #
-# Prepend <dir> to PATH and register it against <flox_env> (default:
-# $FLOX_ENV) in _FLOX_ENV_PATH_PREPENDS so that later invocations of
+# Prepend <dir> to PATH and register it against $FLOX_ENV in
+# _FLOX_ENV_PATH_PREPENDS so that later invocations of
 # 'flox-activations fix-paths' replay the prepend at that environment's
 # position in the layered PATH rather than demoting it behind the
 # activated environments' bin directories. Intended for use by
 # etc/profile.d scripts.
+#
+# <dir> must not contain ':' (illegal in PATH anyway) or '=' — entries
+# are stored as colon-separated "<env>=<dir>" pairs without escaping.
 function flox_prepend_path {
   local _dir="${1?}"
-  local _env="${2:-${FLOX_ENV?}}"
+  local _env="${FLOX_ENV?}"
   case ":${_FLOX_ENV_PATH_PREPENDS:-}:" in
     # Already registered: within an activation a registration is always
     # accompanied by its PATH entry (set together below, or inherited

--- a/assets/environment-interpreter/common/activate.d/helpers.bash
+++ b/assets/environment-interpreter/common/activate.d/helpers.bash
@@ -35,6 +35,29 @@ function source_profile_d {
   unset -f setup_cmake
 }
 
+# flox_prepend_path <dir> [<flox_env>]
+#
+# Prepend <dir> to PATH and register it against <flox_env> (default:
+# $FLOX_ENV) in _FLOX_ENV_PATH_PREPENDS so that later invocations of
+# 'flox-activations fix-paths' replay the prepend at that environment's
+# position in the layered PATH rather than demoting it behind the
+# activated environments' bin directories. Intended for use by
+# etc/profile.d scripts.
+function flox_prepend_path {
+  local _dir="${1?}"
+  local _env="${2:-${FLOX_ENV?}}"
+  case ":${_FLOX_ENV_PATH_PREPENDS:-}:" in
+    *":$_env=$_dir:"*) : ;; # already registered
+    *)
+      export _FLOX_ENV_PATH_PREPENDS="$_env=$_dir${_FLOX_ENV_PATH_PREPENDS:+:$_FLOX_ENV_PATH_PREPENDS}"
+      ;;
+  esac
+  # Take effect immediately in this shell; subsequent fix-paths
+  # invocations keep the dir ordered with its environment's layer.
+  PATH="$_dir:$PATH"
+  export PATH
+}
+
 # set_manifest_vars <flox_env>
 #
 # Set static environment variables from the manifest.

--- a/assets/environment-interpreter/common/activate.d/helpers.bash
+++ b/assets/environment-interpreter/common/activate.d/helpers.bash
@@ -47,15 +47,19 @@ function flox_prepend_path {
   local _dir="${1?}"
   local _env="${2:-${FLOX_ENV?}}"
   case ":${_FLOX_ENV_PATH_PREPENDS:-}:" in
-    *":$_env=$_dir:"*) : ;; # already registered
+    # Already registered: within an activation a registration is always
+    # accompanied by its PATH entry (set together below, or inherited
+    # along with the PATH that already contains the dir), so skip the
+    # prepend as well to keep repeated calls from duplicating it.
+    *":$_env=$_dir:"*) : ;;
     *)
       export _FLOX_ENV_PATH_PREPENDS="$_env=$_dir${_FLOX_ENV_PATH_PREPENDS:+:$_FLOX_ENV_PATH_PREPENDS}"
+      # Take effect immediately in this shell; subsequent fix-paths
+      # invocations keep the dir ordered with its environment's layer.
+      PATH="$_dir:$PATH"
+      export PATH
       ;;
   esac
-  # Take effect immediately in this shell; subsequent fix-paths
-  # invocations keep the dir ordered with its environment's layer.
-  PATH="$_dir:$PATH"
-  export PATH
 }
 
 # set_manifest_vars <flox_env>

--- a/assets/environment-interpreter/common/activate.d/helpers.bash
+++ b/assets/environment-interpreter/common/activate.d/helpers.bash
@@ -46,6 +46,8 @@ function source_profile_d {
 #
 # <dir> must not contain ':' (illegal in PATH anyway) or '=' — entries
 # are stored as colon-separated "<env>=<dir>" pairs without escaping.
+# The same holds for the environment's own path; a mangled entry never
+# matches at replay and is dropped with a debug-level diagnostic.
 function flox_prepend_path {
   local _dir="${1?}"
   local _env="${FLOX_ENV?}"

--- a/cli/flox-activations/src/attach_diff/mod.rs
+++ b/cli/flox-activations/src/attach_diff/mod.rs
@@ -426,6 +426,9 @@ fn fixed_vars_to_export(
     let new_path = fix_path_var(
         &new_flox_env_dirs,
         &vars_from_environment.path.unwrap_or("".to_string()),
+        &vars_from_environment
+            .path_prepends
+            .unwrap_or("".to_string()),
     );
     let new_manpath = fix_manpath_var(
         &new_flox_env_dirs,

--- a/cli/flox-activations/src/cli/fix_fpath.rs
+++ b/cli/flox-activations/src/cli/fix_fpath.rs
@@ -23,7 +23,7 @@ impl FixFpathArgs {
         let env_dirs = separate_dir_list(env_dirs_joined);
         let path_dirs = separate_dir_list(colon_separated_fpath);
         let suffixes = ["share/zsh/site-functions", "share/zsh/vendor-completions"];
-        let fixed_path_dirs = prepend_dirs_to_pathlike_var(&env_dirs, &suffixes, &path_dirs);
+        let fixed_path_dirs = prepend_dirs_to_pathlike_var(&env_dirs, &suffixes, &path_dirs, &[]);
         let as_strs = fixed_path_dirs
             .into_iter()
             .map(|s| s.to_string_lossy().to_string())

--- a/cli/flox-activations/src/cli/fix_paths.rs
+++ b/cli/flox-activations/src/cli/fix_paths.rs
@@ -8,6 +8,12 @@ use tracing::debug;
 
 use super::{join_dir_list, separate_dir_list};
 
+/// The environment variable holding PATH prepends registered by
+/// `etc/profile.d` scripts via the `flox_prepend_path` helper.
+/// The value is a colon-separated list of `<env_dir>=<prepend_dir>` pairs,
+/// most recent registration first.
+pub const FLOX_ENV_PATH_PREPENDS_VAR: &str = "_FLOX_ENV_PATH_PREPENDS";
+
 #[derive(Debug, Args)]
 pub struct FixPathsArgs {
     #[arg(help = "Which shell syntax to return.")]
@@ -22,6 +28,9 @@ pub struct FixPathsArgs {
     #[arg(help = "The contents of MANPATH.")]
     #[arg(short, long, value_name = "STRING")]
     pub manpath: String,
+    #[arg(help = "The contents of _FLOX_ENV_PATH_PREPENDS.")]
+    #[arg(long, value_name = "STRING", default_value = "")]
+    pub path_prepends: String,
 }
 
 impl FixPathsArgs {
@@ -30,7 +39,7 @@ impl FixPathsArgs {
             "Preparing to fix path vars, FLOX_ENV_DIRS={}",
             self.env_dirs
         );
-        let new_path = fix_path_var(&self.env_dirs, &self.path);
+        let new_path = fix_path_var(&self.env_dirs, &self.path, &self.path_prepends);
         let new_manpath = fix_manpath_var(&self.env_dirs, &self.manpath);
         let sourceable_commands = match self.shell.as_ref() {
             "bash" => {
@@ -68,14 +77,36 @@ impl FixPathsArgs {
     }
 }
 
+/// Splits the contents of _FLOX_ENV_PATH_PREPENDS into
+/// (environment dir, prepend dir) pairs.
+/// Entries without a '=' or with an empty half are ignored.
+fn separate_prepends_list(joined: &str) -> Vec<(PathBuf, PathBuf)> {
+    let joined = if joined == "empty" { "" } else { joined };
+    joined
+        .split(':')
+        .filter_map(|entry| {
+            let (env_dir, prepend_dir) = entry.split_once('=')?;
+            if env_dir.is_empty() || prepend_dir.is_empty() {
+                return None;
+            }
+            Some((PathBuf::from(env_dir), PathBuf::from(prepend_dir)))
+        })
+        .collect()
+}
+
 /// Adds subdirectories of FLOX_ENV_DIRS to the front of the provided list
 /// of directories.
 /// If suffixes is empty, adds each dir in FLOX_ENV_DIRS directly.
 /// Suffixes are expected *not* to contain a leading slash.
+/// Each entry of `per_env_prepends` is placed ahead of the suffix dirs of
+/// the environment it is registered against, retaining that environment's
+/// position in the layered ordering. Entries registered against an
+/// environment not present in `flox_env_dirs` are dropped.
 pub fn prepend_dirs_to_pathlike_var(
     flox_env_dirs: &[PathBuf],
     suffixes: &[impl AsRef<str>],
     existing_dirs: &[PathBuf],
+    per_env_prepends: &[(PathBuf, PathBuf)],
 ) -> Vec<PathBuf> {
     let mut dir_set = HashSet::new();
     let mut dirs = VecDeque::new();
@@ -99,6 +130,16 @@ pub fn prepend_dirs_to_pathlike_var(
                 }
             }
         }
+        // Registered prepends go ahead of this environment's own dirs,
+        // mirroring what a plain `PATH="$dir:$PATH"` expressed at
+        // registration time. The list is most-recent-first, so reverse
+        // iteration with push_front keeps the most recent registration
+        // foremost within the layer.
+        for (env_dir, prepend_dir) in per_env_prepends.iter().rev() {
+            if env_dir == dir && dir_set.insert(prepend_dir.clone()) {
+                dirs.push_front(prepend_dir.clone())
+            }
+        }
     }
     // This is an empty string caused by splitting on a leading ':' or by
     // splitting a '::' (as found in MANPATH). We don't want to dedup these.
@@ -120,12 +161,15 @@ pub fn prepend_dirs_to_pathlike_var(
     dirs.into_iter().collect::<Vec<_>>()
 }
 
-/// Calculate the new PATH variable from FLOX_ENV_DIRS and the existing PATH.
-pub fn fix_path_var(flox_env_dirs_var: &str, path_var: &str) -> String {
+/// Calculate the new PATH variable from FLOX_ENV_DIRS, the existing PATH,
+/// and any prepends registered in _FLOX_ENV_PATH_PREPENDS.
+pub fn fix_path_var(flox_env_dirs_var: &str, path_var: &str, path_prepends_var: &str) -> String {
     let path_dirs = separate_dir_list(path_var);
     let flox_env_dirs = separate_dir_list(flox_env_dirs_var);
+    let per_env_prepends = separate_prepends_list(path_prepends_var);
     let suffixes = ["bin", "sbin"];
-    let fixed_path_dirs = prepend_dirs_to_pathlike_var(&flox_env_dirs, &suffixes, &path_dirs);
+    let fixed_path_dirs =
+        prepend_dirs_to_pathlike_var(&flox_env_dirs, &suffixes, &path_dirs, &per_env_prepends);
     join_dir_list(fixed_path_dirs)
 }
 
@@ -151,7 +195,8 @@ pub fn fix_manpath_var(flox_env_dirs_var: &str, manpath_var: &str) -> String {
     let manpath_dirs = separate_dir_list(manpath_var);
     let flox_env_dirs = separate_dir_list(flox_env_dirs_var);
     let suffixes = ["share/man"];
-    let fixed_manpath_dirs = prepend_dirs_to_pathlike_var(&flox_env_dirs, &suffixes, &manpath_dirs);
+    let fixed_manpath_dirs =
+        prepend_dirs_to_pathlike_var(&flox_env_dirs, &suffixes, &manpath_dirs, &[]);
     let mut joined = join_dir_list(fixed_manpath_dirs);
     if !(has_leading_colon || has_trailing_colon || has_double_colon) {
         joined.push(':');
@@ -174,7 +219,7 @@ mod test {
             PathBuf::from_str("/path1").unwrap(),
             PathBuf::from_str("/path2").unwrap(),
         ];
-        let new_dirs = prepend_dirs_to_pathlike_var(&flox_env_dirs, &suffixes, &path_dirs);
+        let new_dirs = prepend_dirs_to_pathlike_var(&flox_env_dirs, &suffixes, &path_dirs, &[]);
         assert_eq!(new_dirs[0], PathBuf::from_str("/flox_env/suffix").unwrap());
     }
 
@@ -189,7 +234,7 @@ mod test {
             PathBuf::from_str("/path1").unwrap(),
             PathBuf::from_str("/path2").unwrap(),
         ];
-        let new_dirs = prepend_dirs_to_pathlike_var(&flox_env_dirs, &suffixes, &path_dirs);
+        let new_dirs = prepend_dirs_to_pathlike_var(&flox_env_dirs, &suffixes, &path_dirs, &[]);
         assert_eq!(new_dirs, vec![
             PathBuf::from_str("/flox_env1/suffix").unwrap(),
             PathBuf::from_str("/flox_env2/suffix").unwrap(),
@@ -213,7 +258,7 @@ mod test {
             PathBuf::from_str("/path2").unwrap(),
             PathBuf::from_str("/path2").unwrap(),
         ];
-        let new_dirs = prepend_dirs_to_pathlike_var(&flox_env_dirs, &suffixes, &path_dirs);
+        let new_dirs = prepend_dirs_to_pathlike_var(&flox_env_dirs, &suffixes, &path_dirs, &[]);
         assert_eq!(new_dirs, vec![
             PathBuf::from_str("/flox_env1/suffix").unwrap(),
             PathBuf::from_str("/flox_env2/suffix").unwrap(),
@@ -269,6 +314,7 @@ mod test {
                 env_dirs: env_dirs.to_string(),
                 path: path.to_string(),
                 manpath: manpath.to_string(),
+                path_prepends: String::new(),
             }
             .handle_inner(&mut buf)
             .unwrap();
@@ -286,7 +332,7 @@ mod test {
             PathBuf::from_str("/path1").unwrap(),
             PathBuf::from_str("/flox_env1/bin").unwrap(),
         ];
-        let new_dirs = prepend_dirs_to_pathlike_var(&flox_env_dirs, &suffixes, &path_dirs);
+        let new_dirs = prepend_dirs_to_pathlike_var(&flox_env_dirs, &suffixes, &path_dirs, &[]);
         assert_eq!(new_dirs, vec![
             PathBuf::from_str("/flox_env1/bin").unwrap(),
             PathBuf::from_str("/flox_env1/sbin").unwrap(),
@@ -315,11 +361,66 @@ mod test {
         let env_dirs = "/env1:/env2";
         let path = "/foo:/bar";
         let manpath = "/baz:/qux";
-        let fixed_path = fix_path_var(env_dirs, path);
+        let fixed_path = fix_path_var(env_dirs, path, "");
         let fixed_manpath = fix_manpath_var(env_dirs, manpath);
-        let fixed_path_again = fix_path_var(env_dirs, &fixed_path);
+        let fixed_path_again = fix_path_var(env_dirs, &fixed_path, "");
         let fixed_manpath_again = fix_manpath_var(env_dirs, &fixed_manpath);
         assert_eq!(fixed_path, fixed_path_again);
         assert_eq!(fixed_manpath, fixed_manpath_again);
+    }
+
+    #[test]
+    fn prepends_are_placed_at_their_environments_layer() {
+        let env_dirs = "/env1:/env2";
+        let path = "/env1/prepend:/foo:/bar";
+        let prepends = "/env2=/env2/prepend:/env1=/env1/prepend";
+        let fixed = fix_path_var(env_dirs, path, prepends);
+        assert_eq!(
+            fixed,
+            "/env1/prepend:/env1/bin:/env1/sbin:/env2/prepend:/env2/bin:/env2/sbin:/foo:/bar"
+        );
+    }
+
+    #[test]
+    fn most_recent_prepend_is_foremost_within_a_layer() {
+        let env_dirs = "/env1";
+        let path = "/foo";
+        // Most recent registration first, as built by `flox_prepend_path`.
+        let prepends = "/env1=/newer:/env1=/older";
+        let fixed = fix_path_var(env_dirs, path, prepends);
+        assert_eq!(fixed, "/newer:/older:/env1/bin:/env1/sbin:/foo");
+    }
+
+    #[test]
+    fn prepends_for_inactive_environments_are_dropped() {
+        let env_dirs = "/env1";
+        let path = "/env2/prepend:/foo";
+        let prepends = "/env2=/env2/prepend";
+        let fixed = fix_path_var(env_dirs, path, prepends);
+        // The dir is no longer treated as a prepend, but an existing PATH
+        // entry is preserved in place like any other inherited dir.
+        assert_eq!(fixed, "/env1/bin:/env1/sbin:/env2/prepend:/foo");
+    }
+
+    #[test]
+    fn malformed_and_sentinel_prepend_entries_are_ignored() {
+        assert_eq!(separate_prepends_list("empty"), vec![]);
+        assert_eq!(separate_prepends_list(""), vec![]);
+        assert_eq!(separate_prepends_list("no-equals-sign"), vec![]);
+        assert_eq!(separate_prepends_list("=/dir:/env=:"), vec![]);
+        assert_eq!(separate_prepends_list("/env=/dir"), vec![(
+            PathBuf::from("/env"),
+            PathBuf::from("/dir")
+        )]);
+    }
+
+    #[test]
+    fn fixing_paths_with_prepends_is_idempotent() {
+        let env_dirs = "/env1:/env2";
+        let path = "/foo:/bar";
+        let prepends = "/env1=/env1/prepend:/env2=/env2/prepend";
+        let fixed = fix_path_var(env_dirs, path, prepends);
+        let fixed_again = fix_path_var(env_dirs, &fixed, prepends);
+        assert_eq!(fixed, fixed_again);
     }
 }

--- a/cli/flox-activations/src/cli/fix_paths.rs
+++ b/cli/flox-activations/src/cli/fix_paths.rs
@@ -148,6 +148,19 @@ pub fn prepend_dirs_to_pathlike_var(
             }
         }
     }
+    // Deactivated environments' registrations are dropped as a matter of
+    // course, but an entry that never matches is otherwise silent and hard
+    // to debug — e.g. an environment path containing '=' mangled by the
+    // unescaped "<env>=<dir>" encoding.
+    for (env_dir, prepend_dir) in per_env_prepends {
+        if !flox_env_dirs.contains(env_dir) {
+            debug!(
+                env_dir = %env_dir.display(),
+                prepend_dir = %prepend_dir.display(),
+                "dropping PATH prepend registered against an environment not in FLOX_ENV_DIRS"
+            );
+        }
+    }
     // This is an empty string caused by splitting on a leading ':' or by
     // splitting a '::' (as found in MANPATH). We don't want to dedup these.
     let empty = PathBuf::from("");

--- a/cli/flox-activations/src/cli/fix_paths.rs
+++ b/cli/flox-activations/src/cli/fix_paths.rs
@@ -12,6 +12,10 @@ use super::{join_dir_list, separate_dir_list};
 /// `etc/profile.d` scripts via the `flox_prepend_path` helper.
 /// The value is a colon-separated list of `<env_dir>=<prepend_dir>` pairs,
 /// most recent registration first.
+///
+/// The name must NOT end in `PATH`: fish auto-treats variables named
+/// `*PATH` as path-list variables (colon-split on import, re-joined on
+/// expansion), which would corrupt the multi-entry value in transit.
 pub const FLOX_ENV_PATH_PREPENDS_VAR: &str = "_FLOX_ENV_PATH_PREPENDS";
 
 #[derive(Debug, Args)]

--- a/cli/flox-activations/src/cli/fix_paths.rs
+++ b/cli/flox-activations/src/cli/fix_paths.rs
@@ -80,6 +80,13 @@ impl FixPathsArgs {
 /// Splits the contents of _FLOX_ENV_PATH_PREPENDS into
 /// (environment dir, prepend dir) pairs.
 /// Entries without a '=' or with an empty half are ignored.
+///
+/// Entries are never pruned from the variable itself: registrations for
+/// deactivated environments accumulate there and are filtered out at
+/// replay time by `prepend_dirs_to_pathlike_var`, which drops entries
+/// whose environment is not in FLOX_ENV_DIRS. Deactivation restores the
+/// variable to its pre-activation value via the recorded env diff, so
+/// accumulation is bounded by the depth of the activation stack.
 fn separate_prepends_list(joined: &str) -> Vec<(PathBuf, PathBuf)> {
     let joined = if joined == "empty" { "" } else { joined };
     joined
@@ -422,5 +429,41 @@ mod test {
         let fixed = fix_path_var(env_dirs, path, prepends);
         let fixed_again = fix_path_var(env_dirs, &fixed, prepends);
         assert_eq!(fixed, fixed_again);
+    }
+
+    #[test]
+    fn same_dir_registered_by_two_envs_keeps_innermost_position() {
+        let env_dirs = "/env1:/env2";
+        let path = "/foo";
+        let prepends = "/env2=/shared:/env1=/shared";
+        let fixed = fix_path_var(env_dirs, path, prepends);
+        // A dir registered by multiple active environments is deduped to
+        // the outermost registering environment's layer: it keeps the
+        // position it already held when the inner environment layered on
+        // top, exactly as an inherited PATH entry would.
+        assert_eq!(
+            fixed,
+            "/env1/bin:/env1/sbin:/shared:/env2/bin:/env2/sbin:/foo"
+        );
+    }
+
+    #[test]
+    fn prepend_equal_to_own_bin_dir_is_deduped() {
+        let env_dirs = "/env1";
+        let path = "/foo";
+        let prepends = "/env1=/env1/bin";
+        let fixed = fix_path_var(env_dirs, path, prepends);
+        // bin/sbin are pushed before prepends are considered, so the
+        // registration dedups away rather than duplicating the entry.
+        assert_eq!(fixed, "/env1/bin:/env1/sbin:/foo");
+    }
+
+    #[test]
+    fn prepend_dirs_containing_spaces_are_preserved() {
+        let env_dirs = "/env one";
+        let path = "/foo";
+        let prepends = "/env one=/env one/extra bin";
+        let fixed = fix_path_var(env_dirs, path, prepends);
+        assert_eq!(fixed, "/env one/extra bin:/env one/bin:/env one/sbin:/foo");
     }
 }

--- a/cli/flox-activations/src/cli/prepend_and_dedup.rs
+++ b/cli/flox-activations/src/cli/prepend_and_dedup.rs
@@ -27,7 +27,7 @@ impl PrependAndDedupArgs {
         let env_dirs = separate_dir_list(env_dirs_joined);
         let path_dirs = separate_dir_list(path_like);
         let suffixes = suffixes.unwrap_or(&[]);
-        let fixed_path_dirs = prepend_dirs_to_pathlike_var(&env_dirs, suffixes, &path_dirs);
+        let fixed_path_dirs = prepend_dirs_to_pathlike_var(&env_dirs, suffixes, &path_dirs, &[]);
         join_dir_list(fixed_path_dirs)
     }
 }

--- a/cli/flox-activations/src/gen_rc/bash.rs
+++ b/cli/flox-activations/src/gen_rc/bash.rs
@@ -193,7 +193,7 @@ pub fn generate_bash_profile_commands(
                 args.flox_env.display()
             ).to_stmt());
             stmts.push(format!(
-                r#"eval "$('{}' fix-paths --shell {} --env-dirs "$FLOX_ENV_DIRS" --path "$PATH" --manpath "${{MANPATH:-}}")";"#,
+                r#"eval "$('{}' fix-paths --shell {} --env-dirs "$FLOX_ENV_DIRS" --path "$PATH" --manpath "${{MANPATH:-}}" --path-prepends "${{_FLOX_ENV_PATH_PREPENDS:-}}")";"#,
                 args.flox_activations.display(),
                 Shell::Bash,
             ).to_stmt());
@@ -394,7 +394,7 @@ mod tests {
             _FLOX_INVOCATION_TYPES="$('/flox_activations' push-invocation-type --invocation-type interactive --env '{"name":"test_env","type":"path"}' --current "${_FLOX_INVOCATION_TYPES:-}")";
             if [ -t 1 ]; then source '/interpreter/activate.d/set-prompt.bash'; fi;
             eval "$('/flox_activations' set-env-dirs --shell bash --flox-env "/flox_env" --env-dirs "${FLOX_ENV_DIRS:-}")";
-            eval "$('/flox_activations' fix-paths --shell bash --env-dirs "$FLOX_ENV_DIRS" --path "$PATH" --manpath "${MANPATH:-}")";
+            eval "$('/flox_activations' fix-paths --shell bash --env-dirs "$FLOX_ENV_DIRS" --path "$PATH" --manpath "${MANPATH:-}" --path-prepends "${_FLOX_ENV_PATH_PREPENDS:-}")";
             eval "$('/flox_activations' profile-scripts --shell bash --already-sourced-env-dirs "${_FLOX_SOURCED_PROFILE_SCRIPTS:-}" --env-dirs "${FLOX_ENV_DIRS:-}")";
             set +h
             set +x
@@ -443,7 +443,7 @@ mod tests {
             _FLOX_INVOCATION_TYPES="$('/flox_activations' push-invocation-type --invocation-type inplace --env '{"name":"test_env","type":"path"}' --current "${_FLOX_INVOCATION_TYPES:-}")";
             if [ -t 1 ]; then source '/interpreter/activate.d/set-prompt.bash'; fi;
             eval "$('/flox_activations' set-env-dirs --shell bash --flox-env "/flox_env" --env-dirs "${FLOX_ENV_DIRS:-}")";
-            eval "$('/flox_activations' fix-paths --shell bash --env-dirs "$FLOX_ENV_DIRS" --path "$PATH" --manpath "${MANPATH:-}")";
+            eval "$('/flox_activations' fix-paths --shell bash --env-dirs "$FLOX_ENV_DIRS" --path "$PATH" --manpath "${MANPATH:-}" --path-prepends "${_FLOX_ENV_PATH_PREPENDS:-}")";
             eval "$('/flox_activations' profile-scripts --shell bash --already-sourced-env-dirs "${_FLOX_SOURCED_PROFILE_SCRIPTS:-}" --env-dirs "${FLOX_ENV_DIRS:-}")";
             set +h
             set +x

--- a/cli/flox-activations/src/gen_rc/fish.rs
+++ b/cli/flox-activations/src/gen_rc/fish.rs
@@ -175,7 +175,7 @@ pub fn generate_fish_profile_commands(
             );
 
             stmts.push(format!(
-                r#"{} fix-paths --shell {} --env-dirs "$FLOX_ENV_DIRS" --path "$PATH" --manpath "$MANPATH" | source;"#,
+                r#"{} fix-paths --shell {} --env-dirs "$FLOX_ENV_DIRS" --path "$PATH" --manpath "$MANPATH" --path-prepends "$_FLOX_ENV_PATH_PREPENDS" | source;"#,
                 args.flox_activations.display(),
                 Shell::Fish,
             ).to_stmt());
@@ -344,7 +344,7 @@ mod tests {
             set -gx FLOX_ENV_DIRS (if set -q FLOX_ENV_DIRS; echo "$FLOX_ENV_DIRS"; else; echo empty; end);
             /flox_activations set-env-dirs --shell fish --flox-env "/flox_env" --env-dirs "$FLOX_ENV_DIRS" | source;
             set -gx MANPATH (if set -q MANPATH; echo "$MANPATH"; else; echo empty; end);
-            /flox_activations fix-paths --shell fish --env-dirs "$FLOX_ENV_DIRS" --path "$PATH" --manpath "$MANPATH" | source;
+            /flox_activations fix-paths --shell fish --env-dirs "$FLOX_ENV_DIRS" --path "$PATH" --manpath "$MANPATH" --path-prepends "$_FLOX_ENV_PATH_PREPENDS" | source;
             set -g  _FLOX_SOURCED_PROFILE_SCRIPTS (if set -q _FLOX_SOURCED_PROFILE_SCRIPTS; echo "$_FLOX_SOURCED_PROFILE_SCRIPTS"; else; echo ""; end);
             /flox_activations profile-scripts --shell fish --already-sourced-env-dirs  "$_FLOX_SOURCED_PROFILE_SCRIPTS" --env-dirs "$FLOX_ENV_DIRS" | source;
             set -gx fish_trace 0;
@@ -401,7 +401,7 @@ mod tests {
             set -gx FLOX_ENV_DIRS (if set -q FLOX_ENV_DIRS; echo "$FLOX_ENV_DIRS"; else; echo empty; end);
             /flox_activations set-env-dirs --shell fish --flox-env "/flox_env" --env-dirs "$FLOX_ENV_DIRS" | source;
             set -gx MANPATH (if set -q MANPATH; echo "$MANPATH"; else; echo empty; end);
-            /flox_activations fix-paths --shell fish --env-dirs "$FLOX_ENV_DIRS" --path "$PATH" --manpath "$MANPATH" | source;
+            /flox_activations fix-paths --shell fish --env-dirs "$FLOX_ENV_DIRS" --path "$PATH" --manpath "$MANPATH" --path-prepends "$_FLOX_ENV_PATH_PREPENDS" | source;
             set -g  _FLOX_SOURCED_PROFILE_SCRIPTS (if set -q _FLOX_SOURCED_PROFILE_SCRIPTS; echo "$_FLOX_SOURCED_PROFILE_SCRIPTS"; else; echo ""; end);
             /flox_activations profile-scripts --shell fish --already-sourced-env-dirs  "$_FLOX_SOURCED_PROFILE_SCRIPTS" --env-dirs "$FLOX_ENV_DIRS" | source;
             set -gx fish_trace 0;

--- a/cli/flox-activations/src/gen_rc/mod.rs
+++ b/cli/flox-activations/src/gen_rc/mod.rs
@@ -194,6 +194,7 @@ pub(crate) mod test_helpers {
             flox_env_dirs: None,
             path: None,
             manpath: None,
+            path_prepends: None,
             full_env: Some(full_env),
         };
         let rc_path = Some(PathBuf::from("/path/to/rc/file"));

--- a/cli/flox-activations/src/gen_rc/tcsh.rs
+++ b/cli/flox-activations/src/gen_rc/tcsh.rs
@@ -204,11 +204,24 @@ pub fn generate_tcsh_profile_commands(
 
             stmts.push(r#"if (! $?MANPATH) setenv MANPATH "empty";"#.to_stmt());
 
+            stmts.push(
+                r#"if (! $?_FLOX_ENV_PATH_PREPENDS) setenv _FLOX_ENV_PATH_PREPENDS "empty";"#
+                    .to_stmt(),
+            );
+
             stmts.push(format!(
-                r#"eval "`'{}' fix-paths --shell {} --env-dirs $FLOX_ENV_DIRS:q --path $PATH:q --manpath $MANPATH:q`";"#,
+                r#"eval "`'{}' fix-paths --shell {} --env-dirs $FLOX_ENV_DIRS:q --path $PATH:q --manpath $MANPATH:q --path-prepends $_FLOX_ENV_PATH_PREPENDS:q`";"#,
                 args.flox_activations.display(),
                 Shell::Tcsh,
             ).to_stmt());
+
+            // Drop the sentinel again so it doesn't outlive the activation;
+            // real registrations never look like "empty" because every entry
+            // contains a '='.
+            stmts.push(
+                r#"if ($_FLOX_ENV_PATH_PREPENDS:q == "empty") unsetenv _FLOX_ENV_PATH_PREPENDS;"#
+                    .to_stmt(),
+            );
         },
         Action::Deactivate(_) => {
             // No-op: covered by environment restoration above
@@ -405,7 +418,9 @@ mod tests {
             if (! $?FLOX_ENV_DIRS) setenv FLOX_ENV_DIRS "empty";
             eval "`'/flox_activations' set-env-dirs --shell tcsh --flox-env '/flox_env' --env-dirs $FLOX_ENV_DIRS:q`";
             if (! $?MANPATH) setenv MANPATH "empty";
-            eval "`'/flox_activations' fix-paths --shell tcsh --env-dirs $FLOX_ENV_DIRS:q --path $PATH:q --manpath $MANPATH:q`";
+            if (! $?_FLOX_ENV_PATH_PREPENDS) setenv _FLOX_ENV_PATH_PREPENDS "empty";
+            eval "`'/flox_activations' fix-paths --shell tcsh --env-dirs $FLOX_ENV_DIRS:q --path $PATH:q --manpath $MANPATH:q --path-prepends $_FLOX_ENV_PATH_PREPENDS:q`";
+            if ($_FLOX_ENV_PATH_PREPENDS:q == "empty") unsetenv _FLOX_ENV_PATH_PREPENDS;
             set _already_sourced_args = ();
             if ($?_FLOX_SOURCED_PROFILE_SCRIPTS) set _already_sourced_args = ( --already-sourced-env-dirs `echo $_FLOX_SOURCED_PROFILE_SCRIPTS:q` );
             eval "`'/flox_activations' profile-scripts --shell tcsh --env-dirs $FLOX_ENV_DIRS:q $_already_sourced_args:q`";
@@ -449,7 +464,9 @@ mod tests {
             if (! $?FLOX_ENV_DIRS) setenv FLOX_ENV_DIRS "empty";
             eval "`'/flox_activations' set-env-dirs --shell tcsh --flox-env '/flox_env' --env-dirs $FLOX_ENV_DIRS:q`";
             if (! $?MANPATH) setenv MANPATH "empty";
-            eval "`'/flox_activations' fix-paths --shell tcsh --env-dirs $FLOX_ENV_DIRS:q --path $PATH:q --manpath $MANPATH:q`";
+            if (! $?_FLOX_ENV_PATH_PREPENDS) setenv _FLOX_ENV_PATH_PREPENDS "empty";
+            eval "`'/flox_activations' fix-paths --shell tcsh --env-dirs $FLOX_ENV_DIRS:q --path $PATH:q --manpath $MANPATH:q --path-prepends $_FLOX_ENV_PATH_PREPENDS:q`";
+            if ($_FLOX_ENV_PATH_PREPENDS:q == "empty") unsetenv _FLOX_ENV_PATH_PREPENDS;
             set _already_sourced_args = ();
             if ($?_FLOX_SOURCED_PROFILE_SCRIPTS) set _already_sourced_args = ( --already-sourced-env-dirs `echo $_FLOX_SOURCED_PROFILE_SCRIPTS:q` );
             eval "`'/flox_activations' profile-scripts --shell tcsh --env-dirs $FLOX_ENV_DIRS:q $_already_sourced_args:q`";

--- a/cli/flox-activations/src/vars_from_env.rs
+++ b/cli/flox-activations/src/vars_from_env.rs
@@ -4,12 +4,15 @@ use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
 use crate::attach_diff::FLOX_ENV_DIRS_VAR;
+use crate::cli::fix_paths::FLOX_ENV_PATH_PREPENDS_VAR;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct VarsFromEnvironment {
     pub flox_env_dirs: Option<String>,
     pub path: Option<String>,
     pub manpath: Option<String>,
+    #[serde(default)]
+    pub path_prepends: Option<String>,
     /// Full environment snapshot for activation diff computation.
     /// Populated by [`VarsFromEnvironment::get_with_snapshot`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -21,11 +24,13 @@ impl VarsFromEnvironment {
         let flox_env_dirs = std::env::var(FLOX_ENV_DIRS_VAR).ok();
         let path = std::env::var("PATH").ok();
         let manpath = std::env::var("MANPATH").ok();
+        let path_prepends = std::env::var(FLOX_ENV_PATH_PREPENDS_VAR).ok();
 
         Ok(Self {
             flox_env_dirs,
             path,
             manpath,
+            path_prepends,
             full_env: None,
         })
     }
@@ -41,6 +46,7 @@ impl VarsFromEnvironment {
             flox_env_dirs: all_vars.get(FLOX_ENV_DIRS_VAR).cloned(),
             path: all_vars.get("PATH").cloned(),
             manpath: all_vars.get("MANPATH").cloned(),
+            path_prepends: all_vars.get(FLOX_ENV_PATH_PREPENDS_VAR).cloned(),
             full_env: Some(all_vars),
         })
     }

--- a/cli/flox-activations/src/vars_from_env.rs
+++ b/cli/flox-activations/src/vars_from_env.rs
@@ -11,7 +11,7 @@ pub struct VarsFromEnvironment {
     pub flox_env_dirs: Option<String>,
     pub path: Option<String>,
     pub manpath: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub path_prepends: Option<String>,
     /// Full environment snapshot for activation diff computation.
     /// Populated by [`VarsFromEnvironment::get_with_snapshot`].

--- a/cli/flox/doc/flox-activate.md
+++ b/cli/flox/doc/flox-activate.md
@@ -94,6 +94,13 @@ the registering environment's own `bin` directory each time `PATH` is
 re-ordered,
 preserving their position as environments are activated, layered,
 and attached to.
+An environment activated later still takes precedence over an earlier
+environment's registered directories,
+just as it does over the earlier environment's `bin` directory.
+Registered directories must not contain `:` or `=` characters.
+Because activations in "run" mode do not source package-provided startup
+scripts,
+`flox_prepend_path` has no effect in that mode.
 
 To reverse activation,
 run [`flox-deactivate(1)`](./flox-deactivate.md).

--- a/cli/flox/doc/flox-activate.md
+++ b/cli/flox/doc/flox-activate.md
@@ -80,6 +80,21 @@ These scripts run before the environment's `[hook]` and `[profile]` scripts.
 Activations in "run" mode source only the startup scripts provided by Flox,
 not those provided by packages.
 
+Startup scripts which add directories to `PATH` should use the
+`flox_prepend_path` shell function rather than modifying `PATH` directly:
+```bash
+flox_prepend_path "$FLOX_ENV/lib/node_modules/.bin"
+```
+Flox re-orders `PATH` at various points to keep each activated environment's
+`bin` and `sbin` directories foremost,
+which would demote a plain `PATH` assignment behind every
+activated environment.
+Directories registered with `flox_prepend_path` are instead replayed ahead of
+the registering environment's own `bin` directory each time `PATH` is
+re-ordered,
+preserving their position as environments are activated, layered,
+and attached to.
+
 To reverse activation,
 run [`flox-deactivate(1)`](./flox-deactivate.md).
 Inside a `flox activate` subshell,

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -2809,6 +2809,37 @@ EOF
   assert_line --partial "$inner/bin:$inner/sbin:$outer/extra-bin:$outer/bin:$outer/sbin"
 }
 
+# A shell attaching to an already-running activation computes PATH from the
+# replayed activation state rather than by running profile.d scripts again;
+# the registered prepend must survive there too.
+# bats test_tags=activate,activate:attach
+@test "profile.d: flox_prepend_path additions survive attach" {
+  project_setup
+  PROJECT_DIR="$(realpath "$PROJECT_DIR")"
+  _install_prepend_path_pkg
+
+  mkfifo activate_started_fifo
+  # Will get cat'ed in teardown
+  TEARDOWN_FIFO="$PROJECT_DIR/teardown_activate"
+  mkfifo "$TEARDOWN_FIFO"
+
+  # Start an activation and keep it running.
+  "$FLOX_BIN" activate -c "bash -c \"echo > activate_started_fifo && echo > $TEARDOWN_FIFO\"" >> output 2>&1 &
+  cat activate_started_fifo
+
+  rendered="$PROJECT_DIR/.flox/run/${NIX_SYSTEM}.${PROJECT_NAME}-dev"
+
+  # Command-mode attach.
+  run --separate-stderr "$FLOX_BIN" activate -- bash -c 'echo "$PATH"'
+  assert_success
+  assert_line --partial "$rendered/extra-bin:$rendered/bin:$rendered/sbin"
+
+  # In-place attach.
+  run bash -c 'eval "$("$FLOX_BIN" activate)"; echo "$PATH"'
+  assert_success
+  assert_line --partial "$rendered/extra-bin:$rendered/bin:$rendered/sbin"
+}
+
 @test "activate works with fish 3.2.2" {
   if [ "$NIX_SYSTEM" == aarch64-linux ]; then
     # running fish at all on aarch64-linux throws:

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -2752,6 +2752,51 @@ EOF
   assert_success
 }
 
+# Fabricate and install a package whose profile.d script registers an
+# extra PATH dir with flox_prepend_path, for the tests below.
+_install_prepend_path_pkg() {
+  mkdir -p "$BATS_TEST_TMPDIR/pkg/etc/profile.d" "$BATS_TEST_TMPDIR/pkg/extra-bin"
+  touch "$BATS_TEST_TMPDIR/pkg/extra-bin/.keep"
+  cat > "$BATS_TEST_TMPDIR/pkg/etc/profile.d/0900_prepend-path.sh" <<'EOF'
+flox_prepend_path "$FLOX_ENV/extra-bin"
+EOF
+  pkg_store_path="$(nix --extra-experimental-features nix-command \
+    store add --name prepend-path-test-pkg "$BATS_TEST_TMPDIR/pkg")"
+  run "$FLOX_BIN" install "$pkg_store_path"
+  assert_success
+}
+
+# PATH dirs registered with flox_prepend_path must survive the PATH
+# re-ordering performed at the end of in-place activation, staying ahead
+# of the registering environment's own bin directory.
+@test "profile.d: flox_prepend_path additions survive PATH re-ordering" {
+  project_setup
+  PROJECT_DIR="$(realpath "$PROJECT_DIR")"
+  _install_prepend_path_pkg
+
+  rendered="$PROJECT_DIR/.flox/run/${NIX_SYSTEM}.${PROJECT_NAME}-dev"
+  run bash -c 'eval "$("$FLOX_BIN" activate)"; echo "$PATH"'
+  assert_success
+  assert_line --partial "$rendered/extra-bin:$rendered/bin:$rendered/sbin"
+}
+
+# When environments are layered, a registered prepend stays with the layer
+# of the environment that registered it: environments activated later still
+# take precedence over it.
+@test "profile.d: flox_prepend_path additions are replayed at their environment's layer" {
+  project_setup
+  PROJECT_DIR="$(realpath "$PROJECT_DIR")"
+  _install_prepend_path_pkg
+  "$FLOX_BIN" init -d inner
+
+  outer="$PROJECT_DIR/.flox/run/${NIX_SYSTEM}.${PROJECT_NAME}-dev"
+  inner="$PROJECT_DIR/inner/.flox/run/${NIX_SYSTEM}.inner-dev"
+  run "$FLOX_BIN" activate -- \
+    "$FLOX_BIN" activate --dir inner -- bash -c 'echo "$PATH"'
+  assert_success
+  assert_line --partial "$inner/bin:$inner/sbin:$outer/extra-bin:$outer/bin:$outer/sbin"
+}
+
 @test "activate works with fish 3.2.2" {
   if [ "$NIX_SYSTEM" == aarch64-linux ]; then
     # running fish at all on aarch64-linux throws:

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -2773,19 +2773,75 @@ EOF
 # PATH dirs registered with flox_prepend_path must survive the PATH
 # re-ordering performed at the end of in-place activation, staying ahead
 # of the registering environment's own bin directory.
-@test "profile.d: flox_prepend_path additions survive PATH re-ordering" {
+_prepend_path_survives_in_place() {
+  shell="${1?}"
   project_setup
   PROJECT_DIR="$(realpath "$PROJECT_DIR")"
   _install_prepend_path_pkg
 
   rendered="$PROJECT_DIR/.flox/run/${NIX_SYSTEM}.${PROJECT_NAME}-dev"
-  run bash -c 'eval "$("$FLOX_BIN" activate)"; echo "$PATH"'
+  if [ "$shell" == "tcsh" ]; then
+    run "$shell" -c 'eval "`"$FLOX_BIN" activate`"; echo "$PATH"'
+  else
+    run "$shell" -c 'eval "$("$FLOX_BIN" activate)"; echo "$PATH"'
+  fi
   assert_success
+  # fish joins quoted expansions of path variables with ':' like the rest.
   assert_line --partial "$rendered/extra-bin:$rendered/bin:$rendered/sbin"
+}
 
-  # Command mode runs fix-paths before profile.d and has no trailing
-  # re-order to dedup PATH, so the helper itself must be idempotent when
-  # two scripts register the same dir.
+@test "bash: profile.d: flox_prepend_path additions survive PATH re-ordering" {
+  _prepend_path_survives_in_place bash
+
+  # Registrations are restored along with the rest of the environment on
+  # deactivation; the variable must not outlive the activation.
+  FLOX_SHELL="bash" run --separate-stderr bash -c '
+    eval "$($FLOX_BIN activate --print-script)"
+    eval "$($FLOX_BIN deactivate --print-script "$_FLOX_INVOCATION_TYPES")"
+    if [ -z "${_FLOX_ENV_PATH_PREPENDS+x}" ]; then
+      echo "after:unset"
+    fi
+  '
+  assert_success
+  assert_line "after:unset"
+}
+
+@test "fish: profile.d: flox_prepend_path additions survive PATH re-ordering" {
+  _prepend_path_survives_in_place fish
+}
+
+@test "tcsh: profile.d: flox_prepend_path additions survive PATH re-ordering" {
+  _prepend_path_survives_in_place tcsh
+
+  # The tcsh rc guards the possibly-unset variable with an "empty"
+  # sentinel; confirm neither the sentinel nor a registration outlives
+  # the activation.
+  SHELL="$(which tcsh)" run --separate-stderr tcsh -c '
+    eval "`$FLOX_BIN activate --print-script`"
+    setenv _FLOX_INVOCATION_TYPES_WIRE $_FLOX_INVOCATION_TYPES:q
+    eval "`$FLOX_BIN deactivate --print-script-from-env`"
+    unsetenv _FLOX_INVOCATION_TYPES_WIRE
+    if ( ! $?_FLOX_ENV_PATH_PREPENDS ) then
+      echo "after:unset"
+    endif
+  '
+  assert_success
+  assert_line "after:unset"
+}
+
+@test "zsh: profile.d: flox_prepend_path additions survive PATH re-ordering" {
+  _prepend_path_survives_in_place zsh
+}
+
+# Command mode runs fix-paths before profile.d and has no trailing
+# re-order to dedup PATH, so the helper itself must be idempotent when
+# two scripts register the same dir.
+@test "profile.d: flox_prepend_path is idempotent across scripts" {
+  project_setup
+  PROJECT_DIR="$(realpath "$PROJECT_DIR")"
+  _install_prepend_path_pkg
+
+  rendered="$PROJECT_DIR/.flox/run/${NIX_SYSTEM}.${PROJECT_NAME}-dev"
   run --separate-stderr "$FLOX_BIN" activate -- bash -c 'echo "$PATH"'
   assert_success
   occurrences="$(echo "$output" | tr ':' '\n' | grep -cx "$rendered/extra-bin")"

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -2752,17 +2752,24 @@ EOF
   assert_success
 }
 
-# Fabricate and install a package whose profile.d scripts register an
-# extra PATH dir with flox_prepend_path, for the tests below. Two scripts
-# register the same dir to cover the helper's idempotency.
+# Fabricate and install a package whose profile.d scripts register extra
+# PATH dirs with flox_prepend_path, for the tests below. Two scripts
+# register the same dir to cover the helper's idempotency, and a third
+# registers a second dir so that _FLOX_ENV_PATH_PREPENDS holds a
+# multi-entry (colon-containing) value, exercising its transport through
+# each shell's variable handling.
 _install_prepend_path_pkg() {
-  mkdir -p "$BATS_TEST_TMPDIR/pkg/etc/profile.d" "$BATS_TEST_TMPDIR/pkg/extra-bin"
-  touch "$BATS_TEST_TMPDIR/pkg/extra-bin/.keep"
+  mkdir -p "$BATS_TEST_TMPDIR/pkg/etc/profile.d" \
+    "$BATS_TEST_TMPDIR/pkg/extra-bin" "$BATS_TEST_TMPDIR/pkg/extra-bin2"
+  touch "$BATS_TEST_TMPDIR/pkg/extra-bin/.keep" "$BATS_TEST_TMPDIR/pkg/extra-bin2/.keep"
   cat > "$BATS_TEST_TMPDIR/pkg/etc/profile.d/0900_prepend-path.sh" <<'EOF'
 flox_prepend_path "$FLOX_ENV/extra-bin"
 EOF
   cat > "$BATS_TEST_TMPDIR/pkg/etc/profile.d/0901_prepend-path-again.sh" <<'EOF'
 flox_prepend_path "$FLOX_ENV/extra-bin"
+EOF
+  cat > "$BATS_TEST_TMPDIR/pkg/etc/profile.d/0902_prepend-path-second.sh" <<'EOF'
+flox_prepend_path "$FLOX_ENV/extra-bin2"
 EOF
   pkg_store_path="$(nix --extra-experimental-features nix-command \
     store add --name prepend-path-test-pkg "$BATS_TEST_TMPDIR/pkg")"
@@ -2787,7 +2794,7 @@ _prepend_path_survives_in_place() {
   fi
   assert_success
   # fish joins quoted expansions of path variables with ':' like the rest.
-  assert_line --partial "$rendered/extra-bin:$rendered/bin:$rendered/sbin"
+  assert_line --partial "$rendered/extra-bin2:$rendered/extra-bin:$rendered/bin:$rendered/sbin"
 }
 
 @test "bash: profile.d: flox_prepend_path additions survive PATH re-ordering" {
@@ -2844,8 +2851,10 @@ _prepend_path_survives_in_place() {
   rendered="$PROJECT_DIR/.flox/run/${NIX_SYSTEM}.${PROJECT_NAME}-dev"
   run --separate-stderr "$FLOX_BIN" activate -- bash -c 'echo "$PATH"'
   assert_success
-  occurrences="$(echo "$output" | tr ':' '\n' | grep -cx "$rendered/extra-bin")"
-  assert_equal "$occurrences" 1
+  for dir in extra-bin extra-bin2; do
+    occurrences="$(echo "$output" | tr ':' '\n' | grep -cx "$rendered/$dir")"
+    assert_equal "$occurrences" 1
+  done
 }
 
 # When environments are layered, a registered prepend stays with the layer
@@ -2862,7 +2871,7 @@ _prepend_path_survives_in_place() {
   run "$FLOX_BIN" activate -- \
     "$FLOX_BIN" activate --dir inner -- bash -c 'echo "$PATH"'
   assert_success
-  assert_line --partial "$inner/bin:$inner/sbin:$outer/extra-bin:$outer/bin:$outer/sbin"
+  assert_line --partial "$inner/bin:$inner/sbin:$outer/extra-bin2:$outer/extra-bin:$outer/bin:$outer/sbin"
 }
 
 # A shell attaching to an already-running activation computes PATH from the
@@ -2888,12 +2897,12 @@ _prepend_path_survives_in_place() {
   # Command-mode attach.
   run --separate-stderr "$FLOX_BIN" activate -- bash -c 'echo "$PATH"'
   assert_success
-  assert_line --partial "$rendered/extra-bin:$rendered/bin:$rendered/sbin"
+  assert_line --partial "$rendered/extra-bin2:$rendered/extra-bin:$rendered/bin:$rendered/sbin"
 
   # In-place attach.
   run bash -c 'eval "$("$FLOX_BIN" activate)"; echo "$PATH"'
   assert_success
-  assert_line --partial "$rendered/extra-bin:$rendered/bin:$rendered/sbin"
+  assert_line --partial "$rendered/extra-bin2:$rendered/extra-bin:$rendered/bin:$rendered/sbin"
 }
 
 @test "activate works with fish 3.2.2" {

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -2752,12 +2752,16 @@ EOF
   assert_success
 }
 
-# Fabricate and install a package whose profile.d script registers an
-# extra PATH dir with flox_prepend_path, for the tests below.
+# Fabricate and install a package whose profile.d scripts register an
+# extra PATH dir with flox_prepend_path, for the tests below. Two scripts
+# register the same dir to cover the helper's idempotency.
 _install_prepend_path_pkg() {
   mkdir -p "$BATS_TEST_TMPDIR/pkg/etc/profile.d" "$BATS_TEST_TMPDIR/pkg/extra-bin"
   touch "$BATS_TEST_TMPDIR/pkg/extra-bin/.keep"
   cat > "$BATS_TEST_TMPDIR/pkg/etc/profile.d/0900_prepend-path.sh" <<'EOF'
+flox_prepend_path "$FLOX_ENV/extra-bin"
+EOF
+  cat > "$BATS_TEST_TMPDIR/pkg/etc/profile.d/0901_prepend-path-again.sh" <<'EOF'
 flox_prepend_path "$FLOX_ENV/extra-bin"
 EOF
   pkg_store_path="$(nix --extra-experimental-features nix-command \
@@ -2778,6 +2782,14 @@ EOF
   run bash -c 'eval "$("$FLOX_BIN" activate)"; echo "$PATH"'
   assert_success
   assert_line --partial "$rendered/extra-bin:$rendered/bin:$rendered/sbin"
+
+  # Command mode runs fix-paths before profile.d and has no trailing
+  # re-order to dedup PATH, so the helper itself must be idempotent when
+  # two scripts register the same dir.
+  run --separate-stderr "$FLOX_BIN" activate -- bash -c 'echo "$PATH"'
+  assert_success
+  occurrences="$(echo "$output" | tr ':' '\n' | grep -cx "$rendered/extra-bin")"
+  assert_equal "$occurrences" 1
 }
 
 # When environments are layered, a registered prepend stays with the layer


### PR DESCRIPTION
## Summary

Fixes a gap in the `etc/profile.d` startup-script contract delivered in #4509: scripts could prepend to `PATH`, but `flox-activations fix-paths` re-orders `PATH` at the end of every activation and attachment to keep each activated environment's `bin`/`sbin` directories foremost, demoting any such prepend behind every layered environment.

- **New helper for profile.d scripts:** `flox_prepend_path <dir>` (defined in the interpreter's `helpers.bash`) prepends `<dir>` to `PATH` immediately and registers it against `$FLOX_ENV` in `_FLOX_ENV_PATH_PREPENDS`, a colon-separated list of `<env_dir>=<prepend_dir>` pairs, newest first. Registration is idempotent, and `<dir>` must not contain `:` or `=`. Because run-mode activations do not source package-provided profile.d scripts (#4514), the helper has no effect in run mode; this is documented in `flox-activate(1)`.
- **`fix-paths` learns `--path-prepends`:** each registered directory is replayed *ahead of the registering environment's own `bin`* at that environment's position in the layered ordering — so an environment activated later still takes precedence over an earlier environment's prepends, exactly like its `bin` dirs do. Entries whose environment is no longer in `FLOX_ENV_DIRS` are dropped, and malformed entries are ignored.
- **Replay falls out of the existing machinery:** profile.d scripts run between the activation's env snapshots, so the registration is captured in the recorded activation diff and replayed into every attaching shell *before* the trailing `fix-paths` runs. The same mechanism that demoted raw prepends now re-asserts registered ones on every attach, rc re-source, and re-layering.
- **Threaded through every `fix-paths` call site:** the bash, fish, and tcsh rc generators, the Rust-side attach export computation (`VarsFromEnvironment`/`fixed_vars_to_export`), and the interpreter's `activate` and `activate.d/zsh` scripts. The tcsh generator guards the possibly-unset variable with the existing `"empty"` sentinel idiom and unsets the sentinel after use so it cannot outlive the activation.
- `flox-activate(1)` documents the helper in the profile.d section.

## Testing

- Eight unit tests in `fix_paths.rs`: layer placement, within-layer ordering of multiple registrations, dropping entries for inactive environments, entry parsing (malformed + sentinel), idempotency of re-fixing, a dir registered by two active environments (dedups to the outermost registering environment's layer), a prepend equal to the environment's own `bin` dir, and dirs containing spaces.
- Seven new bats tests:
  - in-place activation keeps the registered dir immediately ahead of the environment's `bin`/`sbin`, parametrized across bash, fish, tcsh, and zsh — the direct regression test, since the trailing `fix-paths` in the generated rc is what demoted plain prepends. The bash and tcsh variants additionally assert on deactivate that neither a registration nor the tcsh `"empty"` sentinel outlives the activation;
  - command-mode idempotency: two profile.d scripts registering the same dir yield a single `PATH` entry (command mode has no trailing re-order to dedup);
  - layered activation asserts the full ordering `inner/bin:inner/sbin:outer/extra-bin:outer/bin:outer/sbin`;
  - a genuine attach (background activation held open on a fifo) asserts the ordering for both a command-mode and an in-place attach.
- Reproduced the old behavior for comparison: a plain `PATH="$dir:$PATH"` in a profile.d script lands demoted behind all environment dirs in the same in-place flow.
- All 77 profile-related and 51 attach tests in `activate.bats` (all four shells), all 13 `activate-mode.bats` tests, and all 41 `deactivate.bats` tests pass; 108 `flox-activations` unit tests and clippy pass.
- Pre-existing local-only failures in `shell-state-restoration.bats` and `flox-rust-sdk` floxmeta git tests reproduce identically on an unmodified checkout and are unrelated to this diff.

## Release Notes

- `etc/profile.d` startup scripts can now use the `flox_prepend_path` shell function to add directories to `PATH` in a way that is preserved as environments are activated, layered, and attached to. Directories added with a plain `PATH` assignment continue to be re-ordered behind the activated environments' `bin` directories. As with all package-provided startup scripts, this has no effect in run-mode activations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
