### PR TITLE
fix(vars): render [vars] entries in manifest order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1740,6 +1740,7 @@ dependencies = [
  "flox-core",
  "flox-test-utils",
  "indent",
+ "indexmap 2.13.0",
  "indoc",
  "itertools 0.14.0",
  "pretty_assertions",
@@ -1823,6 +1824,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "dirs",
+ "indexmap 2.13.0",
  "indoc",
  "nix",
  "proptest",
@@ -4402,6 +4404,7 @@ checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "chrono",
  "dyn-clone",
+ "indexmap 2.13.0",
  "ref-cast",
  "schemars_derive 1.2.1",
  "serde",
@@ -4703,6 +4706,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap 2.13.0",
  "itoa",
  "memchr",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,10 @@ sentry = { version = "0.38.1", features = [
     "debug-logs",
 ] }
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1"
+# `preserve_order` keeps JSON object order when buffering through
+# `serde_json::Value`, which `Manifest<TypedOnly>` deserialization relies on
+# to preserve the order of `[vars]` read back from a lockfile.
+serde_json = { version = "1", features = ["preserve_order"] }
 serde_with = { version = "3.16.1", features = ["time_0_3"] }
 serde_yaml = "0.9"
 shell-escape = "0.1.5"

--- a/buildenv/buildenv.nix
+++ b/buildenv/buildenv.nix
@@ -8,6 +8,10 @@
   manifestLock,
   name ? "environment",
   serviceConfigYaml ? null,
+  # JSON array of `[vars]` names giving the order in which to render them.
+  # Nix sorts attribute names, so the manifest's ordering cannot be recovered
+  # from the lockfile itself; the CLI passes it explicitly.
+  varsOrder,
 }:
 let
   outdentScript = (import ./buildenvLib/default.nix).outdentText;
@@ -52,16 +56,13 @@ let
   profileSection = if (builtins.hasAttr "profile" manifest) then manifest.profile else { };
   vars =
     if (builtins.hasAttr "vars" manifest) then
+      let
+        varNames = builtins.fromJSON varsOrder;
+      in
       (builtins.toFile "envrc-vars" (
         builtins.concatStringsSep "" (
-          builtins.map (n: "export ${n}=\"${builtins.getAttr n manifest.vars}\"\n") (
-            builtins.attrNames manifest.vars
-          )
+          builtins.map (n: "export ${n}=\"${builtins.getAttr n manifest.vars}\"\n") varNames
         )
-        # alternative ... worth it?
-        #      foldlAttrs (
-        #        acc: n: v: acc + "export ${n}=\"${v}\"\n"
-        #      ) "" manifestData.vars
       ))
     else
       null;

--- a/cli/catalog-api-v1/src/client.rs
+++ b/cli/catalog-api-v1/src/client.rs
@@ -5527,6 +5527,226 @@ impl ClientInfo<crate::hooks::RequestHooks> for Client {
 impl ClientHooks<crate::hooks::RequestHooks> for &Client {}
 #[allow(clippy::all)]
 impl Client {
+    /**Search for packages
+
+Search the catalog(s) under the given criteria for matching packages.
+
+Required Query Parameters:
+- **system**: The system architecture to search for (e.g., x86_64-linux)
+
+Optional Query Parameters:
+- **search_term**: The search term to filter packages by
+- **catalogs**: Comma separated list of catalog names to search; defaults to
+  all catalogs. Note: when searching base catalog, search_term is required.
+- **page**: Page number for pagination (default: 0)
+- **pageSize**: Page size for pagination (default: 10)
+Returns:
+- **PackageSearchResult**: A list of PackageInfoSearch items and total count
+
+Sends a `GET` request to `/api/v1/catalog/search`
+
+*/
+    pub async fn search_api_v1_catalog_search_get<'a>(
+        &'a self,
+        catalogs: Option<&'a str>,
+        page: Option<i64>,
+        page_size: Option<i64>,
+        search_term: Option<&'a types::SearchTerm>,
+        system: types::PackageSystem,
+    ) -> Result<ResponseValue<types::PackageSearchResult>, Error<types::ErrorResponse>> {
+        let url = format!("{}/api/v1/catalog/search", self.baseurl);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+        header_map
+            .append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(Self::api_version()),
+            );
+        #[allow(unused_mut)]
+        let mut request = self
+            .client
+            .get(url)
+            .header(
+                ::reqwest::header::ACCEPT,
+                ::reqwest::header::HeaderValue::from_static("application/json"),
+            )
+            .query(&progenitor_client::QueryParam::new("catalogs", &catalogs))
+            .query(&progenitor_client::QueryParam::new("page", &page))
+            .query(&progenitor_client::QueryParam::new("pageSize", &page_size))
+            .query(&progenitor_client::QueryParam::new("search_term", &search_term))
+            .query(&progenitor_client::QueryParam::new("system", &system))
+            .headers(header_map)
+            .build()?;
+        let info = OperationInfo {
+            operation_id: "search_api_v1_catalog_search_get",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
+            422u16 => {
+                Err(Error::ErrorResponse(ResponseValue::from_response(response).await?))
+            }
+            _ => Err(Error::UnexpectedResponse(response)),
+        }
+    }
+    /**Shows available packages of a specific package
+
+Returns a list of versions for a given attr_path
+
+Required Query Parameters:
+- **attr_path**: The attr_path, must be valid.
+
+Optional Query Parameters:
+- **page**: Optional page number for pagination (def = 0)
+- **pageSize**: Optional page size for pagination (def = 10)
+
+Returns:
+- **PackagesResult**: A list of PackageResolutionInfo and the total result count
+
+Sends a `GET` request to `/api/v1/catalog/packages/{attr_path}`
+
+*/
+    pub async fn packages_api_v1_catalog_packages_attr_path_get<'a>(
+        &'a self,
+        attr_path: &'a str,
+        page: Option<i64>,
+        page_size: Option<i64>,
+    ) -> Result<ResponseValue<types::PackagesResult>, Error<types::ErrorResponse>> {
+        let url = format!(
+            "{}/api/v1/catalog/packages/{}",
+            self.baseurl,
+            encode_path(&attr_path.to_string()),
+        );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+        header_map
+            .append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(Self::api_version()),
+            );
+        #[allow(unused_mut)]
+        let mut request = self
+            .client
+            .get(url)
+            .header(
+                ::reqwest::header::ACCEPT,
+                ::reqwest::header::HeaderValue::from_static("application/json"),
+            )
+            .query(&progenitor_client::QueryParam::new("page", &page))
+            .query(&progenitor_client::QueryParam::new("pageSize", &page_size))
+            .headers(header_map)
+            .build()?;
+        let info = OperationInfo {
+            operation_id: "packages_api_v1_catalog_packages_attr_path_get",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
+            404u16 => {
+                Err(Error::ErrorResponse(ResponseValue::from_response(response).await?))
+            }
+            422u16 => {
+                Err(Error::ErrorResponse(ResponseValue::from_response(response).await?))
+            }
+            _ => Err(Error::UnexpectedResponse(response)),
+        }
+    }
+    /**Resolve a list of Package Groups
+
+Resolves a list of package groups, each being a list of package descriptors.
+
+Required Body:
+- **groups**: An object with an `items` array of PackageGroups to resolve.
+
+Optional Query Parameters:
+- **candidate_pages**: Number of additional candidate pages to return
+  (default: 0)
+
+Returns:
+- **ResolvedPackageGroups**: An object with an `items` array of
+  `ResolvedPackageGroup` items.
+
+Resolution Rules:
+- Each `PackageGroup` is resolved independently.
+- Each page that has packages meeting all descriptors in the group is
+  returned.
+- The latest complete page includes full package details.
+- Additional candidate pages are returned without full details.
+
+PackageDescriptor Fields:
+- **install_id**: [required] Reference identifier for the package in the
+  manifest. Used for error messages and result correlation.
+- **attr_path**: [required] The nix attribute path to match exactly.
+- **systems**: [required] List of systems to resolve for (e.g.,
+  x86_64-linux).
+- **version**: [optional] Version constraint. Can be a literal version or
+  semver constraint. Packages whose version cannot be parsed as semver are
+  excluded when using semver constraints.
+- **derivation**: [optional] Specific derivation path to match.
+- **allow_pre_releases**: [optional] Include pre-release versions when using
+  semver constraints (default: False).
+- **allow_broken**: [optional] Include packages marked as broken
+  (default: False).
+- **allow_unfree**: [optional] Include packages with unfree licenses
+  (default: True).
+- **allow_insecure**: [optional] Include packages marked as insecure
+  (default: False).
+- **allowed_licenses**: [optional] List of acceptable license identifiers.
+- **allow_missing_builds**: [optional] Include packages without confirmed
+  build artifacts (default: False). If resolution fails with this
+  constraint, it may be relaxed with a warning message.
+
+Sends a `POST` request to `/api/v1/catalog/resolve`
+
+*/
+    pub async fn resolve_api_v1_catalog_resolve_post<'a>(
+        &'a self,
+        candidate_pages: Option<i64>,
+        body: &'a types::PackageGroups,
+    ) -> Result<
+        ResponseValue<types::ResolvedPackageGroups>,
+        Error<types::ErrorResponse>,
+    > {
+        let url = format!("{}/api/v1/catalog/resolve", self.baseurl);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+        header_map
+            .append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(Self::api_version()),
+            );
+        #[allow(unused_mut)]
+        let mut request = self
+            .client
+            .post(url)
+            .header(
+                ::reqwest::header::ACCEPT,
+                ::reqwest::header::HeaderValue::from_static("application/json"),
+            )
+            .json(&body)
+            .query(
+                &progenitor_client::QueryParam::new("candidate_pages", &candidate_pages),
+            )
+            .headers(header_map)
+            .build()?;
+        let info = OperationInfo {
+            operation_id: "resolve_api_v1_catalog_resolve_post",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
+            422u16 => {
+                Err(Error::ErrorResponse(ResponseValue::from_response(response).await?))
+            }
+            _ => Err(Error::UnexpectedResponse(response)),
+        }
+    }
     /**Lookup
 
 Resolve build inputs for one or more reference groups.
@@ -5570,6 +5790,61 @@ Sends a `POST` request to `/api/v1/catalog/build-inputs/lookup`
             .build()?;
         let info = OperationInfo {
             operation_id: "lookup_api_v1_catalog_build_inputs_lookup_post",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
+            422u16 => {
+                Err(Error::ErrorResponse(ResponseValue::from_response(response).await?))
+            }
+            _ => Err(Error::UnexpectedResponse(response)),
+        }
+    }
+    /**Adjust various settings
+
+Adjusts various settings on the catalog service.
+
+Query Parameters:
+- **key**: The the key to adjust.
+    - "plan" - Enables the logging of the DB query plan for queries for
+    **value** seconds.  It will be scheduled to turn off automatically after
+    that.
+
+Sends a `POST` request to `/api/v1/catalog/settings/{key}`
+
+*/
+    pub async fn settings_api_v1_catalog_settings_key_post<'a>(
+        &'a self,
+        key: &'a str,
+        value: &'a str,
+    ) -> Result<ResponseValue<::serde_json::Value>, Error<types::ErrorResponse>> {
+        let url = format!(
+            "{}/api/v1/catalog/settings/{}",
+            self.baseurl,
+            encode_path(&key.to_string()),
+        );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+        header_map
+            .append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(Self::api_version()),
+            );
+        #[allow(unused_mut)]
+        let mut request = self
+            .client
+            .post(url)
+            .header(
+                ::reqwest::header::ACCEPT,
+                ::reqwest::header::HeaderValue::from_static("application/json"),
+            )
+            .query(&progenitor_client::QueryParam::new("value", &value))
+            .headers(header_map)
+            .build()?;
+        let info = OperationInfo {
+            operation_id: "settings_api_v1_catalog_settings_key_post",
         };
         self.pre(&mut request, &info).await?;
         let result = self.exec(request, &info).await;
@@ -5746,79 +6021,6 @@ Sends a `DELETE` request to `/api/v1/catalog/catalogs/{catalog_name}`
                 Err(Error::ErrorResponse(ResponseValue::from_response(response).await?))
             }
             501u16 => {
-                Err(Error::ErrorResponse(ResponseValue::from_response(response).await?))
-            }
-            _ => Err(Error::UnexpectedResponse(response)),
-        }
-    }
-    /**List all packages with their locked source metadata
-
-Return a flat paginated list of all packages in the catalog with their
-locked source metadata (url, ref, rev, dir, buildType).
-
-Packages published before source tracking was introduced have
-source=null and buildType=null.
-
-Path Parameters:
-- **catalog_name**: The name of the catalog
-
-Query Parameters:
-- **page**: Zero-indexed page number (default: 0)
-- **pageSize**: Items per page (default: 10)
-
-Returns:
-- **LockedSourcesResponse**: Paginated list with total_count
-
-Sends a `GET` request to `/api/v1/catalog/catalogs/{catalog_name}/locked-sources`
-
-*/
-    pub async fn get_catalog_locked_sources_api_v1_catalog_catalogs_catalog_name_locked_sources_get<
-        'a,
-    >(
-        &'a self,
-        catalog_name: &'a types::CatalogName,
-        page: Option<i64>,
-        page_size: Option<i64>,
-    ) -> Result<
-        ResponseValue<types::LockedSourcesResponse>,
-        Error<types::ErrorResponse>,
-    > {
-        let url = format!(
-            "{}/api/v1/catalog/catalogs/{}/locked-sources",
-            self.baseurl,
-            encode_path(&catalog_name.to_string()),
-        );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
-        header_map
-            .append(
-                ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(Self::api_version()),
-            );
-        #[allow(unused_mut)]
-        let mut request = self
-            .client
-            .get(url)
-            .header(
-                ::reqwest::header::ACCEPT,
-                ::reqwest::header::HeaderValue::from_static("application/json"),
-            )
-            .query(&progenitor_client::QueryParam::new("page", &page))
-            .query(&progenitor_client::QueryParam::new("pageSize", &page_size))
-            .headers(header_map)
-            .build()?;
-        let info = OperationInfo {
-            operation_id: "get_catalog_locked_sources_api_v1_catalog_catalogs_catalog_name_locked_sources_get",
-        };
-        self.pre(&mut request, &info).await?;
-        let result = self.exec(request, &info).await;
-        self.post(&result, &info).await?;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
-            404u16 => {
-                Err(Error::ErrorResponse(ResponseValue::from_response(response).await?))
-            }
-            422u16 => {
                 Err(Error::ErrorResponse(ResponseValue::from_response(response).await?))
             }
             _ => Err(Error::UnexpectedResponse(response)),
@@ -6007,6 +6209,75 @@ Sends a `GET` request to `/api/v1/catalog/catalogs/{catalog_name}/packages/{pack
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
+            404u16 => {
+                Err(Error::ErrorResponse(ResponseValue::from_response(response).await?))
+            }
+            422u16 => {
+                Err(Error::ErrorResponse(ResponseValue::from_response(response).await?))
+            }
+            _ => Err(Error::UnexpectedResponse(response)),
+        }
+    }
+    /**Request access and info to publish a package
+
+Request access and informatin to publish a package to this catalog.
+Path Parameters:
+- **catalog_name**: The name of the catalog
+- **package_name**: The name of the package
+Body Content:
+- **PublishInfoRequest**: The information needed to publish to the catalog
+Returns:
+- **PublishRequestResponse**
+
+Sends a `POST` request to `/api/v1/catalog/catalogs/{catalog_name}/packages/{package_name}/publish/info`
+
+*/
+    pub async fn publish_request_api_v1_catalog_catalogs_catalog_name_packages_package_name_publish_info_post<
+        'a,
+    >(
+        &'a self,
+        catalog_name: &'a types::CatalogName,
+        package_name: &'a types::PackageName,
+        body: &'a types::PublishInfoRequest,
+    ) -> Result<
+        ResponseValue<types::PublishInfoResponseCatalog>,
+        Error<types::ErrorResponse>,
+    > {
+        let url = format!(
+            "{}/api/v1/catalog/catalogs/{}/packages/{}/publish/info",
+            self.baseurl,
+            encode_path(&catalog_name.to_string()),
+            encode_path(&package_name.to_string()),
+        );
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+        header_map
+            .append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(Self::api_version()),
+            );
+        #[allow(unused_mut)]
+        let mut request = self
+            .client
+            .post(url)
+            .header(
+                ::reqwest::header::ACCEPT,
+                ::reqwest::header::HeaderValue::from_static("application/json"),
+            )
+            .json(&body)
+            .headers(header_map)
+            .build()?;
+        let info = OperationInfo {
+            operation_id: "publish_request_api_v1_catalog_catalogs_catalog_name_packages_package_name_publish_info_post",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
+            400u16 => {
+                Err(Error::ErrorResponse(ResponseValue::from_response(response).await?))
+            }
             404u16 => {
                 Err(Error::ErrorResponse(ResponseValue::from_response(response).await?))
             }
@@ -6297,36 +6568,42 @@ Sends a `POST` request to `/api/v1/catalog/catalogs/{catalog_name}/packages/{pac
             _ => Err(Error::UnexpectedResponse(response)),
         }
     }
-    /**Request access and info to publish a package
+    /**List all packages with their locked source metadata
 
-Request access and informatin to publish a package to this catalog.
+Return a flat paginated list of all packages in the catalog with their
+locked source metadata (url, ref, rev, dir, buildType).
+
+Packages published before source tracking was introduced have
+source=null and buildType=null.
+
 Path Parameters:
 - **catalog_name**: The name of the catalog
-- **package_name**: The name of the package
-Body Content:
-- **PublishInfoRequest**: The information needed to publish to the catalog
-Returns:
-- **PublishRequestResponse**
 
-Sends a `POST` request to `/api/v1/catalog/catalogs/{catalog_name}/packages/{package_name}/publish/info`
+Query Parameters:
+- **page**: Zero-indexed page number (default: 0)
+- **pageSize**: Items per page (default: 10)
+
+Returns:
+- **LockedSourcesResponse**: Paginated list with total_count
+
+Sends a `GET` request to `/api/v1/catalog/catalogs/{catalog_name}/locked-sources`
 
 */
-    pub async fn publish_request_api_v1_catalog_catalogs_catalog_name_packages_package_name_publish_info_post<
+    pub async fn get_catalog_locked_sources_api_v1_catalog_catalogs_catalog_name_locked_sources_get<
         'a,
     >(
         &'a self,
         catalog_name: &'a types::CatalogName,
-        package_name: &'a types::PackageName,
-        body: &'a types::PublishInfoRequest,
+        page: Option<i64>,
+        page_size: Option<i64>,
     ) -> Result<
-        ResponseValue<types::PublishInfoResponseCatalog>,
+        ResponseValue<types::LockedSourcesResponse>,
         Error<types::ErrorResponse>,
     > {
         let url = format!(
-            "{}/api/v1/catalog/catalogs/{}/packages/{}/publish/info",
+            "{}/api/v1/catalog/catalogs/{}/locked-sources",
             self.baseurl,
             encode_path(&catalog_name.to_string()),
-            encode_path(&package_name.to_string()),
         );
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map
@@ -6337,16 +6614,17 @@ Sends a `POST` request to `/api/v1/catalog/catalogs/{catalog_name}/packages/{pac
         #[allow(unused_mut)]
         let mut request = self
             .client
-            .post(url)
+            .get(url)
             .header(
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .json(&body)
+            .query(&progenitor_client::QueryParam::new("page", &page))
+            .query(&progenitor_client::QueryParam::new("pageSize", &page_size))
             .headers(header_map)
             .build()?;
         let info = OperationInfo {
-            operation_id: "publish_request_api_v1_catalog_catalogs_catalog_name_packages_package_name_publish_info_post",
+            operation_id: "get_catalog_locked_sources_api_v1_catalog_catalogs_catalog_name_locked_sources_get",
         };
         self.pre(&mut request, &info).await?;
         let result = self.exec(request, &info).await;
@@ -6354,9 +6632,6 @@ Sends a `POST` request to `/api/v1/catalog/catalogs/{catalog_name}/packages/{pac
         let response = result?;
         match response.status().as_u16() {
             200u16 => ResponseValue::from_response(response).await,
-            400u16 => {
-                Err(Error::ErrorResponse(ResponseValue::from_response(response).await?))
-            }
             404u16 => {
                 Err(Error::ErrorResponse(ResponseValue::from_response(response).await?))
             }
@@ -6534,223 +6809,6 @@ Sends a `GET` request to `/api/v1/catalog/info/base-catalog`
             _ => Err(Error::UnexpectedResponse(response)),
         }
     }
-    /**Shows available packages of a specific package
-
-Returns a list of versions for a given attr_path
-
-Required Query Parameters:
-- **attr_path**: The attr_path, must be valid.
-
-Optional Query Parameters:
-- **page**: Optional page number for pagination (def = 0)
-- **pageSize**: Optional page size for pagination (def = 10)
-
-Returns:
-- **PackagesResult**: A list of PackageResolutionInfo and the total result count
-
-Sends a `GET` request to `/api/v1/catalog/packages/{attr_path}`
-
-*/
-    pub async fn packages_api_v1_catalog_packages_attr_path_get<'a>(
-        &'a self,
-        attr_path: &'a str,
-        page: Option<i64>,
-        page_size: Option<i64>,
-    ) -> Result<ResponseValue<types::PackagesResult>, Error<types::ErrorResponse>> {
-        let url = format!(
-            "{}/api/v1/catalog/packages/{}",
-            self.baseurl,
-            encode_path(&attr_path.to_string()),
-        );
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
-        header_map
-            .append(
-                ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(Self::api_version()),
-            );
-        #[allow(unused_mut)]
-        let mut request = self
-            .client
-            .get(url)
-            .header(
-                ::reqwest::header::ACCEPT,
-                ::reqwest::header::HeaderValue::from_static("application/json"),
-            )
-            .query(&progenitor_client::QueryParam::new("page", &page))
-            .query(&progenitor_client::QueryParam::new("pageSize", &page_size))
-            .headers(header_map)
-            .build()?;
-        let info = OperationInfo {
-            operation_id: "packages_api_v1_catalog_packages_attr_path_get",
-        };
-        self.pre(&mut request, &info).await?;
-        let result = self.exec(request, &info).await;
-        self.post(&result, &info).await?;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
-            404u16 => {
-                Err(Error::ErrorResponse(ResponseValue::from_response(response).await?))
-            }
-            422u16 => {
-                Err(Error::ErrorResponse(ResponseValue::from_response(response).await?))
-            }
-            _ => Err(Error::UnexpectedResponse(response)),
-        }
-    }
-    /**Resolve a list of Package Groups
-
-Resolves a list of package groups, each being a list of package descriptors.
-
-Required Body:
-- **groups**: An object with an `items` array of PackageGroups to resolve.
-
-Optional Query Parameters:
-- **candidate_pages**: Number of additional candidate pages to return
-  (default: 0)
-
-Returns:
-- **ResolvedPackageGroups**: An object with an `items` array of
-  `ResolvedPackageGroup` items.
-
-Resolution Rules:
-- Each `PackageGroup` is resolved independently.
-- Each page that has packages meeting all descriptors in the group is
-  returned.
-- The latest complete page includes full package details.
-- Additional candidate pages are returned without full details.
-
-PackageDescriptor Fields:
-- **install_id**: [required] Reference identifier for the package in the
-  manifest. Used for error messages and result correlation.
-- **attr_path**: [required] The nix attribute path to match exactly.
-- **systems**: [required] List of systems to resolve for (e.g.,
-  x86_64-linux).
-- **version**: [optional] Version constraint. Can be a literal version or
-  semver constraint. Packages whose version cannot be parsed as semver are
-  excluded when using semver constraints.
-- **derivation**: [optional] Specific derivation path to match.
-- **allow_pre_releases**: [optional] Include pre-release versions when using
-  semver constraints (default: False).
-- **allow_broken**: [optional] Include packages marked as broken
-  (default: False).
-- **allow_unfree**: [optional] Include packages with unfree licenses
-  (default: True).
-- **allow_insecure**: [optional] Include packages marked as insecure
-  (default: False).
-- **allowed_licenses**: [optional] List of acceptable license identifiers.
-- **allow_missing_builds**: [optional] Include packages without confirmed
-  build artifacts (default: False). If resolution fails with this
-  constraint, it may be relaxed with a warning message.
-
-Sends a `POST` request to `/api/v1/catalog/resolve`
-
-*/
-    pub async fn resolve_api_v1_catalog_resolve_post<'a>(
-        &'a self,
-        candidate_pages: Option<i64>,
-        body: &'a types::PackageGroups,
-    ) -> Result<
-        ResponseValue<types::ResolvedPackageGroups>,
-        Error<types::ErrorResponse>,
-    > {
-        let url = format!("{}/api/v1/catalog/resolve", self.baseurl);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
-        header_map
-            .append(
-                ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(Self::api_version()),
-            );
-        #[allow(unused_mut)]
-        let mut request = self
-            .client
-            .post(url)
-            .header(
-                ::reqwest::header::ACCEPT,
-                ::reqwest::header::HeaderValue::from_static("application/json"),
-            )
-            .json(&body)
-            .query(
-                &progenitor_client::QueryParam::new("candidate_pages", &candidate_pages),
-            )
-            .headers(header_map)
-            .build()?;
-        let info = OperationInfo {
-            operation_id: "resolve_api_v1_catalog_resolve_post",
-        };
-        self.pre(&mut request, &info).await?;
-        let result = self.exec(request, &info).await;
-        self.post(&result, &info).await?;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
-            422u16 => {
-                Err(Error::ErrorResponse(ResponseValue::from_response(response).await?))
-            }
-            _ => Err(Error::UnexpectedResponse(response)),
-        }
-    }
-    /**Get SBOM for an environment
-
-Get SBOM (Software Bill of Materials) for an environment.
-
-Args:
-    body: Request body containing lockfile and environment metadata
-    format: SBOM format (defaults to SbomFormat.SPDX_2_3_JSON)
-    user: Authenticated user context
-    cache: Request-scoped dependency cache (injected)
-
-Returns:
-    SBOM document in the requested format
-
-Raises:
-    HTTPException: If lockfile is malformed, system is invalid, or SBOM generation fails
-
-Sends a `POST` request to `/api/v1/catalog/sbom/environment`
-
-*/
-    pub async fn environment_sbom_api_v1_catalog_sbom_environment_post<'a>(
-        &'a self,
-        format: Option<types::SbomFormat>,
-        body: &'a types::EnvironmentSbomRequest,
-    ) -> Result<
-        ResponseValue<::serde_json::Map<::std::string::String, ::serde_json::Value>>,
-        Error<types::ErrorResponse>,
-    > {
-        let url = format!("{}/api/v1/catalog/sbom/environment", self.baseurl);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
-        header_map
-            .append(
-                ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(Self::api_version()),
-            );
-        #[allow(unused_mut)]
-        let mut request = self
-            .client
-            .post(url)
-            .header(
-                ::reqwest::header::ACCEPT,
-                ::reqwest::header::HeaderValue::from_static("application/json"),
-            )
-            .json(&body)
-            .query(&progenitor_client::QueryParam::new("format", &format))
-            .headers(header_map)
-            .build()?;
-        let info = OperationInfo {
-            operation_id: "environment_sbom_api_v1_catalog_sbom_environment_post",
-        };
-        self.pre(&mut request, &info).await?;
-        let result = self.exec(request, &info).await;
-        self.post(&result, &info).await?;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
-            422u16 => {
-                Err(Error::ErrorResponse(ResponseValue::from_response(response).await?))
-            }
-            _ => Err(Error::UnexpectedResponse(response)),
-        }
-    }
     /**Get SBOM for a package derivation
 
 Get SBOM (Software Bill of Materials) for a package derivation.
@@ -6826,93 +6884,34 @@ Arguments:
             _ => Err(Error::UnexpectedResponse(response)),
         }
     }
-    /**Search for packages
+    /**Get SBOM for an environment
 
-Search the catalog(s) under the given criteria for matching packages.
+Get SBOM (Software Bill of Materials) for an environment.
 
-Required Query Parameters:
-- **system**: The system architecture to search for (e.g., x86_64-linux)
+Args:
+    body: Request body containing lockfile and environment metadata
+    format: SBOM format (defaults to SbomFormat.SPDX_2_3_JSON)
+    user: Authenticated user context
+    cache: Request-scoped dependency cache (injected)
 
-Optional Query Parameters:
-- **search_term**: The search term to filter packages by
-- **catalogs**: Comma separated list of catalog names to search; defaults to
-  all catalogs. Note: when searching base catalog, search_term is required.
-- **page**: Page number for pagination (default: 0)
-- **pageSize**: Page size for pagination (default: 10)
 Returns:
-- **PackageSearchResult**: A list of PackageInfoSearch items and total count
+    SBOM document in the requested format
 
-Sends a `GET` request to `/api/v1/catalog/search`
+Raises:
+    HTTPException: If lockfile is malformed, system is invalid, or SBOM generation fails
 
-*/
-    pub async fn search_api_v1_catalog_search_get<'a>(
-        &'a self,
-        catalogs: Option<&'a str>,
-        page: Option<i64>,
-        page_size: Option<i64>,
-        search_term: Option<&'a types::SearchTerm>,
-        system: types::PackageSystem,
-    ) -> Result<ResponseValue<types::PackageSearchResult>, Error<types::ErrorResponse>> {
-        let url = format!("{}/api/v1/catalog/search", self.baseurl);
-        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
-        header_map
-            .append(
-                ::reqwest::header::HeaderName::from_static("api-version"),
-                ::reqwest::header::HeaderValue::from_static(Self::api_version()),
-            );
-        #[allow(unused_mut)]
-        let mut request = self
-            .client
-            .get(url)
-            .header(
-                ::reqwest::header::ACCEPT,
-                ::reqwest::header::HeaderValue::from_static("application/json"),
-            )
-            .query(&progenitor_client::QueryParam::new("catalogs", &catalogs))
-            .query(&progenitor_client::QueryParam::new("page", &page))
-            .query(&progenitor_client::QueryParam::new("pageSize", &page_size))
-            .query(&progenitor_client::QueryParam::new("search_term", &search_term))
-            .query(&progenitor_client::QueryParam::new("system", &system))
-            .headers(header_map)
-            .build()?;
-        let info = OperationInfo {
-            operation_id: "search_api_v1_catalog_search_get",
-        };
-        self.pre(&mut request, &info).await?;
-        let result = self.exec(request, &info).await;
-        self.post(&result, &info).await?;
-        let response = result?;
-        match response.status().as_u16() {
-            200u16 => ResponseValue::from_response(response).await,
-            422u16 => {
-                Err(Error::ErrorResponse(ResponseValue::from_response(response).await?))
-            }
-            _ => Err(Error::UnexpectedResponse(response)),
-        }
-    }
-    /**Adjust various settings
-
-Adjusts various settings on the catalog service.
-
-Query Parameters:
-- **key**: The the key to adjust.
-    - "plan" - Enables the logging of the DB query plan for queries for
-    **value** seconds.  It will be scheduled to turn off automatically after
-    that.
-
-Sends a `POST` request to `/api/v1/catalog/settings/{key}`
+Sends a `POST` request to `/api/v1/catalog/sbom/environment`
 
 */
