### PR TITLE
feat(factory): add `flox factory list` filters, typed status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,6 +568,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+
+[[package]]
 name = "beta"
 version = "0.0.0"
 dependencies = [
@@ -1577,6 +1583,7 @@ dependencies = [
  "indicatif",
  "indoc",
  "inquire",
+ "interim",
  "itertools 0.14.0",
  "keyring-core",
  "minus",
@@ -2726,6 +2733,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "interim"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9ce9099a85f468663d3225bf87e85d0548968441e1db12248b996b24f0f5b5a"
+dependencies = [
+ "chrono",
+ "logos",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2991,6 +3008,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 dependencies = [
  "value-bag",
+]
+
+[[package]]
+name = "logos"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff472f899b4ec2d99161c51f60ff7075eeb3097069a36050d8037a6325eb8154"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "192a3a2b90b0c05b27a0b2c43eecdb7c415e29243acc3f89cc8247a5b693045c"
+dependencies = [
+ "beef",
+ "fnv",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "regex-syntax",
+ "rustc_version",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "605d9697bcd5ef3a42d38efc51541aa3d6a4a25f7ab6d1ed0da5ac632a26b470"
+dependencies = [
+ "logos-codegen",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1487,6 +1487,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "strum",
  "syn 2.0.114",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ indexmap = { version = "2.13.0", features = ["serde"] }
 indoc = "2.0.7"
 inquire = "0.9.2"
 indicatif = "0.18"
+interim = { version = "0.2.1", features = ["chrono_0_4"] }
 is_executable = "1.0.5"
 itertools = "0.14.0"
 jsonwebtoken = { version = "10.3", features = ["rust_crypto"] }

--- a/cli/catalog-api-v1/openapi.json
+++ b/cli/catalog-api-v1/openapi.json
@@ -43,7 +43,8 @@
               "title": "Search Term",
               "nullable": true,
               "type": "string",
-              "pattern": "[a-zA-Z0-9\\-\\.\\\\@%_,]{2,200}"
+              "minLength": 2,
+              "maxLength": 200
             }
           },
           {
@@ -482,7 +483,7 @@
             "required": true,
             "schema": {
               "type": "string",
-              "pattern": "[a-zA-Z0-9\\-_]{3,64}",
+              "pattern": "^[a-zA-Z0-9\\-_]{3,63}$",
               "title": "Catalog Name",
               "name": "catalog_name",
               "example": "mycatalog"
@@ -546,7 +547,7 @@
             "required": true,
             "schema": {
               "type": "string",
-              "pattern": "[a-zA-Z0-9\\-_]{3,64}",
+              "pattern": "^[a-zA-Z0-9\\-_]{3,63}$",
               "title": "Catalog Name",
               "name": "catalog_name",
               "example": "mycatalog"
@@ -608,7 +609,7 @@
             "required": true,
             "schema": {
               "type": "string",
-              "pattern": "[a-zA-Z0-9\\-_]{3,64}",
+              "pattern": "^[a-zA-Z0-9\\-_]{3,63}$",
               "title": "Catalog Name",
               "name": "catalog_name",
               "example": "mycatalog"
@@ -670,7 +671,7 @@
             "required": true,
             "schema": {
               "type": "string",
-              "pattern": "[a-zA-Z0-9\\-_]{3,64}",
+              "pattern": "^[a-zA-Z0-9\\-_]{3,63}$",
               "title": "Catalog Name",
               "name": "catalog_name",
               "example": "mycatalog"
@@ -774,7 +775,7 @@
             "required": true,
             "schema": {
               "type": "string",
-              "pattern": "[a-zA-Z0-9\\-_]{3,64}",
+              "pattern": "^[a-zA-Z0-9\\-_]{3,63}$",
               "title": "Catalog Name",
               "name": "catalog_name",
               "example": "mycatalog"
@@ -838,7 +839,7 @@
             "required": true,
             "schema": {
               "type": "string",
-              "pattern": "[a-zA-Z0-9\\-_]{3,64}",
+              "pattern": "^[a-zA-Z0-9\\-_]{3,63}$",
               "title": "Catalog Name",
               "name": "catalog_name",
               "example": "mycatalog"
@@ -914,7 +915,7 @@
             "required": true,
             "schema": {
               "type": "string",
-              "pattern": "[a-zA-Z0-9\\-_]{3,64}",
+              "pattern": "^[a-zA-Z0-9\\-_]{3,63}$",
               "title": "Catalog Name",
               "name": "catalog_name",
               "example": "mycatalog"
@@ -1010,7 +1011,7 @@
             "required": true,
             "schema": {
               "type": "string",
-              "pattern": "[a-zA-Z0-9\\-_]{3,64}",
+              "pattern": "^[a-zA-Z0-9\\-_]{3,63}$",
               "title": "Catalog Name",
               "name": "catalog_name",
               "example": "mycatalog"
@@ -1114,7 +1115,7 @@
             "required": true,
             "schema": {
               "type": "string",
-              "pattern": "[a-zA-Z0-9\\-_]{3,64}",
+              "pattern": "^[a-zA-Z0-9\\-_]{3,63}$",
               "title": "Catalog Name",
               "name": "catalog_name",
               "example": "mycatalog"
@@ -1218,7 +1219,7 @@
             "required": true,
             "schema": {
               "type": "string",
-              "pattern": "[a-zA-Z0-9\\-_]{3,64}",
+              "pattern": "^[a-zA-Z0-9\\-_]{3,63}$",
               "title": "Catalog Name",
               "name": "catalog_name",
               "example": "mycatalog"
@@ -1294,7 +1295,7 @@
             "required": true,
             "schema": {
               "type": "string",
-              "pattern": "[a-zA-Z0-9\\-_]{3,64}",
+              "pattern": "^[a-zA-Z0-9\\-_]{3,63}$",
               "title": "Catalog Name",
               "name": "catalog_name",
               "example": "mycatalog"
@@ -1380,7 +1381,7 @@
             "required": true,
             "schema": {
               "type": "string",
-              "pattern": "[a-zA-Z0-9\\-_]{3,64}",
+              "pattern": "^[a-zA-Z0-9\\-_]{3,63}$",
               "title": "Catalog Name",
               "name": "catalog_name",
               "example": "mycatalog"
@@ -1464,7 +1465,7 @@
             "required": true,
             "schema": {
               "type": "string",
-              "pattern": "[a-zA-Z0-9\\-_]{3,64}",
+              "pattern": "^[a-zA-Z0-9\\-_]{3,63}$",
               "title": "Catalog Name",
               "name": "catalog_name",
               "example": "mycatalog"
@@ -1526,7 +1527,7 @@
             "required": true,
             "schema": {
               "type": "string",
-              "pattern": "[a-zA-Z0-9\\-_]{3,64}",
+              "pattern": "^[a-zA-Z0-9\\-_]{3,63}$",
               "title": "Catalog Name",
               "name": "catalog_name",
               "example": "mycatalog"

--- a/cli/catalog-api-v1/src/client.rs
+++ b/cli/catalog-api-v1/src/client.rs
@@ -377,7 +377,7 @@ manifest packages were built via the traditional flox manifest workflow.*/
     ///    "mycatalog"
     ///  ],
     ///  "type": "string",
-    ///  "pattern": "[a-zA-Z0-9\\-_]{3,64}"
+    ///  "pattern": "^[a-zA-Z0-9\\-_]{3,63}$"
     ///}
     /// ```
     /// </details>
@@ -406,9 +406,9 @@ manifest packages were built via the traditional flox manifest workflow.*/
             value: &str,
         ) -> ::std::result::Result<Self, self::error::ConversionError> {
             static PATTERN: ::std::sync::LazyLock<::regress::Regex> = ::std::sync::LazyLock::new(||
-            { ::regress::Regex::new("[a-zA-Z0-9\\-_]{3,64}").unwrap() });
+            { ::regress::Regex::new("^[a-zA-Z0-9\\-_]{3,63}$").unwrap() });
             if PATTERN.find(value).is_none() {
-                return Err("doesn't match pattern \"[a-zA-Z0-9\\-_]{3,64}\"".into());
+                return Err("doesn't match pattern \"^[a-zA-Z0-9\\-_]{3,63}$\"".into());
             }
             Ok(Self(value.to_string()))
         }
@@ -4687,7 +4687,8 @@ because the two anchors carry different value types.*/
     ///{
     ///  "title": "Search Term",
     ///  "type": "string",
-    ///  "pattern": "[a-zA-Z0-9\\-\\.\\\\@%_,]{2,200}"
+    ///  "maxLength": 200,
+    ///  "minLength": 2
     ///}
     /// ```
     /// </details>
@@ -4715,12 +4716,11 @@ because the two anchors carry different value types.*/
         fn from_str(
             value: &str,
         ) -> ::std::result::Result<Self, self::error::ConversionError> {
-            static PATTERN: ::std::sync::LazyLock<::regress::Regex> = ::std::sync::LazyLock::new(||
-            { ::regress::Regex::new("[a-zA-Z0-9\\-\\.\\\\@%_,]{2,200}").unwrap() });
-            if PATTERN.find(value).is_none() {
-                return Err(
-                    "doesn't match pattern \"[a-zA-Z0-9\\-\\.\\\\@%_,]{2,200}\"".into(),
-                );
+            if value.chars().count() > 200usize {
+                return Err("longer than 200 characters".into());
+            }
+            if value.chars().count() < 2usize {
+                return Err("shorter than 2 characters".into());
             }
             Ok(Self(value.to_string()))
         }

--- a/cli/factory-api-v1/Cargo.toml
+++ b/cli/factory-api-v1/Cargo.toml
@@ -9,6 +9,7 @@ reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 chrono.workspace = true
+strum.workspace = true
 
 [build-dependencies]
 prettyplease.workspace = true

--- a/cli/factory-api-v1/build.rs
+++ b/cli/factory-api-v1/build.rs
@@ -13,14 +13,9 @@ fn main() {
     let mut spec_json: serde_json::Value =
         serde_json::from_reader(file).expect("Failed to parse openapi spec");
 
-    // Keep only paths under /api/v1/factory/builds — the endpoints the CLI
-    // verbs (status, list, logs, cancel) call. All other paths are dropped
-    // from codegen (schemas referenced by retained paths are still emitted):
-    //   - /api/v1/factory/health, /ready  — probe endpoints with untyped `{}`
-    //     schemas that Progenitor 0.11.2 cannot process (assertion failure).
-    //   - /api/v1/factory/webhooks/*      — GitHub inbound, never called by CLI.
-    //   - /api/v1/factory/callbacks/*     — Build Coordinator inbound, not for CLI.
-    //   - /api/v1/factory/tasks/*         — task internals, not exposed by CLI verbs.
+    // Keep only the /api/v1/factory/builds paths: the endpoints the CLI verbs
+    // (status, list, logs, cancel) call. Other exported paths are dropped from
+    // codegen; schemas referenced by retained paths are still emitted.
     spec_json["paths"]
         .as_object_mut()
         .unwrap()
@@ -39,6 +34,14 @@ fn main() {
 fn generator() -> progenitor::Generator {
     let mut settings = progenitor::GenerationSettings::default();
     settings.with_derive("PartialEq");
+    // Splice in the hand-written tolerant status enum for both the response
+    // body and the `status` query-param filter, so an unrecognized status
+    // renders as `unknown: <value>` instead of failing deserialization.
+    settings.with_replacement(
+        "EffectiveBuildStatus",
+        "crate::status::EffectiveBuildStatus",
+        vec![].into_iter(),
+    );
     settings.with_inner_type(parse_quote! { crate::hooks::RequestHooks });
     progenitor::Generator::new(&settings)
 }

--- a/cli/factory-api-v1/openapi.json
+++ b/cli/factory-api-v1/openapi.json
@@ -7,135 +7,13 @@
     "version": "unknown"
   },
   "paths": {
-    "/api/v1/factory/health": {
-      "get": {
-        "tags": [
-          "health"
-        ],
-        "summary": "Health",
-        "operationId": "health_api_v1_factory_health_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/factory/ready": {
-      "get": {
-        "tags": [
-          "health"
-        ],
-        "summary": "Ready",
-        "operationId": "ready_api_v1_factory_ready_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/factory/webhooks/github": {
-      "post": {
-        "tags": [
-          "webhooks"
-        ],
-        "summary": "Receive Github Webhook",
-        "description": "Receive a GitHub webhook delivery.\n\nNon-push events are acknowledged and ignored. Push events are\nvalidated, parsed, and stored. Returns a status dict indicating\nwhether the event was accepted, ignored, a duplicate, or caused\na parse error.",
-        "operationId": "receive_github_webhook_api_v1_factory_webhooks_github_post",
-        "parameters": [
-          {
-            "name": "x-github-event",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "X-Github-Event"
-            }
-          },
-          {
-            "name": "x-github-delivery",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "X-Github-Delivery"
-            }
-          },
-          {
-            "name": "x-hub-signature-256",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "title": "X-Hub-Signature-256",
-              "nullable": true,
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true,
-                  "title": "Response Receive Github Webhook Api V1 Factory Webhooks Github Post"
-                }
-              }
-            }
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Unauthorized"
-          },
-          "413": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Request Entity Too Large"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Unprocessable Entity"
-          }
-        }
-      }
-    },
     "/api/v1/factory/builds": {
       "get": {
         "tags": [
           "builds"
         ],
         "summary": "List Builds",
-        "description": "Return a paginated list of builds.\n\nUse the `status` query parameter to filter:\n- ``undispatched``: builds with no task (task_id IS NULL)\n- Any other value: filters by tasks.status (e.g. ``running``)",
+        "description": "Return a paginated list of builds, newest first.\n\nThe ``status`` filter matches builds by an effective status derived\nfrom the build's lifecycle (never stored), drawn from a six-value\nvocabulary:\n\n- ``pending``: accepted but not yet dispatched to a builder.\n- ``running``: dispatched and building.\n- ``completed``: finished successfully.\n- ``failed``: finished unsuccessfully. Excludes timed-out builds,\n  which match ``timed_out``.\n- ``timed_out``: terminated for exceeding its time budget.\n- ``cancelled``: cancelled, whether before or after dispatch.\n\nThese six values are both the filter vocabulary and the response\nvocabulary: a timed-out build matches ``?status=timed_out`` and\nreports ``status: \"timed_out\"`` in the response body.\n\nFilters:\n\n- ``status``: match one or more effective-status values.\n- ``system``: match system names exactly. A name outside the\n  server's system vocabulary returns 422 naming the accepted\n  values, which are the systems this deployment's catalog holds\n  and so may differ between deployments.\n- ``attr_path``: match attr_path by prefix.\n- ``source_commit_sha``: match source commit SHA by prefix.\n- ``since``: return builds created at or after this time. An ISO\n  8601 timestamp carrying a UTC offset, e.g.\n  ``2026-07-17T08:30:00Z``.\n\nFilters combine with AND across parameters and OR within a repeated\none: ``?status=running&status=failed`` matches either status, and\nadding ``&system=x86_64-linux`` further requires that system. Each\nrepeated parameter accepts at most 50 values.\n\n``cursor`` and ``sort`` are reserved for future use and have no\neffect in v1; results are always ordered newest-first.",
         "operationId": "list_builds_api_v1_factory_builds_get",
         "security": [
           {
@@ -151,10 +29,80 @@
             "in": "query",
             "required": false,
             "schema": {
+              "description": "Filter by effective status; repeatable, matched as OR. One of pending, running, completed, failed, timed_out, cancelled.",
               "title": "Status",
               "nullable": true,
-              "type": "string"
-            }
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/EffectiveBuildStatus"
+              },
+              "maxItems": 50
+            },
+            "description": "Filter by effective status; repeatable, matched as OR. One of pending, running, completed, failed, timed_out, cancelled."
+          },
+          {
+            "name": "system",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "description": "Filter by system, matched exactly; repeatable, matched as OR. Values must be non-empty, and a value outside the server's system vocabulary returns 422 naming the accepted values.",
+              "title": "System",
+              "nullable": true,
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "maxItems": 50
+            },
+            "description": "Filter by system, matched exactly; repeatable, matched as OR. Values must be non-empty, and a value outside the server's system vocabulary returns 422 naming the accepted values."
+          },
+          {
+            "name": "attr_path",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "description": "Filter by attr_path prefix; repeatable, matched as OR. Values must be non-empty.",
+              "title": "Attr Path",
+              "nullable": true,
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "maxItems": 50
+            },
+            "description": "Filter by attr_path prefix; repeatable, matched as OR. Values must be non-empty."
+          },
+          {
+            "name": "source_commit_sha",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "description": "Filter by source commit SHA prefix; repeatable, matched as OR. Values must be non-empty.",
+              "title": "Source Commit Sha",
+              "nullable": true,
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "maxItems": 50
+            },
+            "description": "Filter by source commit SHA prefix; repeatable, matched as OR. Values must be non-empty."
+          },
+          {
+            "name": "since",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "description": "Return builds created at or after this time (inclusive). An ISO 8601 timestamp carrying a UTC offset, e.g. '2026-07-17T08:30:00Z'.",
+              "title": "Since",
+              "nullable": true,
+              "type": "string",
+              "format": "date-time"
+            },
+            "description": "Return builds created at or after this time (inclusive). An ISO 8601 timestamp carrying a UTC offset, e.g. '2026-07-17T08:30:00Z'."
           },
           {
             "name": "page",
@@ -162,6 +110,7 @@
             "required": false,
             "schema": {
               "type": "integer",
+              "maximum": 10737418,
               "minimum": 0,
               "default": 0,
               "title": "Page"
@@ -178,6 +127,30 @@
               "default": 50,
               "title": "Page Size"
             }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "description": "Reserved for future use; not implemented in v1 (results are always ordered newest-first).",
+              "title": "Cursor",
+              "nullable": true,
+              "type": "string"
+            },
+            "description": "Reserved for future use; not implemented in v1 (results are always ordered newest-first)."
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "description": "Reserved for future use; not implemented in v1 (results are always ordered newest-first).",
+              "title": "Sort",
+              "nullable": true,
+              "type": "string"
+            },
+            "description": "Reserved for future use; not implemented in v1 (results are always ordered newest-first)."
           }
         ],
         "responses": {
@@ -269,7 +242,7 @@
           "builds"
         ],
         "summary": "Cancel Build",
-        "description": "Cancel a build.\n\nHandles both active builds (delegated to Build Coordinator) and\npre-dispatch builds (cancelled FS-only via an atomic row lock).\n\nThe operation is idempotent with respect to terminal state. When\nthe build has already reached a terminal state (``cancelled``,\n``completed``, or ``failed``) \u2014 whether Build Coordinator reports\nit or the local task row records it \u2014 the response is still 200\nand the ``status`` field carries that terminal state. Coordinator\nstatuses are normalized into the task vocabulary before they are\nsurfaced (BC's ``timed_out`` is reported as ``failed``, exactly as\nthe callback path persists it), so the cancel response and a\nsubsequent ``GET`` always agree.\n\nCancelling a pre-dispatch build permanently retires its identity\ntuple: ``uq_factory_build_identity`` dedup treats the cancelled\nrow like any other terminal build, so a later event expanding to\nthe same identity inserts nothing. Recovery is manual by design \u2014\na cancel that ambient event traffic could overturn would not be a\ncancel.\n\nOutcomes:\n    200 \u2014 Build cancelled, or already terminal. ``BuildResponse.status``\n          reflects the effective state.\n    404 \u2014 No build with the given ID.\n    502 \u2014 Build Coordinator unreachable or returned an unexpected\n          error; or the coordinator does not know the build yet\n          because its dispatch is in flight (the worker commits\n          its claim before the HTTP submit), or no longer knows it\n          (coordinator restart or purge). In every 502 case the\n          correct client action is retry with backoff.\n\nAn audit log line is emitted on every path, including unhandled\nexceptions (``outcome=internal_error``).",
+        "description": "Cancel a build.\n\nHandles both active builds (delegated to Build Coordinator) and\npre-dispatch builds (cancelled FS-only via an atomic row lock).\n\nThe operation is idempotent with respect to terminal state. When\nthe build has already reached a terminal state (``cancelled``,\n``completed``, ``failed``, or ``timed_out``) \u2014 whether Build\nCoordinator reports it or the local task row records it \u2014 the\nresponse is still 200 and the ``status`` field carries that\nterminal state. Coordinator statuses are normalized into the\neffective vocabulary before they are surfaced: BC's ``timed_out``\nsurfaces as ``timed_out``, the same word a subsequent ``GET``\nreconstructs from the footprint the callback path persists\n(status='failed' + error_class='timeout'), so the two surfaces\nalways agree.\n\nCancelling a pre-dispatch build permanently retires its identity\ntuple: ``uq_factory_build_identity`` dedup treats the cancelled\nrow like any other terminal build, so a later event expanding to\nthe same identity inserts nothing. Recovery is manual by design \u2014\na cancel that ambient event traffic could overturn would not be a\ncancel.\n\nOutcomes:\n    200 \u2014 Build cancelled, or already terminal. ``BuildResponse.status``\n          reflects the effective state.\n    404 \u2014 No build with the given ID.\n    502 \u2014 Build Coordinator unreachable or returned an unexpected\n          error; or the coordinator does not know the build yet\n          because its dispatch is in flight (the worker commits\n          its claim before the HTTP submit), or no longer knows it\n          (coordinator restart or purge). In every 502 case the\n          correct client action is retry with backoff.\n\nAn audit log line is emitted on every path, including unhandled\nexceptions (``outcome=internal_error``).",
         "operationId": "cancel_build_api_v1_factory_builds__build_id__delete",
         "security": [
           {
@@ -405,63 +378,6 @@
         }
       }
     },
-    "/api/v1/factory/callbacks/builds/{task_id}": {
-      "post": {
-        "tags": [
-          "callbacks"
-        ],
-        "summary": "Receive Build Callback",
-        "description": "Receive a build coordinator callback for a task.\n\nReturns 200 in all reachable code paths (validation errors are\nauto-converted to 422 by FastAPI); see module docstring for the\nrationale on each branch.",
-        "operationId": "receive_build_callback_api_v1_factory_callbacks_builds__task_id__post",
-        "parameters": [
-          {
-            "name": "task_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "title": "Task Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/BuildCallbackPayload"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "type": "string"
-                  },
-                  "title": "Response Receive Build Callback Api V1 Factory Callbacks Builds  Task Id  Post"
-                }
-              }
-            }
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Unprocessable Entity"
-          }
-        }
-      }
-    },
     "/api/v1/factory/tasks/{task_id}": {
       "get": {
         "tags": [
@@ -526,44 +442,6 @@
   },
   "components": {
     "schemas": {
-      "BuildCallbackPayload": {
-        "properties": {
-          "build_id": {
-            "type": "string",
-            "title": "Build Id"
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "queued",
-              "dispatching",
-              "running",
-              "completed",
-              "failed",
-              "timed_out",
-              "cancelled"
-            ],
-            "title": "Status"
-          },
-          "error_message": {
-            "title": "Error Message",
-            "nullable": true,
-            "type": "string"
-          },
-          "exit_code": {
-            "title": "Exit Code",
-            "nullable": true,
-            "type": "integer"
-          }
-        },
-        "type": "object",
-        "required": [
-          "build_id",
-          "status"
-        ],
-        "title": "BuildCallbackPayload",
-        "description": "Payload posted by the build coordinator to\n``POST /api/v1/factory/callbacks/builds/{task_id}``.\n\nFields match ``build_coordinator/reporter.py:51-56`` exactly.\nAll four are required by the coordinator wire contract; the\nOptional[None] defaults on ``error_message`` and ``exit_code``\naccommodate the ``completed`` and ``cancelled`` terminal cases\nwhere neither is meaningful."
-      },
       "BuildListResponse": {
         "properties": {
           "builds": {
@@ -603,8 +481,7 @@
             "title": "Build Id"
           },
           "status": {
-            "type": "string",
-            "title": "Status"
+            "$ref": "#/components/schemas/EffectiveBuildStatus"
           },
           "source_repo_url": {
             "type": "string",
@@ -663,7 +540,20 @@
           "created_at"
         ],
         "title": "BuildResponse",
-        "description": "Build-specific details with optional task sub-object.\n\nThe task field is None for undispatched builds (task_id IS NULL\nin factory_builds).\n\nThe status field is the build's effective current status, computed\nserver-side from the freshest authoritative source:\n\n- Pre-dispatch (task_id IS NULL): computed from\n  factory_builds.cancelled_at \u2014 ``\"cancelled\"`` when set, else\n  ``\"pending\"``. Neither word is stored; the timestamp is the only\n  persisted pre-dispatch state.\n- Dispatched: tasks.status (``\"running\"``, ``\"completed\"``,\n  ``\"failed\"``, ``\"cancelled\"``).\n- On cancel responses: Build Coordinator's returned status, which\n  is fresher than the local row (which lags until BC's callback\n  lands), normalized into the task vocabulary above \u2014 BC's\n  ``timed_out`` is reported as ``failed``, exactly as the callback\n  path persists it. The field never carries a word outside the\n  union of the two sets above.\n\nStaleness: after handoff the field tracks tasks.status, which only\nadvances when Build Coordinator's terminal callback lands. When\ncallbacks are disabled (no callback base URL configured \u2014 a\nsupported worker configuration), the post-handoff status stays at\nthe last persisted value (typically ``\"running\"``) indefinitely;\na cancel response is then the only place a fresher\ncoordinator-reported status appears."
+        "description": "Build-specific details with optional task sub-object.\n\nThe task field is None for undispatched builds (task_id IS NULL\nin factory_builds).\n\nThe status field is the build's effective current status \u2014 the\nEffectiveBuildStatus vocabulary \u2014 computed server-side from the\nfreshest authoritative source:\n\n- Pre-dispatch (task_id IS NULL): computed from\n  factory_builds.cancelled_at \u2014 ``\"cancelled\"`` when set, else\n  ``\"pending\"``. Neither word is stored; the timestamp is the only\n  persisted pre-dispatch state.\n- Dispatched: tasks.status (``\"running\"``, ``\"completed\"``,\n  ``\"failed\"``, ``\"cancelled\"``), with ``\"timed_out\"``\n  reconstructed from the persisted footprint of an execution\n  timeout (status='failed' + error_class='timeout'). A submit-time\n  ``dispatch_timeout`` is a different failure \u2014 the build never\n  observably started \u2014 and reads as ``\"failed\"``.\n- On cancel responses: Build Coordinator's returned status, which\n  is fresher than the local row (which lags until BC's callback\n  lands), put through the same derivation \u2014 BC's ``timed_out``\n  surfaces as ``\"timed_out\"``, agreeing with what a subsequent GET\n  reconstructs once the callback persists the footprint. The field\n  never carries a word outside the effective vocabulary.\n\nStaleness: after handoff the field tracks tasks.status, which only\nadvances when Build Coordinator's terminal callback lands. When\ncallbacks are disabled (no callback base URL configured \u2014 a\nsupported worker configuration), the post-handoff status stays at\nthe last persisted value (typically ``\"running\"``) indefinitely;\na cancel response is then the only place a fresher\ncoordinator-reported status appears."
+      },
+      "EffectiveBuildStatus": {
+        "type": "string",
+        "enum": [
+          "pending",
+          "running",
+          "completed",
+          "failed",
+          "timed_out",
+          "cancelled"
+        ],
+        "title": "EffectiveBuildStatus",
+        "description": "Effective status of a build, derived server-side and never stored.\n\nA dispatched build's task lifecycle is authoritative, with\ntimed_out reconstructed from a failed task whose error class is\n'timeout'; a build cancelled before dispatch is cancelled; an\nundispatched, uncancelled build is pending. These six values are\nexactly what the derivation can emit; emittable, filterable, and\nthe whole vocabulary are the same set. The member order here is\nthe documentation order."
       },
       "ErrorResponse": {
         "properties": {
@@ -679,6 +569,17 @@
         "title": "ErrorResponse",
         "description": "JSON body returned for all error responses on the builds endpoints."
       },
+      "TaskErrorClass": {
+        "type": "string",
+        "enum": [
+          "transient",
+          "permanent",
+          "timeout",
+          "dispatch_timeout"
+        ],
+        "title": "TaskErrorClass",
+        "description": "Diagnostic class of a failed task.\n\nMirrors the ``ck_task_error_class`` CHECK as of migration 1.8.2:\nerror_class IN ('transient', 'permanent', 'timeout',\n'dispatch_timeout'); the column is NULL for non-failure\nterminals.\n\n- TRANSIENT: retry-able by the sweeper.\n- PERMANENT: will not improve on retry.\n- TIMEOUT: the coordinator reported an execution timeout \u2014 a\n  build that ran and overran its limit.\n- DISPATCH_TIMEOUT: the submit HTTP call to the coordinator\n  itself timed out, so the build's handoff never observably\n  started.\n\nThe last two are kept distinct so the read surface shows an\nexecution timeout as timed_out while a submit timeout reads as\nfailed."
+      },
       "TaskResponse": {
         "properties": {
           "task_id": {
@@ -690,8 +591,7 @@
             "title": "Task Type"
           },
           "status": {
-            "type": "string",
-            "title": "Status"
+            "$ref": "#/components/schemas/TaskStatus"
           },
           "error_message": {
             "title": "Error Message",
@@ -699,9 +599,8 @@
             "type": "string"
           },
           "error_class": {
-            "title": "Error Class",
             "nullable": true,
-            "type": "string"
+            "$ref": "#/components/schemas/TaskErrorClass"
           },
           "created_at": {
             "type": "string",
@@ -735,7 +634,18 @@
           "updated_at"
         ],
         "title": "TaskResponse",
-        "description": "Generic task lifecycle \u2014 same shape for all operation types."
+        "description": "Generic task lifecycle \u2014 same shape for all operation types.\n\nThe status field carries the task vocabulary \u2014 the persisted\nlifecycle words, distinct from the derived effective vocabulary\non BuildResponse.status. The task sub-object reports the stored\nfootprint the top-level status is derived from: a timed-out\nbuild's task still reads status='failed' + error_class='timeout'\nwhile the build-level status reads 'timed_out'."
+      },
+      "TaskStatus": {
+        "type": "string",
+        "enum": [
+          "running",
+          "completed",
+          "failed",
+          "cancelled"
+        ],
+        "title": "TaskStatus",
+        "description": "Valid status values for tasks.\n\nMirrors the CHECK constraint as of migration 1.8.0:\nstatus IN ('running', 'completed', 'failed', 'cancelled').\n\nThe claim CTE inserts tasks directly as 'running' (the claim is\nthe dispatch; there is no separate queued phase). The three\nterminal values are written by ``process_callback`` and\n``mark_task_failed``."
       }
     },
     "securitySchemes": {

--- a/cli/factory-api-v1/src/client.rs
+++ b/cli/factory-api-v1/src/client.rs
@@ -37,74 +37,81 @@ pub mod types {
             }
         }
     }
-    /**Payload posted by the build coordinator to
-``POST /api/v1/factory/callbacks/builds/{task_id}``.
-
-Fields match ``build_coordinator/reporter.py:51-56`` exactly.
-All four are required by the coordinator wire contract; the
-Optional[None] defaults on ``error_message`` and ``exit_code``
-accommodate the ``completed`` and ``cancelled`` terminal cases
-where neither is meaningful.*/
+    ///`AttrPathItem`
     ///
     /// <details><summary>JSON schema</summary>
     ///
     /// ```json
     ///{
-    ///  "title": "BuildCallbackPayload",
-    ///  "description": "Payload posted by the build coordinator to\n``POST /api/v1/factory/callbacks/builds/{task_id}``.\n\nFields match ``build_coordinator/reporter.py:51-56`` exactly.\nAll four are required by the coordinator wire contract; the\nOptional[None] defaults on ``error_message`` and ``exit_code``\naccommodate the ``completed`` and ``cancelled`` terminal cases\nwhere neither is meaningful.",
-    ///  "type": "object",
-    ///  "required": [
-    ///    "build_id",
-    ///    "status"
-    ///  ],
-    ///  "properties": {
-    ///    "build_id": {
-    ///      "title": "Build Id",
-    ///      "type": "string"
-    ///    },
-    ///    "error_message": {
-    ///      "title": "Error Message",
-    ///      "type": [
-    ///        "string",
-    ///        "null"
-    ///      ]
-    ///    },
-    ///    "exit_code": {
-    ///      "title": "Exit Code",
-    ///      "type": [
-    ///        "integer",
-    ///        "null"
-    ///      ]
-    ///    },
-    ///    "status": {
-    ///      "title": "Status",
-    ///      "type": "string",
-    ///      "enum": [
-    ///        "queued",
-    ///        "dispatching",
-    ///        "running",
-    ///        "completed",
-    ///        "failed",
-    ///        "timed_out",
-    ///        "cancelled"
-    ///      ]
-    ///    }
-    ///  }
+    ///  "type": "string",
+    ///  "minLength": 1
     ///}
     /// ```
     /// </details>
-    #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug, PartialEq)]
-    pub struct BuildCallbackPayload {
-        pub build_id: ::std::string::String,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-        pub error_message: ::std::option::Option<::std::string::String>,
-        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-        pub exit_code: ::std::option::Option<i64>,
-        pub status: Status,
+    #[derive(::serde::Serialize, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[serde(transparent)]
+    pub struct AttrPathItem(::std::string::String);
+    impl ::std::ops::Deref for AttrPathItem {
+        type Target = ::std::string::String;
+        fn deref(&self) -> &::std::string::String {
+            &self.0
+        }
     }
-    impl ::std::convert::From<&BuildCallbackPayload> for BuildCallbackPayload {
-        fn from(value: &BuildCallbackPayload) -> Self {
+    impl ::std::convert::From<AttrPathItem> for ::std::string::String {
+        fn from(value: AttrPathItem) -> Self {
+            value.0
+        }
+    }
+    impl ::std::convert::From<&AttrPathItem> for AttrPathItem {
+        fn from(value: &AttrPathItem) -> Self {
             value.clone()
+        }
+    }
+    impl ::std::str::FromStr for AttrPathItem {
+        type Err = self::error::ConversionError;
+        fn from_str(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            if value.chars().count() < 1usize {
+                return Err("shorter than 1 characters".into());
+            }
+            Ok(Self(value.to_string()))
+        }
+    }
+    impl ::std::convert::TryFrom<&str> for AttrPathItem {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<&::std::string::String> for AttrPathItem {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<::std::string::String> for AttrPathItem {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: ::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl<'de> ::serde::Deserialize<'de> for AttrPathItem {
+        fn deserialize<D>(deserializer: D) -> ::std::result::Result<Self, D::Error>
+        where
+            D: ::serde::Deserializer<'de>,
+        {
+            ::std::string::String::deserialize(deserializer)?
+                .parse()
+                .map_err(|e: self::error::ConversionError| {
+                    <D::Error as ::serde::de::Error>::custom(e.to_string())
+                })
         }
     }
     ///Paginated list of builds.
@@ -163,21 +170,26 @@ where neither is meaningful.*/
 The task field is None for undispatched builds (task_id IS NULL
 in factory_builds).
 
-The status field is the build's effective current status, computed
-server-side from the freshest authoritative source:
+The status field is the build's effective current status — the
+EffectiveBuildStatus vocabulary — computed server-side from the
+freshest authoritative source:
 
 - Pre-dispatch (task_id IS NULL): computed from
   factory_builds.cancelled_at — ``"cancelled"`` when set, else
   ``"pending"``. Neither word is stored; the timestamp is the only
   persisted pre-dispatch state.
 - Dispatched: tasks.status (``"running"``, ``"completed"``,
-  ``"failed"``, ``"cancelled"``).
+  ``"failed"``, ``"cancelled"``), with ``"timed_out"``
+  reconstructed from the persisted footprint of an execution
+  timeout (status='failed' + error_class='timeout'). A submit-time
+  ``dispatch_timeout`` is a different failure — the build never
+  observably started — and reads as ``"failed"``.
 - On cancel responses: Build Coordinator's returned status, which
   is fresher than the local row (which lags until BC's callback
-  lands), normalized into the task vocabulary above — BC's
-  ``timed_out`` is reported as ``failed``, exactly as the callback
-  path persists it. The field never carries a word outside the
-  union of the two sets above.
+  lands), put through the same derivation — BC's ``timed_out``
+  surfaces as ``"timed_out"``, agreeing with what a subsequent GET
+  reconstructs once the callback persists the footprint. The field
+  never carries a word outside the effective vocabulary.
 
 Staleness: after handoff the field tracks tasks.status, which only
 advances when Build Coordinator's terminal callback lands. When
@@ -192,7 +204,7 @@ coordinator-reported status appears.*/
     /// ```json
     ///{
     ///  "title": "BuildResponse",
-    ///  "description": "Build-specific details with optional task sub-object.\n\nThe task field is None for undispatched builds (task_id IS NULL\nin factory_builds).\n\nThe status field is the build's effective current status, computed\nserver-side from the freshest authoritative source:\n\n- Pre-dispatch (task_id IS NULL): computed from\n  factory_builds.cancelled_at — ``\"cancelled\"`` when set, else\n  ``\"pending\"``. Neither word is stored; the timestamp is the only\n  persisted pre-dispatch state.\n- Dispatched: tasks.status (``\"running\"``, ``\"completed\"``,\n  ``\"failed\"``, ``\"cancelled\"``).\n- On cancel responses: Build Coordinator's returned status, which\n  is fresher than the local row (which lags until BC's callback\n  lands), normalized into the task vocabulary above — BC's\n  ``timed_out`` is reported as ``failed``, exactly as the callback\n  path persists it. The field never carries a word outside the\n  union of the two sets above.\n\nStaleness: after handoff the field tracks tasks.status, which only\nadvances when Build Coordinator's terminal callback lands. When\ncallbacks are disabled (no callback base URL configured — a\nsupported worker configuration), the post-handoff status stays at\nthe last persisted value (typically ``\"running\"``) indefinitely;\na cancel response is then the only place a fresher\ncoordinator-reported status appears.",
+    ///  "description": "Build-specific details with optional task sub-object.\n\nThe task field is None for undispatched builds (task_id IS NULL\nin factory_builds).\n\nThe status field is the build's effective current status — the\nEffectiveBuildStatus vocabulary — computed server-side from the\nfreshest authoritative source:\n\n- Pre-dispatch (task_id IS NULL): computed from\n  factory_builds.cancelled_at — ``\"cancelled\"`` when set, else\n  ``\"pending\"``. Neither word is stored; the timestamp is the only\n  persisted pre-dispatch state.\n- Dispatched: tasks.status (``\"running\"``, ``\"completed\"``,\n  ``\"failed\"``, ``\"cancelled\"``), with ``\"timed_out\"``\n  reconstructed from the persisted footprint of an execution\n  timeout (status='failed' + error_class='timeout'). A submit-time\n  ``dispatch_timeout`` is a different failure — the build never\n  observably started — and reads as ``\"failed\"``.\n- On cancel responses: Build Coordinator's returned status, which\n  is fresher than the local row (which lags until BC's callback\n  lands), put through the same derivation — BC's ``timed_out``\n  surfaces as ``\"timed_out\"``, agreeing with what a subsequent GET\n  reconstructs once the callback persists the footprint. The field\n  never carries a word outside the effective vocabulary.\n\nStaleness: after handoff the field tracks tasks.status, which only\nadvances when Build Coordinator's terminal callback lands. When\ncallbacks are disabled (no callback base URL configured — a\nsupported worker configuration), the post-handoff status stays at\nthe last persisted value (typically ``\"running\"``) indefinitely;\na cancel response is then the only place a fresher\ncoordinator-reported status appears.",
     ///  "type": "object",
     ///  "required": [
     ///    "attr_path",
@@ -248,8 +260,7 @@ coordinator-reported status appears.*/
     ///      "type": "string"
     ///    },
     ///    "status": {
-    ///      "title": "Status",
-    ///      "type": "string"
+    ///      "$ref": "#/components/schemas/EffectiveBuildStatus"
     ///    },
     ///    "system": {
     ///      "title": "System",
@@ -274,7 +285,7 @@ coordinator-reported status appears.*/
         pub nixpkgs_revision: ::std::string::String,
         pub source_commit_sha: ::std::string::String,
         pub source_repo_url: ::std::string::String,
-        pub status: ::std::string::String,
+        pub status: crate::status::EffectiveBuildStatus,
         pub system: ::std::string::String,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub task: ::std::option::Option<TaskResponse>,
@@ -314,22 +325,191 @@ coordinator-reported status appears.*/
             value.clone()
         }
     }
-    ///`Status`
+    ///`SourceCommitShaItem`
     ///
     /// <details><summary>JSON schema</summary>
     ///
     /// ```json
     ///{
-    ///  "title": "Status",
+    ///  "type": "string",
+    ///  "minLength": 1
+    ///}
+    /// ```
+    /// </details>
+    #[derive(::serde::Serialize, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[serde(transparent)]
+    pub struct SourceCommitShaItem(::std::string::String);
+    impl ::std::ops::Deref for SourceCommitShaItem {
+        type Target = ::std::string::String;
+        fn deref(&self) -> &::std::string::String {
+            &self.0
+        }
+    }
+    impl ::std::convert::From<SourceCommitShaItem> for ::std::string::String {
+        fn from(value: SourceCommitShaItem) -> Self {
+            value.0
+        }
+    }
+    impl ::std::convert::From<&SourceCommitShaItem> for SourceCommitShaItem {
+        fn from(value: &SourceCommitShaItem) -> Self {
+            value.clone()
+        }
+    }
+    impl ::std::str::FromStr for SourceCommitShaItem {
+        type Err = self::error::ConversionError;
+        fn from_str(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            if value.chars().count() < 1usize {
+                return Err("shorter than 1 characters".into());
+            }
+            Ok(Self(value.to_string()))
+        }
+    }
+    impl ::std::convert::TryFrom<&str> for SourceCommitShaItem {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<&::std::string::String> for SourceCommitShaItem {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<::std::string::String> for SourceCommitShaItem {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: ::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl<'de> ::serde::Deserialize<'de> for SourceCommitShaItem {
+        fn deserialize<D>(deserializer: D) -> ::std::result::Result<Self, D::Error>
+        where
+            D: ::serde::Deserializer<'de>,
+        {
+            ::std::string::String::deserialize(deserializer)?
+                .parse()
+                .map_err(|e: self::error::ConversionError| {
+                    <D::Error as ::serde::de::Error>::custom(e.to_string())
+                })
+        }
+    }
+    ///`SystemItem`
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "type": "string",
+    ///  "minLength": 1
+    ///}
+    /// ```
+    /// </details>
+    #[derive(::serde::Serialize, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[serde(transparent)]
+    pub struct SystemItem(::std::string::String);
+    impl ::std::ops::Deref for SystemItem {
+        type Target = ::std::string::String;
+        fn deref(&self) -> &::std::string::String {
+            &self.0
+        }
+    }
+    impl ::std::convert::From<SystemItem> for ::std::string::String {
+        fn from(value: SystemItem) -> Self {
+            value.0
+        }
+    }
+    impl ::std::convert::From<&SystemItem> for SystemItem {
+        fn from(value: &SystemItem) -> Self {
+            value.clone()
+        }
+    }
+    impl ::std::str::FromStr for SystemItem {
+        type Err = self::error::ConversionError;
+        fn from_str(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            if value.chars().count() < 1usize {
+                return Err("shorter than 1 characters".into());
+            }
+            Ok(Self(value.to_string()))
+        }
+    }
+    impl ::std::convert::TryFrom<&str> for SystemItem {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<&::std::string::String> for SystemItem {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<::std::string::String> for SystemItem {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: ::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl<'de> ::serde::Deserialize<'de> for SystemItem {
+        fn deserialize<D>(deserializer: D) -> ::std::result::Result<Self, D::Error>
+        where
+            D: ::serde::Deserializer<'de>,
+        {
+            ::std::string::String::deserialize(deserializer)?
+                .parse()
+                .map_err(|e: self::error::ConversionError| {
+                    <D::Error as ::serde::de::Error>::custom(e.to_string())
+                })
+        }
+    }
+    /**Diagnostic class of a failed task.
+
+Mirrors the ``ck_task_error_class`` CHECK as of migration 1.8.2:
+error_class IN ('transient', 'permanent', 'timeout',
+'dispatch_timeout'); the column is NULL for non-failure
+terminals.
+
+- TRANSIENT: retry-able by the sweeper.
+- PERMANENT: will not improve on retry.
+- TIMEOUT: the coordinator reported an execution timeout — a
+  build that ran and overran its limit.
+- DISPATCH_TIMEOUT: the submit HTTP call to the coordinator
+  itself timed out, so the build's handoff never observably
+  started.
+
+The last two are kept distinct so the read surface shows an
+execution timeout as timed_out while a submit timeout reads as
+failed.*/
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "title": "TaskErrorClass",
+    ///  "description": "Diagnostic class of a failed task.\n\nMirrors the ``ck_task_error_class`` CHECK as of migration 1.8.2:\nerror_class IN ('transient', 'permanent', 'timeout',\n'dispatch_timeout'); the column is NULL for non-failure\nterminals.\n\n- TRANSIENT: retry-able by the sweeper.\n- PERMANENT: will not improve on retry.\n- TIMEOUT: the coordinator reported an execution timeout — a\n  build that ran and overran its limit.\n- DISPATCH_TIMEOUT: the submit HTTP call to the coordinator\n  itself timed out, so the build's handoff never observably\n  started.\n\nThe last two are kept distinct so the read surface shows an\nexecution timeout as timed_out while a submit timeout reads as\nfailed.",
     ///  "type": "string",
     ///  "enum": [
-    ///    "queued",
-    ///    "dispatching",
-    ///    "running",
-    ///    "completed",
-    ///    "failed",
-    ///    "timed_out",
-    ///    "cancelled"
+    ///    "transient",
+    ///    "permanent",
+    ///    "timeout",
+    ///    "dispatch_timeout"
     ///  ]
     ///}
     /// ```
@@ -346,58 +526,46 @@ coordinator-reported status appears.*/
         PartialEq,
         PartialOrd
     )]
-    pub enum Status {
-        #[serde(rename = "queued")]
-        Queued,
-        #[serde(rename = "dispatching")]
-        Dispatching,
-        #[serde(rename = "running")]
-        Running,
-        #[serde(rename = "completed")]
-        Completed,
-        #[serde(rename = "failed")]
-        Failed,
-        #[serde(rename = "timed_out")]
-        TimedOut,
-        #[serde(rename = "cancelled")]
-        Cancelled,
+    pub enum TaskErrorClass {
+        #[serde(rename = "transient")]
+        Transient,
+        #[serde(rename = "permanent")]
+        Permanent,
+        #[serde(rename = "timeout")]
+        Timeout,
+        #[serde(rename = "dispatch_timeout")]
+        DispatchTimeout,
     }
-    impl ::std::convert::From<&Self> for Status {
-        fn from(value: &Status) -> Self {
+    impl ::std::convert::From<&Self> for TaskErrorClass {
+        fn from(value: &TaskErrorClass) -> Self {
             value.clone()
         }
     }
-    impl ::std::fmt::Display for Status {
+    impl ::std::fmt::Display for TaskErrorClass {
         fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
             match *self {
-                Self::Queued => f.write_str("queued"),
-                Self::Dispatching => f.write_str("dispatching"),
-                Self::Running => f.write_str("running"),
-                Self::Completed => f.write_str("completed"),
-                Self::Failed => f.write_str("failed"),
-                Self::TimedOut => f.write_str("timed_out"),
-                Self::Cancelled => f.write_str("cancelled"),
+                Self::Transient => f.write_str("transient"),
+                Self::Permanent => f.write_str("permanent"),
+                Self::Timeout => f.write_str("timeout"),
+                Self::DispatchTimeout => f.write_str("dispatch_timeout"),
             }
         }
     }
-    impl ::std::str::FromStr for Status {
+    impl ::std::str::FromStr for TaskErrorClass {
         type Err = self::error::ConversionError;
         fn from_str(
             value: &str,
         ) -> ::std::result::Result<Self, self::error::ConversionError> {
             match value {
-                "queued" => Ok(Self::Queued),
-                "dispatching" => Ok(Self::Dispatching),
-                "running" => Ok(Self::Running),
-                "completed" => Ok(Self::Completed),
-                "failed" => Ok(Self::Failed),
-                "timed_out" => Ok(Self::TimedOut),
-                "cancelled" => Ok(Self::Cancelled),
+                "transient" => Ok(Self::Transient),
+                "permanent" => Ok(Self::Permanent),
+                "timeout" => Ok(Self::Timeout),
+                "dispatch_timeout" => Ok(Self::DispatchTimeout),
                 _ => Err("invalid value".into()),
             }
         }
     }
-    impl ::std::convert::TryFrom<&str> for Status {
+    impl ::std::convert::TryFrom<&str> for TaskErrorClass {
         type Error = self::error::ConversionError;
         fn try_from(
             value: &str,
@@ -405,7 +573,7 @@ coordinator-reported status appears.*/
             value.parse()
         }
     }
-    impl ::std::convert::TryFrom<&::std::string::String> for Status {
+    impl ::std::convert::TryFrom<&::std::string::String> for TaskErrorClass {
         type Error = self::error::ConversionError;
         fn try_from(
             value: &::std::string::String,
@@ -413,7 +581,7 @@ coordinator-reported status appears.*/
             value.parse()
         }
     }
-    impl ::std::convert::TryFrom<::std::string::String> for Status {
+    impl ::std::convert::TryFrom<::std::string::String> for TaskErrorClass {
         type Error = self::error::ConversionError;
         fn try_from(
             value: ::std::string::String,
@@ -421,14 +589,21 @@ coordinator-reported status appears.*/
             value.parse()
         }
     }
-    ///Generic task lifecycle — same shape for all operation types.
+    /**Generic task lifecycle — same shape for all operation types.
+
+The status field carries the task vocabulary — the persisted
+lifecycle words, distinct from the derived effective vocabulary
+on BuildResponse.status. The task sub-object reports the stored
+footprint the top-level status is derived from: a timed-out
+build's task still reads status='failed' + error_class='timeout'
+while the build-level status reads 'timed_out'.*/
     ///
     /// <details><summary>JSON schema</summary>
     ///
     /// ```json
     ///{
     ///  "title": "TaskResponse",
-    ///  "description": "Generic task lifecycle — same shape for all operation types.",
+    ///  "description": "Generic task lifecycle — same shape for all operation types.\n\nThe status field carries the task vocabulary — the persisted\nlifecycle words, distinct from the derived effective vocabulary\non BuildResponse.status. The task sub-object reports the stored\nfootprint the top-level status is derived from: a timed-out\nbuild's task still reads status='failed' + error_class='timeout'\nwhile the build-level status reads 'timed_out'.",
     ///  "type": "object",
     ///  "required": [
     ///    "created_at",
@@ -452,11 +627,7 @@ coordinator-reported status appears.*/
     ///      "format": "date-time"
     ///    },
     ///    "error_class": {
-    ///      "title": "Error Class",
-    ///      "type": [
-    ///        "string",
-    ///        "null"
-    ///      ]
+    ///      "$ref": "#/components/schemas/TaskErrorClass"
     ///    },
     ///    "error_message": {
     ///      "title": "Error Message",
@@ -474,8 +645,7 @@ coordinator-reported status appears.*/
     ///      "format": "date-time"
     ///    },
     ///    "status": {
-    ///      "title": "Status",
-    ///      "type": "string"
+    ///      "$ref": "#/components/schemas/TaskStatus"
     ///    },
     ///    "task_id": {
     ///      "title": "Task Id",
@@ -502,12 +672,12 @@ coordinator-reported status appears.*/
         >,
         pub created_at: ::chrono::DateTime<::chrono::offset::Utc>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-        pub error_class: ::std::option::Option<::std::string::String>,
+        pub error_class: ::std::option::Option<TaskErrorClass>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub error_message: ::std::option::Option<::std::string::String>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub started_at: ::std::option::Option<::chrono::DateTime<::chrono::offset::Utc>>,
-        pub status: ::std::string::String,
+        pub status: TaskStatus,
         pub task_id: i64,
         pub task_type: ::std::string::String,
         pub updated_at: ::chrono::DateTime<::chrono::offset::Utc>,
@@ -515,6 +685,107 @@ coordinator-reported status appears.*/
     impl ::std::convert::From<&TaskResponse> for TaskResponse {
         fn from(value: &TaskResponse) -> Self {
             value.clone()
+        }
+    }
+    /**Valid status values for tasks.
+
+Mirrors the CHECK constraint as of migration 1.8.0:
+status IN ('running', 'completed', 'failed', 'cancelled').
+
+The claim CTE inserts tasks directly as 'running' (the claim is
+the dispatch; there is no separate queued phase). The three
+terminal values are written by ``process_callback`` and
+``mark_task_failed``.*/
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "title": "TaskStatus",
+    ///  "description": "Valid status values for tasks.\n\nMirrors the CHECK constraint as of migration 1.8.0:\nstatus IN ('running', 'completed', 'failed', 'cancelled').\n\nThe claim CTE inserts tasks directly as 'running' (the claim is\nthe dispatch; there is no separate queued phase). The three\nterminal values are written by ``process_callback`` and\n``mark_task_failed``.",
+    ///  "type": "string",
+    ///  "enum": [
+    ///    "running",
+    ///    "completed",
+    ///    "failed",
+    ///    "cancelled"
+    ///  ]
+    ///}
+    /// ```
+    /// </details>
+    #[derive(
+        ::serde::Deserialize,
+        ::serde::Serialize,
+        Clone,
+        Copy,
+        Debug,
+        Eq,
+        Hash,
+        Ord,
+        PartialEq,
+        PartialOrd
+    )]
+    pub enum TaskStatus {
+        #[serde(rename = "running")]
+        Running,
+        #[serde(rename = "completed")]
+        Completed,
+        #[serde(rename = "failed")]
+        Failed,
+        #[serde(rename = "cancelled")]
+        Cancelled,
+    }
+    impl ::std::convert::From<&Self> for TaskStatus {
+        fn from(value: &TaskStatus) -> Self {
+            value.clone()
+        }
+    }
+    impl ::std::fmt::Display for TaskStatus {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+            match *self {
+                Self::Running => f.write_str("running"),
+                Self::Completed => f.write_str("completed"),
+                Self::Failed => f.write_str("failed"),
+                Self::Cancelled => f.write_str("cancelled"),
+            }
+        }
+    }
+    impl ::std::str::FromStr for TaskStatus {
+        type Err = self::error::ConversionError;
+        fn from_str(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            match value {
+                "running" => Ok(Self::Running),
+                "completed" => Ok(Self::Completed),
+                "failed" => Ok(Self::Failed),
+                "cancelled" => Ok(Self::Cancelled),
+                _ => Err("invalid value".into()),
+            }
+        }
+    }
+    impl ::std::convert::TryFrom<&str> for TaskStatus {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<&::std::string::String> for TaskStatus {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<::std::string::String> for TaskStatus {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: ::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
         }
     }
 }
@@ -582,20 +853,69 @@ impl ClientHooks<crate::hooks::RequestHooks> for &Client {}
 impl Client {
     /**List Builds
 
-Return a paginated list of builds.
+Return a paginated list of builds, newest first.
 
-Use the `status` query parameter to filter:
-- ``undispatched``: builds with no task (task_id IS NULL)
-- Any other value: filters by tasks.status (e.g. ``running``)
+The ``status`` filter matches builds by an effective status derived
+from the build's lifecycle (never stored), drawn from a six-value
+vocabulary:
+
+- ``pending``: accepted but not yet dispatched to a builder.
+- ``running``: dispatched and building.
+- ``completed``: finished successfully.
+- ``failed``: finished unsuccessfully. Excludes timed-out builds,
+  which match ``timed_out``.
+- ``timed_out``: terminated for exceeding its time budget.
+- ``cancelled``: cancelled, whether before or after dispatch.
+
+These six values are both the filter vocabulary and the response
+vocabulary: a timed-out build matches ``?status=timed_out`` and
+reports ``status: "timed_out"`` in the response body.
+
+Filters:
+
+- ``status``: match one or more effective-status values.
+- ``system``: match system names exactly. A name outside the
+  server's system vocabulary returns 422 naming the accepted
+  values, which are the systems this deployment's catalog holds
+  and so may differ between deployments.
+- ``attr_path``: match attr_path by prefix.
+- ``source_commit_sha``: match source commit SHA by prefix.
+- ``since``: return builds created at or after this time. An ISO
+  8601 timestamp carrying a UTC offset, e.g.
+  ``2026-07-17T08:30:00Z``.
+
+Filters combine with AND across parameters and OR within a repeated
+one: ``?status=running&status=failed`` matches either status, and
+adding ``&system=x86_64-linux`` further requires that system. Each
+repeated parameter accepts at most 50 values.
+
+``cursor`` and ``sort`` are reserved for future use and have no
+effect in v1; results are always ordered newest-first.
 
 Sends a `GET` request to `/api/v1/factory/builds`
 
+Arguments:
+- `attr_path`: Filter by attr_path prefix; repeatable, matched as OR. Values must be non-empty.
+- `cursor`: Reserved for future use; not implemented in v1 (results are always ordered newest-first).
+- `page`
+- `page_size`
+- `since`: Return builds created at or after this time (inclusive). An ISO 8601 timestamp carrying a UTC offset, e.g. '2026-07-17T08:30:00Z'.
+- `sort`: Reserved for future use; not implemented in v1 (results are always ordered newest-first).
+- `source_commit_sha`: Filter by source commit SHA prefix; repeatable, matched as OR. Values must be non-empty.
+- `status`: Filter by effective status; repeatable, matched as OR. One of pending, running, completed, failed, timed_out, cancelled.
+- `system`: Filter by system, matched exactly; repeatable, matched as OR. Values must be non-empty, and a value outside the server's system vocabulary returns 422 naming the accepted values.
 */
     pub async fn list_builds_api_v1_factory_builds_get<'a>(
         &'a self,
-        page: Option<u64>,
+        attr_path: Option<&'a ::std::vec::Vec<types::AttrPathItem>>,
+        cursor: Option<&'a str>,
+        page: Option<i64>,
         page_size: Option<::std::num::NonZeroU64>,
-        status: Option<&'a str>,
+        since: Option<&'a ::chrono::DateTime<::chrono::offset::Utc>>,
+        sort: Option<&'a str>,
+        source_commit_sha: Option<&'a ::std::vec::Vec<types::SourceCommitShaItem>>,
+        status: Option<&'a ::std::vec::Vec<crate::status::EffectiveBuildStatus>>,
+        system: Option<&'a ::std::vec::Vec<types::SystemItem>>,
     ) -> Result<ResponseValue<types::BuildListResponse>, Error<types::ErrorResponse>> {
         let url = format!("{}/api/v1/factory/builds", self.baseurl);
         let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
@@ -612,9 +932,20 @@ Sends a `GET` request to `/api/v1/factory/builds`
                 ::reqwest::header::ACCEPT,
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
+            .query(&progenitor_client::QueryParam::new("attr_path", &attr_path))
+            .query(&progenitor_client::QueryParam::new("cursor", &cursor))
             .query(&progenitor_client::QueryParam::new("page", &page))
             .query(&progenitor_client::QueryParam::new("page_size", &page_size))
+            .query(&progenitor_client::QueryParam::new("since", &since))
+            .query(&progenitor_client::QueryParam::new("sort", &sort))
+            .query(
+                &progenitor_client::QueryParam::new(
+                    "source_commit_sha",
+                    &source_commit_sha,
+                ),
+            )
             .query(&progenitor_client::QueryParam::new("status", &status))
+            .query(&progenitor_client::QueryParam::new("system", &system))
             .headers(header_map)
             .build()?;
         let info = OperationInfo {
@@ -691,13 +1022,15 @@ pre-dispatch builds (cancelled FS-only via an atomic row lock).
 
 The operation is idempotent with respect to terminal state. When
 the build has already reached a terminal state (``cancelled``,
-``completed``, or ``failed``) — whether Build Coordinator reports
-it or the local task row records it — the response is still 200
-and the ``status`` field carries that terminal state. Coordinator
-statuses are normalized into the task vocabulary before they are
-surfaced (BC's ``timed_out`` is reported as ``failed``, exactly as
-the callback path persists it), so the cancel response and a
-subsequent ``GET`` always agree.
+``completed``, ``failed``, or ``timed_out``) — whether Build
+Coordinator reports it or the local task row records it — the
+response is still 200 and the ``status`` field carries that
+terminal state. Coordinator statuses are normalized into the
+effective vocabulary before they are surfaced: BC's ``timed_out``
+surfaces as ``timed_out``, the same word a subsequent ``GET``
+reconstructs from the footprint the callback path persists
+(status='failed' + error_class='timeout'), so the two surfaces
+always agree.
 
 Cancelling a pre-dispatch build permanently retires its identity
 tuple: ``uq_factory_build_identity`` dedup treats the cancelled

--- a/cli/factory-api-v1/src/lib.rs
+++ b/cli/factory-api-v1/src/lib.rs
@@ -11,5 +11,11 @@
 
 mod client;
 pub mod hooks;
+mod status;
 pub use client::*;
 pub use hooks::RequestHooks;
+
+pub mod types {
+    pub use crate::client::types::*;
+    pub use crate::status::EffectiveBuildStatus;
+}

--- a/cli/factory-api-v1/src/status.rs
+++ b/cli/factory-api-v1/src/status.rs
@@ -107,6 +107,8 @@ fn unknown_status(s: &str) -> ParseStatusError {
 
 #[cfg(test)]
 mod tests {
+    use strum::IntoEnumIterator;
+
     use super::*;
 
     #[test]
@@ -155,5 +157,31 @@ mod tests {
             "Invalid status 'queued'; valid values are: pending, running, completed, failed, timed_out, cancelled."
         );
         assert!("".parse::<EffectiveBuildStatus>().is_err());
+    }
+
+    /// Pins the known variants to the schema the client is generated from. If
+    /// the server adds or reorders a status, this fails loudly so the enum is
+    /// updated deliberately rather than the new value silently falling into
+    /// `Unknown`.
+    #[test]
+    fn known_matches_openapi_schema() {
+        let spec: serde_json::Value =
+            serde_json::from_str(include_str!("../openapi.json")).unwrap();
+        let schema_values: Vec<String> = spec["components"]["schemas"]["EffectiveBuildStatus"]
+            ["enum"]
+            .as_array()
+            .expect("EffectiveBuildStatus.enum is an array")
+            .iter()
+            .map(|value| {
+                value
+                    .as_str()
+                    .expect("enum value is a string")
+                    .to_string()
+            })
+            .collect();
+        let known: Vec<String> = EffectiveBuildStatus::iter()
+            .map(|status| status.to_string())
+            .collect();
+        assert_eq!(schema_values, known);
     }
 }

--- a/cli/factory-api-v1/src/status.rs
+++ b/cli/factory-api-v1/src/status.rs
@@ -1,0 +1,159 @@
+//! Hand-written, tolerant replacement for the generated `BuildResponse.status`
+//! enum.
+//!
+//! The Factory Service computes an effective build status server-side. We
+//! deserialize it into a closed set of known variants plus an open
+//! [`EffectiveBuildStatus::Unknown`] catch-all: a status the server adds in the
+//! future renders as `unknown: <value>` rather than failing the whole response
+//! and blanking the build list. Progenitor generates the endpoint bindings; this
+//! type is spliced in via `with_replacement` in `build.rs` so the same tolerance
+//! covers both the response body and the `status` query-param filter.
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+use strum::IntoEnumIterator;
+
+/// The server-computed status of a build.
+///
+/// Known variants serialize to their wire word (e.g. `TimedOut` ⇄ `timed_out`).
+/// Any value outside the known set deserializes into [`Self::Unknown`] and
+/// serializes back to the same string, so unknown statuses round-trip.
+///
+/// The two directions are deliberately asymmetric: deserialization (serde) is
+/// tolerant so a response never fails on a new server status, while `FromStr`
+/// (derived by strum, with [`Self::Unknown`] disabled) is strict so user input
+/// is rejected unless it names a known status; the [`ParseStatusError`] it
+/// returns names the accepted values. Iteration (`EnumIter`, also skipping the
+/// disabled [`Self::Unknown`]) yields the known statuses in the order the
+/// OpenAPI schema documents them.
+#[derive(
+    Clone,
+    Debug,
+    Deserialize,
+    Serialize,
+    PartialEq,
+    Eq,
+    Hash,
+    strum::EnumIter,
+    strum::EnumString,
+)]
+#[serde(rename_all = "snake_case")]
+#[strum(
+    serialize_all = "snake_case",
+    parse_err_fn = unknown_status,
+    parse_err_ty = ParseStatusError
+)]
+pub enum EffectiveBuildStatus {
+    Pending,
+    Running,
+    Completed,
+    Failed,
+    TimedOut,
+    Cancelled,
+    /// Any value outside the known statuses. MUST stay last: serde requires
+    /// an untagged variant to trail the tagged ones so the known words are
+    /// tried first.
+    #[serde(untagged)]
+    #[strum(disabled)]
+    Unknown(String),
+}
+
+impl EffectiveBuildStatus {
+    /// The wire word for this status. For [`Self::Unknown`] this is the
+    /// original, unrecognized value.
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Pending => "pending",
+            Self::Running => "running",
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+            Self::TimedOut => "timed_out",
+            Self::Cancelled => "cancelled",
+            Self::Unknown(value) => value,
+        }
+    }
+}
+
+impl fmt::Display for EffectiveBuildStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Rejection of a word outside the known status vocabulary.
+///
+/// Produced by the enum's `FromStr`; the message names the accepted values,
+/// so a caller can show it to a user as-is.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ParseStatusError(String);
+
+impl fmt::Display for ParseStatusError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let valid = EffectiveBuildStatus::iter()
+            .map(|status| status.to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        write!(f, "Invalid status '{}'; valid values are: {valid}.", self.0)
+    }
+}
+
+impl std::error::Error for ParseStatusError {}
+
+/// The `parse_err_fn` for the strum-derived `FromStr`.
+fn unknown_status(s: &str) -> ParseStatusError {
+    ParseStatusError(s.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserializes_known_variant() {
+        let status: EffectiveBuildStatus = serde_json::from_str(r#""timed_out""#).unwrap();
+        assert_eq!(status, EffectiveBuildStatus::TimedOut);
+    }
+
+    #[test]
+    fn deserializes_unknown_variant_tolerantly() {
+        let status: EffectiveBuildStatus = serde_json::from_str(r#""queued""#).unwrap();
+        assert_eq!(status, EffectiveBuildStatus::Unknown("queued".to_string()));
+    }
+
+    #[test]
+    fn serializes_known_and_unknown_to_wire_word() {
+        assert_eq!(
+            serde_json::to_string(&EffectiveBuildStatus::Cancelled).unwrap(),
+            r#""cancelled""#,
+        );
+        assert_eq!(
+            serde_json::to_string(&EffectiveBuildStatus::Unknown("frobnicated".to_string()))
+                .unwrap(),
+            r#""frobnicated""#,
+        );
+    }
+
+    #[test]
+    fn display_matches_as_str() {
+        assert_eq!(EffectiveBuildStatus::Pending.to_string(), "pending");
+        assert_eq!(
+            EffectiveBuildStatus::Unknown("weird".to_string()).to_string(),
+            "weird",
+        );
+    }
+
+    /// `FromStr` is the strict direction: known wire words parse, anything
+    /// else is rejected rather than falling into `Unknown`. Pins the strum
+    /// wiring (`serialize_all` casing and the disabled catch-all) and the
+    /// rejection message naming the accepted values.
+    #[test]
+    fn from_str_parses_known_words_and_rejects_the_rest() {
+        assert_eq!("timed_out".parse(), Ok(EffectiveBuildStatus::TimedOut));
+        assert_eq!(
+            "queued".parse::<EffectiveBuildStatus>().unwrap_err().to_string(),
+            "Invalid status 'queued'; valid values are: pending, running, completed, failed, timed_out, cancelled."
+        );
+        assert!("".parse::<EffectiveBuildStatus>().is_err());
+    }
+}

--- a/cli/flox/Cargo.toml
+++ b/cli/flox/Cargo.toml
@@ -25,6 +25,7 @@ indent.workspace = true
 indicatif.workspace = true
 indoc.workspace = true
 inquire.workspace = true
+interim.workspace = true
 itertools.workspace = true
 keyring-core.workspace = true
 nix.workspace = true

--- a/cli/flox/src/commands/factory/cancel.rs
+++ b/cli/flox/src/commands/factory/cancel.rs
@@ -1,8 +1,12 @@
-use std::num::NonZeroU64;
-
 use anyhow::Result;
 use bpaf::Bpaf;
-use floxhub_client::{BuildResponse, FactoryClientError, FactoryClientTrait, FactoryStatus};
+use floxhub_client::{
+    BuildId,
+    BuildResponse,
+    EffectiveBuildStatus,
+    FactoryClientError,
+    FactoryClientTrait,
+};
 use indoc::{formatdoc, indoc};
 use tracing::instrument;
 
@@ -21,7 +25,7 @@ pub struct Cancel {
 
     /// Build ID to cancel
     #[bpaf(positional("ID"))]
-    pub id: NonZeroU64,
+    pub id: BuildId,
 }
 
 impl Cancel {
@@ -29,20 +33,12 @@ impl Cancel {
     pub async fn handle(self, client: &impl FactoryClientTrait) -> Result<()> {
         subcommand_metric!("factory::cancel");
 
-        // Build IDs are `i64` server-side, so an ID beyond `i64::MAX` cannot
-        // name a real build. Reject it as not found rather than cast with `as`,
-        // whose silent wrap would put a negative ID on the destructive endpoint;
-        // this returns before any request is issued.
-        let Ok(build_id) = i64::try_from(self.id.get()) else {
-            return Err(self.fail(&FactoryClientError::NotFound));
-        };
-
         // Issue the idempotent cancel. A 200 carries the build's effective
         // status, from which the outcome (initiated vs already terminal) is
         // read; every HTTP and transport failure is classified in the client
         // layer into the typed error the exit-code contract maps.
-        match client.cancel_build(build_id).await {
-            Ok(build) => match success_outcome(&build, self.id) {
+        match client.cancel_build(self.id).await {
+            Ok(build) => match success_outcome(&build.status, self.id) {
                 // Terminal: the cancel is fully resolved. Print to stdout, exit 0.
                 CancelOutcome::Resolved(message) => {
                     print!("{}", render(&build, &message, self.json)?);
@@ -84,7 +80,7 @@ impl Cancel {
 /// An unrecognised response degrades to a generic service error (exit 1),
 /// following the codebase's graceful handling of unexpected responses rather
 /// than escalating it to a bespoke outcome.
-fn classify_error(err: &FactoryClientError, id: NonZeroU64) -> (String, u8) {
+fn classify_error(err: &FactoryClientError, id: BuildId) -> (String, u8) {
     match err {
         // No such build: exit 2.
         FactoryClientError::NotFound => (
@@ -120,8 +116,9 @@ fn classify_error(err: &FactoryClientError, id: NonZeroU64) -> (String, u8) {
         ),
         // A non-auth 4xx, or a body that did not parse as a build: an
         // unrecognised response, reported as a generic service error and retried
-        // rather than escalated. Exit 1. Naming the variant rather than `_` makes
-        // a future error variant a compile error rather than a silent default.
+        // rather than escalated. Exit 1. Naming the variant rather than using
+        // `_` makes a future error variant a compile error rather than a silent
+        // default.
         FactoryClientError::APIError(_) => (
             formatdoc! {"
                 The Flox Factory could not cancel build {id}.
@@ -150,49 +147,44 @@ enum CancelOutcome {
 /// Classify a successful (HTTP 200) cancel response from the build's effective
 /// `status`.
 ///
-/// The seven wire statuses parse into [`FactoryStatus`]; matching the enum makes
-/// a newly added server status a compile error here (once the client is
-/// regenerated) rather than a silent contract violation. `pending` is the one
-/// effective status the enum cannot represent: it is synthesized server-side for
-/// an undispatched build (`task_id IS NULL`), so it is matched on the string.
+/// Matching the typed [`EffectiveBuildStatus`] exhaustively makes a status
+/// newly added to the enum a compile error here rather than a silent
+/// fall-through; until the enum names it, a new server status arrives as
+/// `Unknown`.
 ///
 /// A satisfied cancel reports a terminal `cancelled`/`completed`/`failed`/
-/// `timed_out`. A non-terminal status (`running`/`queued`/`dispatching`/
-/// `pending`) means the cancel was accepted but the build has not yet stopped;
-/// like the read verbs, that is a normal outcome, not a retryable error. Only a
-/// status outside the lifecycle vocabulary is a contract violation.
-fn success_outcome(build: &BuildResponse, id: NonZeroU64) -> CancelOutcome {
-    let status = build.status.as_str();
-    match build.status.parse::<FactoryStatus>() {
-        Ok(FactoryStatus::Cancelled) => {
+/// `timed_out`. A non-terminal `running`/`pending` means the cancel was accepted
+/// but the build has not yet stopped; like the read verbs, that is a normal
+/// outcome, not a retryable error. Only an unrecognized status is a contract
+/// violation.
+fn success_outcome(status: &EffectiveBuildStatus, id: BuildId) -> CancelOutcome {
+    let word = status.as_str();
+    match status {
+        EffectiveBuildStatus::Cancelled => {
             CancelOutcome::Resolved(format!("Cancellation initiated for build {id}."))
         },
-        // `timed_out` is a terminal status in the factory `Status` vocabulary;
-        // the service normalizes it to `failed` on a response (see the
-        // `BuildResponse.status` docs), so it should not appear here, but a
-        // known terminal status must not read as a contract violation.
-        Ok(FactoryStatus::Completed | FactoryStatus::Failed | FactoryStatus::TimedOut) => {
-            CancelOutcome::Resolved(format!(
-                "Build {id} is already {status}; nothing to cancel."
-            ))
+        EffectiveBuildStatus::Completed => {
+            CancelOutcome::Resolved(format!("Build {id} already completed; nothing to cancel."))
         },
-        Ok(FactoryStatus::Running | FactoryStatus::Queued | FactoryStatus::Dispatching) => {
-            CancelOutcome::Accepted(accepted_message(id, status))
+        EffectiveBuildStatus::Failed => {
+            CancelOutcome::Resolved(format!("Build {id} already failed; nothing to cancel."))
         },
-        // `pending`: an undispatched build's synthesized status, outside the
-        // `FactoryStatus` enum but a known, non-terminal outcome.
-        Err(_) if status == "pending" => CancelOutcome::Accepted(accepted_message(id, status)),
-        // A status outside the lifecycle vocabulary is a contract violation, not
-        // a successful cancel.
-        Err(_) => CancelOutcome::Unexpected(formatdoc! {"
-            The Flox Factory returned an unexpected status '{status}' for build {id}.
+        EffectiveBuildStatus::TimedOut => {
+            CancelOutcome::Resolved(format!("Build {id} already timed out; nothing to cancel."))
+        },
+        EffectiveBuildStatus::Running | EffectiveBuildStatus::Pending => {
+            CancelOutcome::Accepted(accepted_message(id, word))
+        },
+        // A status outside the known vocabulary is a contract violation, not a
+        // successful cancel.
+        EffectiveBuildStatus::Unknown(_) => CancelOutcome::Unexpected(formatdoc! {"
+            The Flox Factory returned an unexpected status '{word}' for build {id}.
             Run 'flox factory status {id}' to check the build."}),
     }
 }
 
-/// The "accepted but not yet terminal" message, shared by the non-terminal wire
-/// statuses and the synthesized `pending`.
-fn accepted_message(id: NonZeroU64, status: &str) -> String {
+/// The "accepted but not yet terminal" message for a non-terminal status.
+fn accepted_message(id: BuildId, status: &str) -> String {
     formatdoc! {"
         Cancellation accepted for build {id}; it is {status} and not yet terminal.
         Run 'flox factory status {id}' to follow it."}
@@ -210,8 +202,6 @@ fn render(build: &BuildResponse, outcome: &str, json: bool) -> Result<String> {
 
 #[cfg(test)]
 mod tests {
-    use std::num::NonZeroU64;
-
     use flox_rust_sdk::utils::logging::test_helpers::test_subscriber_message_only;
     use floxhub_client::FactoryApiError;
     use pretty_assertions::assert_eq;
@@ -220,22 +210,18 @@ mod tests {
     use super::*;
     use crate::commands::factory::test_helpers::{StubFactoryClient, StubResult, make_build};
 
-    fn id(n: u64) -> NonZeroU64 {
-        NonZeroU64::new(n).unwrap()
+    fn id(n: i64) -> BuildId {
+        n.to_string().parse().unwrap()
     }
 
     // -------------------------------------------------------------------------
-    // success_outcome — the body-status -> outcome mapping
+    // success_outcome: the status-to-outcome mapping
     // -------------------------------------------------------------------------
-
-    fn build_with_status(status: &str) -> BuildResponse {
-        make_build(42, "x86_64-linux", "hello", Some(status))
-    }
 
     #[test]
     fn cancelled_status_is_resolved() {
         assert_eq!(
-            success_outcome(&build_with_status("cancelled"), id(42)),
+            success_outcome(&EffectiveBuildStatus::Cancelled, id(42)),
             CancelOutcome::Resolved("Cancellation initiated for build 42.".to_string())
         );
     }
@@ -243,18 +229,16 @@ mod tests {
     #[test]
     fn completed_status_is_resolved() {
         assert_eq!(
-            success_outcome(&build_with_status("completed"), id(42)),
-            CancelOutcome::Resolved(
-                "Build 42 is already completed; nothing to cancel.".to_string()
-            )
+            success_outcome(&EffectiveBuildStatus::Completed, id(42)),
+            CancelOutcome::Resolved("Build 42 already completed; nothing to cancel.".to_string())
         );
     }
 
     #[test]
     fn failed_status_is_resolved() {
         assert_eq!(
-            success_outcome(&build_with_status("failed"), id(42)),
-            CancelOutcome::Resolved("Build 42 is already failed; nothing to cancel.".to_string())
+            success_outcome(&EffectiveBuildStatus::Failed, id(42)),
+            CancelOutcome::Resolved("Build 42 already failed; nothing to cancel.".to_string())
         );
     }
 
@@ -263,10 +247,8 @@ mod tests {
         // `timed_out` is terminal, so it is an "already terminal" exit-0
         // outcome, not a contract violation.
         assert_eq!(
-            success_outcome(&build_with_status("timed_out"), id(42)),
-            CancelOutcome::Resolved(
-                "Build 42 is already timed_out; nothing to cancel.".to_string()
-            )
+            success_outcome(&EffectiveBuildStatus::TimedOut, id(42)),
+            CancelOutcome::Resolved("Build 42 already timed out; nothing to cancel.".to_string())
         );
     }
 
@@ -275,7 +257,7 @@ mod tests {
         // A 200 with a non-terminal status means the cancel was accepted but the
         // build has not yet stopped: a normal exit-0 outcome, not a retry.
         assert_eq!(
-            success_outcome(&build_with_status("running"), id(42)),
+            success_outcome(&EffectiveBuildStatus::Running, id(42)),
             CancelOutcome::Accepted(
                 indoc! {"
                     Cancellation accepted for build 42; it is running and not yet terminal.
@@ -287,11 +269,11 @@ mod tests {
 
     #[test]
     fn pending_status_is_accepted() {
-        // `pending` is an undispatched build's synthesized status: not in the
-        // `FactoryStatus` enum, but a known non-terminal outcome, so the cancel
-        // is accepted (exit 0) rather than read as a contract violation.
+        // `pending` is an undispatched build's effective status: a known
+        // non-terminal outcome, so the cancel is accepted (exit 0) rather than
+        // read as a contract violation.
         assert_eq!(
-            success_outcome(&build_with_status("pending"), id(42)),
+            success_outcome(&EffectiveBuildStatus::Pending, id(42)),
             CancelOutcome::Accepted(
                 indoc! {"
                     Cancellation accepted for build 42; it is pending and not yet terminal.
@@ -303,9 +285,12 @@ mod tests {
 
     #[test]
     fn out_of_vocabulary_status_is_unexpected() {
-        // Only a status outside the lifecycle vocabulary is a contract violation.
+        // Only a status outside the known vocabulary is a contract violation.
         assert_eq!(
-            success_outcome(&build_with_status("frobnicated"), id(42)),
+            success_outcome(
+                &EffectiveBuildStatus::Unknown("frobnicated".to_string()),
+                id(42)
+            ),
             CancelOutcome::Unexpected(
                 indoc! {"
                     The Flox Factory returned an unexpected status 'frobnicated' for build 42.
@@ -407,7 +392,12 @@ mod tests {
 
     #[test]
     fn render_human_prints_the_outcome_line() {
-        let build = make_build(42, "x86_64-linux", "hello", Some("running"));
+        let build = make_build(
+            42,
+            "x86_64-linux",
+            "hello",
+            Some(EffectiveBuildStatus::Running),
+        );
         assert_eq!(
             render(&build, "Cancellation initiated for build 42.", false).unwrap(),
             "Cancellation initiated for build 42.\n"
@@ -416,7 +406,12 @@ mod tests {
 
     #[test]
     fn render_json_emits_the_build_and_ignores_the_outcome() {
-        let build = make_build(42, "x86_64-linux", "hello", Some("running"));
+        let build = make_build(
+            42,
+            "x86_64-linux",
+            "hello",
+            Some(EffectiveBuildStatus::Running),
+        );
         let rendered = render(&build, "OUTCOME LINE", true).unwrap();
         // The JSON branch serializes the build and drops the human outcome
         // line. Assert the behavior of the branch, not serde's round-trip
@@ -432,7 +427,8 @@ mod tests {
 
     #[tokio::test]
     async fn successful_cancel_issues_delete_and_returns_ok() {
-        let client = StubFactoryClient::with_cancel(StubResult::Build("cancelled".to_string()));
+        let client =
+            StubFactoryClient::with_cancel(StubResult::Build(EffectiveBuildStatus::Cancelled));
         let args = Cancel {
             json: false,
             id: id(42),
@@ -478,7 +474,8 @@ mod tests {
         // A 200 with a non-terminal status means the cancel was accepted but the
         // build has not yet stopped: a normal success (exit 0) with a warning,
         // not a retryable error.
-        let client = StubFactoryClient::with_cancel(StubResult::Build("running".to_string()));
+        let client =
+            StubFactoryClient::with_cancel(StubResult::Build(EffectiveBuildStatus::Running));
         let args = Cancel {
             json: false,
             id: id(42),
@@ -505,7 +502,9 @@ mod tests {
         // A 200 whose status is outside the lifecycle vocabulary is a contract
         // violation, not a successful cancel: the verb returns exit 1 and emits
         // the error to stderr rather than printing the build to stdout.
-        let client = StubFactoryClient::with_cancel(StubResult::Build("frobnicated".to_string()));
+        let client = StubFactoryClient::with_cancel(StubResult::Build(
+            EffectiveBuildStatus::Unknown("frobnicated".to_string()),
+        ));
         let args = Cancel {
             json: false,
             id: id(42),
@@ -572,33 +571,6 @@ mod tests {
         assert_eq!(writer.to_string(), indoc! {"
             ✘ ERROR: Authentication was rejected by the Flox Factory.
             Run 'flox auth login' and try again.
-        "});
-    }
-
-    #[tokio::test]
-    async fn id_beyond_i64_max_is_not_found_without_a_request() {
-        // An ID above i64::MAX cannot name a real build. The stub would answer
-        // the DELETE successfully, so reaching the not-found path at all proves
-        // the range guard fired before any request — and no DELETE was issued.
-        let client = StubFactoryClient::with_cancel(StubResult::Build("cancelled".to_string()));
-        let args = Cancel {
-            json: false,
-            id: NonZeroU64::new(u64::MAX).unwrap(),
-        };
-
-        let (subscriber, writer) = test_subscriber_message_only();
-        let err = async { args.handle(&client).await.unwrap_err() }
-            .with_subscriber(subscriber)
-            .await;
-
-        assert!(err.is::<Exit>(), "expected an Exit error, got {err:?}");
-        assert!(
-            !client.cancel_was_called(),
-            "no DELETE should be issued for an out-of-range ID"
-        );
-        assert_eq!(writer.to_string(), indoc! {"
-            ✘ ERROR: No Flox Factory build found with ID 18446744073709551615.
-            Use 'flox factory list' to see existing builds.
         "});
     }
 }

--- a/cli/flox/src/commands/factory/list.rs
+++ b/cli/flox/src/commands/factory/list.rs
@@ -1,8 +1,19 @@
 use std::fmt;
+use std::str::FromStr;
 
-use anyhow::Result;
+use anyhow::{Result, anyhow, bail};
 use bpaf::Bpaf;
-use floxhub_client::{BuildFilters, BuildResponse, EffectiveBuildStatus, FactoryClientTrait};
+use chrono::{DateTime, Months, TimeDelta, Utc};
+use floxhub_client::{
+    AttrPathItem,
+    BuildFilters,
+    BuildResponse,
+    EffectiveBuildStatus,
+    FactoryClientTrait,
+    SourceCommitShaItem,
+    SystemItem,
+};
+use interim::{Dialect, Interval, parse_date_string, parse_duration};
 use serde::Serialize;
 use tracing::instrument;
 
@@ -12,8 +23,8 @@ use crate::utils::message::page_output;
 
 /// List Flox Factory builds.
 ///
-/// Each filter is repeatable and ORs its values; different filters AND together.
-/// An unfiltered invocation lists every build.
+/// Each filter except --since is repeatable and ORs its values; different
+/// filters AND together. An unfiltered invocation lists every build.
 #[derive(Debug, Clone, PartialEq, Bpaf)]
 pub struct List {
     /// Filter by build status; repeat to match any of several.
@@ -21,6 +32,27 @@ pub struct List {
     /// cancelled.
     #[bpaf(long, argument::<String>("STATUS"), parse(parse_status), many)]
     pub status: Vec<EffectiveBuildStatus>,
+
+    /// Filter by system; repeat to match any of several.
+    /// Examples: aarch64-darwin, aarch64-linux, x86_64-darwin, x86_64-linux.
+    /// A system the server does not know is reported with the values it does.
+    #[bpaf(long, argument::<String>("SYSTEM"), parse(parse_non_empty("System")), many)]
+    pub system: Vec<SystemItem>,
+
+    /// Filter by attribute path; a prefix matches; repeat to match any of
+    /// several.
+    #[bpaf(long, argument::<String>("PATH"), parse(parse_non_empty("Attribute path")), many)]
+    pub attr_path: Vec<AttrPathItem>,
+
+    /// Filter by source revision (commit SHA); a prefix matches; repeat to
+    /// match any of several.
+    #[bpaf(long("source-rev"), argument::<String>("REV"), parse(parse_non_empty("Source revision")), many)]
+    pub source_commit_sha: Vec<SourceCommitShaItem>,
+
+    /// Only builds created at or after this time, given as a duration counted
+    /// back from now ("7d"), a phrase ("yesterday"), or an ISO 8601 timestamp.
+    #[bpaf(long, argument::<String>("TIME"), parse(parse_since), optional)]
+    pub since: Option<DateTime<Utc>>,
 
     /// Display output as JSON
     #[bpaf(long)]
@@ -38,7 +70,10 @@ impl List {
 
         let filters = BuildFilters {
             status: self.status,
-            ..Default::default()
+            system: self.system,
+            attr_path: self.attr_path,
+            source_commit_sha: self.source_commit_sha,
+            since: self.since,
         };
 
         // Depage the full result set, mirroring `flox generations list`: the
@@ -65,8 +100,79 @@ impl List {
 /// Parse one `--status` value into a typed [`EffectiveBuildStatus`] at the
 /// CLI boundary. The type's `FromStr` is strict and its error names the
 /// accepted values, so the message is shown as-is.
-fn parse_status(s: String) -> Result<EffectiveBuildStatus, String> {
-    s.parse::<EffectiveBuildStatus>().map_err(|e| e.to_string())
+fn parse_status(s: String) -> Result<EffectiveBuildStatus> {
+    Ok(s.parse()?)
+}
+
+/// Build a bpaf `parse` function for one flag value, naming `noun` in either
+/// failure so a user passing several empty values can tell which flag was
+/// rejected.
+///
+/// The empty case gets its own message; any other constraint the parsed type
+/// enforces reports the type's own error, so the message stays truthful if
+/// the schema tightens.
+fn parse_non_empty<T>(noun: &'static str) -> impl Fn(String) -> Result<T>
+where
+    T: FromStr,
+    T::Err: fmt::Display,
+{
+    move |s: String| {
+        if s.is_empty() {
+            bail!("{noun} must not be empty.");
+        }
+        s.parse()
+            .map_err(|e| anyhow!("{noun} '{s}' is invalid: {e}."))
+    }
+}
+
+/// Fixes the reading of an ambiguous slash-date: `01/07/2026` is 7 January.
+const SINCE_DIALECT: Dialect = Dialect::Us;
+
+/// Parse the `--since` value at the CLI boundary, against the current time.
+fn parse_since(s: String) -> Result<DateTime<Utc>> {
+    resolve_since(&s, Utc::now())
+}
+
+/// Resolve a `--since` expression to the instant it names, relative to `now`.
+///
+/// A duration counts backwards, so `7d` and `7 days ago` name the same bound;
+/// anything else is read as an absolute date or timestamp. Resolving here means
+/// every page of one listing is sent the same bound, rather than a moving one.
+/// The bound must not lie in the future, which no build could satisfy.
+fn resolve_since(s: &str, now: DateTime<Utc>) -> Result<DateTime<Utc>> {
+    if s.is_empty() {
+        bail!("Time must not be empty.");
+    }
+
+    let resolved = match parse_duration(s) {
+        Ok(interval) => {
+            back_from(now, interval).ok_or_else(|| anyhow!("Time '{s}' is out of range."))?
+        },
+        Err(_) => parse_date_string(s, now, SINCE_DIALECT).map_err(|_| {
+            anyhow!("Time '{s}' is invalid; use a duration like '7d', a phrase like 'yesterday', or an ISO 8601 timestamp.")
+        })?,
+    };
+
+    if resolved > now {
+        bail!("Time '{s}' is in the future; '--since' names a point in the past.");
+    }
+
+    Ok(resolved)
+}
+
+/// Move `now` back by the interval's magnitude, whichever sign it carries.
+/// Months are subtracted as calendar months, so the day of the month and the
+/// time of day both survive.
+fn back_from(now: DateTime<Utc>, interval: Interval) -> Option<DateTime<Utc>> {
+    match interval {
+        Interval::Seconds(seconds) => {
+            now.checked_sub_signed(TimeDelta::try_seconds(seconds.unsigned_abs().into())?)
+        },
+        Interval::Days(days) => {
+            now.checked_sub_signed(TimeDelta::try_days(days.unsigned_abs().into())?)
+        },
+        Interval::Months(months) => now.checked_sub_months(Months::new(months.unsigned_abs())),
+    }
 }
 
 /// Render the builds as either pretty-printed JSON or a table.
@@ -233,13 +339,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn list_handler_forwards_status_filters() {
+    async fn list_handler_forwards_all_filters() {
         let client = StubFactoryClient::with_outcomes(
             StubResult::Build(EffectiveBuildStatus::Completed),
             StubResult::NotFound,
         );
         let args = List {
             status: vec![EffectiveBuildStatus::Running, EffectiveBuildStatus::Failed],
+            system: vec!["aarch64-darwin".parse().unwrap()],
+            attr_path: vec!["hello".parse().unwrap()],
+            source_commit_sha: vec!["abc123".parse().unwrap()],
+            since: Some("2026-07-17T12:00:00Z".parse().unwrap()),
             json: false,
             no_pager: true,
         };
@@ -250,7 +360,10 @@ mod tests {
             client.last_filters(),
             Some(BuildFilters {
                 status: vec![EffectiveBuildStatus::Running, EffectiveBuildStatus::Failed],
-                ..Default::default()
+                system: vec!["aarch64-darwin".parse().unwrap()],
+                attr_path: vec!["hello".parse().unwrap()],
+                source_commit_sha: vec!["abc123".parse().unwrap()],
+                since: Some("2026-07-17T12:00:00Z".parse().unwrap()),
             })
         );
     }
@@ -277,5 +390,119 @@ mod tests {
             ),
             "unexpected parse failure: {message}"
         );
+    }
+
+    /// Every filter rejects an empty value at the boundary, before it becomes
+    /// an unmatchable filter or a doomed request, and each names itself so a
+    /// user passing several empty values can tell which one was rejected.
+    #[test]
+    fn empty_filter_values_are_rejected_and_name_their_flag() {
+        // `--since` is optional rather than repeatable, so its boundary parse
+        // applies inside the optional lift; it is covered here to pin that the
+        // lift does not skip the parse.
+        let cases = [
+            ("--attr-path", "Attribute path must not be empty."),
+            ("--source-rev", "Source revision must not be empty."),
+            ("--system", "System must not be empty."),
+            ("--since", "Time must not be empty."),
+        ];
+
+        for (flag, expected) in cases {
+            let Err(failure) = list().to_options().run_inner(&[flag, ""][..]) else {
+                panic!("expected an empty {flag} to fail parsing");
+            };
+            let message = failure.unwrap_stderr().replace('\n', " ");
+            assert!(
+                message.contains(expected),
+                "expected {flag} to report {expected:?}, got: {message}"
+            );
+        }
+    }
+
+    fn utc(s: &str) -> DateTime<Utc> {
+        s.parse().expect("test timestamp should parse")
+    }
+
+    /// The clock the resolver tests run against, so they check its arithmetic
+    /// rather than the machine's current time. A Friday, strictly after
+    /// midnight, which [`a_time_that_cannot_be_used_is_rejected_with_a_reason`]
+    /// relies on: a same-weekday name resolves to today's midnight and only
+    /// advances a week once that midnight is already behind `now`.
+    fn now() -> DateTime<Utc> {
+        utc("2026-07-24T12:00:00Z")
+    }
+
+    /// `--since` names a lower bound in the past, so a duration is an offset
+    /// backwards from now however it is spelled.
+    #[test]
+    fn a_duration_counts_backwards_from_now() {
+        let resolved: Vec<_> = ["30s", "15m", "2h", "7d", "3w", "7 days", "7 days ago"]
+            .iter()
+            .map(|input| resolve_since(input, now()).map_err(|e| e.to_string()))
+            .collect();
+
+        assert_eq!(resolved, vec![
+            Ok(utc("2026-07-24T11:59:30Z")),
+            Ok(utc("2026-07-24T11:45:00Z")),
+            Ok(utc("2026-07-24T10:00:00Z")),
+            Ok(utc("2026-07-17T12:00:00Z")),
+            Ok(utc("2026-07-03T12:00:00Z")),
+            Ok(utc("2026-07-17T12:00:00Z")),
+            Ok(utc("2026-07-17T12:00:00Z")),
+        ]);
+    }
+
+    /// A year and a month are calendar quantities rather than fixed spans of
+    /// days, and neither disturbs the time of day.
+    #[test]
+    fn a_year_and_a_month_are_calendar_quantities() {
+        let resolved: Vec<_> = ["1y", "1 month", "3 months ago"]
+            .iter()
+            .map(|input| resolve_since(input, now()).map_err(|e| e.to_string()))
+            .collect();
+
+        assert_eq!(resolved, vec![
+            Ok(utc("2025-07-24T12:00:00Z")),
+            Ok(utc("2026-06-24T12:00:00Z")),
+            Ok(utc("2026-04-24T12:00:00Z")),
+        ]);
+    }
+
+    /// Anything that is not a duration names an instant outright. A value
+    /// without an offset is read as UTC.
+    #[test]
+    fn an_absolute_value_names_its_own_instant() {
+        let resolved: Vec<_> = [
+            "2026-07-01",
+            "2026-07-01T06:30:00Z",
+            "2026-07-01T06:30:00+02:00",
+            "2026-07-01 06:30",
+        ]
+        .iter()
+        .map(|input| resolve_since(input, now()).map_err(|e| e.to_string()))
+        .collect();
+
+        assert_eq!(resolved, vec![
+            Ok(utc("2026-07-01T00:00:00Z")),
+            Ok(utc("2026-07-01T06:30:00Z")),
+            Ok(utc("2026-07-01T04:30:00Z")),
+            Ok(utc("2026-07-01T06:30:00Z")),
+        ]);
+    }
+
+    /// Each rejection says what is wrong with the value and offers a spelling
+    /// that works, without exposing the parser's own diagnostics.
+    #[test]
+    fn a_time_that_cannot_be_used_is_rejected_with_a_reason() {
+        let failures: Vec<_> = ["banana", "friday", "2027-01-01"]
+            .iter()
+            .map(|input| resolve_since(input, now()).unwrap_err().to_string())
+            .collect();
+
+        assert_eq!(failures, vec![
+            "Time 'banana' is invalid; use a duration like '7d', a phrase like 'yesterday', or an ISO 8601 timestamp.".to_string(),
+            "Time 'friday' is in the future; '--since' names a point in the past.".to_string(),
+            "Time '2027-01-01' is in the future; '--since' names a point in the past.".to_string(),
+        ]);
     }
 }

--- a/cli/flox/src/commands/factory/list.rs
+++ b/cli/flox/src/commands/factory/list.rs
@@ -1,9 +1,8 @@
 use std::fmt;
-use std::str::FromStr;
 
 use anyhow::Result;
 use bpaf::Bpaf;
-use floxhub_client::{BuildResponse, FactoryClientTrait, FactoryStatus};
+use floxhub_client::{BuildFilters, BuildResponse, EffectiveBuildStatus, FactoryClientTrait};
 use serde::Serialize;
 use tracing::instrument;
 
@@ -11,57 +10,17 @@ use super::{effective_status, effective_updated_at};
 use crate::subcommand_metric;
 use crate::utils::message::page_output;
 
-/// CLI-boundary filter for `--status`, extending the seven wire `Status`
-/// values with the server-side keyword `undispatched` (builds where
-/// `task_id IS NULL`).
-///
-/// `undispatched` is accepted by the GET /builds query parameter but is NOT
-/// a value of the `Status` enum. It is the mechanism for filtering builds
-/// the CLI renders as "pending (not dispatched)". The richer list-query
-/// contract — including effective-status matching semantics and what
-/// `undispatched` precisely means — is owned by ECO-97.
-#[derive(Debug, Clone, PartialEq)]
-pub enum StatusFilter {
-    /// One of the seven task lifecycle statuses on the wire.
-    Status(FactoryStatus),
-    /// Server-side keyword: builds with no dispatched task (`task_id IS NULL`).
-    Undispatched,
-}
-
-impl FromStr for StatusFilter {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s == "undispatched" {
-            return Ok(StatusFilter::Undispatched);
-        }
-        FactoryStatus::from_str(s)
-            .map(StatusFilter::Status)
-            .map_err(|_| {
-                format!("Invalid status '{s}'; valid values are: queued, dispatching, running, completed, failed, timed_out, cancelled, undispatched.")
-            })
-    }
-}
-
-impl fmt::Display for StatusFilter {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            StatusFilter::Status(s) => fmt::Display::fmt(s, f),
-            StatusFilter::Undispatched => f.write_str("undispatched"),
-        }
-    }
-}
-
 /// List Flox Factory builds.
+///
+/// Each filter is repeatable and ORs its values; different filters AND together.
+/// An unfiltered invocation lists every build.
 #[derive(Debug, Clone, PartialEq, Bpaf)]
 pub struct List {
-    /// Filter by build status.
-    /// Valid values: queued, dispatching, running, completed, failed,
-    /// timed_out, cancelled, undispatched.
-    /// Use "undispatched" to show builds that have not yet been sent
-    /// to Build Coordinator (displayed as "pending (not dispatched)").
-    #[bpaf(long)]
-    pub status: Option<StatusFilter>,
+    /// Filter by build status; repeat to match any of several.
+    /// Valid values: pending, running, completed, failed, timed_out,
+    /// cancelled.
+    #[bpaf(long, argument::<String>("STATUS"), parse(parse_status), many)]
+    pub status: Vec<EffectiveBuildStatus>,
 
     /// Display output as JSON
     #[bpaf(long)]
@@ -77,16 +36,16 @@ impl List {
     pub async fn handle(self, client: &impl FactoryClientTrait) -> Result<()> {
         subcommand_metric!("factory::list");
 
-        // Convert the validated filter to its wire string. The seven Status
-        // values use their own Display ("running", etc.); "undispatched" is
-        // forwarded as the literal keyword the server accepts.
-        let status_str = self.status.as_ref().map(|f| f.to_string());
+        let filters = BuildFilters {
+            status: self.status,
+            ..Default::default()
+        };
 
         // Depage the full result set, mirroring `flox generations list`: the
         // operator sees every matching build at once and scrolls with the
         // pager, rather than stepping server-side pages by hand.
         let builds = client
-            .list_builds(status_str.as_deref())
+            .list_builds(&filters)
             .await
             .map_err(|e| super::user_facing_error(e, None))?;
 
@@ -101,6 +60,13 @@ impl List {
 
         page_output(output)
     }
+}
+
+/// Parse one `--status` value into a typed [`EffectiveBuildStatus`] at the
+/// CLI boundary. The type's `FromStr` is strict and its error names the
+/// accepted values, so the message is shown as-is.
+fn parse_status(s: String) -> Result<EffectiveBuildStatus, String> {
+    s.parse::<EffectiveBuildStatus>().map_err(|e| e.to_string())
 }
 
 /// Render the builds as either pretty-printed JSON or a table.
@@ -203,40 +169,113 @@ impl fmt::Display for BuildListDisplay {
 
 #[cfg(test)]
 mod tests {
+    use bpaf::Parser;
     use indoc::indoc;
     use pretty_assertions::assert_eq;
 
     use super::*;
-    use crate::commands::factory::test_helpers::make_build;
-
-    #[test]
-    fn status_filter_parses_undispatched_keyword() {
-        let f: StatusFilter = "undispatched".parse().unwrap();
-        assert_eq!(f, StatusFilter::Undispatched);
-    }
-
-    #[test]
-    fn status_filter_rejects_invalid_value_with_named_values() {
-        let err = "garbage".parse::<StatusFilter>().unwrap_err();
-        assert_eq!(
-            err,
-            "Invalid status 'garbage'; valid values are: queued, dispatching, running, completed, failed, timed_out, cancelled, undispatched."
-        );
-    }
+    use crate::commands::factory::test_helpers::{StubFactoryClient, StubResult, make_build};
 
     #[test]
     fn list_display_renders_table_exactly() {
         // A dispatched build shows its task's updated_at; an undispatched build
         // has no task, so UPDATED falls back to the build's created_at.
         let builds = vec![
-            make_build(1, "x86_64-linux", "hello", Some("running")),
+            make_build(
+                1,
+                "x86_64-linux",
+                "hello",
+                Some(EffectiveBuildStatus::Running),
+            ),
             make_build(2, "aarch64-darwin", "ripgrep", None),
         ];
         let display = BuildListDisplay::from(builds);
         assert_eq!(display.to_string(), indoc! {"
-            BUILD ID  ATTR PATH  SYSTEM          STATUS                    UPDATED
-            1         hello      x86_64-linux    running                   2025-01-01T00:00:01+00:00
-            2         ripgrep    aarch64-darwin  pending (not dispatched)  2025-01-01T00:00:00+00:00
+            BUILD ID  ATTR PATH  SYSTEM          STATUS   UPDATED
+            1         hello      x86_64-linux    running  2025-01-01T00:00:01+00:00
+            2         ripgrep    aarch64-darwin  pending  2025-01-01T00:00:00+00:00
         "});
+    }
+
+    #[test]
+    fn list_display_renders_new_status_labels() {
+        // The labels introduced with the typed status: a timed-out build reads
+        // `timed_out` (not `failed`), a pre-dispatch cancel reads `cancelled`
+        // (not `pending`), and an unrecognized status renders tolerantly as
+        // `unknown: <value>` rather than blanking the row.
+        let builds = vec![
+            make_build(
+                3,
+                "x86_64-linux",
+                "curl",
+                Some(EffectiveBuildStatus::TimedOut),
+            ),
+            make_build(
+                4,
+                "aarch64-darwin",
+                "jq",
+                Some(EffectiveBuildStatus::Cancelled),
+            ),
+            make_build(
+                5,
+                "x86_64-linux",
+                "wget",
+                Some(EffectiveBuildStatus::Unknown("frobnicated".to_string())),
+            ),
+        ];
+        let display = BuildListDisplay::from(builds);
+        assert_eq!(display.to_string(), indoc! {"
+            BUILD ID  ATTR PATH  SYSTEM          STATUS                UPDATED
+            3         curl       x86_64-linux    timed_out             2025-01-01T00:00:01+00:00
+            4         jq         aarch64-darwin  cancelled             2025-01-01T00:00:00+00:00
+            5         wget       x86_64-linux    unknown: frobnicated  2025-01-01T00:00:00+00:00
+        "});
+    }
+
+    #[tokio::test]
+    async fn list_handler_forwards_status_filters() {
+        let client = StubFactoryClient::with_outcomes(
+            StubResult::Build(EffectiveBuildStatus::Completed),
+            StubResult::NotFound,
+        );
+        let args = List {
+            status: vec![EffectiveBuildStatus::Running, EffectiveBuildStatus::Failed],
+            json: false,
+            no_pager: true,
+        };
+
+        args.handle(&client).await.unwrap();
+
+        assert_eq!(
+            client.last_filters(),
+            Some(BuildFilters {
+                status: vec![EffectiveBuildStatus::Running, EffectiveBuildStatus::Failed],
+                ..Default::default()
+            })
+        );
+    }
+
+    #[test]
+    fn unknown_status_is_rejected_at_parse_time() {
+        // The status vocabulary is pinned by the vendored schema, so an unknown
+        // value is a definite user error caught at the flag boundary, and the
+        // failure names the accepted values.
+        let failure = list()
+            .to_options()
+            .run_inner(&["--status", "garbage"][..])
+            .expect_err("expected an unknown --status to fail parsing");
+        // bpaf line-wraps the rendered failure, so compare with newlines
+        // collapsed to spaces.
+        let message = failure.unwrap_stderr().replace('\n', " ");
+        assert!(
+            message.contains("Invalid status 'garbage'"),
+            "unexpected parse failure: {message}"
+        );
+        assert!(
+            message.contains(
+                "valid values are: pending, running, completed, failed, timed_out, cancelled"
+            ),
+            "unexpected parse failure: {message}"
+        );
     }
 }

--- a/cli/flox/src/commands/factory/logs.rs
+++ b/cli/flox/src/commands/factory/logs.rs
@@ -1,10 +1,9 @@
 use std::io::{BufWriter, Write};
-use std::num::NonZeroU64;
 
 use anstream::adapter::StripBytes;
 use anyhow::Result;
 use bpaf::Bpaf;
-use floxhub_client::{FactoryClientError, FactoryClientTrait};
+use floxhub_client::{BuildId, FactoryClientError, FactoryClientTrait};
 use futures::StreamExt;
 use tracing::instrument;
 
@@ -20,7 +19,7 @@ pub struct Logs {
 
     /// Build ID to fetch logs for
     #[bpaf(positional("ID"))]
-    pub id: NonZeroU64,
+    pub id: BuildId,
 }
 
 impl Logs {
@@ -28,7 +27,7 @@ impl Logs {
     pub async fn handle(self, client: &impl FactoryClientTrait) -> Result<()> {
         subcommand_metric!("factory::logs");
 
-        let mut stream = match client.get_build_logs(self.id.get() as i64).await {
+        let mut stream = match client.get_build_logs(self.id).await {
             Ok(stream) => stream,
             Err(FactoryClientError::NotFound) => {
                 message::error(format!("No logs available for build {}.", self.id));
@@ -95,8 +94,6 @@ impl<W: Write> LogWriter<W> {
 
 #[cfg(test)]
 mod tests {
-    use std::num::NonZeroU64;
-
     use flox_rust_sdk::utils::logging::test_helpers::test_subscriber_message_only;
     use pretty_assertions::assert_eq;
     use tracing::instrument::WithSubscriber;
@@ -187,7 +184,7 @@ mod tests {
         let client = StubFactoryClient::with_not_found();
         let args = Logs {
             raw: false,
-            id: NonZeroU64::new(42).unwrap(),
+            id: "42".parse().unwrap(),
         };
 
         let (subscriber, writer) = test_subscriber_message_only();

--- a/cli/flox/src/commands/factory/mod.rs
+++ b/cli/flox/src/commands/factory/mod.rs
@@ -11,34 +11,22 @@ mod status;
 use anyhow::{Result, anyhow};
 use bpaf::Bpaf;
 use flox_rust_sdk::flox::Flox;
-use floxhub_client::{BuildResponse, FactoryClientError};
+use floxhub_client::{BuildResponse, EffectiveBuildStatus, FactoryClientError};
 use indoc::indoc;
 use tracing::instrument;
 
 use crate::commands::display_help;
 
-/// The label shown for an undispatched build's effective status.
+/// Compute the effective status label for a build from its server-computed
+/// `status`.
 ///
-/// A build with no task has never been dispatched to Build Coordinator, so it
-/// has no task lifecycle status. `pending` is synthesized by the CLI — it is
-/// NOT a value of the API `Status` enum (`queued`, `dispatching`, `running`,
-/// `completed`, `failed`, `timed_out`, `cancelled`), so the "(not dispatched)"
-/// suffix keeps a user from typing it as a `--status` filter and getting an
-/// empty result or 422.
-const UNDISPATCHED_STATUS_LABEL: &str = "pending (not dispatched)";
-
-/// Compute the effective status string for a build.
-///
-/// Returns the task's lifecycle status when the build has been dispatched
-/// (a task exists), otherwise the synthesized undispatched label. An
-/// undispatched build always reads as pending — never as a terminal status —
-/// because no task lifecycle has begun.
+/// An unrecognized future status renders as `unknown: <value>` rather than
+/// blanking the row; every other status renders as its wire word.
 fn effective_status(build: &BuildResponse) -> String {
-    build
-        .task
-        .as_ref()
-        .map(|task| task.status.clone())
-        .unwrap_or_else(|| UNDISPATCHED_STATUS_LABEL.to_string())
+    match &build.status {
+        EffectiveBuildStatus::Unknown(value) => format!("unknown: {value}"),
+        status => status.to_string(),
+    }
 }
 
 /// Compute the effective "last updated" timestamp for a build, as an RFC 3339
@@ -129,12 +117,16 @@ impl FactoryCommands {
 pub(crate) mod test_helpers {
     //! Shared test fixtures for the factory verb handler tests.
 
+    use std::sync::Mutex;
     use std::sync::atomic::{AtomicBool, Ordering};
 
     use chrono::TimeZone;
-    use factory_api_v1::types::TaskResponse;
+    use factory_api_v1::types::{TaskErrorClass, TaskResponse, TaskStatus};
     use floxhub_client::{
+        BuildFilters,
+        BuildId,
         BuildResponse,
+        EffectiveBuildStatus,
         FactoryApiError,
         FactoryByteStream,
         FactoryClientError,
@@ -142,32 +134,48 @@ pub(crate) mod test_helpers {
         FactoryErrorResponse,
     };
 
-    /// Construct a `BuildResponse` fixture. A `Some(task_status)` attaches a
-    /// dispatch task with that lifecycle status; `None` leaves the build
-    /// undispatched (no task).
+    /// Construct a `BuildResponse` fixture whose effective `status` is the given
+    /// value, defaulting to pre-dispatch `pending` for `None`.
+    ///
+    /// The attached task mirrors the server's persisted shape: a pending or
+    /// pre-dispatch-cancelled build carries no task; a timed-out build is
+    /// persisted as a failed task carrying the `timeout` error class; the other
+    /// dispatched states carry the matching task lifecycle status.
     pub fn make_build(
         id: i64,
         system: &str,
         attr_path: &str,
-        task_status: Option<&str>,
+        status: Option<EffectiveBuildStatus>,
     ) -> BuildResponse {
-        let task = task_status.map(|s| TaskResponse {
+        let status = status.unwrap_or(EffectiveBuildStatus::Pending);
+
+        let task_footprint = match &status {
+            EffectiveBuildStatus::Running => Some((TaskStatus::Running, None)),
+            EffectiveBuildStatus::Completed => Some((TaskStatus::Completed, None)),
+            EffectiveBuildStatus::Failed => Some((TaskStatus::Failed, None)),
+            EffectiveBuildStatus::TimedOut => {
+                Some((TaskStatus::Failed, Some(TaskErrorClass::Timeout)))
+            },
+            EffectiveBuildStatus::Pending
+            | EffectiveBuildStatus::Cancelled
+            | EffectiveBuildStatus::Unknown(_) => None,
+        };
+
+        let task = task_footprint.map(|(task_status, error_class)| TaskResponse {
             task_id: id,
             task_type: "dispatch_build".to_string(),
-            status: s.to_string(),
+            status: task_status,
             created_at: chrono::Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap(),
             updated_at: chrono::Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 1).unwrap(),
             completed_at: None,
-            error_class: None,
+            error_class,
             error_message: None,
             started_at: None,
         });
 
         BuildResponse {
             build_id: id,
-            // Mirrors the server's effective status: the task lifecycle status
-            // when dispatched, else the pre-dispatch default of "pending".
-            status: task_status.unwrap_or("pending").to_string(),
+            status,
             system: system.to_string(),
             attr_path: attr_path.to_string(),
             catalog_name: "my-catalog".to_string(),
@@ -190,8 +198,8 @@ pub(crate) mod test_helpers {
     /// transport path is covered by the pure classifier tests instead.
     #[derive(Clone)]
     pub enum StubResult {
-        /// Return a build whose top-level `status` is this string.
-        Build(String),
+        /// Return a build whose effective `status` is this value.
+        Build(EffectiveBuildStatus),
         /// Return [`FactoryClientError::NotFound`].
         NotFound,
         /// Return [`FactoryClientError::AuthRejected`].
@@ -203,11 +211,11 @@ pub(crate) mod test_helpers {
     impl StubResult {
         fn realize(&self) -> Result<BuildResponse, FactoryClientError> {
             match self {
-                // Build the fixture coherently: `Some(status)` sets both the
-                // task lifecycle status and the top-level status, preserving
-                // `make_build`'s invariant rather than mutating after the fact.
+                // Build the fixture coherently from the effective status,
+                // preserving `make_build`'s server-shaped invariant rather than
+                // mutating after the fact.
                 StubResult::Build(status) => {
-                    Ok(make_build(1, "x86_64-linux", "hello", Some(status)))
+                    Ok(make_build(1, "x86_64-linux", "hello", Some(status.clone())))
                 },
                 StubResult::NotFound => Err(FactoryClientError::NotFound),
                 StubResult::AuthRejected => Err(FactoryClientError::AuthRejected(stub_api_error())),
@@ -228,13 +236,15 @@ pub(crate) mod test_helpers {
     /// In-test stub implementing [`FactoryClientTrait`].
     ///
     /// Drives `get_build` (the `status` lookup) and `cancel_build` (the DELETE)
-    /// to independent [`StubResult`] outcomes, and records whether the DELETE was
-    /// issued so a cancel test can assert the range guard short-circuits before
-    /// it.
+    /// to independent [`StubResult`] outcomes, records whether the DELETE was
+    /// issued, and captures the last [`BuildFilters`] passed to `list_builds`
+    /// so a list test can assert the CLI's filter translation without a mock
+    /// server.
     pub struct StubFactoryClient {
         get_build: StubResult,
         cancel_build: StubResult,
         cancel_called: AtomicBool,
+        last_filters: Mutex<Option<BuildFilters>>,
     }
 
     impl StubFactoryClient {
@@ -250,6 +260,7 @@ pub(crate) mod test_helpers {
                 get_build,
                 cancel_build,
                 cancel_called: AtomicBool::new(false),
+                last_filters: Mutex::new(None),
             }
         }
 
@@ -263,13 +274,19 @@ pub(crate) mod test_helpers {
         pub fn cancel_was_called(&self) -> bool {
             self.cancel_called.load(Ordering::SeqCst)
         }
+
+        /// The [`BuildFilters`] from the most recent `list_builds` call, if any.
+        pub fn last_filters(&self) -> Option<BuildFilters> {
+            self.last_filters.lock().unwrap().clone()
+        }
     }
 
     impl FactoryClientTrait for StubFactoryClient {
         async fn list_builds(
             &self,
-            _status: Option<&str>,
+            filters: &BuildFilters,
         ) -> Result<floxhub_client::ResultsPage<BuildResponse>, FactoryClientError> {
+            *self.last_filters.lock().unwrap() = Some(filters.clone());
             // Mirror the get_build outcome's error, if any, so a not-found stub
             // stays not-found across endpoints; otherwise an empty page.
             self.get_build.realize()?;
@@ -279,18 +296,21 @@ pub(crate) mod test_helpers {
             })
         }
 
-        async fn get_build(&self, _build_id: i64) -> Result<BuildResponse, FactoryClientError> {
+        async fn get_build(&self, _build_id: BuildId) -> Result<BuildResponse, FactoryClientError> {
             self.get_build.realize()
         }
 
-        async fn cancel_build(&self, _build_id: i64) -> Result<BuildResponse, FactoryClientError> {
+        async fn cancel_build(
+            &self,
+            _build_id: BuildId,
+        ) -> Result<BuildResponse, FactoryClientError> {
             self.cancel_called.store(true, Ordering::SeqCst);
             self.cancel_build.realize()
         }
 
         async fn get_build_logs(
             &self,
-            _build_id: i64,
+            _build_id: BuildId,
         ) -> Result<FactoryByteStream, FactoryClientError> {
             // Mirror the get_build outcome's error, if any, so a not-found stub
             // stays not-found across endpoints; otherwise serve the canned stream.

--- a/cli/flox/src/commands/factory/status.rs
+++ b/cli/flox/src/commands/factory/status.rs
@@ -46,8 +46,7 @@ impl Status {
 /// Render a single build as either raw JSON or a human-readable table.
 ///
 /// The JSON form is intentionally the bare [`BuildResponse`] object, with no
-/// surrounding envelope: a single build has no pagination to report, unlike the
-/// `list` verb whose JSON form carries the page envelope.
+/// surrounding envelope: a single build has no pagination to report.
 fn render(build: BuildResponse, json: bool) -> Result<String> {
     if json {
         Ok(format!("{}\n", serde_json::to_string_pretty(&build)?))

--- a/cli/flox/src/commands/factory/status.rs
+++ b/cli/flox/src/commands/factory/status.rs
@@ -1,8 +1,6 @@
-use std::num::NonZeroU64;
-
 use anyhow::Result;
 use bpaf::Bpaf;
-use floxhub_client::{BuildResponse, FactoryClientTrait};
+use floxhub_client::{BuildId, BuildResponse, FactoryClientTrait};
 use indoc::formatdoc;
 use serde::Serialize;
 use tracing::instrument;
@@ -19,7 +17,7 @@ pub struct Status {
 
     /// Build ID to query
     #[bpaf(positional("ID"))]
-    pub id: NonZeroU64,
+    pub id: BuildId,
 }
 
 impl Status {
@@ -27,16 +25,16 @@ impl Status {
     pub async fn handle(self, client: &impl FactoryClientTrait) -> Result<()> {
         subcommand_metric!("factory::status");
 
-        let build = client.get_build(self.id.get() as i64).await.map_err(|e| {
-            super::user_facing_error(
-                e,
-                Some(formatdoc! {"
-                    No Flox Factory build found with ID {id}.
-                    Use 'flox factory list' to see existing builds.",
-                    id = self.id,
-                }),
-            )
-        })?;
+        let not_found = formatdoc! {"
+            No Flox Factory build found with ID {id}.
+            Use 'flox factory list' to see existing builds.",
+            id = self.id,
+        };
+
+        let build = client
+            .get_build(self.id)
+            .await
+            .map_err(|e| super::user_facing_error(e, Some(not_found)))?;
 
         print!("{}", render(build, self.json)?);
         Ok(())
@@ -95,8 +93,7 @@ impl std::fmt::Display for BuildStatusDisplay {
 
 #[cfg(test)]
 mod tests {
-    use std::num::NonZeroU64;
-
+    use floxhub_client::EffectiveBuildStatus;
     use indoc::indoc;
     use pretty_assertions::assert_eq;
 
@@ -107,7 +104,7 @@ mod tests {
     async fn status_renders_not_found_message() {
         let client = StubFactoryClient::with_not_found();
         let args = Status {
-            id: NonZeroU64::new(42).unwrap(),
+            id: "42".parse().unwrap(),
             json: false,
         };
 
@@ -118,8 +115,13 @@ mod tests {
     }
 
     #[test]
-    fn status_table_uses_task_status_when_dispatched() {
-        let build = make_build(42, "x86_64-linux", "hello", Some("running"));
+    fn status_table_shows_effective_status_when_dispatched() {
+        let build = make_build(
+            42,
+            "x86_64-linux",
+            "hello",
+            Some(EffectiveBuildStatus::Running),
+        );
         assert_eq!(render(build, false).unwrap(), indoc! {"
             Build ID:      42
             System:        x86_64-linux
@@ -131,14 +133,14 @@ mod tests {
     }
 
     #[test]
-    fn status_table_marks_undispatched_build_distinctly() {
+    fn status_table_shows_pending_before_dispatch() {
         let build = make_build(42, "x86_64-linux", "hello", None);
         assert_eq!(render(build, false).unwrap(), indoc! {"
             Build ID:      42
             System:        x86_64-linux
             Attr path:     hello
             Catalog:       my-catalog
-            Status:        pending (not dispatched)
+            Status:        pending
             Created:       2025-01-01T00:00:00+00:00
         "});
     }

--- a/cli/floxhub-client/src/factory.rs
+++ b/cli/floxhub-client/src/factory.rs
@@ -8,9 +8,19 @@
 //! is implemented for [`FloxhubClient`]. Callers construct a [`FloxhubClient`]
 //! and use it for both catalog and factory operations.
 
+use std::fmt;
 use std::num::{NonZeroU32, NonZeroU64};
+use std::str::FromStr;
 
-use factory_api_v1::types::{BuildResponse, ErrorResponse};
+use chrono::{DateTime, Utc};
+use factory_api_v1::types::{
+    AttrPathItem,
+    BuildResponse,
+    EffectiveBuildStatus,
+    ErrorResponse,
+    SourceCommitShaItem,
+    SystemItem,
+};
 use factory_api_v1::{ByteStream, Error as APIError, ResponseValue};
 
 use crate::client::{collect_all_results, make_depaging_stream};
@@ -173,6 +183,80 @@ fn classify_build_error(err: FactoryClientError) -> FactoryClientError {
 }
 
 // ---------------------------------------------------------------------------
+// BuildId
+// ---------------------------------------------------------------------------
+
+/// A Flox Factory build ID.
+///
+/// Server build IDs are positive `i64`. Parsing rejects zero, negative,
+/// non-numeric, and out-of-range values, so a holder only ever carries an ID
+/// the server could have assigned.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct BuildId(i64);
+
+impl From<BuildId> for i64 {
+    fn from(id: BuildId) -> Self {
+        id.0
+    }
+}
+
+/// Rejection of a string that does not name a possible build ID.
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+#[error("Invalid build ID '{0}'; expected a positive integer.")]
+pub struct ParseBuildIdError(String);
+
+impl FromStr for BuildId {
+    type Err = ParseBuildIdError;
+
+    /// Accept only a positive `i64`. Parsing as `i64` first rejects values
+    /// above `i64::MAX` as overflow rather than wrapping them onto the wire.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.parse::<i64>() {
+            Ok(id) if id >= 1 => Ok(BuildId(id)),
+            _ => Err(ParseBuildIdError(s.to_string())),
+        }
+    }
+}
+
+impl fmt::Display for BuildId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// BuildFilters
+// ---------------------------------------------------------------------------
+
+/// Server-side filters for [`FactoryClientTrait::list_builds`], one field per
+/// query parameter.
+///
+/// Every field holds an already-parsed value: the prefix and system fields are
+/// the generated newtypes, which the schema pins as non-empty, while the status
+/// vocabulary and the `since` instant are parsed at the CLI flag boundary.
+/// Empty collections and `None` mean "no
+/// filter": a default `BuildFilters` requests every build, and the emitted
+/// request omits the filter parameters entirely, so it is byte-identical to an
+/// unfiltered call. The server ORs the values within a field (any match) and
+/// ANDs across fields (all must match).
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct BuildFilters {
+    /// Match builds whose effective status is any of these.
+    pub status: Vec<EffectiveBuildStatus>,
+    /// Match builds for any of these systems, compared exactly. The server owns
+    /// the system vocabulary and rejects a name outside it.
+    pub system: Vec<SystemItem>,
+    /// Match builds whose attribute path starts with any of these prefixes.
+    pub attr_path: Vec<AttrPathItem>,
+    /// Match builds whose source commit SHA starts with any of these prefixes.
+    pub source_commit_sha: Vec<SourceCommitShaItem>,
+    /// Restrict to builds created at or after this instant. Resolving a time
+    /// expression to an instant is the caller's job, so every page of one
+    /// listing is evaluated against the same bound.
+    pub since: Option<DateTime<Utc>>,
+}
+
+// ---------------------------------------------------------------------------
 // FactoryClientTrait
 // ---------------------------------------------------------------------------
 
@@ -183,24 +267,24 @@ fn classify_build_error(err: FactoryClientError) -> FactoryClientError {
 /// HTTP types contained within the `floxhub-client` crate.
 #[allow(async_fn_in_trait)]
 pub trait FactoryClientTrait {
-    /// Return all builds across pages, optionally filtered by status.
+    /// Return all builds across pages, narrowed by `filters`.
     async fn list_builds(
         &self,
-        status: Option<&str>,
+        filters: &BuildFilters,
     ) -> Result<ResultsPage<BuildResponse>, FactoryClientError>;
 
-    /// Fetch a single build by its numeric ID.
-    async fn get_build(&self, build_id: i64) -> Result<BuildResponse, FactoryClientError>;
+    /// Fetch a single build by its ID.
+    async fn get_build(&self, build_id: BuildId) -> Result<BuildResponse, FactoryClientError>;
 
-    /// Cancel a single build by its numeric ID (DELETE).
+    /// Cancel a single build by its ID (DELETE).
     ///
     /// Idempotent: a satisfied-intent cancel returns the build with its
     /// effective `status`; the caller reads that field to distinguish a
     /// just-initiated cancellation from an already-terminal build.
-    async fn cancel_build(&self, build_id: i64) -> Result<BuildResponse, FactoryClientError>;
+    async fn cancel_build(&self, build_id: BuildId) -> Result<BuildResponse, FactoryClientError>;
 
     /// Proxy the raw log stream for a build.
-    async fn get_build_logs(&self, build_id: i64) -> Result<ByteStream, FactoryClientError>;
+    async fn get_build_logs(&self, build_id: BuildId) -> Result<ByteStream, FactoryClientError>;
 }
 
 // ---------------------------------------------------------------------------
@@ -210,16 +294,32 @@ pub trait FactoryClientTrait {
 impl FactoryClientTrait for crate::FloxhubClient {
     async fn list_builds(
         &self,
-        status: Option<&str>,
+        filters: &BuildFilters,
     ) -> Result<ResultsPage<BuildResponse>, FactoryClientError> {
+        // Map empty collections to None so an unfiltered call omits the query
+        // parameter entirely. These references are Copy, so the per-page
+        // closure reuses them each call.
+        let status = (!filters.status.is_empty()).then_some(&filters.status);
+        let system = (!filters.system.is_empty()).then_some(&filters.system);
+        let attr_path = (!filters.attr_path.is_empty()).then_some(&filters.attr_path);
+        let source_commit_sha =
+            (!filters.source_commit_sha.is_empty()).then_some(&filters.source_commit_sha);
+        let since = filters.since.as_ref();
+
         let stream = make_depaging_stream(
             |page_number, page_size| async move {
                 let response = self
                     .factory
                     .list_builds_api_v1_factory_builds_get(
-                        Some(page_number as u64),
+                        attr_path,
+                        None,
+                        Some(page_number),
                         NonZeroU64::new(page_size as u64),
+                        since,
+                        None,
+                        source_commit_sha,
                         status,
+                        system,
                     )
                     .await
                     .map_api_error()
@@ -235,13 +335,13 @@ impl FactoryClientTrait for crate::FloxhubClient {
         Ok(ResultsPage { results, count })
     }
 
-    async fn get_build(&self, build_id: i64) -> Result<BuildResponse, FactoryClientError> {
+    async fn get_build(&self, build_id: BuildId) -> Result<BuildResponse, FactoryClientError> {
         // A 404 on this resource-specific endpoint means the build ID does not
         // exist; reclassify it so the `status` verb can report it as such. Other
         // endpoints leave a 404 as the underlying API error.
         Ok(self
             .factory
-            .get_build_api_v1_factory_builds_build_id_get(build_id)
+            .get_build_api_v1_factory_builds_build_id_get(build_id.into())
             .await
             .map_api_error()
             .await
@@ -249,13 +349,13 @@ impl FactoryClientTrait for crate::FloxhubClient {
             .into_inner())
     }
 
-    async fn cancel_build(&self, build_id: i64) -> Result<BuildResponse, FactoryClientError> {
+    async fn cancel_build(&self, build_id: BuildId) -> Result<BuildResponse, FactoryClientError> {
         // The slice's one destructive call. Every HTTP and transport outcome is
         // classified here so the verb can map each to a distinct exit code
         // without re-inspecting raw responses at the call site.
         Ok(self
             .factory
-            .cancel_build_api_v1_factory_builds_build_id_delete(build_id)
+            .cancel_build_api_v1_factory_builds_build_id_delete(build_id.into())
             .await
             .map_api_error()
             .await
@@ -263,14 +363,14 @@ impl FactoryClientTrait for crate::FloxhubClient {
             .into_inner())
     }
 
-    async fn get_build_logs(&self, build_id: i64) -> Result<ByteStream, FactoryClientError> {
+    async fn get_build_logs(&self, build_id: BuildId) -> Result<ByteStream, FactoryClientError> {
         // A 404 on this resource-specific endpoint means there are no logs to
         // serve — the build does not exist, was never dispatched, or its
         // coordinator counterpart is gone. Reclassify it so the caller can say
         // so. Other endpoints leave a 404 as the underlying API error.
         Ok(self
             .factory
-            .get_build_logs_api_v1_factory_builds_build_id_logs_get(build_id)
+            .get_build_logs_api_v1_factory_builds_build_id_logs_get(build_id.into())
             .await
             .map_api_error()
             .await
@@ -295,10 +395,32 @@ pub mod tests {
     use crate::client::test_helpers::client_config;
     use crate::{AccessToken, AuthContext, FloxhubClientConfig, FloxhubMockMode};
 
+    /// A `since` bound, spelled as both the parsed filter value and the query
+    /// param it is expected to reach the wire as. Using one string for both
+    /// pins the serialization the server's `format: date-time` requires.
+    const SINCE: &str = "2026-07-17T12:00:00Z";
+
     /// Build a bearer credential for tests. A personal access token is just a
     /// string, so no JWT construction is needed to test header handling.
     fn make_test_auth(secret: &str) -> AuthContext {
         AuthContext::AccessToken(AccessToken::new(secret.to_string()))
+    }
+
+    #[test]
+    fn build_id_accepts_the_positive_i64_range() {
+        assert_eq!("1".parse::<BuildId>().map(i64::from), Ok(1));
+        assert_eq!(
+            i64::MAX.to_string().parse::<BuildId>().map(i64::from),
+            Ok(i64::MAX)
+        );
+    }
+
+    #[test]
+    fn build_id_rejects_zero_negative_overflow_and_garbage() {
+        assert!("0".parse::<BuildId>().is_err());
+        assert!("-1".parse::<BuildId>().is_err());
+        assert!(u64::MAX.to_string().parse::<BuildId>().is_err());
+        assert!("abc".parse::<BuildId>().is_err());
     }
 
     /// Exercise `list_builds` against a mock server, asserting:
@@ -329,7 +451,7 @@ pub mod tests {
             ..client_config(&server.base_url())
         };
         let client = crate::FloxhubClient::new(config).unwrap();
-        let result = client.list_builds(None).await.unwrap();
+        let result = client.list_builds(&BuildFilters::default()).await.unwrap();
 
         mock.assert();
         assert_eq!(result, ResultsPage {
@@ -338,7 +460,8 @@ pub mod tests {
         });
     }
 
-    /// Verify `list_builds` forwards the `status` filter as a query param.
+    /// Verify `list_builds` forwards each status as a repeated `status` query
+    /// param; the server ORs them.
     #[tokio::test]
     async fn list_builds_forwards_status_filter() {
         let server = MockServer::start_async().await;
@@ -346,7 +469,8 @@ pub mod tests {
         let mock = server.mock(|when, then| {
             when.method("GET")
                 .path("/api/v1/factory/builds")
-                .query_param("status", "running");
+                .query_param("status", "running")
+                .query_param("status", "failed");
             then.status(200).json_body(json!({
                 "builds": [],
                 "page": 0,
@@ -360,7 +484,159 @@ pub mod tests {
             ..client_config(&server.base_url())
         };
         let client = crate::FloxhubClient::new(config).unwrap();
-        let result = client.list_builds(Some("running")).await.unwrap();
+        let filters = BuildFilters {
+            status: vec![EffectiveBuildStatus::Running, EffectiveBuildStatus::Failed],
+            ..Default::default()
+        };
+        let result = client.list_builds(&filters).await.unwrap();
+
+        mock.assert();
+        assert_eq!(result, ResultsPage {
+            results: vec![],
+            count: Some(0),
+        });
+    }
+
+    /// Verify `list_builds` forwards the system, attr_path, source_commit_sha,
+    /// and since filters as query params.
+    #[tokio::test]
+    async fn list_builds_forwards_remaining_filter_params() {
+        let server = MockServer::start_async().await;
+
+        let mock = server.mock(|when, then| {
+            when.method("GET")
+                .path("/api/v1/factory/builds")
+                .query_param("system", "aarch64-darwin")
+                .query_param("attr_path", "hello")
+                .query_param("source_commit_sha", "abc123")
+                .query_param("since", SINCE);
+            then.status(200).json_body(json!({
+                "builds": [],
+                "page": 0,
+                "page_size": 50,
+                "total": 0
+            }));
+        });
+
+        let config = FloxhubClientConfig {
+            base_url: server.base_url(),
+            ..client_config(&server.base_url())
+        };
+        let client = crate::FloxhubClient::new(config).unwrap();
+        let filters = BuildFilters {
+            system: vec!["aarch64-darwin".parse().unwrap()],
+            attr_path: vec!["hello".parse().unwrap()],
+            source_commit_sha: vec!["abc123".parse().unwrap()],
+            since: Some(SINCE.parse().unwrap()),
+            ..Default::default()
+        };
+        let result = client.list_builds(&filters).await.unwrap();
+
+        mock.assert();
+        assert_eq!(result, ResultsPage {
+            results: vec![],
+            count: Some(0),
+        });
+    }
+
+    /// The filters are re-sent on every page, not just the first. The depaging
+    /// loop holds them across iterations, so a change that dropped them after
+    /// page one would return unfiltered builds presented as matches: a wrong
+    /// answer with no error to signal it.
+    #[tokio::test]
+    async fn list_builds_forwards_filters_on_every_page() {
+        let server = MockServer::start_async().await;
+
+        // A full page is what makes the loop ask for a second one, and the
+        // total must exceed one page so it does not stop on the count check.
+        let full_page: Vec<serde_json::Value> = (0..200)
+            .map(|_| valid_build_json(EffectiveBuildStatus::Completed))
+            .collect();
+
+        let page_zero = server.mock(|when, then| {
+            when.method("GET")
+                .path("/api/v1/factory/builds")
+                .query_param("page", "0")
+                .query_param("status", "running")
+                .query_param("system", "aarch64-darwin")
+                .query_param("attr_path", "hello")
+                .query_param("source_commit_sha", "abc123")
+                .query_param("since", SINCE);
+            then.status(200).json_body(json!({
+                "builds": full_page,
+                "page": 0,
+                "page_size": 200,
+                "total": 201
+            }));
+        });
+
+        let page_one = server.mock(|when, then| {
+            when.method("GET")
+                .path("/api/v1/factory/builds")
+                .query_param("page", "1")
+                .query_param("status", "running")
+                .query_param("system", "aarch64-darwin")
+                .query_param("attr_path", "hello")
+                .query_param("source_commit_sha", "abc123")
+                .query_param("since", SINCE);
+            then.status(200).json_body(json!({
+                "builds": [valid_build_json(EffectiveBuildStatus::Completed)],
+                "page": 1,
+                "page_size": 200,
+                "total": 201
+            }));
+        });
+
+        let config = FloxhubClientConfig {
+            base_url: server.base_url(),
+            ..client_config(&server.base_url())
+        };
+        let client = crate::FloxhubClient::new(config).unwrap();
+        let filters = BuildFilters {
+            status: vec![EffectiveBuildStatus::Running],
+            system: vec!["aarch64-darwin".parse().unwrap()],
+            attr_path: vec!["hello".parse().unwrap()],
+            source_commit_sha: vec!["abc123".parse().unwrap()],
+            since: Some(SINCE.parse().unwrap()),
+        };
+        let result = client.list_builds(&filters).await.unwrap();
+
+        // The second mock only matches a request carrying the filters, so both
+        // assertions passing is what proves they survived the page boundary.
+        page_zero.assert();
+        page_one.assert();
+        assert_eq!(result.count, Some(201));
+        assert_eq!(result.results.len(), 201);
+    }
+
+    /// A default (empty) `BuildFilters` sends no filter query params, so the
+    /// request is byte-identical to an unfiltered call.
+    #[tokio::test]
+    async fn list_builds_empty_filters_send_no_filter_params() {
+        let server = MockServer::start_async().await;
+
+        let mock = server.mock(|when, then| {
+            when.method("GET")
+                .path("/api/v1/factory/builds")
+                .query_param_missing("status")
+                .query_param_missing("system")
+                .query_param_missing("attr_path")
+                .query_param_missing("source_commit_sha")
+                .query_param_missing("since");
+            then.status(200).json_body(json!({
+                "builds": [],
+                "page": 0,
+                "page_size": 50,
+                "total": 0
+            }));
+        });
+
+        let config = FloxhubClientConfig {
+            base_url: server.base_url(),
+            ..client_config(&server.base_url())
+        };
+        let client = crate::FloxhubClient::new(config).unwrap();
+        let result = client.list_builds(&BuildFilters::default()).await.unwrap();
 
         mock.assert();
         assert_eq!(result, ResultsPage {
@@ -394,7 +670,7 @@ pub mod tests {
         };
 
         let client = crate::FloxhubClient::new(config).unwrap();
-        let _ = client.list_builds(None).await;
+        let _ = client.list_builds(&BuildFilters::default()).await;
         mock.assert();
     }
 
@@ -544,7 +820,7 @@ pub mod tests {
             ..client_config(&server.base_url())
         };
         let client = crate::FloxhubClient::new(config).unwrap();
-        let err = client.get_build(BUILD_ID).await.unwrap_err();
+        let err = client.get_build(BuildId(BUILD_ID)).await.unwrap_err();
 
         mock.assert();
         assert!(
@@ -568,7 +844,7 @@ pub mod tests {
     /// from the typed `BuildResponse` and serialized so the wire fixture fails
     /// loudly if a required field is added or changed, rather than silently
     /// omitting it and parsing a degenerate body.
-    fn valid_build_json(status: &str) -> serde_json::Value {
+    fn valid_build_json(status: EffectiveBuildStatus) -> serde_json::Value {
         serde_json::to_value(BuildResponse {
             attr_path: "hello".to_string(),
             build_id: BUILD_ID,
@@ -579,7 +855,7 @@ pub mod tests {
             nixpkgs_revision: "deadbeef1234567890deadbeef1234567890dead".to_string(),
             source_commit_sha: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2".to_string(),
             source_repo_url: "https://github.com/example/repo".to_string(),
-            status: status.to_string(),
+            status,
             system: "x86_64-linux".to_string(),
             task: None,
         })
@@ -604,7 +880,7 @@ pub mod tests {
             ..client_config(&server.base_url())
         };
         let client = crate::FloxhubClient::new(config).unwrap();
-        let result = client.cancel_build(BUILD_ID).await;
+        let result = client.cancel_build(BuildId(BUILD_ID)).await;
 
         mock.assert();
         result
@@ -614,9 +890,10 @@ pub mod tests {
     async fn cancel_build_returns_build_on_200() {
         // A satisfied cancel returns the build; the caller reads the effective
         // `status` to tell a fresh cancellation from an already-terminal build.
-        let build = cancel_build_against_mock(200, valid_build_json("cancelled"))
-            .await
-            .unwrap();
+        let build =
+            cancel_build_against_mock(200, valid_build_json(EffectiveBuildStatus::Cancelled))
+                .await
+                .unwrap();
         let expected = BuildResponse {
             attr_path: "hello".to_string(),
             build_id: BUILD_ID,
@@ -627,7 +904,7 @@ pub mod tests {
             nixpkgs_revision: "deadbeef1234567890deadbeef1234567890dead".to_string(),
             source_commit_sha: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2".to_string(),
             source_repo_url: "https://github.com/example/repo".to_string(),
-            status: "cancelled".to_string(),
+            status: EffectiveBuildStatus::Cancelled,
             system: "x86_64-linux".to_string(),
             task: None,
         };
@@ -719,7 +996,7 @@ pub mod tests {
             ..client_config("http://127.0.0.1:0")
         };
         let client = crate::FloxhubClient::new(config).unwrap();
-        let err = client.cancel_build(7).await.unwrap_err();
+        let err = client.cancel_build(BuildId(7)).await.unwrap_err();
         assert!(
             matches!(err, FactoryClientError::Transport(_)),
             "expected Transport, got {err:?}"
@@ -745,7 +1022,7 @@ pub mod tests {
         };
         let client = crate::FloxhubClient::new(config).unwrap();
         // `ByteStream` is not `Debug`, so destructure rather than `unwrap_err`.
-        let Err(err) = client.get_build_logs(7).await else {
+        let Err(err) = client.get_build_logs(BuildId(7)).await else {
             panic!("expected an error, got an Ok stream");
         };
 
@@ -772,7 +1049,10 @@ pub mod tests {
             ..client_config(&server.base_url())
         };
         let client = crate::FloxhubClient::new(config).unwrap();
-        let err = client.list_builds(None).await.unwrap_err();
+        let err = client
+            .list_builds(&BuildFilters::default())
+            .await
+            .unwrap_err();
 
         assert!(
             matches!(err, FactoryClientError::APIError(_)),
@@ -819,7 +1099,7 @@ pub mod tests {
                 ..client_config(&server.base_url())
             };
             let client = crate::FloxhubClient::new(config).unwrap();
-            let result = client.list_builds(None).await.unwrap();
+            let result = client.list_builds(&BuildFilters::default()).await.unwrap();
             assert_eq!(result, ResultsPage {
                 results: vec![],
                 count: Some(0),
@@ -843,7 +1123,7 @@ pub mod tests {
                 ..client_config("http://localhost:0")
             };
             let client = crate::FloxhubClient::new(config).unwrap();
-            let result = client.list_builds(None).await.unwrap();
+            let result = client.list_builds(&BuildFilters::default()).await.unwrap();
             assert_eq!(result, ResultsPage {
                 results: vec![],
                 count: Some(0),

--- a/cli/floxhub-client/src/lib.rs
+++ b/cli/floxhub-client/src/lib.rs
@@ -29,7 +29,7 @@
 //!
 //! let client = FloxhubClient::new(config)?;
 //! let results = client.search("curl", system, None).await?;
-//! let builds = client.list_builds(None).await?;
+//! let builds = client.list_builds(&Default::default()).await?;
 //! ```
 
 mod accounts;
@@ -76,14 +76,20 @@ pub use config::{FloxhubClientConfig, FloxhubMockMode};
 pub use error::*;
 // Re-export factory types so consumers depend only on floxhub-client.
 pub use factory::{
+    BuildFilters,
+    BuildId,
     FactoryClientError,
     FactoryClientTrait,
     MapApiErrorExt as FactoryMapApiErrorExt,
+    ParseBuildIdError,
 };
 pub use factory_api_v1::types::{
+    AttrPathItem,
     BuildResponse,
+    EffectiveBuildStatus,
     ErrorResponse as FactoryErrorResponse,
-    Status as FactoryStatus,
+    SourceCommitShaItem,
+    SystemItem,
 };
 // Re-export factory-api-v1 types for consumers.
 pub use factory_api_v1::{


### PR DESCRIPTION
## Summary

The Factory Service computes a typed effective build status (`pending`, `running`, `completed`, `failed`, `timed_out`, `cancelled`) and accepts multi-value filters on its builds endpoint. This brings the CLI up to that contract and exposes the filters on `flox factory list`.

The vendored `factory-api-v1` client is regenerated from the Factory Service's exported OpenAPI spec, with a hand-written `EffectiveBuildStatus` enum spliced into both the response body and the `status` query parameter through `with_replacement`. The enum is tolerant: a value outside the known set deserializes into an `Unknown` variant and renders as `unknown: <value>`, so a status the server adds later degrades one row instead of blanking the build list. A spec-pinning test keeps the enum aligned with the schema. The exported spec covers only the surface a generated client can call, so the generated code holds one status vocabulary and only the endpoints the CLI uses.

The `catalog-api-v1` snapshot is refreshed in the same commit. It carries user-visible changes to `flox search` and to catalog-name validation, described in the release notes.

Input parsing takes one position throughout: every request value is parsed once, at the CLI flag boundary, into a type that cannot hold invalid data. The rule is that the CLI validates exactly what the vendored schema pins and defers everything deployment-specific to the server. The schema pins non-emptiness on the three string filters, so `BuildFilters` holds generated newtypes for `--system`, `--attr-path`, and `--source-rev`, and it holds `--since` as a `chrono` timestamp, which the schema's `date-time` format produces directly. The client layer performs no validation of its own. Build IDs parse into a `BuildId` newtype holding a positive `i64`, so a verb only ever holds an ID the server could have assigned. What the CLI does not judge is what only the server knows: which systems a given deployment has. Those are forwarded once non-empty, and the server answers with the values it accepts.

`--since` takes a duration (`7d`), an English phrase (`yesterday`), or an ISO 8601 timestamp, and the CLI resolves it to an instant before the first request. That matters because the listing depages: an expression the server re-read on every request would drift between the first page and the last, and under offset paging a moving cutoff can duplicate or skip rows at the boundary. The `interim` crate reads the expression, and a duration always counts backwards from now, so `7d` and `7 days ago` name the same bound. A value that resolves to the future is refused at the flag boundary rather than quietly matching nothing.

The status column shows the server's computed status, so a timed-out build reads `timed_out` and a build canceled before dispatch reads `cancelled`. The cancel verb spells the status out in prose: "Build 42 already timed out; nothing to cancel."

`flox factory list` takes repeatable `--status`, `--system`, `--attr-path`, and `--source-rev` filters and a single `--since`. Repeated values within a filter are ORed by the server; different filters are ANDed.

#4531 bumps the same schema without the code to compile against it, so it can be closed once this lands.

Closes [ECO-152](https://linear.app/floxdotdev/issue/ECO-152).

## Release Notes

`flox search` accepts more search terms. Terms such as `c++` and `g++`, and terms written in non-Latin scripts, now work, and the message for a rejected term no longer prints a regular expression at the user. Search terms longer than 200 characters are rejected before the request is sent.

Catalog names are checked against the same rule the server applies: 3 to 63 characters of letters, digits, hyphens, and underscores. A name the CLI rejects would be rejected by the server anyway, so the failure arrives sooner and reads more clearly.

### Test plan

- [x] `cargo test` passes for `factory-api-v1`, `floxhub-client`, and `flox`; `cargo clippy --all --all-targets` with warnings denied is clean, and `pre-commit run -a` is clean.
- [x] `flox factory list --help` renders the five filters and the OR/AND semantics.
- [x] `flox factory list --status garbage` fails at parse time naming the valid values. Each of `--attr-path ''`, `--source-rev ''`, `--system ''`, and `--since ''` fails before any request, and each names its own flag. `--since banana` names the accepted time forms and `--since friday` is refused as a future bound. `flox factory status 0` is rejected as an invalid build ID.