-    pub async fn settings_api_v1_catalog_settings_key_post<'a>(
+    pub async fn environment_sbom_api_v1_catalog_sbom_environment_post<'a>(
         &'a self,
-        key: &'a str,
-        value: &'a str,
-    ) -> Result<ResponseValue<::serde_json::Value>, Error<types::ErrorResponse>> {
-        let url = format!(
-            "{}/api/v1/catalog/settings/{}",
-            self.baseurl,
-            encode_path(&key.to_string()),
-        );
+        format: Option<types::SbomFormat>,
+        body: &'a types::EnvironmentSbomRequest,
+    ) -> Result<
+        ResponseValue<::serde_json::Map<::std::string::String, ::serde_json::Value>>,
+        Error<types::ErrorResponse>,
+    > {
+        let url = format!("{}/api/v1/catalog/sbom/environment", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
         header_map
             .append(
@@ -6927,11 +6926,12 @@ Sends a `POST` request to `/api/v1/catalog/settings/{key}`
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
-            .query(&progenitor_client::QueryParam::new("value", &value))
+            .json(&body)
+            .query(&progenitor_client::QueryParam::new("format", &format))
             .headers(header_map)
             .build()?;
         let info = OperationInfo {
-            operation_id: "settings_api_v1_catalog_settings_key_post",
+            operation_id: "environment_sbom_api_v1_catalog_sbom_environment_post",
         };
         self.pre(&mut request, &info).await?;
         let result = self.exec(request, &info).await;

--- a/cli/flox-manifest/Cargo.toml
+++ b/cli/flox-manifest/Cargo.toml
@@ -8,9 +8,10 @@ thiserror.workspace = true
 toml.workspace = true
 toml_edit.workspace = true
 serde.workspace = true
+indexmap.workspace = true
 indoc.workspace = true
 itertools.workspace = true
-schemars = { workspace = true, features = ["chrono04"] }
+schemars = { workspace = true, features = ["chrono04", "indexmap2"] }
 serde_with.workspace = true
 systemd.workspace = true
 derive_more.workspace = true

--- a/cli/flox-manifest/src/compose/mod.rs
+++ b/cli/flox-manifest/src/compose/mod.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::fmt::{self, Display, Formatter};
 pub mod shallow;
+use indexmap::IndexMap;
 #[cfg(any(test, feature = "tests"))]
 use proptest::prelude::*;
 use schemars::JsonSchema;
@@ -254,6 +255,30 @@ where
     (merged, warnings)
 }
 
+/// Like [map_union], but preserves the insertion order of both maps:
+/// low priority entries keep their positions, high priority entries either
+/// override in place or are appended in their own order.
+#[must_use]
+fn index_map_union(
+    base_key: KeyPath,
+    low_priority: &IndexMap<String, String>,
+    high_priority: &IndexMap<String, String>,
+) -> (IndexMap<String, String>, Vec<Warning>) {
+    let warnings = high_priority
+        .keys()
+        .filter(|key| low_priority.contains_key(*key))
+        .map(|key| Warning::Overriding(base_key.push(key)))
+        .collect();
+
+    let mut merged = low_priority.clone();
+    merged.extend(
+        high_priority
+            .iter()
+            .map(|(key, value)| (key.clone(), value.clone())),
+    );
+    (merged, warnings)
+}
+
 /// Takes the high priority `T` if it's present, otherwise the low priority `T`.
 #[must_use]
 fn shallow_merge_options<M, T: Into<M>>(
@@ -380,10 +405,44 @@ pub fn new_package_overrides(old_ids: &[String], new_ids: &[String]) -> Vec<Stri
 
 #[cfg(test)]
 mod tests {
+    use indoc::indoc;
+
     use super::shallow::ShallowMerger;
     use super::*;
     use crate::parsed::common::Vars;
     use crate::parsed::v1_13_0::Profile;
+    use crate::test_helpers::with_latest_schema;
+
+    #[test]
+    fn merged_vars_preserve_definition_order() {
+        let dep = toml_edit::de::from_str::<ManifestLatest>(&with_latest_schema(indoc! {r#"
+            [vars]
+            zebra = "stripes"
+            apple = "fruit"
+        "#}))
+        .unwrap();
+        let composer = toml_edit::de::from_str::<ManifestLatest>(&with_latest_schema(indoc! {r#"
+            [vars]
+            mango = "tropical"
+            apple = "overridden"
+        "#}))
+        .unwrap();
+        let composite = CompositeManifest {
+            composer,
+            deps: vec![("dep".to_string(), dep)],
+        };
+
+        let (merged, _warnings) = composite
+            .merge_all(ManifestMerger::Shallow(ShallowMerger))
+            .unwrap();
+
+        // Vars from included environments keep their definition order and
+        // come before vars first defined by the composer. An overriding var
+        // keeps the position of the definition it overrides.
+        let keys = merged.vars.inner().keys().cloned().collect::<Vec<_>>();
+        assert_eq!(keys, ["zebra", "apple", "mango"]);
+        assert_eq!(merged.vars.inner()["apple"], "overridden");
+    }
 
     #[test]
     fn composite_manifest_runs_merger() {
@@ -403,10 +462,7 @@ mod tests {
             manifest
         };
         let manifest2 = ManifestLatest {
-            vars: Vars(BTreeMap::from([(
-                "var2".to_string(),
-                "manifest2".to_string(),
-            )])),
+            vars: Vars::from_map([("var2".to_string(), "manifest2".to_string())]),
             profile: Some(Profile {
                 common: Some("manifest2".to_string()),
                 ..Default::default()

--- a/cli/flox-manifest/src/compose/shallow.rs
+++ b/cli/flox-manifest/src/compose/shallow.rs
@@ -7,6 +7,7 @@ use super::{
     Warning,
     append_optional_strings,
     deep_merge_optional_containerize_config,
+    index_map_union,
     map_union,
     shallow_merge_options,
 };
@@ -79,7 +80,7 @@ impl ShallowMerger {
         low_priority: &Vars,
         high_priority: &Vars,
     ) -> Result<(Vars, Vec<Warning>), MergeError> {
-        let (merged, warnings) = map_union(
+        let (merged, warnings) = index_map_union(
             KeyPath::from_iter(["vars"]),
             low_priority.inner(),
             high_priority.inner(),
@@ -438,8 +439,8 @@ mod tests {
         // in the merged output.
         #[test]
         fn merges_vars_section(maps in btree_maps_overlapping_keys::<String>(1, 3)) {
-            let vars1 = Vars(maps.map1.clone());
-            let vars2 = Vars(maps.map2.clone());
+            let vars1 = Vars::from_map(maps.map1.clone());
+            let vars2 = Vars::from_map(maps.map2.clone());
             let (merged, warnings) = ShallowMerger::merge_vars(&vars1, &vars2).unwrap();
             let merged = merged.inner();
             for key in maps.unique_keys_map1.iter() {

--- a/cli/flox-manifest/src/lib.rs
+++ b/cli/flox-manifest/src/lib.rs
@@ -712,6 +712,35 @@ impl JsonSchema for Manifest<TypedOnly> {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use crate::Manifest;
+    use crate::interfaces::AsLatestSchema;
+    use crate::parsed::Inner;
+    use crate::parsed::common::KnownSchemaVersion;
+
+    #[test]
+    fn parse_json_preserves_vars_order() {
+        let json = format!(
+            r#"{{"schema-version": "{}", "vars": {{"zebra": "stripes", "apple": "fruit", "mango": "tropical"}}}}"#,
+            KnownSchemaVersion::latest()
+        );
+
+        let manifest = Manifest::parse_json(&json).unwrap();
+        let migrated = manifest.migrate_typed_only(None).unwrap();
+        let keys = migrated
+            .as_latest_schema()
+            .vars
+            .inner()
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>();
+        assert_eq!(keys, ["zebra", "apple", "mango"]);
+    }
+}
+
 #[cfg(any(test, feature = "tests"))]
 pub mod test_helpers {
     use indoc::formatdoc;

--- a/cli/flox-manifest/src/parsed/common.rs
+++ b/cli/flox-manifest/src/parsed/common.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Display;
+use std::hash::{Hash, Hasher};
 use std::path::PathBuf;
 
 use flox_core::activate::mode::ActivateMode;
@@ -10,11 +11,13 @@ use flox_test_utils::proptest::{
     alphanum_and_whitespace_string,
     alphanum_string,
     btree_map_strategy,
+    index_map_strategy,
     optional_btree_map,
     optional_btree_set,
     optional_string,
     optional_vec_of_strings,
 };
+use indexmap::IndexMap;
 use indoc::formatdoc;
 use itertools::Itertools;
 #[cfg(any(test, feature = "tests"))]
@@ -146,19 +149,42 @@ pub struct PackageDescriptorStorePath {
     pub priority: Option<u64>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash, JsonSchema)]
+/// The `[vars]` section of a manifest.
+///
+/// Entries preserve the order in which they are defined in the manifest and
+/// are rendered to the activation script in that order, so an entry may
+/// reference entries defined above it.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, JsonSchema)]
 #[cfg_attr(any(test, feature = "tests"), derive(proptest_derive::Arbitrary))]
 pub struct Vars(
     #[cfg_attr(
         any(test, feature = "tests"),
-        proptest(strategy = "btree_map_strategy::<String>(5, 3)")
+        proptest(strategy = "index_map_strategy::<String>(5, 3)")
     )]
-    pub(crate) BTreeMap<String, String>,
+    pub(crate) IndexMap<String, String>,
 );
 
 impl Vars {
-    pub fn from_map(map: BTreeMap<String, String>) -> Self {
-        Self(map)
+    pub fn from_map(map: impl IntoIterator<Item = (String, String)>) -> Self {
+        Self(map.into_iter().collect())
+    }
+}
+
+// Order affects how vars are rendered, so equality and hashing are
+// order-sensitive, unlike `IndexMap`'s own order-insensitive `PartialEq`.
+impl PartialEq for Vars {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.iter().eq(other.0.iter())
+    }
+}
+
+impl Eq for Vars {}
+
+impl Hash for Vars {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        for entry in &self.0 {
+            entry.hash(state);
+        }
     }
 }
 
@@ -168,7 +194,7 @@ impl SkipSerializing for Vars {
     }
 }
 
-impl_into_inner!(Vars, BTreeMap<String, String>);
+impl_into_inner!(Vars, IndexMap<String, String>);
 #[skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash, JsonSchema)]
 #[cfg_attr(any(test, feature = "tests"), derive(proptest_derive::Arbitrary))]

--- a/cli/flox-manifest/src/parsed/latest.rs
+++ b/cli/flox-manifest/src/parsed/latest.rs
@@ -439,6 +439,21 @@ mod tests {
     }
 
     #[test]
+    fn vars_preserve_manifest_file_order() {
+        let manifest = with_latest_schema(indoc! {r#"
+            [vars]
+            zebra = "stripes"
+            apple = "${zebra}/fruit"
+            mango = "tropical"
+        "#});
+
+        let parsed = toml_edit::de::from_str::<ManifestLatest>(&manifest).unwrap();
+
+        let keys = parsed.vars.inner().keys().cloned().collect::<Vec<_>>();
+        assert_eq!(keys, ["zebra", "apple", "mango"]);
+    }
+
+    #[test]
     fn auto_start_is_not_treated_as_service_name() {
         let manifest = with_latest_schema(indoc! {r#"
             [services]

--- a/cli/flox-rust-sdk/src/providers/buildenv.rs
+++ b/cli/flox-rust-sdk/src/providers/buildenv.rs
@@ -19,6 +19,7 @@ use flox_manifest::lockfile::{
     Lockfile,
     PackageToList,
 };
+use flox_manifest::parsed::Inner;
 use flox_manifest::parsed::latest::SelectedOutputs;
 use floxhub_client::{CatalogClientTrait, FloxhubClientError, StoreInfo};
 use pollster::FutureExt as _;
@@ -969,6 +970,7 @@ where
         &self,
         lockfile_path: &Path,
         service_config_path: Option<PathBuf>,
+        vars_order: &[String],
         out_link_prefix: Option<&Path>,
     ) -> Result<BuildEnvOutputs, BuildEnvError> {
         let mut nix_build_command = base_command();
@@ -983,6 +985,12 @@ where
             .arg("--argstr")
             .arg("manifestLock")
             .arg(lockfile_path);
+        // Nix sorts attribute names, so `buildenv.nix` cannot recover the
+        // manifest's `[vars]` order from the lockfile itself.
+        nix_build_command
+            .arg("--argstr")
+            .arg("varsOrder")
+            .arg(serde_json::to_string(vars_order).expect("var names serialize to JSON"));
         if let Some(service_config_path) = &service_config_path {
             nix_build_command
                 .arg("--argstr")
@@ -1434,6 +1442,16 @@ where
             });
         }
 
+        // `[vars]` are rendered to the activation envrc in manifest order so
+        // an entry may reference entries defined above it.
+        let vars_order: Vec<String> = manifest
+            .as_latest_schema()
+            .vars
+            .inner()
+            .keys()
+            .cloned()
+            .collect();
+
         // Realise the packages in the lockfile, for the current system.
         // "Realising" a package means to check if the associated store paths are valid
         // and otherwise building the package to _create_ valid store paths.
@@ -1479,7 +1497,14 @@ where
                     .collect()
             },
             || all_env_paths.clone(),
-            || self.call_buildenv_nix(lockfile_path, service_config_path.clone(), out_link_prefix),
+            || {
+                self.call_buildenv_nix(
+                    lockfile_path,
+                    service_config_path.clone(),
+                    &vars_order,
+                    out_link_prefix,
+                )
+            },
         )
     }
 }
@@ -2494,6 +2519,33 @@ mod buildenv_tests {
             let content = std::fs::read_to_string(&envrc_path).unwrap();
             assert!(content.contains(r#"export singlequotes="'bar'""#));
             assert!(content.contains(r#"export singlequoteescaped="\'baz""#));
+        }
+    }
+
+    /// `[vars]` are rendered to the envrc in manifest order rather than
+    /// alphabetical order, so an entry may reference entries defined above it.
+    #[test]
+    fn environment_renders_vars_in_manifest_order() {
+        let buildenv = buildenv_instance();
+        let lockfile_path = MANUALLY_GENERATED.join("buildenv/lockfiles/vars_order/manifest.lock");
+        let client = MockClient::new();
+        let result = buildenv.build(&client, &lockfile_path, None, None).unwrap();
+
+        let runtime = result.run.as_ref();
+        let develop = result.dev.as_ref();
+
+        for envrc_path in [
+            runtime.join("activate.d/envrc"),
+            develop.join("activate.d/envrc"),
+        ] {
+            let content = std::fs::read_to_string(&envrc_path).unwrap();
+            let zebra = content.find(r#"export zebra="stripes""#).unwrap();
+            let mango = content.find(r#"export mango="tropical""#).unwrap();
+            let apple = content.find(r#"export apple="${zebra}/fruit""#).unwrap();
+            assert!(
+                zebra < mango && mango < apple,
+                "expected `[vars]` in manifest order in envrc: {content}"
+            );
         }
     }
 

--- a/cli/flox-rust-sdk/src/providers/lock_manifest.rs
+++ b/cli/flox-rust-sdk/src/providers/lock_manifest.rs
@@ -3384,10 +3384,10 @@ mod tests {
         .unwrap();
 
         assert_eq!(merged, ManifestLatest {
-            vars: Vars::from_map(BTreeMap::from([
+            vars: Vars::from_map([
                 ("foo".to_string(), "highest_precedence".to_string()),
-                ("bar".to_string(), "higher_precedence".to_string())
-            ])),
+                ("bar".to_string(), "higher_precedence".to_string()),
+            ]),
             ..Default::default()
         });
         assert_eq!(
@@ -3823,12 +3823,12 @@ mod tests {
         assert_eq!(
             lockfile.manifest,
             ManifestLatest {
-                vars: Vars::from_map(BTreeMap::from([
+                vars: Vars::from_map([
                     ("child_local".to_string(), "hi".to_string()),
                     ("child_remote".to_string(), "hi".to_string()),
                     ("parent".to_string(), "hi".to_string()),
                     ("composer".to_string(), "hi".to_string()),
-                ])),
+                ]),
                 ..Default::default()
             }
             .as_typed_only(),

--- a/cli/flox-rust-sdk/src/providers/services/process_compose.rs
+++ b/cli/flox-rust-sdk/src/providers/services/process_compose.rs
@@ -228,7 +228,9 @@ impl From<v1_12_0::Services> for ProcessComposeConfig {
             .into_iter()
             .map(|(name, service)| {
                 let command = service.command;
-                let environment = service.vars.map(|vars| vars.inner().clone());
+                let environment = service
+                    .vars
+                    .map(|vars| vars.into_inner().into_iter().collect());
                 (name, ProcessConfig {
                     command,
                     vars: environment,

--- a/cli/flox-rust-sdk/src/providers/services/systemd.rs
+++ b/cli/flox-rust-sdk/src/providers/services/systemd.rs
@@ -54,11 +54,11 @@ impl<'a> ServiceUnitContext<'a> {
         &self,
         systemd_env: Option<std::collections::BTreeMap<String, String>>,
     ) -> Option<std::collections::BTreeMap<String, String>> {
-        let mut env = self
+        let mut env: std::collections::BTreeMap<String, String> = self
             .descriptor
             .vars
             .as_ref()
-            .map(|v| v.inner().clone())
+            .map(|v| v.inner().clone().into_iter().collect())
             .unwrap_or_default();
 
         if let Some(e) = systemd_env {

--- a/cli/flox-test-utils/Cargo.toml
+++ b/cli/flox-test-utils/Cargo.toml
@@ -8,6 +8,7 @@ anyhow.workspace = true
 # rexpect.workspace = true
 tempfile.workspace = true
 nix.workspace = true
+indexmap.workspace = true
 indoc.workspace = true
 dirs.workspace = true
 proptest.workspace = true

--- a/cli/flox-test-utils/src/proptest.rs
+++ b/cli/flox-test-utils/src/proptest.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 
+use indexmap::IndexMap;
 use prop::option;
 use proptest::collection::{btree_map, btree_set as prop_btree_set, vec as prop_vec};
 use proptest::prelude::*;
@@ -68,6 +69,16 @@ pub fn btree_map_strategy<T: Arbitrary>(
     max_keys: usize,
 ) -> impl Strategy<Value = BTreeMap<String, T>> {
     btree_map(alphanum_string(key_max_size), any::<T>(), 0..max_keys)
+}
+
+/// Produces insertion-ordered maps whose keys are strings that only contain
+/// alphanumeric characters, in a randomized (not sorted) order.
+pub fn index_map_strategy<T: Arbitrary>(
+    key_max_size: usize,
+    max_keys: usize,
+) -> impl Strategy<Value = IndexMap<String, T>> {
+    prop_vec((alphanum_string(key_max_size), any::<T>()), 0..max_keys)
+        .prop_map(|pairs| pairs.into_iter().collect())
 }
 
 /// Produces optional maps with limited sizes for performance reasons

--- a/cli/schemas/generations-metadata-v2.schema.json
+++ b/cli/schemas/generations-metadata-v2.schema.json
@@ -1,183 +1,209 @@
 {
+  "type": "object",
+  "properties": {
+    "version": {
+      "$ref": "#/$defs/version",
+      "description": "Schema version of the metadata file"
+    },
+    "history": {
+      "$ref": "#/$defs/History"
+    },
+    "total_generations": {
+      "type": "integer",
+      "format": "uint",
+      "minimum": 0
+    }
+  },
+  "required": [
+    "version",
+    "history",
+    "total_generations"
+  ],
+  "description": "flox environment metadata for managed environments\n\nManaged environments support rolling back to previous generations.\nGenerations are defined as immutable copy-on-write folders.\nRollbacks and associated [SingleGenerationMetadata] are tracked per environment\nin a metadata file at the root of the environment branch.",
+  "title": "AllGenerationsMetadata",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$defs": {
-    "GenerationId": {
-      "type": "string"
+    "version": {
+      "type": "integer",
+      "const": 2
     },
     "History": {
+      "type": "array",
       "items": {
         "$ref": "#/$defs/HistorySpec"
-      },
-      "type": "array"
+      }
     },
     "HistorySpec": {
+      "type": "object",
       "anyOf": [
         {
+          "type": "object",
           "properties": {
             "kind": {
-              "const": "import",
-              "type": "string"
+              "type": "string",
+              "const": "import"
             }
           },
           "required": [
             "kind"
           ],
-          "title": "Import",
-          "type": "object"
+          "title": "Import"
         },
         {
+          "type": "object",
           "properties": {
             "kind": {
-              "const": "initialize",
-              "type": "string"
+              "type": "string",
+              "const": "initialize"
             }
           },
           "required": [
             "kind"
           ],
-          "title": "Initialize",
-          "type": "object"
+          "title": "Initialize"
         },
         {
+          "type": "object",
           "properties": {
             "description": {
               "type": "string"
             },
             "kind": {
-              "const": "migrate_v1",
-              "type": "string"
+              "type": "string",
+              "const": "migrate_v1"
             }
           },
           "required": [
             "kind",
             "description"
           ],
-          "title": "MigrateV1",
-          "type": "object"
+          "title": "MigrateV1"
         },
         {
+          "type": "object",
           "properties": {
-            "kind": {
-              "const": "install",
-              "type": "string"
-            },
             "targets": {
+              "type": "array",
               "items": {
                 "type": "string"
-              },
-              "type": "array"
+              }
+            },
+            "kind": {
+              "type": "string",
+              "const": "install"
             }
           },
           "required": [
             "kind",
             "targets"
           ],
-          "title": "Install",
-          "type": "object"
+          "title": "Install"
         },
         {
+          "type": "object",
           "properties": {
             "kind": {
-              "const": "edit",
-              "type": "string"
+              "type": "string",
+              "const": "edit"
             }
           },
           "required": [
             "kind"
           ],
-          "title": "Edit",
-          "type": "object"
+          "title": "Edit"
         },
         {
+          "type": "object",
           "properties": {
-            "kind": {
-              "const": "uninstall",
-              "type": "string"
-            },
             "targets": {
+              "type": "array",
               "items": {
                 "type": "string"
-              },
-              "type": "array"
+              }
+            },
+            "kind": {
+              "type": "string",
+              "const": "uninstall"
             }
           },
           "required": [
             "kind",
             "targets"
           ],
-          "title": "Uninstall",
-          "type": "object"
+          "title": "Uninstall"
         },
         {
+          "type": "object",
           "properties": {
-            "kind": {
-              "const": "upgrade",
-              "type": "string"
-            },
             "targets": {
+              "type": "array",
               "items": {
                 "type": "string"
-              },
-              "type": "array"
+              }
+            },
+            "kind": {
+              "type": "string",
+              "const": "upgrade"
             }
           },
           "required": [
             "kind",
             "targets"
           ],
-          "title": "Upgrade",
-          "type": "object"
+          "title": "Upgrade"
         },
         {
+          "type": "object",
           "properties": {
-            "kind": {
-              "const": "include_upgrade",
-              "type": "string"
-            },
             "targets": {
+              "type": "array",
               "items": {
                 "type": "string"
-              },
-              "type": "array"
+              }
+            },
+            "kind": {
+              "type": "string",
+              "const": "include_upgrade"
             }
           },
           "required": [
             "kind",
             "targets"
           ],
-          "title": "IncludeUpgrade",
-          "type": "object"
+          "title": "IncludeUpgrade"
         },
         {
+          "type": "object",
           "properties": {
             "kind": {
-              "const": "switch_generation",
-              "type": "string"
+              "type": "string",
+              "const": "switch_generation"
             }
           },
           "required": [
             "kind"
           ],
-          "title": "SwitchGeneration",
-          "type": "object"
+          "title": "SwitchGeneration"
         },
         {
+          "type": "object",
           "properties": {
-            "kind": {
-              "const": "other",
-              "type": "string"
-            },
             "summary": {
               "type": "string"
+            },
+            "kind": {
+              "type": "string",
+              "const": "other"
             }
           },
           "required": [
             "kind",
             "summary"
           ],
-          "title": "Other",
-          "type": "object"
+          "title": "Other"
         },
         {
+          "type": "object",
           "properties": {
             "kind": {
               "type": "string"
@@ -186,33 +212,38 @@
           "required": [
             "kind"
           ],
-          "title": "Unknown",
-          "type": "object"
+          "title": "Unknown"
         }
       ],
       "description": "The structure of a single change, tying together\n_who_ performed _what_ change, where and when.",
       "properties": {
         "author": {
-          "description": "Local username of the user performing the change",
-          "type": "string"
+          "type": "string",
+          "description": "Local username of the user performing the change"
+        },
+        "hostname": {
+          "type": "string",
+          "description": "Hostname of the machine, on which the change was made"
         },
         "command": {
-          "description": "Command line args to the command that performed the change\nThis can be `None` if the change was invoked by a unit test or FloxHub.",
-          "items": {
-            "type": "string"
-          },
           "type": [
             "array",
             "null"
-          ]
+          ],
+          "items": {
+            "type": "string"
+          },
+          "description": "Command line args to the command that performed the change\nThis can be `None` if the change was invoked by a unit test or FloxHub."
+        },
+        "timestamp": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0,
+          "description": "Timestamp associated with the change"
         },
         "current_generation": {
           "$ref": "#/$defs/GenerationId",
           "description": "Currently live generation, e.g. created by the change\nor switched to."
-        },
-        "hostname": {
-          "description": "Hostname of the machine, on which the change was made",
-          "type": "string"
         },
         "previous_generation": {
           "anyOf": [
@@ -224,12 +255,6 @@
             }
           ],
           "description": "Previous generation before a new generation was created,\nor the generation live before a generation switch."
-        },
-        "timestamp": {
-          "description": "Timestamp associated with the change",
-          "format": "uint",
-          "minimum": 0,
-          "type": "integer"
         }
       },
       "required": [
@@ -237,35 +262,10 @@
         "hostname",
         "timestamp",
         "current_generation"
-      ],
-      "type": "object"
+      ]
     },
-    "version": {
-      "const": 2,
-      "type": "integer"
+    "GenerationId": {
+      "type": "string"
     }
-  },
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "description": "flox environment metadata for managed environments\n\nManaged environments support rolling back to previous generations.\nGenerations are defined as immutable copy-on-write folders.\nRollbacks and associated [SingleGenerationMetadata] are tracked per environment\nin a metadata file at the root of the environment branch.",
-  "properties": {
-    "history": {
-      "$ref": "#/$defs/History"
-    },
-    "total_generations": {
-      "format": "uint",
-      "minimum": 0,
-      "type": "integer"
-    },
-    "version": {
-      "$ref": "#/$defs/version",
-      "description": "Schema version of the metadata file"
-    }
-  },
-  "required": [
-    "version",
-    "history",
-    "total_generations"
-  ],
-  "title": "AllGenerationsMetadata",
-  "type": "object"
+  }
 }

--- a/cli/schemas/lockfile-v1.schema.json
+++ b/cli/schemas/lockfile-v1.schema.json
@@ -1,852 +1,149 @@
 {
-  "$defs": {
-    "Compose": {
-      "properties": {
-        "composer": {
-          "$ref": "#/$defs/Manifest",
-          "description": "The composing environment's manifest that was on disk at lock-time."
-        },
-        "include": {
-          "description": "Metadata and manifests for the included environments in the order\nthat they were specified in the composing environment's manifest.",
-          "items": {
-            "$ref": "#/$defs/LockedInclude"
-          },
-          "type": "array"
-        },
-        "warnings": {
-          "description": "Warnings generated during composition + locking.",
-          "items": {
-            "$ref": "#/$defs/WarningWithContext"
-          },
-          "type": "array"
-        }
-      },
-      "required": [
-        "composer",
-        "include",
-        "warnings"
-      ],
-      "type": "object"
+  "type": "object",
+  "properties": {
+    "lockfile-version": {
+      "$ref": "#/$defs/version"
     },
-    "EnvironmentRef": {
-      "description": "Environment Reference",
-      "type": "string"
+    "manifest": {
+      "$ref": "#/$defs/Manifest",
+      "description": "The manifest that was locked.\n\nFor an environment that doesn't include any others, this is the `manifest.toml`\non disk at lock-time. For an environment that *does* include others, this is\nthe merged manifest that was locked."
     },
-    "IncludeDescriptor": {
-      "anyOf": [
-        {
-          "additionalProperties": false,
-          "properties": {
-            "dir": {
-              "description": "The directory where the environment is located.",
-              "type": "string"
-            },
-            "name": {
-              "description": "A name similar to an install ID that a user could use to specify\nthe environment on the command line e.g. for upgrades, or in an\nerror message.",
-              "type": [
-                "string",
-                "null"
-              ]
-            }
-          },
-          "required": [
-            "dir"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "generation": {
-              "format": "uint",
-              "minimum": 0,
-              "type": [
-                "integer",
-                "null"
-              ]
-            },
-            "name": {
-              "description": "A name similar to an install ID that a user could use to specify\nthe environment on the command line e.g. for upgrades, or in an\nerror message.",
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "remote": {
-              "$ref": "#/$defs/EnvironmentRef",
-              "description": "The remote environment reference in the form `owner/name`."
-            }
-          },
-          "required": [
-            "remote"
-          ],
-          "type": "object"
-        }
-      ],
-      "description": "The structure for how a user is able to declare a dependency on an environment."
-    },
-    "KeyPath": {
-      "description": "A key path to a value in a manifest.\nThis is used to provide the location for warnings.\n\nThe `KeyPath` behaves like an immutable stack of keys,\nwhere [`KeyPath::push`] and [`KeyPath::extend`] return a new `KeyPath`\nwith the new key(s) added to the top of the stack,\nleaving the original `KeyPath` unchanged.",
+    "packages": {
+      "type": "array",
       "items": {
-        "type": "string"
+        "$ref": "#/$defs/LockedPackage"
       },
-      "type": "array"
+      "description": "Locked packages"
     },
-    "LockedInclude": {
-      "properties": {
-        "descriptor": {
-          "$ref": "#/$defs/IncludeDescriptor"
-        },
-        "manifest": {
-          "$ref": "#/$defs/Manifest"
-        },
-        "name": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "manifest",
-        "name",
-        "descriptor"
-      ],
-      "type": "object"
-    },
-    "LockedPackage": {
+    "compose": {
       "anyOf": [
         {
-          "$ref": "#/$defs/LockedPackageCatalog"
+          "$ref": "#/$defs/Compose"
         },
         {
-          "$ref": "#/$defs/LockedPackageFlake"
-        },
-        {
-          "$ref": "#/$defs/LockedPackageStorePath"
+          "type": "null"
         }
-      ]
-    },
-    "LockedPackageCatalog": {
-      "properties": {
-        "attr_path": {
-          "type": "string"
-        },
-        "broken": {
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
-        "derivation": {
-          "type": "string"
-        },
-        "description": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "group": {
-          "type": "string"
-        },
-        "install_id": {
-          "type": "string"
-        },
-        "license": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "locked_url": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "outputs": {
-          "additionalProperties": {
-            "type": "string"
-          },
-          "description": "A map of output name to store path",
-          "type": "object"
-        },
-        "outputs_to_install": {
-          "items": {
-            "type": "string"
-          },
-          "type": [
-            "array",
-            "null"
-          ]
-        },
-        "pname": {
-          "type": "string"
-        },
-        "priority": {
-          "format": "uint64",
-          "minimum": 0,
-          "type": "integer"
-        },
-        "rev": {
-          "type": "string"
-        },
-        "rev_count": {
-          "format": "int64",
-          "type": "integer"
-        },
-        "rev_date": {
-          "format": "date-time",
-          "type": "string"
-        },
-        "scrape_date": {
-          "format": "date-time",
-          "type": "string"
-        },
-        "stabilities": {
-          "items": {
-            "type": "string"
-          },
-          "type": [
-            "array",
-            "null"
-          ]
-        },
-        "system": {
-          "type": "string"
-        },
-        "unfree": {
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
-        "version": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "attr_path",
-        "derivation",
-        "install_id",
-        "locked_url",
-        "name",
-        "pname",
-        "rev",
-        "rev_count",
-        "rev_date",
-        "scrape_date",
-        "version",
-        "outputs",
-        "system",
-        "group",
-        "priority"
       ],
-      "type": "object"
-    },
-    "LockedPackageFlake": {
-      "description": "Rust representation of the output of `builtins.lockFlakeInstallable`\nThis is a direct translation of the definition in\n`<flox>/nix-plugins/include/flox/lock-flake-installable.hh`",
-      "properties": {
-        "broken": {
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
-        "derivation": {
-          "type": "string"
-        },
-        "description": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "flake-description": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "install_id": {
-          "type": "string"
-        },
-        "licenses": {
-          "items": {
-            "type": "string"
-          },
-          "type": [
-            "array",
-            "null"
-          ]
-        },
-        "locked-flake-attr-path": {
-          "type": "string"
-        },
-        "locked-url": {
-          "description": "locked url of the flakeref component of the installable",
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "output-names": {
-          "description": "List of output names in the original order",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "outputs": {
-          "additionalProperties": {
-            "type": "string"
-          },
-          "description": "Map of output names to their paths\nThe values are expected to be nix store paths",
-          "type": "object"
-        },
-        "outputs-to-install": {
-          "description": "List of output names to install as defined by the package",
-          "items": {
-            "type": "string"
-          },
-          "type": [
-            "array",
-            "null"
-          ]
-        },
-        "package-system": {
-          "description": "System as defined by the package",
-          "type": "string"
-        },
-        "pname": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "priority": {
-          "default": 5,
-          "format": "uint64",
-          "minimum": 0,
-          "type": "integer"
-        },
-        "requested-outputs-to-install": {
-          "description": "List of output names to install as requested by the user",
-          "items": {
-            "type": "string"
-          },
-          "type": [
-            "array",
-            "null"
-          ]
-        },
-        "system": {
-          "description": "System as specified by the manifest and used to set default attribute\npaths when locking the installable",
-          "type": "string"
-        },
-        "unfree": {
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
-        "version": {
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      },
-      "required": [
-        "install_id",
-        "locked-url",
-        "locked-flake-attr-path",
-        "derivation",
-        "outputs",
-        "output-names",
-        "package-system",
-        "system",
-        "name"
-      ],
-      "type": "object"
-    },
-    "LockedPackageStorePath": {
-      "properties": {
-        "install_id": {
-          "description": "The install_id of the descriptor in the manifest",
-          "type": "string"
-        },
-        "priority": {
-          "format": "uint64",
-          "minimum": 0,
-          "type": "integer"
-        },
-        "store_path": {
-          "description": "Store path to add to the environment",
-          "type": "string"
-        },
-        "system": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "install_id",
-        "store_path",
-        "system",
-        "priority"
-      ],
-      "type": "object"
+      "description": "Composition information. This will be `None` when there are no includes."
+    }
+  },
+  "required": [
+    "lockfile-version",
+    "manifest",
+    "packages"
+  ],
+  "title": "Lockfile",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$defs": {
+    "version": {
+      "type": "integer",
+      "const": 1
     },
     "Manifest": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ManifestV1"
+        },
+        {
+          "$ref": "#/$defs/ManifestV1_10_0"
+        },
+        {
+          "$ref": "#/$defs/ManifestV1_11_0"
+        },
+        {
+          "$ref": "#/$defs/ManifestV1_12_0"
+        },
+        {
+          "$ref": "#/$defs/ManifestV1_13_0"
+        },
+        {
+          "$ref": "#/$defs/ManifestV1_14_0"
+        }
+      ],
+      "description": "A validated, typed manifest with a known schema.",
+      "title": "Parsed",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$defs": {
-        "ActivateMode": {
-          "enum": [
-            "dev",
-            "run"
-          ],
-          "type": "string"
-        },
-        "ActivateOptions": {
+        "ManifestV1": {
+          "type": "object",
           "additionalProperties": false,
           "properties": {
-            "mode": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/ActivateMode"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            }
-          },
-          "type": "object"
-        },
-        "AllSentinel": {
-          "enum": [
-            "all"
-          ],
-          "type": "string"
-        },
-        "Allows": {
-          "additionalProperties": false,
-          "properties": {
-            "broken": {
-              "description": "Whether to allow packages that are marked as `broken`",
-              "type": [
-                "boolean",
-                "null"
-              ]
-            },
-            "licenses": {
-              "description": "A list of license descriptors that are allowed",
-              "items": {
-                "type": "string"
-              },
-              "type": [
-                "array",
-                "null"
-              ]
-            },
-            "unfree": {
-              "description": "Whether to allow packages that are marked as `unfree`",
-              "type": [
-                "boolean",
-                "null"
-              ]
-            }
-          },
-          "type": "object"
-        },
-        "Build": {
-          "additionalProperties": {
-            "$ref": "#/$defs/BuildDescriptor"
-          },
-          "description": "A map of package ids to package build descriptors",
-          "type": "object"
-        },
-        "Build2": {
-          "additionalProperties": {
-            "$ref": "#/$defs/BuildDescriptor2"
-          },
-          "description": "A map of package ids to package build descriptors.\n\nThis is a version-specific copy of `common::Build` because V1_13_0 adds the\n`sandbox-allow` field to [BuildDescriptor]; the map is otherwise identical.",
-          "type": "object"
-        },
-        "BuildDescriptor": {
-          "additionalProperties": false,
-          "description": "The definition of a package built from within the environment",
-          "properties": {
-            "command": {
-              "description": "The command to run to build a package.",
-              "type": "string"
-            },
-            "description": {
-              "description": "A short description of the package that will appear on FloxHub and in\nsearch results.",
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "license": {
-              "description": "A license to assign to the package in SPDX format.",
-              "items": {
-                "type": "string"
-              },
-              "type": [
-                "array",
-                "null"
-              ]
-            },
-            "runtime-packages": {
-              "description": "Packages from the 'toplevel' group to include in the closure of the build result.",
-              "items": {
-                "type": "string"
-              },
-              "type": [
-                "array",
-                "null"
-              ]
-            },
-            "sandbox": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/BuildSandbox"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Sandbox mode for the build."
-            },
             "version": {
+              "$ref": "#/$defs/ManifestVersion"
+            },
+            "install": {
+              "$ref": "#/$defs/Install",
+              "description": "The packages to install in the form of a map from install_id\nto package descriptor."
+            },
+            "vars": {
+              "$ref": "#/$defs/Vars",
+              "description": "Variables that are exported to the shell environment upon activation."
+            },
+            "hook": {
               "anyOf": [
                 {
-                  "$ref": "#/$defs/BuildVersion"
+                  "$ref": "#/$defs/Hook"
                 },
                 {
                   "type": "null"
                 }
               ],
-              "description": "The version to assign the package."
+              "description": "Hooks that are run at various times during the lifecycle of the manifest\nin a known shell environment."
+            },
+            "profile": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Profile"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Profile scripts that are run in the user's shell upon activation."
+            },
+            "options": {
+              "$ref": "#/$defs/Options",
+              "description": "Options that control the behavior of the manifest.",
+              "default": {}
+            },
+            "services": {
+              "$ref": "#/$defs/Services",
+              "description": "Service definitions"
+            },
+            "build": {
+              "$ref": "#/$defs/Build",
+              "description": "Package build definitions"
+            },
+            "containerize": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Containerize"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "include": {
+              "$ref": "#/$defs/Include"
             }
           },
           "required": [
-            "command"
+            "version"
           ],
-          "type": "object"
+          "description": "Not meant for writing manifest files, only for reading them.\nModifications should be made using `manifest::raw`."
         },
-        "BuildDescriptor2": {
-          "additionalProperties": false,
-          "description": "The definition of a package built from within the environment.\n\nV1_13_0 adds `sandbox-allow`: a list of paths/globs the build is permitted\nto read from outside its closure without a sandbox warning (or, under\n`enforce`, without failing). Otherwise identical to `common::BuildDescriptor`.",
-          "properties": {
-            "command": {
-              "description": "The command to run to build a package.",
-              "type": "string"
-            },
-            "description": {
-              "description": "A short description of the package that will appear on FloxHub and in\nsearch results.",
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "license": {
-              "description": "A license to assign to the package in SPDX format.",
-              "items": {
-                "type": "string"
-              },
-              "type": [
-                "array",
-                "null"
-              ]
-            },
-            "runtime-packages": {
-              "description": "Packages from the 'toplevel' group to include in the closure of the\nbuild result.",
-              "items": {
-                "type": "string"
-              },
-              "type": [
-                "array",
-                "null"
-              ]
-            },
-            "sandbox": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/BuildSandbox2"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Sandbox mode for the build."
-            },
-            "sandbox-allow": {
-              "description": "Paths or glob patterns the build may read from outside its closure\nwithout the virtual sandbox warning about them (or, under `enforce`,\nblocking them). A leading `~/` is expanded to `$HOME`; `*`/`**` are\nmatched with `fnmatch`. Only meaningful for the local sandbox modes\n(`warn`/`enforce`).",
-              "items": {
-                "type": "string"
-              },
-              "type": [
-                "array",
-                "null"
-              ]
-            },
-            "version": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/BuildVersion"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "The version to assign the package."
-            }
-          },
-          "required": [
-            "command"
-          ],
-          "type": "object"
-        },
-        "BuildSandbox": {
-          "description": "The definition of a package built from within the environment",
-          "enum": [
-            "off",
-            "pure"
-          ],
-          "type": "string"
-        },
-        "BuildSandbox2": {
-          "description": "Sandbox mode for a build.\n\nThis is a version-specific copy of `common::BuildSandbox` because V1_13_0\nadds the local `warn` and `enforce` modes. Keeping the new variants out of\nthe common enum is what stops older schema versions (whose `BuildDescriptor`\nuses `common::BuildSandbox`) from accepting `sandbox = \"warn\" | \"enforce\"`.",
-          "oneOf": [
-            {
-              "enum": [
-                "off",
-                "pure"
-              ],
-              "type": "string"
-            },
-            {
-              "const": "warn",
-              "description": "Local build; out-of-closure file access is reported with a warning.",
-              "type": "string"
-            },
-            {
-              "const": "enforce",
-              "description": "Local build; out-of-closure file access is denied (the build fails).",
-              "type": "string"
-            }
-          ]
-        },
-        "BuildVersion": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "properties": {
-                "file": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "file"
-              ],
-              "type": "object"
-            },
-            {
-              "properties": {
-                "command": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "command"
-              ],
-              "type": "object"
-            }
-          ],
-          "description": "The definition of a package built from within the environment"
-        },
-        "Containerize": {
-          "additionalProperties": false,
-          "properties": {
-            "config": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/ContainerizeConfig"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            }
-          },
-          "type": "object"
-        },
-        "ContainerizeConfig": {
-          "additionalProperties": false,
-          "description": "Container config derived from\nhttps://github.com/opencontainers/image-spec/blob/main/config.md\n\nEnv and Entrypoint are left out since they interfere with our activation implementation\nDeprecated and reserved keys are also left out",
-          "properties": {
-            "cmd": {
-              "description": "Default arguments to the entrypoint of the container.\nThese values act as defaults and may be replaced by any specified when creating a container.\nFlox sets an entrypoint to activate the containerized environment,\nand `cmd` is then run inside the activation, similar to\n`flox activate -c cmd`.",
-              "items": {
-                "type": "string"
-              },
-              "type": [
-                "array",
-                "null"
-              ]
-            },
-            "exposed-ports": {
-              "description": "A set of ports to expose from a container running this image.\nIts keys can be in the format of:\n`port/tcp`, `port/udp`, `port` with the default protocol being `tcp` if not specified.\nThese values act as defaults and are merged with any specified when creating a container.",
-              "items": {
-                "type": "string"
-              },
-              "type": [
-                "array",
-                "null"
-              ],
-              "uniqueItems": true
-            },
-            "labels": {
-              "additionalProperties": {
-                "type": "string"
-              },
-              "description": "This field contains arbitrary metadata for the container.\nThis property MUST use the [annotation rules](https://github.com/opencontainers/image-spec/blob/main/annotations.md#rules).",
-              "type": [
-                "object",
-                "null"
-              ]
-            },
-            "stop-signal": {
-              "description": "This field contains the system call signal that will be sent to the container to exit. The signal can be a signal name in the format `SIGNAME`, for instance `SIGKILL` or `SIGRTMIN+3`.",
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "user": {
-              "description": "The username or UID which is a platform-specific structure that allows specific control over which user the process run as.\nThis acts as a default value to use when the value is not specified when creating a container.\nFor Linux based systems, all of the following are valid: `user`, `uid`, `user:group`, `uid:gid`, `uid:group`, `user:gid`.\nIf `group`/`gid` is not specified, the default group and supplementary groups of the given `user`/`uid` in `/etc/passwd` and `/etc/group` from the container are applied.\nIf `group`/`gid` is specified, supplementary groups from the container are ignored.",
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "volumes": {
-              "description": "A set of directories describing where the process is\nlikely to write data specific to a container instance.",
-              "items": {
-                "type": "string"
-              },
-              "type": [
-                "array",
-                "null"
-              ],
-              "uniqueItems": true
-            },
-            "working-dir": {
-              "description": "Sets the current working directory of the entrypoint process in the container.\nThis value acts as a default and may be replaced by a working directory specified when creating a container.",
-              "type": [
-                "string",
-                "null"
-              ]
-            }
-          },
-          "type": "object"
-        },
-        "EnvironmentRef": {
-          "description": "Environment Reference",
-          "type": "string"
-        },
-        "Hook": {
-          "additionalProperties": false,
-          "properties": {
-            "on-activate": {
-              "description": "A script that is run at activation time,\nin a flox provided bash shell",
-              "type": [
-                "string",
-                "null"
-              ]
-            }
-          },
-          "type": "object"
-        },
-        "Include": {
-          "additionalProperties": false,
-          "description": "The section where users can declare dependencies on other environments.",
-          "properties": {
-            "environments": {
-              "default": [],
-              "items": {
-                "$ref": "#/$defs/IncludeDescriptor"
-              },
-              "type": "array"
-            }
-          },
-          "type": "object"
-        },
-        "IncludeDescriptor": {
-          "anyOf": [
-            {
-              "additionalProperties": false,
-              "properties": {
-                "dir": {
-                  "description": "The directory where the environment is located.",
-                  "type": "string"
-                },
-                "name": {
-                  "description": "A name similar to an install ID that a user could use to specify\nthe environment on the command line e.g. for upgrades, or in an\nerror message.",
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                }
-              },
-              "required": [
-                "dir"
-              ],
-              "type": "object"
-            },
-            {
-              "additionalProperties": false,
-              "properties": {
-                "generation": {
-                  "format": "uint",
-                  "minimum": 0,
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
-                },
-                "name": {
-                  "description": "A name similar to an install ID that a user could use to specify\nthe environment on the command line e.g. for upgrades, or in an\nerror message.",
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "remote": {
-                  "$ref": "#/$defs/EnvironmentRef",
-                  "description": "The remote environment reference in the form `owner/name`."
-                }
-              },
-              "required": [
-                "remote"
-              ],
-              "type": "object"
-            }
-          ],
-          "description": "The structure for how a user is able to declare a dependency on an environment."
+        "ManifestVersion": {
+          "type": "integer",
+          "format": "uint8",
+          "minimum": 0,
+          "maximum": 255
         },
         "Install": {
+          "type": "object",
           "additionalProperties": {
             "$ref": "#/$defs/ManifestPackageDescriptor"
-          },
-          "type": "object"
-        },
-        "Install2": {
-          "additionalProperties": {
-            "$ref": "#/$defs/ManifestPackageDescriptor2"
-          },
-          "type": "object"
+          }
         },
         "ManifestPackageDescriptor": {
           "anyOf": [
@@ -861,1025 +158,448 @@
             }
           ]
         },
-        "ManifestPackageDescriptor2": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/PackageDescriptorCatalog2"
-            },
-            {
-              "$ref": "#/$defs/PackageDescriptorFlake2"
-            },
-            {
-              "$ref": "#/$defs/PackageDescriptorStorePath"
-            }
-          ]
-        },
-        "ManifestV1": {
+        "PackageDescriptorCatalog": {
+          "type": "object",
           "additionalProperties": false,
-          "description": "Not meant for writing manifest files, only for reading them.\nModifications should be made using `manifest::raw`.",
           "properties": {
-            "build": {
-              "$ref": "#/$defs/Build",
-              "description": "Package build definitions"
+            "pkg-path": {
+              "type": "string"
             },
-            "containerize": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/Containerize"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "hook": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/Hook"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Hooks that are run at various times during the lifecycle of the manifest\nin a known shell environment."
-            },
-            "include": {
-              "$ref": "#/$defs/Include"
-            },
-            "install": {
-              "$ref": "#/$defs/Install",
-              "description": "The packages to install in the form of a map from install_id\nto package descriptor."
-            },
-            "options": {
-              "$ref": "#/$defs/Options",
-              "default": {},
-              "description": "Options that control the behavior of the manifest."
-            },
-            "profile": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/Profile"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Profile scripts that are run in the user's shell upon activation."
-            },
-            "services": {
-              "$ref": "#/$defs/Services",
-              "description": "Service definitions"
-            },
-            "vars": {
-              "$ref": "#/$defs/Vars",
-              "description": "Variables that are exported to the shell environment upon activation."
-            },
-            "version": {
-              "$ref": "#/$defs/ManifestVersion"
-            }
-          },
-          "required": [
-            "version"
-          ],
-          "type": "object"
-        },
-        "ManifestV1_10_0": {
-          "additionalProperties": false,
-          "description": "Not meant for writing manifest files, only for reading them.\nModifications should be made using `manifest::raw`.",
-          "properties": {
-            "build": {
-              "$ref": "#/$defs/Build",
-              "description": "Package build definitions"
-            },
-            "containerize": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/Containerize"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "hook": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/Hook"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Hooks that are run at various times during the lifecycle of the manifest\nin a known shell environment."
-            },
-            "include": {
-              "$ref": "#/$defs/Include"
-            },
-            "install": {
-              "$ref": "#/$defs/Install2",
-              "description": "The packages to install in the form of a map from install_id\nto package descriptor."
-            },
-            "minimum-cli-version": {
-              "description": "The minimum CLI version that can activate this environment.",
+            "pkg-group": {
               "type": [
                 "string",
                 "null"
               ]
             },
-            "options": {
-              "$ref": "#/$defs/Options",
-              "default": {},
-              "description": "Options that control the behavior of the manifest."
-            },
-            "profile": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/Profile"
-                },
-                {
-                  "type": "null"
-                }
+            "priority": {
+              "type": [
+                "integer",
+                "null"
               ],
-              "description": "Profile scripts that are run in the user's shell upon activation."
+              "format": "uint64",
+              "minimum": 0
             },
-            "schema-version": {
-              "description": "Which schema version this manifest adheres to.\n\nMust be a valid Flox CLI version listed in [`KnownSchemaVersion`].",
-              "type": "string"
-            },
-            "services": {
-              "$ref": "#/$defs/Services",
-              "description": "Service definitions"
-            },
-            "vars": {
-              "$ref": "#/$defs/Vars",
-              "description": "Variables that are exported to the shell environment upon activation."
-            }
-          },
-          "required": [
-            "schema-version"
-          ],
-          "type": "object"
-        },
-        "ManifestV1_11_0": {
-          "additionalProperties": false,
-          "description": "Not meant for writing manifest files, only for reading them.\nModifications should be made using `manifest::raw`.",
-          "properties": {
-            "build": {
-              "$ref": "#/$defs/Build",
-              "description": "Package build definitions"
-            },
-            "containerize": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/Containerize"
-                },
-                {
-                  "type": "null"
-                }
+            "version": {
+              "type": [
+                "string",
+                "null"
               ]
             },
-            "hook": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/Hook"
-                },
-                {
-                  "type": "null"
-                }
+            "systems": {
+              "type": [
+                "array",
+                "null"
               ],
-              "description": "Hooks that are run at various times during the lifecycle of the manifest\nin a known shell environment."
-            },
-            "include": {
-              "$ref": "#/$defs/Include"
-            },
-            "install": {
-              "$ref": "#/$defs/Install2",
-              "description": "The packages to install in the form of a map from install_id\nto package descriptor."
-            },
-            "minimum-cli-version": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/MinimumCliVersion"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "The minimum CLI version that can activate this environment."
-            },
-            "options": {
-              "$ref": "#/$defs/Options",
-              "default": {},
-              "description": "Options that control the behavior of the manifest."
-            },
-            "profile": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/Profile"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Profile scripts that are run in the user's shell upon activation."
-            },
-            "schema-version": {
-              "description": "Which schema version this manifest adheres to.\n\nMust be a valid Flox CLI version listed in [`KnownSchemaVersion`].",
-              "type": "string"
-            },
-            "services": {
-              "$ref": "#/$defs/Services",
-              "description": "Service definitions"
-            },
-            "vars": {
-              "$ref": "#/$defs/Vars",
-              "description": "Variables that are exported to the shell environment upon activation."
+              "items": {
+                "type": "string"
+              }
             }
           },
           "required": [
-            "schema-version"
-          ],
-          "type": "object"
+            "pkg-path"
+          ]
         },
-        "ManifestV1_12_0": {
+        "PackageDescriptorFlake": {
+          "type": "object",
           "additionalProperties": false,
-          "description": "Not meant for writing manifest files, only for reading them.\nModifications should be made using `manifest::raw`.",
           "properties": {
-            "build": {
-              "$ref": "#/$defs/Build",
-              "description": "Package build definitions"
-            },
-            "containerize": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/Containerize"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "hook": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/Hook"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Hooks that are run at various times during the lifecycle of the manifest\nin a known shell environment."
-            },
-            "include": {
-              "$ref": "#/$defs/Include"
-            },
-            "install": {
-              "$ref": "#/$defs/Install2",
-              "description": "The packages to install in the form of a map from install_id\nto package descriptor."
-            },
-            "minimum-cli-version": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/MinimumCliVersion"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "The minimum CLI version that can activate this environment."
-            },
-            "options": {
-              "$ref": "#/$defs/Options",
-              "default": {},
-              "description": "Options that control the behavior of the manifest."
-            },
-            "profile": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/Profile"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Profile scripts that are run in the user's shell upon activation."
-            },
-            "schema-version": {
-              "description": "Which schema version this manifest adheres to.\n\nMust be a valid Flox CLI version listed in [`KnownSchemaVersion`].",
+            "flake": {
               "type": "string"
             },
-            "services": {
-              "$ref": "#/$defs/Services2",
-              "description": "Service definitions"
+            "priority": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0
             },
-            "vars": {
-              "$ref": "#/$defs/Vars",
-              "description": "Variables that are exported to the shell environment upon activation."
+            "systems": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
             }
           },
           "required": [
-            "schema-version"
-          ],
-          "type": "object"
+            "flake"
+          ]
         },
-        "ManifestV1_13_0": {
+        "PackageDescriptorStorePath": {
+          "type": "object",
           "additionalProperties": false,
-          "description": "Not meant for writing manifest files, only for reading them.\nModifications should be made using `manifest::raw`.",
           "properties": {
-            "build": {
-              "$ref": "#/$defs/Build2",
-              "description": "Package build definitions"
-            },
-            "containerize": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/Containerize"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "hook": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/Hook"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Hooks that are run at various times during the lifecycle of the manifest\nin a known shell environment."
-            },
-            "include": {
-              "$ref": "#/$defs/Include"
-            },
-            "install": {
-              "$ref": "#/$defs/Install2",
-              "description": "The packages to install in the form of a map from install_id\nto package descriptor."
-            },
-            "minimum-cli-version": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/MinimumCliVersion"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "The minimum CLI version that can activate this environment."
-            },
-            "options": {
-              "$ref": "#/$defs/Options",
-              "default": {},
-              "description": "Options that control the behavior of the manifest."
-            },
-            "profile": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/Profile2"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Profile scripts that are run in the user's shell upon activation\n(and, optionally, upon deactivation)."
-            },
-            "schema-version": {
-              "description": "Which schema version this manifest adheres to.\n\nMust be a valid Flox CLI version listed in [`KnownSchemaVersion`].",
+            "store-path": {
               "type": "string"
             },
-            "services": {
-              "$ref": "#/$defs/Services2",
-              "description": "Service definitions"
+            "systems": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
             },
-            "vars": {
-              "$ref": "#/$defs/Vars",
-              "description": "Variables that are exported to the shell environment upon activation."
+            "priority": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0
             }
           },
           "required": [
-            "schema-version"
-          ],
-          "type": "object"
+            "store-path"
+          ]
         },
-        "ManifestV1_14_0": {
+        "Vars": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "The `[vars]` section of a manifest.\n\nEntries preserve the order in which they are defined in the manifest and\nare rendered to the activation script in that order, so an entry may\nreference entries defined above it."
+        },
+        "Hook": {
+          "type": "object",
           "additionalProperties": false,
-          "description": "Not meant for writing manifest files, only for reading them.\nModifications should be made using `manifest::raw`.",
           "properties": {
-            "build": {
-              "$ref": "#/$defs/Build2",
-              "description": "Package build definitions"
-            },
-            "containerize": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/Containerize"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "hook": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/Hook"
-                },
-                {
-                  "type": "null"
-                }
+            "on-activate": {
+              "type": [
+                "string",
+                "null"
               ],
-              "description": "Hooks that are run at various times during the lifecycle of the manifest\nin a known shell environment."
-            },
-            "include": {
-              "$ref": "#/$defs/Include"
-            },
-            "install": {
-              "$ref": "#/$defs/Install2",
-              "description": "The packages to install in the form of a map from install_id\nto package descriptor."
-            },
-            "minimum-cli-version": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/MinimumCliVersion"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "The minimum CLI version that can activate this environment."
-            },
-            "options": {
-              "$ref": "#/$defs/Options",
-              "default": {},
-              "description": "Options that control the behavior of the manifest."
-            },
-            "plugins": {
-              "$ref": "#/$defs/Plugins",
-              "description": "Free-form data provided by installed plugins, keyed by plugin\npackage name (`[plugins.<pkg-name>]`). Each plugin defines and\nvalidates the shape of its own table; Flox does not interpret it.\nThe convention for secrets plugins is a flat table of\n`ENV_VAR_NAME = \"path/to/secret/in/store\"`, read by the plugin's\n`profile.d` script at activation."
-            },
-            "profile": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/Profile2"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Profile scripts that are run in the user's shell upon activation\n(and, optionally, upon deactivation)."
-            },
-            "schema-version": {
-              "description": "Which schema version this manifest adheres to.\n\nMust be a valid Flox CLI version listed in [`KnownSchemaVersion`].",
-              "type": "string"
-            },
-            "services": {
-              "$ref": "#/$defs/Services2",
-              "description": "Service definitions"
-            },
-            "vars": {
-              "$ref": "#/$defs/Vars",
-              "description": "Variables that are exported to the shell environment upon activation."
+              "description": "A script that is run at activation time,\nin a flox provided bash shell"
             }
-          },
-          "required": [
-            "schema-version"
-          ],
-          "type": "object"
+          }
         },
-        "ManifestVersion": {
-          "format": "uint8",
-          "maximum": 255,
-          "minimum": 0,
-          "type": "integer"
-        },
-        "MinimumCliVersion": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "properties": {
-                "reason": {
-                  "type": "string"
-                },
-                "version": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "version",
-                "reason"
+        "Profile": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "common": {
+              "type": [
+                "string",
+                "null"
               ],
-              "type": "object"
+              "description": "When defined, this hook is run by _all_ shells upon activation"
+            },
+            "bash": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "When defined, this hook is run upon activation in a bash shell"
+            },
+            "zsh": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "When defined, this hook is run upon activation in a zsh shell"
+            },
+            "fish": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "When defined, this hook is run upon activation in a fish shell"
+            },
+            "tcsh": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "When defined, this hook is run upon activation in a tcsh shell"
             }
-          ],
-          "description": "The minimum CLI version required to use the environment.\n\nAccepts either a plain version string:\n  minimum-cli-version = \"1.11.0\"\n\nOr an inline table with a reason:\n  minimum-cli-version = { version = \"1.11.0\", reason = \"needs feature X\" }"
+          }
         },
         "Options": {
+          "type": "object",
           "additionalProperties": false,
           "properties": {
-            "activate": {
-              "$ref": "#/$defs/ActivateOptions",
-              "description": "Options that control the behavior of activations."
+            "systems": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              },
+              "description": "A list of systems that each package is resolved for."
             },
             "allow": {
               "$ref": "#/$defs/Allows",
               "description": "Options that control what types of packages are allowed."
             },
-            "cuda-detection": {
-              "description": "Whether to detect CUDA devices and libs during activation.",
-              "type": [
-                "boolean",
-                "null"
-              ]
-            },
             "semver": {
               "$ref": "#/$defs/SemverOptions",
               "description": "Options that control how semver versions are resolved."
             },
-            "systems": {
-              "description": "A list of systems that each package is resolved for.",
-              "items": {
-                "type": "string"
-              },
-              "type": [
-                "array",
-                "null"
-              ]
-            }
-          },
-          "type": "object"
-        },
-        "PackageDescriptorCatalog": {
-          "additionalProperties": false,
-          "properties": {
-            "pkg-group": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "pkg-path": {
-              "type": "string"
-            },
-            "priority": {
-              "format": "uint64",
-              "minimum": 0,
-              "type": [
-                "integer",
-                "null"
-              ]
-            },
-            "systems": {
-              "items": {
-                "type": "string"
-              },
-              "type": [
-                "array",
-                "null"
-              ]
-            },
-            "version": {
-              "type": [
-                "string",
-                "null"
-              ]
-            }
-          },
-          "required": [
-            "pkg-path"
-          ],
-          "type": "object"
-        },
-        "PackageDescriptorCatalog2": {
-          "additionalProperties": false,
-          "properties": {
-            "outputs": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/SelectedOutputs"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "pkg-group": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "pkg-path": {
-              "type": "string"
-            },
-            "priority": {
-              "format": "uint64",
-              "minimum": 0,
-              "type": [
-                "integer",
-                "null"
-              ]
-            },
-            "systems": {
-              "items": {
-                "type": "string"
-              },
-              "type": [
-                "array",
-                "null"
-              ]
-            },
-            "version": {
-              "type": [
-                "string",
-                "null"
-              ]
-            }
-          },
-          "required": [
-            "pkg-path"
-          ],
-          "type": "object"
-        },
-        "PackageDescriptorFlake": {
-          "additionalProperties": false,
-          "properties": {
-            "flake": {
-              "type": "string"
-            },
-            "priority": {
-              "format": "uint64",
-              "minimum": 0,
-              "type": [
-                "integer",
-                "null"
-              ]
-            },
-            "systems": {
-              "items": {
-                "type": "string"
-              },
-              "type": [
-                "array",
-                "null"
-              ]
-            }
-          },
-          "required": [
-            "flake"
-          ],
-          "type": "object"
-        },
-        "PackageDescriptorFlake2": {
-          "additionalProperties": false,
-          "properties": {
-            "flake": {
-              "type": "string"
-            },
-            "outputs": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/SelectedOutputs"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "priority": {
-              "format": "uint64",
-              "minimum": 0,
-              "type": [
-                "integer",
-                "null"
-              ]
-            },
-            "systems": {
-              "items": {
-                "type": "string"
-              },
-              "type": [
-                "array",
-                "null"
-              ]
-            }
-          },
-          "required": [
-            "flake"
-          ],
-          "type": "object"
-        },
-        "PackageDescriptorStorePath": {
-          "additionalProperties": false,
-          "properties": {
-            "priority": {
-              "format": "uint64",
-              "minimum": 0,
-              "type": [
-                "integer",
-                "null"
-              ]
-            },
-            "store-path": {
-              "type": "string"
-            },
-            "systems": {
-              "items": {
-                "type": "string"
-              },
-              "type": [
-                "array",
-                "null"
-              ]
-            }
-          },
-          "required": [
-            "store-path"
-          ],
-          "type": "object"
-        },
-        "Plugins": {
-          "additionalProperties": true,
-          "description": "A map of plugin package names to that plugin's free-form manifest data.\n\nValues are opaque JSON: the plugin that owns a given table defines and\nvalidates its own shape, so Flox stores whatever the user writes without\ninterpreting it.",
-          "type": "object"
-        },
-        "Profile": {
-          "additionalProperties": false,
-          "properties": {
-            "bash": {
-              "description": "When defined, this hook is run upon activation in a bash shell",
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "common": {
-              "description": "When defined, this hook is run by _all_ shells upon activation",
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "fish": {
-              "description": "When defined, this hook is run upon activation in a fish shell",
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "tcsh": {
-              "description": "When defined, this hook is run upon activation in a tcsh shell",
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "zsh": {
-              "description": "When defined, this hook is run upon activation in a zsh shell",
-              "type": [
-                "string",
-                "null"
-              ]
-            }
-          },
-          "type": "object"
-        },
-        "Profile2": {
-          "additionalProperties": false,
-          "description": "Profile scripts for V1_13_0: adds an optional `deactivate` table holding\nper-shell scripts to run when the environment is deactivated. The\nactivation fields (`common`, `bash`, `zsh`, `fish`, `tcsh`) are the same\nas earlier schema versions.",
-          "properties": {
-            "bash": {
-              "description": "When defined, this hook is run upon activation in a bash shell",
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "common": {
-              "description": "When defined, this hook is run by _all_ shells upon activation",
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "deactivate": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/ProfileDeactivate"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Per-shell scripts to run when the environment is deactivated.\nMirrors the activation fields above; each is optional."
-            },
-            "fish": {
-              "description": "When defined, this hook is run upon activation in a fish shell",
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "tcsh": {
-              "description": "When defined, this hook is run upon activation in a tcsh shell",
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "zsh": {
-              "description": "When defined, this hook is run upon activation in a zsh shell",
-              "type": [
-                "string",
-                "null"
-              ]
-            }
-          },
-          "type": "object"
-        },
-        "ProfileDeactivate": {
-          "additionalProperties": false,
-          "description": "Deactivation profile scripts. Each field, when defined, is sourced as\nthe user's environment is being torn down — symmetric to the activation\nscripts on the enclosing [`Profile`].",
-          "properties": {
-            "bash": {
-              "description": "Run upon deactivation in a bash shell.",
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "common": {
-              "description": "Run by all shells when the environment is deactivated.",
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "fish": {
-              "description": "Run upon deactivation in a fish shell.",
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "tcsh": {
-              "description": "Run upon deactivation in a tcsh shell.",
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "zsh": {
-              "description": "Run upon deactivation in a zsh shell.",
-              "type": [
-                "string",
-                "null"
-              ]
-            }
-          },
-          "type": "object"
-        },
-        "ProtectHome": {
-          "enum": [
-            "No",
-            "Yes",
-            "ReadOnly",
-            "Tmpfs"
-          ],
-          "type": "string"
-        },
-        "ProtectSystem": {
-          "enum": [
-            "No",
-            "Yes",
-            "Full",
-            "Strict"
-          ],
-          "type": "string"
-        },
-        "ResourceLimit": {
-          "oneOf": [
-            {
-              "additionalProperties": false,
-              "properties": {
-                "Value": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "Value"
-              ],
-              "type": "object"
-            },
-            {
-              "additionalProperties": false,
-              "properties": {
-                "Range": {
-                  "properties": {
-                    "hard": {
-                      "type": "string"
-                    },
-                    "soft": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "soft",
-                    "hard"
-                  ],
-                  "type": "object"
-                }
-              },
-              "required": [
-                "Range"
-              ],
-              "type": "object"
-            }
-          ]
-        },
-        "RestartPolicy": {
-          "enum": [
-            "No",
-            "OnSuccess",
-            "OnFailure",
-            "OnAbnormal",
-            "OnWatchdog",
-            "OnAbort",
-            "Always"
-          ],
-          "type": "string"
-        },
-        "SelectedOutputs": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/AllSentinel"
-            },
-            {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            }
-          ]
-        },
-        "SemverOptions": {
-          "additionalProperties": false,
-          "properties": {
-            "allow-pre-releases": {
-              "description": "Whether to allow pre-release versions when resolving",
+            "cuda-detection": {
               "type": [
                 "boolean",
                 "null"
+              ],
+              "description": "Whether to detect CUDA devices and libs during activation."
+            },
+            "activate": {
+              "$ref": "#/$defs/ActivateOptions",
+              "description": "Options that control the behavior of activations."
+            }
+          }
+        },
+        "Allows": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "unfree": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "description": "Whether to allow packages that are marked as `unfree`"
+            },
+            "broken": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "description": "Whether to allow packages that are marked as `broken`"
+            },
+            "licenses": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              },
+              "description": "A list of license descriptors that are allowed"
+            }
+          }
+        },
+        "SemverOptions": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "allow-pre-releases": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "description": "Whether to allow pre-release versions when resolving"
+            }
+          }
+        },
+        "ActivateOptions": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "mode": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ActivateMode"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        },
+        "ActivateMode": {
+          "type": "string",
+          "enum": [
+            "dev",
+            "run"
+          ]
+        },
+        "Services": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/ServiceDescriptor"
+          },
+          "description": "A map of service names to service definitions."
+        },
+        "ServiceDescriptor": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "command": {
+              "type": "string",
+              "description": "The command to run to start the service"
+            },
+            "vars": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Vars"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Service-specific environment variables"
+            },
+            "is-daemon": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "description": "Whether the service spawns a background process (daemon)"
+            },
+            "shutdown": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ServiceShutdown"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "How to shut down the service"
+            },
+            "systemd": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ServiceUnit"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Additional manual config of the systemd service generated for persistent services"
+            },
+            "systems": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              },
+              "description": "Systems to allow running the service on"
+            }
+          },
+          "required": [
+            "command"
+          ],
+          "description": "The definition of a service in a manifest"
+        },
+        "ServiceShutdown": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "command": {
+              "type": "string",
+              "description": "What command to run to shut down the service"
+            }
+          },
+          "required": [
+            "command"
+          ]
+        },
+        "ServiceUnit": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "unit": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Unit"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "service": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Service"
+                },
+                {
+                  "type": "null"
+                }
               ]
             }
           },
-          "type": "object"
+          "description": "Represents a systemd service configuration"
         },
-        "Service": {
+        "Unit": {
+          "type": "object",
           "additionalProperties": false,
-          "description": "Service section configuration with resource limits",
           "properties": {
-            "cpu_quota": {
+            "description": {
               "type": [
                 "string",
                 "null"
               ]
             },
-            "cpu_shares": {
-              "format": "uint32",
-              "minimum": 0,
-              "type": [
-                "integer",
-                "null"
-              ]
-            },
-            "cpu_weight": {
-              "format": "uint32",
-              "minimum": 0,
-              "type": [
-                "integer",
-                "null"
-              ]
-            },
-            "environment": {
-              "additionalProperties": {
-                "type": "string"
-              },
-              "type": [
-                "object",
-                "null"
-              ]
-            },
-            "environment_file": {
-              "items": {
-                "type": "string"
-              },
+            "documentation": {
               "type": [
                 "array",
                 "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
+            "wants": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
+            "requires": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
+            "before": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
+            "after": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "description": "Unit section configuration"
+        },
+        "Service": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "type_": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ServiceType"
+                },
+                {
+                  "type": "null"
+                }
               ]
             },
             "exec_start": {
@@ -1888,23 +608,23 @@
                 "null"
               ]
             },
-            "exec_start_post": {
-              "items": {
-                "type": "string"
-              },
-              "type": [
-                "array",
-                "null"
-              ]
-            },
             "exec_start_pre": {
-              "items": {
-                "type": "string"
-              },
               "type": [
                 "array",
                 "null"
-              ]
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
+            "exec_start_post": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
             },
             "exec_stop": {
               "type": [
@@ -1912,45 +632,95 @@
                 "null"
               ]
             },
-            "io_weight": {
-              "format": "uint32",
-              "minimum": 0,
+            "restart": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RestartPolicy"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "restart_sec": {
               "type": [
                 "integer",
                 "null"
+              ],
+              "format": "uint32",
+              "minimum": 0
+            },
+            "timeout_start_sec": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint32",
+              "minimum": 0
+            },
+            "timeout_stop_sec": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint32",
+              "minimum": 0
+            },
+            "cpu_quota": {
+              "type": [
+                "string",
+                "null"
               ]
             },
-            "limit_as": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/ResourceLimit"
-                },
-                {
-                  "type": "null"
-                }
+            "cpu_shares": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint32",
+              "minimum": 0
+            },
+            "cpu_weight": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint32",
+              "minimum": 0
+            },
+            "memory_max": {
+              "type": [
+                "string",
+                "null"
               ]
             },
-            "limit_core": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/ResourceLimit"
-                },
-                {
-                  "type": "null"
-                }
+            "memory_high": {
+              "type": [
+                "string",
+                "null"
               ]
+            },
+            "memory_low": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "tasks_max": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "io_weight": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint32",
+              "minimum": 0
             },
             "limit_cpu": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/ResourceLimit"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "limit_data": {
               "anyOf": [
                 {
                   "$ref": "#/$defs/ResourceLimit"
@@ -1970,7 +740,67 @@
                 }
               ]
             },
-            "limit_locks": {
+            "limit_data": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ResourceLimit"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "limit_stack": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ResourceLimit"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "limit_core": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ResourceLimit"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "limit_rss": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ResourceLimit"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "limit_nofile": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ResourceLimit"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "limit_as": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ResourceLimit"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "limit_nproc": {
               "anyOf": [
                 {
                   "$ref": "#/$defs/ResourceLimit"
@@ -1981,6 +811,26 @@
               ]
             },
             "limit_memlock": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ResourceLimit"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "limit_locks": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ResourceLimit"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "limit_sigpending": {
               "anyOf": [
                 {
                   "$ref": "#/$defs/ResourceLimit"
@@ -2010,36 +860,6 @@
                 }
               ]
             },
-            "limit_nofile": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/ResourceLimit"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "limit_nproc": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/ResourceLimit"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "limit_rss": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/ResourceLimit"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
             "limit_rtprio": {
               "anyOf": [
                 {
@@ -2060,64 +880,10 @@
                 }
               ]
             },
-            "limit_sigpending": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/ResourceLimit"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "limit_stack": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/ResourceLimit"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "memory_high": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "memory_low": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "memory_max": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "no_new_privileges": {
-              "type": [
-                "boolean",
-                "null"
-              ]
-            },
             "private_tmp": {
               "type": [
                 "boolean",
                 "null"
-              ]
-            },
-            "protect_home": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/ProtectHome"
-                },
-                {
-                  "type": "null"
-                }
               ]
             },
             "protect_system": {
@@ -2130,137 +896,45 @@
                 }
               ]
             },
-            "restart": {
+            "protect_home": {
               "anyOf": [
                 {
-                  "$ref": "#/$defs/RestartPolicy"
+                  "$ref": "#/$defs/ProtectHome"
                 },
                 {
                   "type": "null"
                 }
               ]
             },
-            "restart_sec": {
-              "format": "uint32",
-              "minimum": 0,
-              "type": [
-                "integer",
-                "null"
-              ]
-            },
-            "tasks_max": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "timeout_start_sec": {
-              "format": "uint32",
-              "minimum": 0,
-              "type": [
-                "integer",
-                "null"
-              ]
-            },
-            "timeout_stop_sec": {
-              "format": "uint32",
-              "minimum": 0,
-              "type": [
-                "integer",
-                "null"
-              ]
-            },
-            "type_": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/ServiceType"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            }
-          },
-          "type": "object"
-        },
-        "ServiceDescriptor": {
-          "additionalProperties": false,
-          "description": "The definition of a service in a manifest",
-          "properties": {
-            "command": {
-              "description": "The command to run to start the service",
-              "type": "string"
-            },
-            "is-daemon": {
-              "description": "Whether the service spawns a background process (daemon)",
+            "no_new_privileges": {
               "type": [
                 "boolean",
                 "null"
               ]
             },
-            "shutdown": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/ServiceShutdown"
-                },
-                {
-                  "type": "null"
-                }
+            "environment": {
+              "type": [
+                "object",
+                "null"
               ],
-              "description": "How to shut down the service"
-            },
-            "systemd": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/ServiceUnit"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Additional manual config of the systemd service generated for persistent services"
-            },
-            "systems": {
-              "description": "Systems to allow running the service on",
-              "items": {
+              "additionalProperties": {
                 "type": "string"
-              },
+              }
+            },
+            "environment_file": {
               "type": [
                 "array",
                 "null"
-              ]
-            },
-            "vars": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/Vars"
-                },
-                {
-                  "type": "null"
-                }
               ],
-              "description": "Service-specific environment variables"
+              "items": {
+                "type": "string"
+              }
             }
           },
-          "required": [
-            "command"
-          ],
-          "type": "object"
-        },
-        "ServiceShutdown": {
-          "additionalProperties": false,
-          "properties": {
-            "command": {
-              "description": "What command to run to shut down the service",
-              "type": "string"
-            }
-          },
-          "required": [
-            "command"
-          ],
-          "type": "object"
+          "description": "Service section configuration with resource limits"
         },
         "ServiceType": {
+          "type": "string",
           "enum": [
             "Simple",
             "Exec",
@@ -2269,153 +943,1528 @@
             "Dbus",
             "Notify",
             "Idle"
-          ],
-          "type": "string"
+          ]
         },
-        "ServiceUnit": {
+        "RestartPolicy": {
+          "type": "string",
+          "enum": [
+            "No",
+            "OnSuccess",
+            "OnFailure",
+            "OnAbnormal",
+            "OnWatchdog",
+            "OnAbort",
+            "Always"
+          ]
+        },
+        "ResourceLimit": {
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "Value": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "Value"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "Range": {
+                  "type": "object",
+                  "properties": {
+                    "soft": {
+                      "type": "string"
+                    },
+                    "hard": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "soft",
+                    "hard"
+                  ]
+                }
+              },
+              "required": [
+                "Range"
+              ],
+              "additionalProperties": false
+            }
+          ]
+        },
+        "ProtectSystem": {
+          "type": "string",
+          "enum": [
+            "No",
+            "Yes",
+            "Full",
+            "Strict"
+          ]
+        },
+        "ProtectHome": {
+          "type": "string",
+          "enum": [
+            "No",
+            "Yes",
+            "ReadOnly",
+            "Tmpfs"
+          ]
+        },
+        "Build": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/BuildDescriptor"
+          },
+          "description": "A map of package ids to package build descriptors"
+        },
+        "BuildDescriptor": {
+          "type": "object",
           "additionalProperties": false,
-          "description": "Represents a systemd service configuration",
           "properties": {
-            "service": {
+            "command": {
+              "type": "string",
+              "description": "The command to run to build a package."
+            },
+            "runtime-packages": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              },
+              "description": "Packages from the 'toplevel' group to include in the closure of the build result."
+            },
+            "sandbox": {
               "anyOf": [
                 {
-                  "$ref": "#/$defs/Service"
+                  "$ref": "#/$defs/BuildSandbox"
                 },
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Sandbox mode for the build."
             },
-            "unit": {
+            "version": {
               "anyOf": [
                 {
-                  "$ref": "#/$defs/Unit"
+                  "$ref": "#/$defs/BuildVersion"
                 },
                 {
                   "type": "null"
                 }
-              ]
-            }
-          },
-          "type": "object"
-        },
-        "Services": {
-          "additionalProperties": {
-            "$ref": "#/$defs/ServiceDescriptor"
-          },
-          "description": "A map of service names to service definitions.",
-          "type": "object"
-        },
-        "Services2": {
-          "additionalProperties": {
-            "$ref": "#/$defs/ServiceDescriptor"
-          },
-          "description": "Service configuration for V1_12_0: adds optional auto-start behavior\nalongside the map of service names to service definitions.\n\nThe `service_map` field is a `parsed::common::Services` (BTreeMap tuple\nstruct) to allow the internal `CommonFields::services()` accessor on\n`Parsed` to return a uniform `&common::Services` across all versions.",
-          "properties": {
-            "auto-start": {
-              "description": "Whether to start all services automatically on `flox activate`.\nCan be suppressed with `--no-start-services`.",
-              "type": [
-                "boolean",
-                "null"
-              ]
-            }
-          },
-          "type": "object"
-        },
-        "Unit": {
-          "additionalProperties": false,
-          "description": "Unit section configuration",
-          "properties": {
-            "after": {
-              "items": {
-                "type": "string"
-              },
-              "type": [
-                "array",
-                "null"
-              ]
-            },
-            "before": {
-              "items": {
-                "type": "string"
-              },
-              "type": [
-                "array",
-                "null"
-              ]
+              ],
+              "description": "The version to assign the package."
             },
             "description": {
               "type": [
                 "string",
                 "null"
-              ]
+              ],
+              "description": "A short description of the package that will appear on FloxHub and in\nsearch results."
             },
-            "documentation": {
-              "items": {
-                "type": "string"
-              },
+            "license": {
               "type": [
                 "array",
                 "null"
-              ]
-            },
-            "requires": {
+              ],
               "items": {
                 "type": "string"
               },
+              "description": "A license to assign to the package in SPDX format."
+            }
+          },
+          "required": [
+            "command"
+          ],
+          "description": "The definition of a package built from within the environment"
+        },
+        "BuildSandbox": {
+          "type": "string",
+          "enum": [
+            "off",
+            "pure"
+          ],
+          "description": "The definition of a package built from within the environment"
+        },
+        "BuildVersion": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "file": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "file"
+              ]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "command": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "command"
+              ]
+            }
+          ],
+          "description": "The definition of a package built from within the environment"
+        },
+        "Containerize": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "config": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ContainerizeConfig"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        },
+        "ContainerizeConfig": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "user": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "The username or UID which is a platform-specific structure that allows specific control over which user the process run as.\nThis acts as a default value to use when the value is not specified when creating a container.\nFor Linux based systems, all of the following are valid: `user`, `uid`, `user:group`, `uid:gid`, `uid:group`, `user:gid`.\nIf `group`/`gid` is not specified, the default group and supplementary groups of the given `user`/`uid` in `/etc/passwd` and `/etc/group` from the container are applied.\nIf `group`/`gid` is specified, supplementary groups from the container are ignored."
+            },
+            "exposed-ports": {
               "type": [
                 "array",
                 "null"
-              ]
-            },
-            "wants": {
+              ],
+              "uniqueItems": true,
               "items": {
                 "type": "string"
               },
+              "description": "A set of ports to expose from a container running this image.\nIts keys can be in the format of:\n`port/tcp`, `port/udp`, `port` with the default protocol being `tcp` if not specified.\nThese values act as defaults and are merged with any specified when creating a container."
+            },
+            "cmd": {
               "type": [
                 "array",
                 "null"
+              ],
+              "items": {
+                "type": "string"
+              },
+              "description": "Default arguments to the entrypoint of the container.\nThese values act as defaults and may be replaced by any specified when creating a container.\nFlox sets an entrypoint to activate the containerized environment,\nand `cmd` is then run inside the activation, similar to\n`flox activate -c cmd`."
+            },
+            "volumes": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "uniqueItems": true,
+              "items": {
+                "type": "string"
+              },
+              "description": "A set of directories describing where the process is\nlikely to write data specific to a container instance."
+            },
+            "working-dir": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Sets the current working directory of the entrypoint process in the container.\nThis value acts as a default and may be replaced by a working directory specified when creating a container."
+            },
+            "labels": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "This field contains arbitrary metadata for the container.\nThis property MUST use the [annotation rules](https://github.com/opencontainers/image-spec/blob/main/annotations.md#rules)."
+            },
+            "stop-signal": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "This field contains the system call signal that will be sent to the container to exit. The signal can be a signal name in the format `SIGNAME`, for instance `SIGKILL` or `SIGRTMIN+3`."
+            }
+          },
+          "description": "Container config derived from\nhttps://github.com/opencontainers/image-spec/blob/main/config.md\n\nEnv and Entrypoint are left out since they interfere with our activation implementation\nDeprecated and reserved keys are also left out"
+        },
+        "Include": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "environments": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/IncludeDescriptor"
+              },
+              "default": []
+            }
+          },
+          "description": "The section where users can declare dependencies on other environments."
+        },
+        "IncludeDescriptor": {
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "dir": {
+                  "type": "string",
+                  "description": "The directory where the environment is located."
+                },
+                "name": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "A name similar to an install ID that a user could use to specify\nthe environment on the command line e.g. for upgrades, or in an\nerror message."
+                }
+              },
+              "required": [
+                "dir"
+              ]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "remote": {
+                  "$ref": "#/$defs/EnvironmentRef",
+                  "description": "The remote environment reference in the form `owner/name`."
+                },
+                "name": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "A name similar to an install ID that a user could use to specify\nthe environment on the command line e.g. for upgrades, or in an\nerror message."
+                },
+                "generation": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ],
+                  "format": "uint",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "remote"
+              ]
+            }
+          ],
+          "description": "The structure for how a user is able to declare a dependency on an environment."
+        },
+        "EnvironmentRef": {
+          "description": "Environment Reference",
+          "type": "string"
+        },
+        "ManifestV1_10_0": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "schema-version": {
+              "type": "string",
+              "description": "Which schema version this manifest adheres to.\n\nMust be a valid Flox CLI version listed in [`KnownSchemaVersion`]."
+            },
+            "minimum-cli-version": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "The minimum CLI version that can activate this environment."
+            },
+            "install": {
+              "$ref": "#/$defs/Install2",
+              "description": "The packages to install in the form of a map from install_id\nto package descriptor."
+            },
+            "vars": {
+              "$ref": "#/$defs/Vars",
+              "description": "Variables that are exported to the shell environment upon activation."
+            },
+            "hook": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Hook"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Hooks that are run at various times during the lifecycle of the manifest\nin a known shell environment."
+            },
+            "profile": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Profile"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Profile scripts that are run in the user's shell upon activation."
+            },
+            "options": {
+              "$ref": "#/$defs/Options",
+              "description": "Options that control the behavior of the manifest.",
+              "default": {}
+            },
+            "services": {
+              "$ref": "#/$defs/Services",
+              "description": "Service definitions"
+            },
+            "build": {
+              "$ref": "#/$defs/Build",
+              "description": "Package build definitions"
+            },
+            "containerize": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Containerize"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "include": {
+              "$ref": "#/$defs/Include"
+            }
+          },
+          "required": [
+            "schema-version"
+          ],
+          "description": "Not meant for writing manifest files, only for reading them.\nModifications should be made using `manifest::raw`."
+        },
+        "Install2": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/ManifestPackageDescriptor2"
+          }
+        },
+        "ManifestPackageDescriptor2": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PackageDescriptorCatalog2"
+            },
+            {
+              "$ref": "#/$defs/PackageDescriptorFlake2"
+            },
+            {
+              "$ref": "#/$defs/PackageDescriptorStorePath"
+            }
+          ]
+        },
+        "PackageDescriptorCatalog2": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "pkg-path": {
+              "type": "string"
+            },
+            "pkg-group": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "priority": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0
+            },
+            "version": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "systems": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
+            "outputs": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/SelectedOutputs"
+                },
+                {
+                  "type": "null"
+                }
               ]
             }
           },
-          "type": "object"
+          "required": [
+            "pkg-path"
+          ]
         },
-        "Vars": {
+        "SelectedOutputs": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AllSentinel"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "AllSentinel": {
+          "type": "string",
+          "enum": [
+            "all"
+          ]
+        },
+        "PackageDescriptorFlake2": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "flake": {
+              "type": "string"
+            },
+            "priority": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0
+            },
+            "systems": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
+            "outputs": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/SelectedOutputs"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [
+            "flake"
+          ]
+        },
+        "ManifestV1_11_0": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "schema-version": {
+              "type": "string",
+              "description": "Which schema version this manifest adheres to.\n\nMust be a valid Flox CLI version listed in [`KnownSchemaVersion`]."
+            },
+            "minimum-cli-version": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/MinimumCliVersion"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The minimum CLI version that can activate this environment."
+            },
+            "install": {
+              "$ref": "#/$defs/Install2",
+              "description": "The packages to install in the form of a map from install_id\nto package descriptor."
+            },
+            "vars": {
+              "$ref": "#/$defs/Vars",
+              "description": "Variables that are exported to the shell environment upon activation."
+            },
+            "hook": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Hook"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Hooks that are run at various times during the lifecycle of the manifest\nin a known shell environment."
+            },
+            "profile": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Profile"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Profile scripts that are run in the user's shell upon activation."
+            },
+            "options": {
+              "$ref": "#/$defs/Options",
+              "description": "Options that control the behavior of the manifest.",
+              "default": {}
+            },
+            "services": {
+              "$ref": "#/$defs/Services",
+              "description": "Service definitions"
+            },
+            "build": {
+              "$ref": "#/$defs/Build",
+              "description": "Package build definitions"
+            },
+            "containerize": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Containerize"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "include": {
+              "$ref": "#/$defs/Include"
+            }
+          },
+          "required": [
+            "schema-version"
+          ],
+          "description": "Not meant for writing manifest files, only for reading them.\nModifications should be made using `manifest::raw`."
+        },
+        "MinimumCliVersion": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "version": {
+                  "type": "string"
+                },
+                "reason": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "version",
+                "reason"
+              ]
+            }
+          ],
+          "description": "The minimum CLI version required to use the environment.\n\nAccepts either a plain version string:\n  minimum-cli-version = \"1.11.0\"\n\nOr an inline table with a reason:\n  minimum-cli-version = { version = \"1.11.0\", reason = \"needs feature X\" }"
+        },
+        "ManifestV1_12_0": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "schema-version": {
+              "type": "string",
+              "description": "Which schema version this manifest adheres to.\n\nMust be a valid Flox CLI version listed in [`KnownSchemaVersion`]."
+            },
+            "minimum-cli-version": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/MinimumCliVersion"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The minimum CLI version that can activate this environment."
+            },
+            "install": {
+              "$ref": "#/$defs/Install2",
+              "description": "The packages to install in the form of a map from install_id\nto package descriptor."
+            },
+            "vars": {
+              "$ref": "#/$defs/Vars",
+              "description": "Variables that are exported to the shell environment upon activation."
+            },
+            "hook": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Hook"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Hooks that are run at various times during the lifecycle of the manifest\nin a known shell environment."
+            },
+            "profile": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Profile"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Profile scripts that are run in the user's shell upon activation."
+            },
+            "options": {
+              "$ref": "#/$defs/Options",
+              "description": "Options that control the behavior of the manifest.",
+              "default": {}
+            },
+            "services": {
+              "$ref": "#/$defs/Services2",
+              "description": "Service definitions"
+            },
+            "build": {
+              "$ref": "#/$defs/Build",
+              "description": "Package build definitions"
+            },
+            "containerize": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Containerize"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "include": {
+              "$ref": "#/$defs/Include"
+            }
+          },
+          "required": [
+            "schema-version"
+          ],
+          "description": "Not meant for writing manifest files, only for reading them.\nModifications should be made using `manifest::raw`."
+        },
+        "Services2": {
+          "type": "object",
+          "properties": {
+            "auto-start": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "description": "Whether to start all services automatically on `flox activate`.\nCan be suppressed with `--no-start-services`."
+            }
+          },
+          "additionalProperties": {
+            "$ref": "#/$defs/ServiceDescriptor"
+          },
+          "description": "Service configuration for V1_12_0: adds optional auto-start behavior\nalongside the map of service names to service definitions.\n\nThe `service_map` field is a `parsed::common::Services` (BTreeMap tuple\nstruct) to allow the internal `CommonFields::services()` accessor on\n`Parsed` to return a uniform `&common::Services` across all versions."
+        },
+        "ManifestV1_13_0": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "schema-version": {
+              "type": "string",
+              "description": "Which schema version this manifest adheres to.\n\nMust be a valid Flox CLI version listed in [`KnownSchemaVersion`]."
+            },
+            "minimum-cli-version": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/MinimumCliVersion"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The minimum CLI version that can activate this environment."
+            },
+            "install": {
+              "$ref": "#/$defs/Install2",
+              "description": "The packages to install in the form of a map from install_id\nto package descriptor."
+            },
+            "vars": {
+              "$ref": "#/$defs/Vars",
+              "description": "Variables that are exported to the shell environment upon activation."
+            },
+            "hook": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Hook"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Hooks that are run at various times during the lifecycle of the manifest\nin a known shell environment."
+            },
+            "profile": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Profile2"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Profile scripts that are run in the user's shell upon activation\n(and, optionally, upon deactivation)."
+            },
+            "options": {
+              "$ref": "#/$defs/Options",
+              "description": "Options that control the behavior of the manifest.",
+              "default": {}
+            },
+            "services": {
+              "$ref": "#/$defs/Services2",
+              "description": "Service definitions"
+            },
+            "build": {
+              "$ref": "#/$defs/Build2",
+              "description": "Package build definitions"
+            },
+            "containerize": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Containerize"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "include": {
+              "$ref": "#/$defs/Include"
+            }
+          },
+          "required": [
+            "schema-version"
+          ],
+          "description": "Not meant for writing manifest files, only for reading them.\nModifications should be made using `manifest::raw`."
+        },
+        "Profile2": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "common": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "When defined, this hook is run by _all_ shells upon activation"
+            },
+            "bash": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "When defined, this hook is run upon activation in a bash shell"
+            },
+            "zsh": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "When defined, this hook is run upon activation in a zsh shell"
+            },
+            "fish": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "When defined, this hook is run upon activation in a fish shell"
+            },
+            "tcsh": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "When defined, this hook is run upon activation in a tcsh shell"
+            },
+            "deactivate": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ProfileDeactivate"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Per-shell scripts to run when the environment is deactivated.\nMirrors the activation fields above; each is optional."
+            }
+          },
+          "description": "Profile scripts for V1_13_0: adds an optional `deactivate` table holding\nper-shell scripts to run when the environment is deactivated. The\nactivation fields (`common`, `bash`, `zsh`, `fish`, `tcsh`) are the same\nas earlier schema versions."
+        },
+        "ProfileDeactivate": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "common": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Run by all shells when the environment is deactivated."
+            },
+            "bash": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Run upon deactivation in a bash shell."
+            },
+            "zsh": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Run upon deactivation in a zsh shell."
+            },
+            "fish": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Run upon deactivation in a fish shell."
+            },
+            "tcsh": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Run upon deactivation in a tcsh shell."
+            }
+          },
+          "description": "Deactivation profile scripts. Each field, when defined, is sourced as\nthe user's environment is being torn down — symmetric to the activation\nscripts on the enclosing [`Profile`]."
+        },
+        "Build2": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/BuildDescriptor2"
+          },
+          "description": "A map of package ids to package build descriptors.\n\nThis is a version-specific copy of `common::Build` because V1_13_0 adds the\n`sandbox-allow` field to [BuildDescriptor]; the map is otherwise identical."
+        },
+        "BuildDescriptor2": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "command": {
+              "type": "string",
+              "description": "The command to run to build a package."
+            },
+            "runtime-packages": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              },
+              "description": "Packages from the 'toplevel' group to include in the closure of the\nbuild result."
+            },
+            "sandbox": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BuildSandbox2"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Sandbox mode for the build."
+            },
+            "sandbox-allow": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              },
+              "description": "Paths or glob patterns the build may read from outside its closure\nwithout the virtual sandbox warning about them (or, under `enforce`,\nblocking them). A leading `~/` is expanded to `$HOME`; `*`/`**` are\nmatched with `fnmatch`. Only meaningful for the local sandbox modes\n(`warn`/`enforce`)."
+            },
+            "version": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/BuildVersion"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The version to assign the package."
+            },
+            "description": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "A short description of the package that will appear on FloxHub and in\nsearch results."
+            },
+            "license": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              },
+              "description": "A license to assign to the package in SPDX format."
+            }
+          },
+          "required": [
+            "command"
+          ],
+          "description": "The definition of a package built from within the environment.\n\nV1_13_0 adds `sandbox-allow`: a list of paths/globs the build is permitted\nto read from outside its closure without a sandbox warning (or, under\n`enforce`, without failing). Otherwise identical to `common::BuildDescriptor`."
+        },
+        "BuildSandbox2": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "off",
+                "pure"
+              ]
+            },
+            {
+              "type": "string",
+              "const": "warn",
+              "description": "Local build; out-of-closure file access is reported with a warning."
+            },
+            {
+              "type": "string",
+              "const": "enforce",
+              "description": "Local build; out-of-closure file access is denied (the build fails)."
+            }
+          ],
+          "description": "Sandbox mode for a build.\n\nThis is a version-specific copy of `common::BuildSandbox` because V1_13_0\nadds the local `warn` and `enforce` modes. Keeping the new variants out of\nthe common enum is what stops older schema versions (whose `BuildDescriptor`\nuses `common::BuildSandbox`) from accepting `sandbox = \"warn\" | \"enforce\"`."
+        },
+        "ManifestV1_14_0": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "schema-version": {
+              "type": "string",
+              "description": "Which schema version this manifest adheres to.\n\nMust be a valid Flox CLI version listed in [`KnownSchemaVersion`]."
+            },
+            "minimum-cli-version": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/MinimumCliVersion"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The minimum CLI version that can activate this environment."
+            },
+            "install": {
+              "$ref": "#/$defs/Install2",
+              "description": "The packages to install in the form of a map from install_id\nto package descriptor."
+            },
+            "vars": {
+              "$ref": "#/$defs/Vars",
+              "description": "Variables that are exported to the shell environment upon activation."
+            },
+            "hook": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Hook"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Hooks that are run at various times during the lifecycle of the manifest\nin a known shell environment."
+            },
+            "profile": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Profile2"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Profile scripts that are run in the user's shell upon activation\n(and, optionally, upon deactivation)."
+            },
+            "options": {
+              "$ref": "#/$defs/Options",
+              "description": "Options that control the behavior of the manifest.",
+              "default": {}
+            },
+            "services": {
+              "$ref": "#/$defs/Services2",
+              "description": "Service definitions"
+            },
+            "build": {
+              "$ref": "#/$defs/Build2",
+              "description": "Package build definitions"
+            },
+            "containerize": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Containerize"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "include": {
+              "$ref": "#/$defs/Include"
+            },
+            "plugins": {
+              "$ref": "#/$defs/Plugins",
+              "description": "Free-form data provided by installed plugins, keyed by plugin\npackage name (`[plugins.<pkg-name>]`). Each plugin defines and\nvalidates the shape of its own table; Flox does not interpret it.\nThe convention for secrets plugins is a flat table of\n`ENV_VAR_NAME = \"path/to/secret/in/store\"`, read by the plugin's\n`profile.d` script at activation."
+            }
+          },
+          "required": [
+            "schema-version"
+          ],
+          "description": "Not meant for writing manifest files, only for reading them.\nModifications should be made using `manifest::raw`."
+        },
+        "Plugins": {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "A map of plugin package names to that plugin's free-form manifest data.\n\nValues are opaque JSON: the plugin that owns a given table defines and\nvalidates its own shape, so Flox stores whatever the user writes without\ninterpreting it."
+        }
+      }
+    },
+    "LockedPackage": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/LockedPackageCatalog"
+        },
+        {
+          "$ref": "#/$defs/LockedPackageFlake"
+        },
+        {
+          "$ref": "#/$defs/LockedPackageStorePath"
+        }
+      ]
+    },
+    "LockedPackageCatalog": {
+      "type": "object",
+      "properties": {
+        "attr_path": {
+          "type": "string"
+        },
+        "broken": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "derivation": {
+          "type": "string"
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "install_id": {
+          "type": "string"
+        },
+        "license": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "locked_url": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "pname": {
+          "type": "string"
+        },
+        "rev": {
+          "type": "string"
+        },
+        "rev_count": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "rev_date": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "scrape_date": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "stabilities": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "unfree": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "version": {
+          "type": "string"
+        },
+        "outputs_to_install": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "outputs": {
+          "type": "object",
           "additionalProperties": {
             "type": "string"
           },
-          "type": "object"
+          "description": "A map of output name to store path"
+        },
+        "system": {
+          "type": "string"
+        },
+        "group": {
+          "type": "string"
+        },
+        "priority": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0
         }
       },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "required": [
+        "attr_path",
+        "derivation",
+        "install_id",
+        "locked_url",
+        "name",
+        "pname",
+        "rev",
+        "rev_count",
+        "rev_date",
+        "scrape_date",
+        "version",
+        "outputs",
+        "system",
+        "group",
+        "priority"
+      ]
+    },
+    "LockedPackageFlake": {
+      "type": "object",
+      "properties": {
+        "install_id": {
+          "type": "string"
+        },
+        "locked-url": {
+          "type": "string",
+          "description": "locked url of the flakeref component of the installable"
+        },
+        "flake-description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "locked-flake-attr-path": {
+          "type": "string"
+        },
+        "derivation": {
+          "type": "string"
+        },
+        "outputs": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Map of output names to their paths\nThe values are expected to be nix store paths"
+        },
+        "output-names": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of output names in the original order"
+        },
+        "outputs-to-install": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "description": "List of output names to install as defined by the package"
+        },
+        "requested-outputs-to-install": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "description": "List of output names to install as requested by the user"
+        },
+        "package-system": {
+          "type": "string",
+          "description": "System as defined by the package"
+        },
+        "system": {
+          "type": "string",
+          "description": "System as specified by the manifest and used to set default attribute\npaths when locking the installable"
+        },
+        "name": {
+          "type": "string"
+        },
+        "pname": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "version": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "licenses": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "broken": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "unfree": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "priority": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0,
+          "default": 5
+        }
+      },
+      "required": [
+        "install_id",
+        "locked-url",
+        "locked-flake-attr-path",
+        "derivation",
+        "outputs",
+        "output-names",
+        "package-system",
+        "system",
+        "name"
+      ],
+      "description": "Rust representation of the output of `builtins.lockFlakeInstallable`\nThis is a direct translation of the definition in\n`<flox>/nix-plugins/include/flox/lock-flake-installable.hh`"
+    },
+    "LockedPackageStorePath": {
+      "type": "object",
+      "properties": {
+        "install_id": {
+          "type": "string",
+          "description": "The install_id of the descriptor in the manifest"
+        },
+        "store_path": {
+          "type": "string",
+          "description": "Store path to add to the environment"
+        },
+        "system": {
+          "type": "string"
+        },
+        "priority": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0
+        }
+      },
+      "required": [
+        "install_id",
+        "store_path",
+        "system",
+        "priority"
+      ]
+    },
+    "Compose": {
+      "type": "object",
+      "properties": {
+        "composer": {
+          "$ref": "#/$defs/Manifest",
+          "description": "The composing environment's manifest that was on disk at lock-time."
+        },
+        "include": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/LockedInclude"
+          },
+          "description": "Metadata and manifests for the included environments in the order\nthat they were specified in the composing environment's manifest."
+        },
+        "warnings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/WarningWithContext"
+          },
+          "description": "Warnings generated during composition + locking."
+        }
+      },
+      "required": [
+        "composer",
+        "include",
+        "warnings"
+      ]
+    },
+    "LockedInclude": {
+      "type": "object",
+      "properties": {
+        "manifest": {
+          "$ref": "#/$defs/Manifest"
+        },
+        "name": {
+          "type": "string"
+        },
+        "descriptor": {
+          "$ref": "#/$defs/IncludeDescriptor"
+        }
+      },
+      "required": [
+        "manifest",
+        "name",
+        "descriptor"
+      ]
+    },
+    "IncludeDescriptor": {
       "anyOf": [
         {
-          "$ref": "#/$defs/ManifestV1"
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "dir": {
+              "type": "string",
+              "description": "The directory where the environment is located."
+            },
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "A name similar to an install ID that a user could use to specify\nthe environment on the command line e.g. for upgrades, or in an\nerror message."
+            }
+          },
+          "required": [
+            "dir"
+          ]
         },
         {
-          "$ref": "#/$defs/ManifestV1_10_0"
-        },
-        {
-          "$ref": "#/$defs/ManifestV1_11_0"
-        },
-        {
-          "$ref": "#/$defs/ManifestV1_12_0"
-        },
-        {
-          "$ref": "#/$defs/ManifestV1_13_0"
-        },
-        {
-          "$ref": "#/$defs/ManifestV1_14_0"
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "remote": {
+              "$ref": "#/$defs/EnvironmentRef",
+              "description": "The remote environment reference in the form `owner/name`."
+            },
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "A name similar to an install ID that a user could use to specify\nthe environment on the command line e.g. for upgrades, or in an\nerror message."
+            },
+            "generation": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint",
+              "minimum": 0
+            }
+          },
+          "required": [
+            "remote"
+          ]
         }
       ],
-      "description": "A validated, typed manifest with a known schema.",
-      "title": "Parsed"
+      "description": "The structure for how a user is able to declare a dependency on an environment."
+    },
+    "EnvironmentRef": {
+      "description": "Environment Reference",
+      "type": "string"
+    },
+    "WarningWithContext": {
+      "type": "object",
+      "properties": {
+        "warning": {
+          "$ref": "#/$defs/Warning"
+        },
+        "higher_priority_name": {
+          "type": "string",
+          "description": "The name of the manifest that did the overriding."
+        }
+      },
+      "required": [
+        "warning",
+        "higher_priority_name"
+      ],
+      "description": "A warning that occurred during the merge of two manifests,\nalong with the names of the overriding manifest."
     },
     "Warning": {
-      "description": "A warning that occurred during the merge of two manifests.\nThis is used to provide feedback to the user about potential issues.\n\nWarnings are not errors, but they may indicate\nthat the user should review the merged manifest or its dependencies.",
       "oneOf": [
         {
-          "additionalProperties": false,
+          "type": "object",
           "properties": {
             "Overriding": {
               "$ref": "#/$defs/KeyPath"
@@ -2424,65 +2473,17 @@
           "required": [
             "Overriding"
           ],
-          "type": "object"
-        }
-      ]
-    },
-    "WarningWithContext": {
-      "description": "A warning that occurred during the merge of two manifests,\nalong with the names of the overriding manifest.",
-      "properties": {
-        "higher_priority_name": {
-          "description": "The name of the manifest that did the overriding.",
-          "type": "string"
-        },
-        "warning": {
-          "$ref": "#/$defs/Warning"
-        }
-      },
-      "required": [
-        "warning",
-        "higher_priority_name"
-      ],
-      "type": "object"
-    },
-    "version": {
-      "const": 1,
-      "type": "integer"
-    }
-  },
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "properties": {
-    "compose": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/Compose"
-        },
-        {
-          "type": "null"
+          "additionalProperties": false
         }
       ],
-      "description": "Composition information. This will be `None` when there are no includes."
+      "description": "A warning that occurred during the merge of two manifests.\nThis is used to provide feedback to the user about potential issues.\n\nWarnings are not errors, but they may indicate\nthat the user should review the merged manifest or its dependencies."
     },
-    "lockfile-version": {
-      "$ref": "#/$defs/version"
-    },
-    "manifest": {
-      "$ref": "#/$defs/Manifest",
-      "description": "The manifest that was locked.\n\nFor an environment that doesn't include any others, this is the `manifest.toml`\non disk at lock-time. For an environment that *does* include others, this is\nthe merged manifest that was locked."
-    },
-    "packages": {
-      "description": "Locked packages",
+    "KeyPath": {
+      "type": "array",
       "items": {
-        "$ref": "#/$defs/LockedPackage"
+        "type": "string"
       },
-      "type": "array"
+      "description": "A key path to a value in a manifest.\nThis is used to provide the location for warnings.\n\nThe `KeyPath` behaves like an immutable stack of keys,\nwhere [`KeyPath::push`] and [`KeyPath::extend`] return a new `KeyPath`\nwith the new key(s) added to the top of the stack,\nleaving the original `KeyPath` unchanged."
     }
-  },
-  "required": [
-    "lockfile-version",
-    "manifest",
-    "packages"
-  ],
-  "title": "Lockfile",
-  "type": "object"
+  }
 }

--- a/cli/schemas/manifest-v1.schema.json
+++ b/cli/schemas/manifest-v1.schema.json
@@ -1,455 +1,108 @@
 {
+  "anyOf": [
+    {
+      "$ref": "#/$defs/ManifestV1"
+    },
+    {
+      "$ref": "#/$defs/ManifestV1_10_0"
+    },
+    {
+      "$ref": "#/$defs/ManifestV1_11_0"
+    },
+    {
+      "$ref": "#/$defs/ManifestV1_12_0"
+    },
+    {
+      "$ref": "#/$defs/ManifestV1_13_0"
+    },
+    {
+      "$ref": "#/$defs/ManifestV1_14_0"
+    }
+  ],
+  "description": "A validated, typed manifest with a known schema.",
+  "title": "Parsed",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$defs": {
-    "ActivateMode": {
-      "enum": [
-        "dev",
-        "run"
-      ],
-      "type": "string"
-    },
-    "ActivateOptions": {
+    "ManifestV1": {
+      "type": "object",
       "additionalProperties": false,
       "properties": {
-        "mode": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ActivateMode"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      },
-      "type": "object"
-    },
-    "AllSentinel": {
-      "enum": [
-        "all"
-      ],
-      "type": "string"
-    },
-    "Allows": {
-      "additionalProperties": false,
-      "properties": {
-        "broken": {
-          "description": "Whether to allow packages that are marked as `broken`",
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
-        "licenses": {
-          "description": "A list of license descriptors that are allowed",
-          "items": {
-            "type": "string"
-          },
-          "type": [
-            "array",
-            "null"
-          ]
-        },
-        "unfree": {
-          "description": "Whether to allow packages that are marked as `unfree`",
-          "type": [
-            "boolean",
-            "null"
-          ]
-        }
-      },
-      "type": "object"
-    },
-    "Build": {
-      "additionalProperties": {
-        "$ref": "#/$defs/BuildDescriptor"
-      },
-      "description": "A map of package ids to package build descriptors",
-      "type": "object"
-    },
-    "Build2": {
-      "additionalProperties": {
-        "$ref": "#/$defs/BuildDescriptor2"
-      },
-      "description": "A map of package ids to package build descriptors.\n\nThis is a version-specific copy of `common::Build` because V1_13_0 adds the\n`sandbox-allow` field to [BuildDescriptor]; the map is otherwise identical.",
-      "type": "object"
-    },
-    "BuildDescriptor": {
-      "additionalProperties": false,
-      "description": "The definition of a package built from within the environment",
-      "properties": {
-        "command": {
-          "description": "The command to run to build a package.",
-          "type": "string"
-        },
-        "description": {
-          "description": "A short description of the package that will appear on FloxHub and in\nsearch results.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "license": {
-          "description": "A license to assign to the package in SPDX format.",
-          "items": {
-            "type": "string"
-          },
-          "type": [
-            "array",
-            "null"
-          ]
-        },
-        "runtime-packages": {
-          "description": "Packages from the 'toplevel' group to include in the closure of the build result.",
-          "items": {
-            "type": "string"
-          },
-          "type": [
-            "array",
-            "null"
-          ]
-        },
-        "sandbox": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/BuildSandbox"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "Sandbox mode for the build."
-        },
         "version": {
+          "$ref": "#/$defs/ManifestVersion"
+        },
+        "install": {
+          "$ref": "#/$defs/Install",
+          "description": "The packages to install in the form of a map from install_id\nto package descriptor."
+        },
+        "vars": {
+          "$ref": "#/$defs/Vars",
+          "description": "Variables that are exported to the shell environment upon activation."
+        },
+        "hook": {
           "anyOf": [
             {
-              "$ref": "#/$defs/BuildVersion"
+              "$ref": "#/$defs/Hook"
             },
             {
               "type": "null"
             }
           ],
-          "description": "The version to assign the package."
+          "description": "Hooks that are run at various times during the lifecycle of the manifest\nin a known shell environment."
+        },
+        "profile": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Profile"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Profile scripts that are run in the user's shell upon activation."
+        },
+        "options": {
+          "$ref": "#/$defs/Options",
+          "description": "Options that control the behavior of the manifest.",
+          "default": {}
+        },
+        "services": {
+          "$ref": "#/$defs/Services",
+          "description": "Service definitions"
+        },
+        "build": {
+          "$ref": "#/$defs/Build",
+          "description": "Package build definitions"
+        },
+        "containerize": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Containerize"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "include": {
+          "$ref": "#/$defs/Include"
         }
       },
       "required": [
-        "command"
+        "version"
       ],
-      "type": "object"
+      "description": "Not meant for writing manifest files, only for reading them.\nModifications should be made using `manifest::raw`."
     },
-    "BuildDescriptor2": {
-      "additionalProperties": false,
-      "description": "The definition of a package built from within the environment.\n\nV1_13_0 adds `sandbox-allow`: a list of paths/globs the build is permitted\nto read from outside its closure without a sandbox warning (or, under\n`enforce`, without failing). Otherwise identical to `common::BuildDescriptor`.",
-      "properties": {
-        "command": {
-          "description": "The command to run to build a package.",
-          "type": "string"
-        },
-        "description": {
-          "description": "A short description of the package that will appear on FloxHub and in\nsearch results.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "license": {
-          "description": "A license to assign to the package in SPDX format.",
-          "items": {
-            "type": "string"
-          },
-          "type": [
-            "array",
-            "null"
-          ]
-        },
-        "runtime-packages": {
-          "description": "Packages from the 'toplevel' group to include in the closure of the\nbuild result.",
-          "items": {
-            "type": "string"
-          },
-          "type": [
-            "array",
-            "null"
-          ]
-        },
-        "sandbox": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/BuildSandbox2"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "Sandbox mode for the build."
-        },
-        "sandbox-allow": {
-          "description": "Paths or glob patterns the build may read from outside its closure\nwithout the virtual sandbox warning about them (or, under `enforce`,\nblocking them). A leading `~/` is expanded to `$HOME`; `*`/`**` are\nmatched with `fnmatch`. Only meaningful for the local sandbox modes\n(`warn`/`enforce`).",
-          "items": {
-            "type": "string"
-          },
-          "type": [
-            "array",
-            "null"
-          ]
-        },
-        "version": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/BuildVersion"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "The version to assign the package."
-        }
-      },
-      "required": [
-        "command"
-      ],
-      "type": "object"
-    },
-    "BuildSandbox": {
-      "description": "The definition of a package built from within the environment",
-      "enum": [
-        "off",
-        "pure"
-      ],
-      "type": "string"
-    },
-    "BuildSandbox2": {
-      "description": "Sandbox mode for a build.\n\nThis is a version-specific copy of `common::BuildSandbox` because V1_13_0\nadds the local `warn` and `enforce` modes. Keeping the new variants out of\nthe common enum is what stops older schema versions (whose `BuildDescriptor`\nuses `common::BuildSandbox`) from accepting `sandbox = \"warn\" | \"enforce\"`.",
-      "oneOf": [
-        {
-          "enum": [
-            "off",
-            "pure"
-          ],
-          "type": "string"
-        },
-        {
-          "const": "warn",
-          "description": "Local build; out-of-closure file access is reported with a warning.",
-          "type": "string"
-        },
-        {
-          "const": "enforce",
-          "description": "Local build; out-of-closure file access is denied (the build fails).",
-          "type": "string"
-        }
-      ]
-    },
-    "BuildVersion": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "properties": {
-            "file": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "file"
-          ],
-          "type": "object"
-        },
-        {
-          "properties": {
-            "command": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "command"
-          ],
-          "type": "object"
-        }
-      ],
-      "description": "The definition of a package built from within the environment"
-    },
-    "Containerize": {
-      "additionalProperties": false,
-      "properties": {
-        "config": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ContainerizeConfig"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      },
-      "type": "object"
-    },
-    "ContainerizeConfig": {
-      "additionalProperties": false,
-      "description": "Container config derived from\nhttps://github.com/opencontainers/image-spec/blob/main/config.md\n\nEnv and Entrypoint are left out since they interfere with our activation implementation\nDeprecated and reserved keys are also left out",
-      "properties": {
-        "cmd": {
-          "description": "Default arguments to the entrypoint of the container.\nThese values act as defaults and may be replaced by any specified when creating a container.\nFlox sets an entrypoint to activate the containerized environment,\nand `cmd` is then run inside the activation, similar to\n`flox activate -c cmd`.",
-          "items": {
-            "type": "string"
-          },
-          "type": [
-            "array",
-            "null"
-          ]
-        },
-        "exposed-ports": {
-          "description": "A set of ports to expose from a container running this image.\nIts keys can be in the format of:\n`port/tcp`, `port/udp`, `port` with the default protocol being `tcp` if not specified.\nThese values act as defaults and are merged with any specified when creating a container.",
-          "items": {
-            "type": "string"
-          },
-          "type": [
-            "array",
-            "null"
-          ],
-          "uniqueItems": true
-        },
-        "labels": {
-          "additionalProperties": {
-            "type": "string"
-          },
-          "description": "This field contains arbitrary metadata for the container.\nThis property MUST use the [annotation rules](https://github.com/opencontainers/image-spec/blob/main/annotations.md#rules).",
-          "type": [
-            "object",
-            "null"
-          ]
-        },
-        "stop-signal": {
-          "description": "This field contains the system call signal that will be sent to the container to exit. The signal can be a signal name in the format `SIGNAME`, for instance `SIGKILL` or `SIGRTMIN+3`.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "user": {
-          "description": "The username or UID which is a platform-specific structure that allows specific control over which user the process run as.\nThis acts as a default value to use when the value is not specified when creating a container.\nFor Linux based systems, all of the following are valid: `user`, `uid`, `user:group`, `uid:gid`, `uid:group`, `user:gid`.\nIf `group`/`gid` is not specified, the default group and supplementary groups of the given `user`/`uid` in `/etc/passwd` and `/etc/group` from the container are applied.\nIf `group`/`gid` is specified, supplementary groups from the container are ignored.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "volumes": {
-          "description": "A set of directories describing where the process is\nlikely to write data specific to a container instance.",
-          "items": {
-            "type": "string"
-          },
-          "type": [
-            "array",
-            "null"
-          ],
-          "uniqueItems": true
-        },
-        "working-dir": {
-          "description": "Sets the current working directory of the entrypoint process in the container.\nThis value acts as a default and may be replaced by a working directory specified when creating a container.",
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      },
-      "type": "object"
-    },
-    "EnvironmentRef": {
-      "description": "Environment Reference",
-      "type": "string"
-    },
-    "Hook": {
-      "additionalProperties": false,
-      "properties": {
-        "on-activate": {
-          "description": "A script that is run at activation time,\nin a flox provided bash shell",
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      },
-      "type": "object"
-    },
-    "Include": {
-      "additionalProperties": false,
-      "description": "The section where users can declare dependencies on other environments.",
-      "properties": {
-        "environments": {
-          "default": [],
-          "items": {
-            "$ref": "#/$defs/IncludeDescriptor"
-          },
-          "type": "array"
-        }
-      },
-      "type": "object"
-    },
-    "IncludeDescriptor": {
-      "anyOf": [
-        {
-          "additionalProperties": false,
-          "properties": {
-            "dir": {
-              "description": "The directory where the environment is located.",
-              "type": "string"
-            },
-            "name": {
-              "description": "A name similar to an install ID that a user could use to specify\nthe environment on the command line e.g. for upgrades, or in an\nerror message.",
-              "type": [
-                "string",
-                "null"
-              ]
-            }
-          },
-          "required": [
-            "dir"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "generation": {
-              "format": "uint",
-              "minimum": 0,
-              "type": [
-                "integer",
-                "null"
-              ]
-            },
-            "name": {
-              "description": "A name similar to an install ID that a user could use to specify\nthe environment on the command line e.g. for upgrades, or in an\nerror message.",
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "remote": {
-              "$ref": "#/$defs/EnvironmentRef",
-              "description": "The remote environment reference in the form `owner/name`."
-            }
-          },
-          "required": [
-            "remote"
-          ],
-          "type": "object"
-        }
-      ],
-      "description": "The structure for how a user is able to declare a dependency on an environment."
+    "ManifestVersion": {
+      "type": "integer",
+      "format": "uint8",
+      "minimum": 0,
+      "maximum": 255
     },
     "Install": {
+      "type": "object",
       "additionalProperties": {
         "$ref": "#/$defs/ManifestPackageDescriptor"
-      },
-      "type": "object"
-    },
-    "Install2": {
-      "additionalProperties": {
-        "$ref": "#/$defs/ManifestPackageDescriptor2"
-      },
-      "type": "object"
+      }
     },
     "ManifestPackageDescriptor": {
       "anyOf": [
@@ -464,1025 +117,448 @@
         }
       ]
     },
-    "ManifestPackageDescriptor2": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/PackageDescriptorCatalog2"
-        },
-        {
-          "$ref": "#/$defs/PackageDescriptorFlake2"
-        },
-        {
-          "$ref": "#/$defs/PackageDescriptorStorePath"
-        }
-      ]
-    },
-    "ManifestV1": {
+    "PackageDescriptorCatalog": {
+      "type": "object",
       "additionalProperties": false,
-      "description": "Not meant for writing manifest files, only for reading them.\nModifications should be made using `manifest::raw`.",
       "properties": {
-        "build": {
-          "$ref": "#/$defs/Build",
-          "description": "Package build definitions"
+        "pkg-path": {
+          "type": "string"
         },
-        "containerize": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Containerize"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "hook": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Hook"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "Hooks that are run at various times during the lifecycle of the manifest\nin a known shell environment."
-        },
-        "include": {
-          "$ref": "#/$defs/Include"
-        },
-        "install": {
-          "$ref": "#/$defs/Install",
-          "description": "The packages to install in the form of a map from install_id\nto package descriptor."
-        },
-        "options": {
-          "$ref": "#/$defs/Options",
-          "default": {},
-          "description": "Options that control the behavior of the manifest."
-        },
-        "profile": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Profile"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "Profile scripts that are run in the user's shell upon activation."
-        },
-        "services": {
-          "$ref": "#/$defs/Services",
-          "description": "Service definitions"
-        },
-        "vars": {
-          "$ref": "#/$defs/Vars",
-          "description": "Variables that are exported to the shell environment upon activation."
-        },
-        "version": {
-          "$ref": "#/$defs/ManifestVersion"
-        }
-      },
-      "required": [
-        "version"
-      ],
-      "type": "object"
-    },
-    "ManifestV1_10_0": {
-      "additionalProperties": false,
-      "description": "Not meant for writing manifest files, only for reading them.\nModifications should be made using `manifest::raw`.",
-      "properties": {
-        "build": {
-          "$ref": "#/$defs/Build",
-          "description": "Package build definitions"
-        },
-        "containerize": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Containerize"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "hook": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Hook"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "Hooks that are run at various times during the lifecycle of the manifest\nin a known shell environment."
-        },
-        "include": {
-          "$ref": "#/$defs/Include"
-        },
-        "install": {
-          "$ref": "#/$defs/Install2",
-          "description": "The packages to install in the form of a map from install_id\nto package descriptor."
-        },
-        "minimum-cli-version": {
-          "description": "The minimum CLI version that can activate this environment.",
+        "pkg-group": {
           "type": [
             "string",
             "null"
           ]
         },
-        "options": {
-          "$ref": "#/$defs/Options",
-          "default": {},
-          "description": "Options that control the behavior of the manifest."
-        },
-        "profile": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Profile"
-            },
-            {
-              "type": "null"
-            }
+        "priority": {
+          "type": [
+            "integer",
+            "null"
           ],
-          "description": "Profile scripts that are run in the user's shell upon activation."
+          "format": "uint64",
+          "minimum": 0
         },
-        "schema-version": {
-          "description": "Which schema version this manifest adheres to.\n\nMust be a valid Flox CLI version listed in [`KnownSchemaVersion`].",
-          "type": "string"
-        },
-        "services": {
-          "$ref": "#/$defs/Services",
-          "description": "Service definitions"
-        },
-        "vars": {
-          "$ref": "#/$defs/Vars",
-          "description": "Variables that are exported to the shell environment upon activation."
-        }
-      },
-      "required": [
-        "schema-version"
-      ],
-      "type": "object"
-    },
-    "ManifestV1_11_0": {
-      "additionalProperties": false,
-      "description": "Not meant for writing manifest files, only for reading them.\nModifications should be made using `manifest::raw`.",
-      "properties": {
-        "build": {
-          "$ref": "#/$defs/Build",
-          "description": "Package build definitions"
-        },
-        "containerize": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Containerize"
-            },
-            {
-              "type": "null"
-            }
+        "version": {
+          "type": [
+            "string",
+            "null"
           ]
         },
-        "hook": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Hook"
-            },
-            {
-              "type": "null"
-            }
+        "systems": {
+          "type": [
+            "array",
+            "null"
           ],
-          "description": "Hooks that are run at various times during the lifecycle of the manifest\nin a known shell environment."
-        },
-        "include": {
-          "$ref": "#/$defs/Include"
-        },
-        "install": {
-          "$ref": "#/$defs/Install2",
-          "description": "The packages to install in the form of a map from install_id\nto package descriptor."
-        },
-        "minimum-cli-version": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/MinimumCliVersion"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "The minimum CLI version that can activate this environment."
-        },
-        "options": {
-          "$ref": "#/$defs/Options",
-          "default": {},
-          "description": "Options that control the behavior of the manifest."
-        },
-        "profile": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Profile"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "Profile scripts that are run in the user's shell upon activation."
-        },
-        "schema-version": {
-          "description": "Which schema version this manifest adheres to.\n\nMust be a valid Flox CLI version listed in [`KnownSchemaVersion`].",
-          "type": "string"
-        },
-        "services": {
-          "$ref": "#/$defs/Services",
-          "description": "Service definitions"
-        },
-        "vars": {
-          "$ref": "#/$defs/Vars",
-          "description": "Variables that are exported to the shell environment upon activation."
+          "items": {
+            "type": "string"
+          }
         }
       },
       "required": [
-        "schema-version"
-      ],
-      "type": "object"
+        "pkg-path"
+      ]
     },
-    "ManifestV1_12_0": {
+    "PackageDescriptorFlake": {
+      "type": "object",
       "additionalProperties": false,
-      "description": "Not meant for writing manifest files, only for reading them.\nModifications should be made using `manifest::raw`.",
       "properties": {
-        "build": {
-          "$ref": "#/$defs/Build",
-          "description": "Package build definitions"
-        },
-        "containerize": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Containerize"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "hook": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Hook"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "Hooks that are run at various times during the lifecycle of the manifest\nin a known shell environment."
-        },
-        "include": {
-          "$ref": "#/$defs/Include"
-        },
-        "install": {
-          "$ref": "#/$defs/Install2",
-          "description": "The packages to install in the form of a map from install_id\nto package descriptor."
-        },
-        "minimum-cli-version": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/MinimumCliVersion"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "The minimum CLI version that can activate this environment."
-        },
-        "options": {
-          "$ref": "#/$defs/Options",
-          "default": {},
-          "description": "Options that control the behavior of the manifest."
-        },
-        "profile": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Profile"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "Profile scripts that are run in the user's shell upon activation."
-        },
-        "schema-version": {
-          "description": "Which schema version this manifest adheres to.\n\nMust be a valid Flox CLI version listed in [`KnownSchemaVersion`].",
+        "flake": {
           "type": "string"
         },
-        "services": {
-          "$ref": "#/$defs/Services2",
-          "description": "Service definitions"
+        "priority": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0
         },
-        "vars": {
-          "$ref": "#/$defs/Vars",
-          "description": "Variables that are exported to the shell environment upon activation."
+        "systems": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
         }
       },
       "required": [
-        "schema-version"
-      ],
-      "type": "object"
+        "flake"
+      ]
     },
-    "ManifestV1_13_0": {
+    "PackageDescriptorStorePath": {
+      "type": "object",
       "additionalProperties": false,
-      "description": "Not meant for writing manifest files, only for reading them.\nModifications should be made using `manifest::raw`.",
       "properties": {
-        "build": {
-          "$ref": "#/$defs/Build2",
-          "description": "Package build definitions"
-        },
-        "containerize": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Containerize"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "hook": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Hook"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "Hooks that are run at various times during the lifecycle of the manifest\nin a known shell environment."
-        },
-        "include": {
-          "$ref": "#/$defs/Include"
-        },
-        "install": {
-          "$ref": "#/$defs/Install2",
-          "description": "The packages to install in the form of a map from install_id\nto package descriptor."
-        },
-        "minimum-cli-version": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/MinimumCliVersion"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "The minimum CLI version that can activate this environment."
-        },
-        "options": {
-          "$ref": "#/$defs/Options",
-          "default": {},
-          "description": "Options that control the behavior of the manifest."
-        },
-        "profile": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Profile2"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "Profile scripts that are run in the user's shell upon activation\n(and, optionally, upon deactivation)."
-        },
-        "schema-version": {
-          "description": "Which schema version this manifest adheres to.\n\nMust be a valid Flox CLI version listed in [`KnownSchemaVersion`].",
+        "store-path": {
           "type": "string"
         },
-        "services": {
-          "$ref": "#/$defs/Services2",
-          "description": "Service definitions"
+        "systems": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
         },
-        "vars": {
-          "$ref": "#/$defs/Vars",
-          "description": "Variables that are exported to the shell environment upon activation."
+        "priority": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0
         }
       },
       "required": [
-        "schema-version"
-      ],
-      "type": "object"
+        "store-path"
+      ]
     },
-    "ManifestV1_14_0": {
+    "Vars": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "The `[vars]` section of a manifest.\n\nEntries preserve the order in which they are defined in the manifest and\nare rendered to the activation script in that order, so an entry may\nreference entries defined above it."
+    },
+    "Hook": {
+      "type": "object",
       "additionalProperties": false,
-      "description": "Not meant for writing manifest files, only for reading them.\nModifications should be made using `manifest::raw`.",
       "properties": {
-        "build": {
-          "$ref": "#/$defs/Build2",
-          "description": "Package build definitions"
-        },
-        "containerize": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Containerize"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "hook": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Hook"
-            },
-            {
-              "type": "null"
-            }
+        "on-activate": {
+          "type": [
+            "string",
+            "null"
           ],
-          "description": "Hooks that are run at various times during the lifecycle of the manifest\nin a known shell environment."
-        },
-        "include": {
-          "$ref": "#/$defs/Include"
-        },
-        "install": {
-          "$ref": "#/$defs/Install2",
-          "description": "The packages to install in the form of a map from install_id\nto package descriptor."
-        },
-        "minimum-cli-version": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/MinimumCliVersion"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "The minimum CLI version that can activate this environment."
-        },
-        "options": {
-          "$ref": "#/$defs/Options",
-          "default": {},
-          "description": "Options that control the behavior of the manifest."
-        },
-        "plugins": {
-          "$ref": "#/$defs/Plugins",
-          "description": "Free-form data provided by installed plugins, keyed by plugin\npackage name (`[plugins.<pkg-name>]`). Each plugin defines and\nvalidates the shape of its own table; Flox does not interpret it.\nThe convention for secrets plugins is a flat table of\n`ENV_VAR_NAME = \"path/to/secret/in/store\"`, read by the plugin's\n`profile.d` script at activation."
-        },
-        "profile": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Profile2"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "Profile scripts that are run in the user's shell upon activation\n(and, optionally, upon deactivation)."
-        },
-        "schema-version": {
-          "description": "Which schema version this manifest adheres to.\n\nMust be a valid Flox CLI version listed in [`KnownSchemaVersion`].",
-          "type": "string"
-        },
-        "services": {
-          "$ref": "#/$defs/Services2",
-          "description": "Service definitions"
-        },
-        "vars": {
-          "$ref": "#/$defs/Vars",
-          "description": "Variables that are exported to the shell environment upon activation."
+          "description": "A script that is run at activation time,\nin a flox provided bash shell"
         }
-      },
-      "required": [
-        "schema-version"
-      ],
-      "type": "object"
+      }
     },
-    "ManifestVersion": {
-      "format": "uint8",
-      "maximum": 255,
-      "minimum": 0,
-      "type": "integer"
-    },
-    "MinimumCliVersion": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "properties": {
-            "reason": {
-              "type": "string"
-            },
-            "version": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "version",
-            "reason"
+    "Profile": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "common": {
+          "type": [
+            "string",
+            "null"
           ],
-          "type": "object"
+          "description": "When defined, this hook is run by _all_ shells upon activation"
+        },
+        "bash": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "When defined, this hook is run upon activation in a bash shell"
+        },
+        "zsh": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "When defined, this hook is run upon activation in a zsh shell"
+        },
+        "fish": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "When defined, this hook is run upon activation in a fish shell"
+        },
+        "tcsh": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "When defined, this hook is run upon activation in a tcsh shell"
         }
-      ],
-      "description": "The minimum CLI version required to use the environment.\n\nAccepts either a plain version string:\n  minimum-cli-version = \"1.11.0\"\n\nOr an inline table with a reason:\n  minimum-cli-version = { version = \"1.11.0\", reason = \"needs feature X\" }"
+      }
     },
     "Options": {
+      "type": "object",
       "additionalProperties": false,
       "properties": {
-        "activate": {
-          "$ref": "#/$defs/ActivateOptions",
-          "description": "Options that control the behavior of activations."
+        "systems": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "description": "A list of systems that each package is resolved for."
         },
         "allow": {
           "$ref": "#/$defs/Allows",
           "description": "Options that control what types of packages are allowed."
         },
-        "cuda-detection": {
-          "description": "Whether to detect CUDA devices and libs during activation.",
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
         "semver": {
           "$ref": "#/$defs/SemverOptions",
           "description": "Options that control how semver versions are resolved."
         },
-        "systems": {
-          "description": "A list of systems that each package is resolved for.",
-          "items": {
-            "type": "string"
-          },
-          "type": [
-            "array",
-            "null"
-          ]
-        }
-      },
-      "type": "object"
-    },
-    "PackageDescriptorCatalog": {
-      "additionalProperties": false,
-      "properties": {
-        "pkg-group": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "pkg-path": {
-          "type": "string"
-        },
-        "priority": {
-          "format": "uint64",
-          "minimum": 0,
-          "type": [
-            "integer",
-            "null"
-          ]
-        },
-        "systems": {
-          "items": {
-            "type": "string"
-          },
-          "type": [
-            "array",
-            "null"
-          ]
-        },
-        "version": {
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      },
-      "required": [
-        "pkg-path"
-      ],
-      "type": "object"
-    },
-    "PackageDescriptorCatalog2": {
-      "additionalProperties": false,
-      "properties": {
-        "outputs": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/SelectedOutputs"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "pkg-group": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "pkg-path": {
-          "type": "string"
-        },
-        "priority": {
-          "format": "uint64",
-          "minimum": 0,
-          "type": [
-            "integer",
-            "null"
-          ]
-        },
-        "systems": {
-          "items": {
-            "type": "string"
-          },
-          "type": [
-            "array",
-            "null"
-          ]
-        },
-        "version": {
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      },
-      "required": [
-        "pkg-path"
-      ],
-      "type": "object"
-    },
-    "PackageDescriptorFlake": {
-      "additionalProperties": false,
-      "properties": {
-        "flake": {
-          "type": "string"
-        },
-        "priority": {
-          "format": "uint64",
-          "minimum": 0,
-          "type": [
-            "integer",
-            "null"
-          ]
-        },
-        "systems": {
-          "items": {
-            "type": "string"
-          },
-          "type": [
-            "array",
-            "null"
-          ]
-        }
-      },
-      "required": [
-        "flake"
-      ],
-      "type": "object"
-    },
-    "PackageDescriptorFlake2": {
-      "additionalProperties": false,
-      "properties": {
-        "flake": {
-          "type": "string"
-        },
-        "outputs": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/SelectedOutputs"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "priority": {
-          "format": "uint64",
-          "minimum": 0,
-          "type": [
-            "integer",
-            "null"
-          ]
-        },
-        "systems": {
-          "items": {
-            "type": "string"
-          },
-          "type": [
-            "array",
-            "null"
-          ]
-        }
-      },
-      "required": [
-        "flake"
-      ],
-      "type": "object"
-    },
-    "PackageDescriptorStorePath": {
-      "additionalProperties": false,
-      "properties": {
-        "priority": {
-          "format": "uint64",
-          "minimum": 0,
-          "type": [
-            "integer",
-            "null"
-          ]
-        },
-        "store-path": {
-          "type": "string"
-        },
-        "systems": {
-          "items": {
-            "type": "string"
-          },
-          "type": [
-            "array",
-            "null"
-          ]
-        }
-      },
-      "required": [
-        "store-path"
-      ],
-      "type": "object"
-    },
-    "Plugins": {
-      "additionalProperties": true,
-      "description": "A map of plugin package names to that plugin's free-form manifest data.\n\nValues are opaque JSON: the plugin that owns a given table defines and\nvalidates its own shape, so Flox stores whatever the user writes without\ninterpreting it.",
-      "type": "object"
-    },
-    "Profile": {
-      "additionalProperties": false,
-      "properties": {
-        "bash": {
-          "description": "When defined, this hook is run upon activation in a bash shell",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "common": {
-          "description": "When defined, this hook is run by _all_ shells upon activation",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "fish": {
-          "description": "When defined, this hook is run upon activation in a fish shell",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "tcsh": {
-          "description": "When defined, this hook is run upon activation in a tcsh shell",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "zsh": {
-          "description": "When defined, this hook is run upon activation in a zsh shell",
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      },
-      "type": "object"
-    },
-    "Profile2": {
-      "additionalProperties": false,
-      "description": "Profile scripts for V1_13_0: adds an optional `deactivate` table holding\nper-shell scripts to run when the environment is deactivated. The\nactivation fields (`common`, `bash`, `zsh`, `fish`, `tcsh`) are the same\nas earlier schema versions.",
-      "properties": {
-        "bash": {
-          "description": "When defined, this hook is run upon activation in a bash shell",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "common": {
-          "description": "When defined, this hook is run by _all_ shells upon activation",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "deactivate": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ProfileDeactivate"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "Per-shell scripts to run when the environment is deactivated.\nMirrors the activation fields above; each is optional."
-        },
-        "fish": {
-          "description": "When defined, this hook is run upon activation in a fish shell",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "tcsh": {
-          "description": "When defined, this hook is run upon activation in a tcsh shell",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "zsh": {
-          "description": "When defined, this hook is run upon activation in a zsh shell",
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      },
-      "type": "object"
-    },
-    "ProfileDeactivate": {
-      "additionalProperties": false,
-      "description": "Deactivation profile scripts. Each field, when defined, is sourced as\nthe user's environment is being torn down — symmetric to the activation\nscripts on the enclosing [`Profile`].",
-      "properties": {
-        "bash": {
-          "description": "Run upon deactivation in a bash shell.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "common": {
-          "description": "Run by all shells when the environment is deactivated.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "fish": {
-          "description": "Run upon deactivation in a fish shell.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "tcsh": {
-          "description": "Run upon deactivation in a tcsh shell.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "zsh": {
-          "description": "Run upon deactivation in a zsh shell.",
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      },
-      "type": "object"
-    },
-    "ProtectHome": {
-      "enum": [
-        "No",
-        "Yes",
-        "ReadOnly",
-        "Tmpfs"
-      ],
-      "type": "string"
-    },
-    "ProtectSystem": {
-      "enum": [
-        "No",
-        "Yes",
-        "Full",
-        "Strict"
-      ],
-      "type": "string"
-    },
-    "ResourceLimit": {
-      "oneOf": [
-        {
-          "additionalProperties": false,
-          "properties": {
-            "Value": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "Value"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "Range": {
-              "properties": {
-                "hard": {
-                  "type": "string"
-                },
-                "soft": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "soft",
-                "hard"
-              ],
-              "type": "object"
-            }
-          },
-          "required": [
-            "Range"
-          ],
-          "type": "object"
-        }
-      ]
-    },
-    "RestartPolicy": {
-      "enum": [
-        "No",
-        "OnSuccess",
-        "OnFailure",
-        "OnAbnormal",
-        "OnWatchdog",
-        "OnAbort",
-        "Always"
-      ],
-      "type": "string"
-    },
-    "SelectedOutputs": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/AllSentinel"
-        },
-        {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        }
-      ]
-    },
-    "SemverOptions": {
-      "additionalProperties": false,
-      "properties": {
-        "allow-pre-releases": {
-          "description": "Whether to allow pre-release versions when resolving",
+        "cuda-detection": {
           "type": [
             "boolean",
             "null"
+          ],
+          "description": "Whether to detect CUDA devices and libs during activation."
+        },
+        "activate": {
+          "$ref": "#/$defs/ActivateOptions",
+          "description": "Options that control the behavior of activations."
+        }
+      }
+    },
+    "Allows": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "unfree": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "Whether to allow packages that are marked as `unfree`"
+        },
+        "broken": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "Whether to allow packages that are marked as `broken`"
+        },
+        "licenses": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "description": "A list of license descriptors that are allowed"
+        }
+      }
+    },
+    "SemverOptions": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allow-pre-releases": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "Whether to allow pre-release versions when resolving"
+        }
+      }
+    },
+    "ActivateOptions": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "mode": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ActivateMode"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "ActivateMode": {
+      "type": "string",
+      "enum": [
+        "dev",
+        "run"
+      ]
+    },
+    "Services": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/ServiceDescriptor"
+      },
+      "description": "A map of service names to service definitions."
+    },
+    "ServiceDescriptor": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "command": {
+          "type": "string",
+          "description": "The command to run to start the service"
+        },
+        "vars": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Vars"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Service-specific environment variables"
+        },
+        "is-daemon": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "Whether the service spawns a background process (daemon)"
+        },
+        "shutdown": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ServiceShutdown"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "How to shut down the service"
+        },
+        "systemd": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ServiceUnit"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Additional manual config of the systemd service generated for persistent services"
+        },
+        "systems": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "description": "Systems to allow running the service on"
+        }
+      },
+      "required": [
+        "command"
+      ],
+      "description": "The definition of a service in a manifest"
+    },
+    "ServiceShutdown": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "command": {
+          "type": "string",
+          "description": "What command to run to shut down the service"
+        }
+      },
+      "required": [
+        "command"
+      ]
+    },
+    "ServiceUnit": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "unit": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Unit"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "service": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Service"
+            },
+            {
+              "type": "null"
+            }
           ]
         }
       },
-      "type": "object"
+      "description": "Represents a systemd service configuration"
     },
-    "Service": {
+    "Unit": {
+      "type": "object",
       "additionalProperties": false,
-      "description": "Service section configuration with resource limits",
       "properties": {
-        "cpu_quota": {
+        "description": {
           "type": [
             "string",
             "null"
           ]
         },
-        "cpu_shares": {
-          "format": "uint32",
-          "minimum": 0,
-          "type": [
-            "integer",
-            "null"
-          ]
-        },
-        "cpu_weight": {
-          "format": "uint32",
-          "minimum": 0,
-          "type": [
-            "integer",
-            "null"
-          ]
-        },
-        "environment": {
-          "additionalProperties": {
-            "type": "string"
-          },
-          "type": [
-            "object",
-            "null"
-          ]
-        },
-        "environment_file": {
-          "items": {
-            "type": "string"
-          },
+        "documentation": {
           "type": [
             "array",
             "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "wants": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "requires": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "before": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "after": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "description": "Unit section configuration"
+    },
+    "Service": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type_": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ServiceType"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "exec_start": {
@@ -1491,23 +567,23 @@
             "null"
           ]
         },
-        "exec_start_post": {
-          "items": {
-            "type": "string"
-          },
-          "type": [
-            "array",
-            "null"
-          ]
-        },
         "exec_start_pre": {
-          "items": {
-            "type": "string"
-          },
           "type": [
             "array",
             "null"
-          ]
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "exec_start_post": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
         },
         "exec_stop": {
           "type": [
@@ -1515,45 +591,95 @@
             "null"
           ]
         },
-        "io_weight": {
-          "format": "uint32",
-          "minimum": 0,
+        "restart": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RestartPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "restart_sec": {
           "type": [
             "integer",
             "null"
+          ],
+          "format": "uint32",
+          "minimum": 0
+        },
+        "timeout_start_sec": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0
+        },
+        "timeout_stop_sec": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0
+        },
+        "cpu_quota": {
+          "type": [
+            "string",
+            "null"
           ]
         },
-        "limit_as": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ResourceLimit"
-            },
-            {
-              "type": "null"
-            }
+        "cpu_shares": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0
+        },
+        "cpu_weight": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0
+        },
+        "memory_max": {
+          "type": [
+            "string",
+            "null"
           ]
         },
-        "limit_core": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ResourceLimit"
-            },
-            {
-              "type": "null"
-            }
+        "memory_high": {
+          "type": [
+            "string",
+            "null"
           ]
+        },
+        "memory_low": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "tasks_max": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "io_weight": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0
         },
         "limit_cpu": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ResourceLimit"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "limit_data": {
           "anyOf": [
             {
               "$ref": "#/$defs/ResourceLimit"
@@ -1573,7 +699,67 @@
             }
           ]
         },
-        "limit_locks": {
+        "limit_data": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ResourceLimit"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "limit_stack": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ResourceLimit"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "limit_core": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ResourceLimit"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "limit_rss": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ResourceLimit"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "limit_nofile": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ResourceLimit"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "limit_as": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ResourceLimit"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "limit_nproc": {
           "anyOf": [
             {
               "$ref": "#/$defs/ResourceLimit"
@@ -1584,6 +770,26 @@
           ]
         },
         "limit_memlock": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ResourceLimit"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "limit_locks": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ResourceLimit"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "limit_sigpending": {
           "anyOf": [
             {
               "$ref": "#/$defs/ResourceLimit"
@@ -1613,36 +819,6 @@
             }
           ]
         },
-        "limit_nofile": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ResourceLimit"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "limit_nproc": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ResourceLimit"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "limit_rss": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ResourceLimit"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
         "limit_rtprio": {
           "anyOf": [
             {
@@ -1663,64 +839,10 @@
             }
           ]
         },
-        "limit_sigpending": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ResourceLimit"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "limit_stack": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ResourceLimit"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "memory_high": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "memory_low": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "memory_max": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "no_new_privileges": {
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
         "private_tmp": {
           "type": [
             "boolean",
             "null"
-          ]
-        },
-        "protect_home": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ProtectHome"
-            },
-            {
-              "type": "null"
-            }
           ]
         },
         "protect_system": {
@@ -1733,137 +855,45 @@
             }
           ]
         },
-        "restart": {
+        "protect_home": {
           "anyOf": [
             {
-              "$ref": "#/$defs/RestartPolicy"
+              "$ref": "#/$defs/ProtectHome"
             },
             {
               "type": "null"
             }
           ]
         },
-        "restart_sec": {
-          "format": "uint32",
-          "minimum": 0,
-          "type": [
-            "integer",
-            "null"
-          ]
-        },
-        "tasks_max": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "timeout_start_sec": {
-          "format": "uint32",
-          "minimum": 0,
-          "type": [
-            "integer",
-            "null"
-          ]
-        },
-        "timeout_stop_sec": {
-          "format": "uint32",
-          "minimum": 0,
-          "type": [
-            "integer",
-            "null"
-          ]
-        },
-        "type_": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ServiceType"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      },
-      "type": "object"
-    },
-    "ServiceDescriptor": {
-      "additionalProperties": false,
-      "description": "The definition of a service in a manifest",
-      "properties": {
-        "command": {
-          "description": "The command to run to start the service",
-          "type": "string"
-        },
-        "is-daemon": {
-          "description": "Whether the service spawns a background process (daemon)",
+        "no_new_privileges": {
           "type": [
             "boolean",
             "null"
           ]
         },
-        "shutdown": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ServiceShutdown"
-            },
-            {
-              "type": "null"
-            }
+        "environment": {
+          "type": [
+            "object",
+            "null"
           ],
-          "description": "How to shut down the service"
-        },
-        "systemd": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ServiceUnit"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "Additional manual config of the systemd service generated for persistent services"
-        },
-        "systems": {
-          "description": "Systems to allow running the service on",
-          "items": {
+          "additionalProperties": {
             "type": "string"
-          },
+          }
+        },
+        "environment_file": {
           "type": [
             "array",
             "null"
-          ]
-        },
-        "vars": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Vars"
-            },
-            {
-              "type": "null"
-            }
           ],
-          "description": "Service-specific environment variables"
+          "items": {
+            "type": "string"
+          }
         }
       },
-      "required": [
-        "command"
-      ],
-      "type": "object"
-    },
-    "ServiceShutdown": {
-      "additionalProperties": false,
-      "properties": {
-        "command": {
-          "description": "What command to run to shut down the service",
-          "type": "string"
-        }
-      },
-      "required": [
-        "command"
-      ],
-      "type": "object"
+      "description": "Service section configuration with resource limits"
     },
     "ServiceType": {
+      "type": "string",
       "enum": [
         "Simple",
         "Exec",
@@ -1872,145 +902,1116 @@
         "Dbus",
         "Notify",
         "Idle"
-      ],
-      "type": "string"
+      ]
     },
-    "ServiceUnit": {
+    "RestartPolicy": {
+      "type": "string",
+      "enum": [
+        "No",
+        "OnSuccess",
+        "OnFailure",
+        "OnAbnormal",
+        "OnWatchdog",
+        "OnAbort",
+        "Always"
+      ]
+    },
+    "ResourceLimit": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "Value": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "Value"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "Range": {
+              "type": "object",
+              "properties": {
+                "soft": {
+                  "type": "string"
+                },
+                "hard": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "soft",
+                "hard"
+              ]
+            }
+          },
+          "required": [
+            "Range"
+          ],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "ProtectSystem": {
+      "type": "string",
+      "enum": [
+        "No",
+        "Yes",
+        "Full",
+        "Strict"
+      ]
+    },
+    "ProtectHome": {
+      "type": "string",
+      "enum": [
+        "No",
+        "Yes",
+        "ReadOnly",
+        "Tmpfs"
+      ]
+    },
+    "Build": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/BuildDescriptor"
+      },
+      "description": "A map of package ids to package build descriptors"
+    },
+    "BuildDescriptor": {
+      "type": "object",
       "additionalProperties": false,
-      "description": "Represents a systemd service configuration",
       "properties": {
-        "service": {
+        "command": {
+          "type": "string",
+          "description": "The command to run to build a package."
+        },
+        "runtime-packages": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "description": "Packages from the 'toplevel' group to include in the closure of the build result."
+        },
+        "sandbox": {
           "anyOf": [
             {
-              "$ref": "#/$defs/Service"
+              "$ref": "#/$defs/BuildSandbox"
             },
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Sandbox mode for the build."
         },
-        "unit": {
+        "version": {
           "anyOf": [
             {
-              "$ref": "#/$defs/Unit"
+              "$ref": "#/$defs/BuildVersion"
             },
             {
               "type": "null"
             }
-          ]
-        }
-      },
-      "type": "object"
-    },
-    "Services": {
-      "additionalProperties": {
-        "$ref": "#/$defs/ServiceDescriptor"
-      },
-      "description": "A map of service names to service definitions.",
-      "type": "object"
-    },
-    "Services2": {
-      "additionalProperties": {
-        "$ref": "#/$defs/ServiceDescriptor"
-      },
-      "description": "Service configuration for V1_12_0: adds optional auto-start behavior\nalongside the map of service names to service definitions.\n\nThe `service_map` field is a `parsed::common::Services` (BTreeMap tuple\nstruct) to allow the internal `CommonFields::services()` accessor on\n`Parsed` to return a uniform `&common::Services` across all versions.",
-      "properties": {
-        "auto-start": {
-          "description": "Whether to start all services automatically on `flox activate`.\nCan be suppressed with `--no-start-services`.",
-          "type": [
-            "boolean",
-            "null"
-          ]
-        }
-      },
-      "type": "object"
-    },
-    "Unit": {
-      "additionalProperties": false,
-      "description": "Unit section configuration",
-      "properties": {
-        "after": {
-          "items": {
-            "type": "string"
-          },
-          "type": [
-            "array",
-            "null"
-          ]
-        },
-        "before": {
-          "items": {
-            "type": "string"
-          },
-          "type": [
-            "array",
-            "null"
-          ]
+          ],
+          "description": "The version to assign the package."
         },
         "description": {
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "description": "A short description of the package that will appear on FloxHub and in\nsearch results."
         },
-        "documentation": {
-          "items": {
-            "type": "string"
-          },
+        "license": {
           "type": [
             "array",
             "null"
-          ]
-        },
-        "requires": {
+          ],
           "items": {
             "type": "string"
           },
+          "description": "A license to assign to the package in SPDX format."
+        }
+      },
+      "required": [
+        "command"
+      ],
+      "description": "The definition of a package built from within the environment"
+    },
+    "BuildSandbox": {
+      "type": "string",
+      "enum": [
+        "off",
+        "pure"
+      ],
+      "description": "The definition of a package built from within the environment"
+    },
+    "BuildVersion": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "file": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "file"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "command": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "command"
+          ]
+        }
+      ],
+      "description": "The definition of a package built from within the environment"
+    },
+    "Containerize": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "config": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ContainerizeConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "ContainerizeConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "user": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "The username or UID which is a platform-specific structure that allows specific control over which user the process run as.\nThis acts as a default value to use when the value is not specified when creating a container.\nFor Linux based systems, all of the following are valid: `user`, `uid`, `user:group`, `uid:gid`, `uid:group`, `user:gid`.\nIf `group`/`gid` is not specified, the default group and supplementary groups of the given `user`/`uid` in `/etc/passwd` and `/etc/group` from the container are applied.\nIf `group`/`gid` is specified, supplementary groups from the container are ignored."
+        },
+        "exposed-ports": {
           "type": [
             "array",
             "null"
-          ]
-        },
-        "wants": {
+          ],
+          "uniqueItems": true,
           "items": {
             "type": "string"
           },
+          "description": "A set of ports to expose from a container running this image.\nIts keys can be in the format of:\n`port/tcp`, `port/udp`, `port` with the default protocol being `tcp` if not specified.\nThese values act as defaults and are merged with any specified when creating a container."
+        },
+        "cmd": {
           "type": [
             "array",
             "null"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "description": "Default arguments to the entrypoint of the container.\nThese values act as defaults and may be replaced by any specified when creating a container.\nFlox sets an entrypoint to activate the containerized environment,\nand `cmd` is then run inside the activation, similar to\n`flox activate -c cmd`."
+        },
+        "volumes": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          },
+          "description": "A set of directories describing where the process is\nlikely to write data specific to a container instance."
+        },
+        "working-dir": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Sets the current working directory of the entrypoint process in the container.\nThis value acts as a default and may be replaced by a working directory specified when creating a container."
+        },
+        "labels": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "This field contains arbitrary metadata for the container.\nThis property MUST use the [annotation rules](https://github.com/opencontainers/image-spec/blob/main/annotations.md#rules)."
+        },
+        "stop-signal": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "This field contains the system call signal that will be sent to the container to exit. The signal can be a signal name in the format `SIGNAME`, for instance `SIGKILL` or `SIGRTMIN+3`."
+        }
+      },
+      "description": "Container config derived from\nhttps://github.com/opencontainers/image-spec/blob/main/config.md\n\nEnv and Entrypoint are left out since they interfere with our activation implementation\nDeprecated and reserved keys are also left out"
+    },
+    "Include": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "environments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/IncludeDescriptor"
+          },
+          "default": []
+        }
+      },
+      "description": "The section where users can declare dependencies on other environments."
+    },
+    "IncludeDescriptor": {
+      "anyOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "dir": {
+              "type": "string",
+              "description": "The directory where the environment is located."
+            },
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "A name similar to an install ID that a user could use to specify\nthe environment on the command line e.g. for upgrades, or in an\nerror message."
+            }
+          },
+          "required": [
+            "dir"
+          ]
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "remote": {
+              "$ref": "#/$defs/EnvironmentRef",
+              "description": "The remote environment reference in the form `owner/name`."
+            },
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "A name similar to an install ID that a user could use to specify\nthe environment on the command line e.g. for upgrades, or in an\nerror message."
+            },
+            "generation": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint",
+              "minimum": 0
+            }
+          },
+          "required": [
+            "remote"
+          ]
+        }
+      ],
+      "description": "The structure for how a user is able to declare a dependency on an environment."
+    },
+    "EnvironmentRef": {
+      "description": "Environment Reference",
+      "type": "string"
+    },
+    "ManifestV1_10_0": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "schema-version": {
+          "type": "string",
+          "description": "Which schema version this manifest adheres to.\n\nMust be a valid Flox CLI version listed in [`KnownSchemaVersion`]."
+        },
+        "minimum-cli-version": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "The minimum CLI version that can activate this environment."
+        },
+        "install": {
+          "$ref": "#/$defs/Install2",
+          "description": "The packages to install in the form of a map from install_id\nto package descriptor."
+        },
+        "vars": {
+          "$ref": "#/$defs/Vars",
+          "description": "Variables that are exported to the shell environment upon activation."
+        },
+        "hook": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Hook"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Hooks that are run at various times during the lifecycle of the manifest\nin a known shell environment."
+        },
+        "profile": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Profile"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Profile scripts that are run in the user's shell upon activation."
+        },
+        "options": {
+          "$ref": "#/$defs/Options",
+          "description": "Options that control the behavior of the manifest.",
+          "default": {}
+        },
+        "services": {
+          "$ref": "#/$defs/Services",
+          "description": "Service definitions"
+        },
+        "build": {
+          "$ref": "#/$defs/Build",
+          "description": "Package build definitions"
+        },
+        "containerize": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Containerize"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "include": {
+          "$ref": "#/$defs/Include"
+        }
+      },
+      "required": [
+        "schema-version"
+      ],
+      "description": "Not meant for writing manifest files, only for reading them.\nModifications should be made using `manifest::raw`."
+    },
+    "Install2": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/ManifestPackageDescriptor2"
+      }
+    },
+    "ManifestPackageDescriptor2": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/PackageDescriptorCatalog2"
+        },
+        {
+          "$ref": "#/$defs/PackageDescriptorFlake2"
+        },
+        {
+          "$ref": "#/$defs/PackageDescriptorStorePath"
+        }
+      ]
+    },
+    "PackageDescriptorCatalog2": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "pkg-path": {
+          "type": "string"
+        },
+        "pkg-group": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "priority": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0
+        },
+        "version": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "systems": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "outputs": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SelectedOutputs"
+            },
+            {
+              "type": "null"
+            }
           ]
         }
       },
-      "type": "object"
+      "required": [
+        "pkg-path"
+      ]
     },
-    "Vars": {
-      "additionalProperties": {
-        "type": "string"
+    "SelectedOutputs": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/AllSentinel"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "AllSentinel": {
+      "type": "string",
+      "enum": [
+        "all"
+      ]
+    },
+    "PackageDescriptorFlake2": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "flake": {
+          "type": "string"
+        },
+        "priority": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0
+        },
+        "systems": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "outputs": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SelectedOutputs"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
       },
-      "type": "object"
+      "required": [
+        "flake"
+      ]
+    },
+    "ManifestV1_11_0": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "schema-version": {
+          "type": "string",
+          "description": "Which schema version this manifest adheres to.\n\nMust be a valid Flox CLI version listed in [`KnownSchemaVersion`]."
+        },
+        "minimum-cli-version": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/MinimumCliVersion"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The minimum CLI version that can activate this environment."
+        },
+        "install": {
+          "$ref": "#/$defs/Install2",
+          "description": "The packages to install in the form of a map from install_id\nto package descriptor."
+        },
+        "vars": {
+          "$ref": "#/$defs/Vars",
+          "description": "Variables that are exported to the shell environment upon activation."
+        },
+        "hook": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Hook"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Hooks that are run at various times during the lifecycle of the manifest\nin a known shell environment."
+        },
+        "profile": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Profile"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Profile scripts that are run in the user's shell upon activation."
+        },
+        "options": {
+          "$ref": "#/$defs/Options",
+          "description": "Options that control the behavior of the manifest.",
+          "default": {}
+        },
+        "services": {
+          "$ref": "#/$defs/Services",
+          "description": "Service definitions"
+        },
+        "build": {
+          "$ref": "#/$defs/Build",
+          "description": "Package build definitions"
+        },
+        "containerize": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Containerize"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "include": {
+          "$ref": "#/$defs/Include"
+        }
+      },
+      "required": [
+        "schema-version"
+      ],
+      "description": "Not meant for writing manifest files, only for reading them.\nModifications should be made using `manifest::raw`."
+    },
+    "MinimumCliVersion": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "version": {
+              "type": "string"
+            },
+            "reason": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "version",
+            "reason"
+          ]
+        }
+      ],
+      "description": "The minimum CLI version required to use the environment.\n\nAccepts either a plain version string:\n  minimum-cli-version = \"1.11.0\"\n\nOr an inline table with a reason:\n  minimum-cli-version = { version = \"1.11.0\", reason = \"needs feature X\" }"
+    },
+    "ManifestV1_12_0": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "schema-version": {
+          "type": "string",
+          "description": "Which schema version this manifest adheres to.\n\nMust be a valid Flox CLI version listed in [`KnownSchemaVersion`]."
+        },
+        "minimum-cli-version": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/MinimumCliVersion"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The minimum CLI version that can activate this environment."
+        },
+        "install": {
+          "$ref": "#/$defs/Install2",
+          "description": "The packages to install in the form of a map from install_id\nto package descriptor."
+        },
+        "vars": {
+          "$ref": "#/$defs/Vars",
+          "description": "Variables that are exported to the shell environment upon activation."
+        },
+        "hook": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Hook"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Hooks that are run at various times during the lifecycle of the manifest\nin a known shell environment."
+        },
+        "profile": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Profile"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Profile scripts that are run in the user's shell upon activation."
+        },
+        "options": {
+          "$ref": "#/$defs/Options",
+          "description": "Options that control the behavior of the manifest.",
+          "default": {}
+        },
+        "services": {
+          "$ref": "#/$defs/Services2",
+          "description": "Service definitions"
+        },
+        "build": {
+          "$ref": "#/$defs/Build",
+          "description": "Package build definitions"
+        },
+        "containerize": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Containerize"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "include": {
+          "$ref": "#/$defs/Include"
+        }
+      },
+      "required": [
+        "schema-version"
+      ],
+      "description": "Not meant for writing manifest files, only for reading them.\nModifications should be made using `manifest::raw`."
+    },
+    "Services2": {
+      "type": "object",
+      "properties": {
+        "auto-start": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "Whether to start all services automatically on `flox activate`.\nCan be suppressed with `--no-start-services`."
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/$defs/ServiceDescriptor"
+      },
+      "description": "Service configuration for V1_12_0: adds optional auto-start behavior\nalongside the map of service names to service definitions.\n\nThe `service_map` field is a `parsed::common::Services` (BTreeMap tuple\nstruct) to allow the internal `CommonFields::services()` accessor on\n`Parsed` to return a uniform `&common::Services` across all versions."
+    },
+    "ManifestV1_13_0": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "schema-version": {
+          "type": "string",
+          "description": "Which schema version this manifest adheres to.\n\nMust be a valid Flox CLI version listed in [`KnownSchemaVersion`]."
+        },
+        "minimum-cli-version": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/MinimumCliVersion"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The minimum CLI version that can activate this environment."
+        },
+        "install": {
+          "$ref": "#/$defs/Install2",
+          "description": "The packages to install in the form of a map from install_id\nto package descriptor."
+        },
+        "vars": {
+          "$ref": "#/$defs/Vars",
+          "description": "Variables that are exported to the shell environment upon activation."
+        },
+        "hook": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Hook"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Hooks that are run at various times during the lifecycle of the manifest\nin a known shell environment."
+        },
+        "profile": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Profile2"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Profile scripts that are run in the user's shell upon activation\n(and, optionally, upon deactivation)."
+        },
+        "options": {
+          "$ref": "#/$defs/Options",
+          "description": "Options that control the behavior of the manifest.",
+          "default": {}
+        },
+        "services": {
+          "$ref": "#/$defs/Services2",
+          "description": "Service definitions"
+        },
+        "build": {
+          "$ref": "#/$defs/Build2",
+          "description": "Package build definitions"
+        },
+        "containerize": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Containerize"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "include": {
+          "$ref": "#/$defs/Include"
+        }
+      },
+      "required": [
+        "schema-version"
+      ],
+      "description": "Not meant for writing manifest files, only for reading them.\nModifications should be made using `manifest::raw`."
+    },
+    "Profile2": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "common": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "When defined, this hook is run by _all_ shells upon activation"
+        },
+        "bash": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "When defined, this hook is run upon activation in a bash shell"
+        },
+        "zsh": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "When defined, this hook is run upon activation in a zsh shell"
+        },
+        "fish": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "When defined, this hook is run upon activation in a fish shell"
+        },
+        "tcsh": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "When defined, this hook is run upon activation in a tcsh shell"
+        },
+        "deactivate": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ProfileDeactivate"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Per-shell scripts to run when the environment is deactivated.\nMirrors the activation fields above; each is optional."
+        }
+      },
+      "description": "Profile scripts for V1_13_0: adds an optional `deactivate` table holding\nper-shell scripts to run when the environment is deactivated. The\nactivation fields (`common`, `bash`, `zsh`, `fish`, `tcsh`) are the same\nas earlier schema versions."
+    },
+    "ProfileDeactivate": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "common": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Run by all shells when the environment is deactivated."
+        },
+        "bash": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Run upon deactivation in a bash shell."
+        },
+        "zsh": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Run upon deactivation in a zsh shell."
+        },
+        "fish": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Run upon deactivation in a fish shell."
+        },
+        "tcsh": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Run upon deactivation in a tcsh shell."
+        }
+      },
+      "description": "Deactivation profile scripts. Each field, when defined, is sourced as\nthe user's environment is being torn down — symmetric to the activation\nscripts on the enclosing [`Profile`]."
+    },
+    "Build2": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/BuildDescriptor2"
+      },
+      "description": "A map of package ids to package build descriptors.\n\nThis is a version-specific copy of `common::Build` because V1_13_0 adds the\n`sandbox-allow` field to [BuildDescriptor]; the map is otherwise identical."
+    },
+    "BuildDescriptor2": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "command": {
+          "type": "string",
+          "description": "The command to run to build a package."
+        },
+        "runtime-packages": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "description": "Packages from the 'toplevel' group to include in the closure of the\nbuild result."
+        },
+        "sandbox": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BuildSandbox2"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Sandbox mode for the build."
+        },
+        "sandbox-allow": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "description": "Paths or glob patterns the build may read from outside its closure\nwithout the virtual sandbox warning about them (or, under `enforce`,\nblocking them). A leading `~/` is expanded to `$HOME`; `*`/`**` are\nmatched with `fnmatch`. Only meaningful for the local sandbox modes\n(`warn`/`enforce`)."
+        },
+        "version": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BuildVersion"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The version to assign the package."
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "A short description of the package that will appear on FloxHub and in\nsearch results."
+        },
+        "license": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "description": "A license to assign to the package in SPDX format."
+        }
+      },
+      "required": [
+        "command"
+      ],
+      "description": "The definition of a package built from within the environment.\n\nV1_13_0 adds `sandbox-allow`: a list of paths/globs the build is permitted\nto read from outside its closure without a sandbox warning (or, under\n`enforce`, without failing). Otherwise identical to `common::BuildDescriptor`."
+    },
+    "BuildSandbox2": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "off",
+            "pure"
+          ]
+        },
+        {
+          "type": "string",
+          "const": "warn",
+          "description": "Local build; out-of-closure file access is reported with a warning."
+        },
+        {
+          "type": "string",
+          "const": "enforce",
+          "description": "Local build; out-of-closure file access is denied (the build fails)."
+        }
+      ],
+      "description": "Sandbox mode for a build.\n\nThis is a version-specific copy of `common::BuildSandbox` because V1_13_0\nadds the local `warn` and `enforce` modes. Keeping the new variants out of\nthe common enum is what stops older schema versions (whose `BuildDescriptor`\nuses `common::BuildSandbox`) from accepting `sandbox = \"warn\" | \"enforce\"`."
+    },
+    "ManifestV1_14_0": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "schema-version": {
+          "type": "string",
+          "description": "Which schema version this manifest adheres to.\n\nMust be a valid Flox CLI version listed in [`KnownSchemaVersion`]."
+        },
+        "minimum-cli-version": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/MinimumCliVersion"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The minimum CLI version that can activate this environment."
+        },
+        "install": {
+          "$ref": "#/$defs/Install2",
+          "description": "The packages to install in the form of a map from install_id\nto package descriptor."
+        },
+        "vars": {
+          "$ref": "#/$defs/Vars",
+          "description": "Variables that are exported to the shell environment upon activation."
+        },
+        "hook": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Hook"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Hooks that are run at various times during the lifecycle of the manifest\nin a known shell environment."
+        },
+        "profile": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Profile2"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Profile scripts that are run in the user's shell upon activation\n(and, optionally, upon deactivation)."
+        },
+        "options": {
+          "$ref": "#/$defs/Options",
+          "description": "Options that control the behavior of the manifest.",
+          "default": {}
+        },
+        "services": {
+          "$ref": "#/$defs/Services2",
+          "description": "Service definitions"
+        },
+        "build": {
+          "$ref": "#/$defs/Build2",
+          "description": "Package build definitions"
+        },
+        "containerize": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Containerize"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "include": {
+          "$ref": "#/$defs/Include"
+        },
+        "plugins": {
+          "$ref": "#/$defs/Plugins",
+          "description": "Free-form data provided by installed plugins, keyed by plugin\npackage name (`[plugins.<pkg-name>]`). Each plugin defines and\nvalidates the shape of its own table; Flox does not interpret it.\nThe convention for secrets plugins is a flat table of\n`ENV_VAR_NAME = \"path/to/secret/in/store\"`, read by the plugin's\n`profile.d` script at activation."
+        }
+      },
+      "required": [
+        "schema-version"
+      ],
+      "description": "Not meant for writing manifest files, only for reading them.\nModifications should be made using `manifest::raw`."
+    },
+    "Plugins": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "A map of plugin package names to that plugin's free-form manifest data.\n\nValues are opaque JSON: the plugin that owns a given table defines and\nvalidates its own shape, so Flox stores whatever the user writes without\ninterpreting it."
     }
-  },
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "anyOf": [
-    {
-      "$ref": "#/$defs/ManifestV1"
-    },
-    {
-      "$ref": "#/$defs/ManifestV1_10_0"
-    },
-    {
-      "$ref": "#/$defs/ManifestV1_11_0"
-    },
-    {
-      "$ref": "#/$defs/ManifestV1_12_0"
-    },
-    {
-      "$ref": "#/$defs/ManifestV1_13_0"
-    },
-    {
-      "$ref": "#/$defs/ManifestV1_14_0"
-    }
-  ],
-  "description": "A validated, typed manifest with a known schema.",
-  "title": "Parsed"
+  }
 }

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -1080,6 +1080,23 @@ EOF
   assert_output --partial "baz"
 }
 
+# bats test_tags=activate,activate:envVar
+@test "activate renders vars in manifest order so entries can reference earlier entries" {
+  project_setup
+  ORDERED_VARS=$(
+    cat <<EOF
+[vars]
+zzz_base = "base"
+aaa_derived = "\${zzz_base}-derived"
+EOF
+  )
+  sed -i -e "s/^\[vars\]/${ORDERED_VARS//$'\n'/\\n}/" "$PROJECT_DIR/.flox/env/manifest.toml"
+
+  FLOX_SHELL="bash" NO_COLOR=1 run "$FLOX_BIN" activate --dir "$PROJECT_DIR" -c 'echo "$aaa_derived"'
+  assert_success
+  assert_output --partial "base-derived"
+}
+
 # ---------------------------------------------------------------------------- #
 
 # bats test_tags=activate,activate:envVar-before-hook

--- a/test_data/manually_generated/buildenv/lockfiles/vars_order/manifest.lock
+++ b/test_data/manually_generated/buildenv/lockfiles/vars_order/manifest.lock
@@ -1,0 +1,26 @@
+{
+  "lockfile-version": 1,
+  "manifest": {
+    "version": 1,
+    "vars": {
+      "zebra": "stripes",
+      "mango": "tropical",
+      "apple": "${zebra}/fruit"
+    },
+    "hook": {},
+    "profile": {},
+    "options": {
+      "systems": [
+        "aarch64-darwin",
+        "x86_64-darwin",
+        "aarch64-linux",
+        "x86_64-linux"
+      ],
+      "allow": {
+        "licenses": []
+      },
+      "semver": {}
+    }
+  },
+  "packages": []
+}


### PR DESCRIPTION
## What

`[vars]` entries are rendered to the activation `envrc` as `export` lines that bash sources in order, but the manifest's `[vars]` table was parsed into a `BTreeMap`, so entries were always rendered **alphabetically**. A value referencing another entry only resolved when that entry happened to sort earlier, and aborted activation with `unbound variable` otherwise.

This PR stores `[vars]` in an `IndexMap` so entries keep their manifest order end to end: an entry may reference any entry defined **above** it.

This is the alternative approach discussed in #4360 (see the review thread there) — instead of inferring a dependency order by parsing references and toposorting, it preserves the order the user wrote. Opening as a draft to make that discussion concrete.

## How

- `toml_edit` already preserves document order, so parsing picks up manifest order for free.
- serde_json's `preserve_order` feature is enabled so the order survives the `Value` buffering in `Manifest<TypedOnly>` deserialization when a manifest is read back out of a lockfile. This also changes the emission order of the generated OpenAPI clients and JSON schemas (now spec/generation order); they are regenerated here — reordering only, no semantic change, which accounts for most of the diff size.
- The order is passed to `buildenv.nix` as a new required `varsOrder` argument, since nix sorts attrset names and cannot recover manifest order from the lockfile JSON.
- `Vars` equality and hashing are order-sensitive now that order affects rendering, so a reorder-only edit is detected as a change.
- Composition merges vars preserving order: included entries keep their positions, an override replaces the value **in place** (keeping the include's position), and new entries are appended. This makes the "include declares `BASE_URL` with a default and derived vars below it; composer overrides `BASE_URL`" pattern resolve correctly.

## Compatibility

The lockfile format is unchanged — `[vars]` remains a JSON object — so older flox versions can read new lockfiles and no schema version bump is needed. Lockfiles written before this change deserialize in alphabetical order, which matches the previous rendering behavior until the environment is re-locked.

One behavioral edge, stated openly: a manifest that today relies on alphabetical luck (e.g. `b = "${a}"` written *above* `a = "x"`) works currently and would break after re-locking under manifest order. The failure is the same `unbound variable` users already hit, and the fix (move the entry up) is intuitive, but unlike the toposort in #4360 this is not a strict superset of current behavior.

## Testing

- Unit: manifest order preserved through TOML parse, through the lockfile JSON round-trip, and through composition merge (`flox-manifest`); envrc rendered in manifest order from a fixture lockfile (`flox-rust-sdk` buildenv test).
- Integration: new `activate.bats` test where an entry references an alphabetically-later entry defined above it — fails on `main` with `unbound variable`, passes here.
- Full unit (1374) and impure (1378) suites pass; neighboring env-var bats tests pass.

## Release Notes

`[vars]` entries are now rendered in the order they are written in the manifest, so an entry can reference any entry defined above it with `$NAME`/`${NAME}` regardless of alphabetical order. Previously entries were rendered alphabetically, which made such references work or fail depending on variable names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)