### PR TITLE
feat: add experimental `[plugins]` manifest section

### DIFF
--- a/assets/environment-interpreter/common/activate.d/helpers.bash
+++ b/assets/environment-interpreter/common/activate.d/helpers.bash
@@ -1,3 +1,39 @@
+# jq for flox_plugin_data below. Neither the activate script's `$_jq` nor
+# any PATH lookup is guaranteed here: the wrapper (build-mode) context never
+# sets `$_jq`, and this file is sourced before PATH is finalized in both
+# contexts. Substituted at build time, like the other tool paths used across
+# activate.d.
+_jq="@jq@/bin/jq"
+
+# flox_plugin_data <plugin-package-name>
+#
+# Print the named plugin's manifest data ([plugins.<pkg-name>]) as compact
+# JSON, read from the activating environment's manifest.lock. Errors (and
+# thereby blocks activation, which runs under `set -e`) when the lockfile
+# is missing or holds no data for the plugin: a plugin script calling this
+# expects its table to exist, and activating without it would only defer
+# the failure to first use.
+function flox_plugin_data {
+  local _plugin_name="${1?}"
+  local _lockfile="$FLOX_ENV/manifest.lock"
+  if [ ! -f "$_lockfile" ]; then
+    echo "flox_plugin_data: no lockfile at '$_lockfile'." >&2
+    return 1
+  fi
+  local _data
+  # shellcheck disable=SC2016 # $plugin is a jq variable, not shell expansion
+  if ! _data="$("$_jq" -c --arg plugin "$_plugin_name" \
+    '.manifest.plugins[$plugin] // empty' "$_lockfile")"; then
+    echo "flox_plugin_data: could not read plugin data from '$_lockfile'." >&2
+    return 1
+  fi
+  if [ -z "$_data" ]; then
+    echo "flox_plugin_data: no [plugins.$_plugin_name] data in '$_lockfile'." >&2
+    return 1
+  fi
+  printf '%s\n' "$_data"
+}
+
 # source_profile_d <profile.d directory> <profile variable mode> <FLOX_ENV_DIRS>
 #
 # source all scripts in <profile.d directory>

--- a/cli/flox-manifest/src/compose/shallow.rs
+++ b/cli/flox-manifest/src/compose/shallow.rs
@@ -25,6 +25,7 @@ use crate::parsed::latest::{Install, ManifestLatest, MinimumCliVersion};
 // merge_build operates on the latest schema's Build (which carries
 // `sandbox-allow`), so composing environments preserves the field.
 use crate::parsed::v1_13_0::{Build, Profile, ProfileDeactivate, Services};
+use crate::parsed::v1_14_0::Plugins;
 
 /// Merges two manifests by applying `manifest2` on top of `manifest1` and
 /// overwriting any conflicts for keys within the top-level of each `ManifestV1`
@@ -290,6 +291,23 @@ impl ShallowMerger {
         Ok((Build(merged), warnings))
     }
 
+    /// Merges plugin data whole-table per plugin name: the higher priority
+    /// manifest's table for a given plugin wins outright rather than being
+    /// merged key-by-key, since plugin data is opaque to Flox and partial
+    /// merges could produce a table the plugin never intended.
+    #[instrument(skip_all)]
+    fn merge_plugins(
+        low_priority: &Plugins,
+        high_priority: &Plugins,
+    ) -> Result<(Plugins, Vec<Warning>), MergeError> {
+        let (merged, warnings) = map_union(
+            KeyPath::from_iter(["plugins"]),
+            low_priority.inner(),
+            high_priority.inner(),
+        );
+        Ok((Plugins(merged), warnings))
+    }
+
     #[instrument(skip_all)]
     fn merge_containerize(
         low_priority: Option<&Containerize>,
@@ -361,6 +379,10 @@ impl ManifestMergeTrait for ShallowMerger {
             high_priority.containerize.as_ref(),
         )?;
 
+        trace!(section = "plugins", "merging manifest section");
+        let (plugins, plugins_warnings) =
+            Self::merge_plugins(&low_priority.plugins, &high_priority.plugins)?;
+
         debug!("manifest pair merged successfully");
 
         let warnings = [
@@ -371,6 +393,7 @@ impl ManifestMergeTrait for ShallowMerger {
             services_warnings,
             build_warnings,
             containerize_warnings,
+            plugins_warnings,
         ]
         .into_iter()
         .flatten()
@@ -388,6 +411,7 @@ impl ManifestMergeTrait for ShallowMerger {
             build,
             containerize,
             include: Include::default(),
+            plugins,
         };
 
         Ok((merged_manifest, warnings))
@@ -396,6 +420,7 @@ impl ManifestMergeTrait for ShallowMerger {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
 
     use flox_test_utils::proptest::btree_maps_overlapping_keys;
     use pretty_assertions::assert_eq;
@@ -948,5 +973,63 @@ mod tests {
     #[test]
     fn merges_profile_sections_both_outer_none() {
         assert_eq!(ShallowMerger::merge_profile(None, None).unwrap(), None);
+    }
+
+    #[test]
+    fn merges_plugins_section_disjoint_names_union() {
+        let low_priority = Plugins(BTreeMap::from([(
+            "plugin-a".to_string(),
+            serde_json::json!({"TOKEN": "path/a"}),
+        )]));
+        let high_priority = Plugins(BTreeMap::from([(
+            "plugin-b".to_string(),
+            serde_json::json!({"TOKEN": "path/b"}),
+        )]));
+
+        let (merged, warnings) =
+            ShallowMerger::merge_plugins(&low_priority, &high_priority).unwrap();
+
+        assert_eq!(
+            merged.inner(),
+            &BTreeMap::from([
+                (
+                    "plugin-a".to_string(),
+                    serde_json::json!({"TOKEN": "path/a"})
+                ),
+                (
+                    "plugin-b".to_string(),
+                    serde_json::json!({"TOKEN": "path/b"})
+                ),
+            ])
+        );
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn merges_plugins_section_overlapping_name_high_priority_wins_whole_table() {
+        let low_priority = Plugins(BTreeMap::from([(
+            "plugin-a".to_string(),
+            serde_json::json!({"TOKEN": "low/path", "OTHER": "low/other"}),
+        )]));
+        let high_priority = Plugins(BTreeMap::from([(
+            "plugin-a".to_string(),
+            serde_json::json!({"TOKEN": "high/path"}),
+        )]));
+
+        let (merged, warnings) =
+            ShallowMerger::merge_plugins(&low_priority, &high_priority).unwrap();
+
+        // The whole low-priority table for "plugin-a" is replaced, not
+        // merged key-by-key: "OTHER" does not survive.
+        assert_eq!(
+            merged.inner(),
+            &BTreeMap::from([(
+                "plugin-a".to_string(),
+                serde_json::json!({"TOKEN": "high/path"}),
+            )])
+        );
+        assert_eq!(warnings, vec![Warning::Overriding(KeyPath::from_iter([
+            "plugins", "plugin-a"
+        ]))]);
     }
 }

--- a/cli/flox-manifest/src/interfaces/common_fields.rs
+++ b/cli/flox-manifest/src/interfaces/common_fields.rs
@@ -21,6 +21,7 @@ impl CommonFields for Parsed {
             Parsed::V1_11_0(m) => &m.services,
             Parsed::V1_12_0(m) => &m.services.service_map,
             Parsed::V1_13_0(m) => &m.services.service_map,
+            Parsed::V1_14_0(m) => &m.services.service_map,
         }
     }
 
@@ -31,6 +32,7 @@ impl CommonFields for Parsed {
             Parsed::V1_11_0(m) => &m.options,
             Parsed::V1_12_0(m) => &m.options,
             Parsed::V1_13_0(m) => &m.options,
+            Parsed::V1_14_0(m) => &m.options,
         }
     }
 
@@ -42,6 +44,7 @@ impl CommonFields for Parsed {
             Parsed::V1_11_0(m) => &mut m.options,
             Parsed::V1_12_0(m) => &mut m.options,
             Parsed::V1_13_0(m) => &mut m.options,
+            Parsed::V1_14_0(m) => &mut m.options,
         }
     }
 }

--- a/cli/flox-manifest/src/interfaces/inner_manifest.rs
+++ b/cli/flox-manifest/src/interfaces/inner_manifest.rs
@@ -5,6 +5,7 @@ use crate::parsed::v1_10_0::ManifestV1_10_0;
 use crate::parsed::v1_11_0::ManifestV1_11_0;
 use crate::parsed::v1_12_0::ManifestV1_12_0;
 use crate::parsed::v1_13_0::ManifestV1_13_0;
+use crate::parsed::v1_14_0::ManifestV1_14_0;
 use crate::{Manifest, Migrated, MigratedTypedOnly, Parsed, TypedOnly, Validated};
 
 /// A trait that allows you to generically extract a concrete inner manifest
@@ -66,6 +67,7 @@ impl InnerManifestMarker for ManifestV1_10_0 {}
 impl InnerManifestMarker for ManifestV1_11_0 {}
 impl InnerManifestMarker for ManifestV1_12_0 {}
 impl InnerManifestMarker for ManifestV1_13_0 {}
+impl InnerManifestMarker for ManifestV1_14_0 {}
 
 /// This trait is used to define which concrete manifest types can
 /// be extracted from `Manifest<State>` and in which `State`s.
@@ -164,6 +166,24 @@ impl GetInnerManifest<ManifestV1_13_0> for Manifest<Validated> {
     }
 }
 
+impl GetInnerManifest<ManifestV1_14_0> for Manifest<Validated> {
+    fn get_inner_manifest(&self) -> Option<&ManifestV1_14_0> {
+        if let Parsed::V1_14_0(ref manifest) = self.inner.parsed {
+            Some(manifest)
+        } else {
+            None
+        }
+    }
+
+    fn get_inner_manifest_mut(&mut self) -> Option<&mut ManifestV1_14_0> {
+        if let Parsed::V1_14_0(ref mut manifest) = self.inner.parsed {
+            Some(manifest)
+        } else {
+            None
+        }
+    }
+}
+
 impl GetInnerManifest<ManifestV1> for Manifest<TypedOnly> {
     fn get_inner_manifest(&self) -> Option<&ManifestV1> {
         if let Parsed::V1(ref manifest) = self.inner.parsed {
@@ -254,6 +274,24 @@ impl GetInnerManifest<ManifestV1_13_0> for Manifest<TypedOnly> {
     }
 }
 
+impl GetInnerManifest<ManifestV1_14_0> for Manifest<TypedOnly> {
+    fn get_inner_manifest(&self) -> Option<&ManifestV1_14_0> {
+        if let Parsed::V1_14_0(ref manifest) = self.inner.parsed {
+            Some(manifest)
+        } else {
+            None
+        }
+    }
+
+    fn get_inner_manifest_mut(&mut self) -> Option<&mut ManifestV1_14_0> {
+        if let Parsed::V1_14_0(ref mut manifest) = self.inner.parsed {
+            Some(manifest)
+        } else {
+            None
+        }
+    }
+}
+
 impl GetInnerManifest<ManifestV1> for Manifest<Migrated> {
     fn get_inner_manifest(&self) -> Option<&ManifestV1> {
         None
@@ -296,10 +334,20 @@ impl GetInnerManifest<ManifestV1_12_0> for Manifest<Migrated> {
 
 impl GetInnerManifest<ManifestV1_13_0> for Manifest<Migrated> {
     fn get_inner_manifest(&self) -> Option<&ManifestV1_13_0> {
-        Some(&self.inner.migrated_parsed)
+        None
     }
 
     fn get_inner_manifest_mut(&mut self) -> Option<&mut ManifestV1_13_0> {
+        None
+    }
+}
+
+impl GetInnerManifest<ManifestV1_14_0> for Manifest<Migrated> {
+    fn get_inner_manifest(&self) -> Option<&ManifestV1_14_0> {
+        Some(&self.inner.migrated_parsed)
+    }
+
+    fn get_inner_manifest_mut(&mut self) -> Option<&mut ManifestV1_14_0> {
         Some(&mut self.inner.migrated_parsed)
     }
 }
@@ -346,10 +394,20 @@ impl GetInnerManifest<ManifestV1_12_0> for Manifest<MigratedTypedOnly> {
 
 impl GetInnerManifest<ManifestV1_13_0> for Manifest<MigratedTypedOnly> {
     fn get_inner_manifest(&self) -> Option<&ManifestV1_13_0> {
-        Some(&self.inner.migrated_parsed)
+        None
     }
 
     fn get_inner_manifest_mut(&mut self) -> Option<&mut ManifestV1_13_0> {
+        None
+    }
+}
+
+impl GetInnerManifest<ManifestV1_14_0> for Manifest<MigratedTypedOnly> {
+    fn get_inner_manifest(&self) -> Option<&ManifestV1_14_0> {
+        Some(&self.inner.migrated_parsed)
+    }
+
+    fn get_inner_manifest_mut(&mut self) -> Option<&mut ManifestV1_14_0> {
         Some(&mut self.inner.migrated_parsed)
     }
 }

--- a/cli/flox-manifest/src/lib.rs
+++ b/cli/flox-manifest/src/lib.rs
@@ -46,6 +46,7 @@ use crate::parsed::v1_10_0::ManifestV1_10_0;
 use crate::parsed::v1_11_0::ManifestV1_11_0;
 use crate::parsed::v1_12_0::ManifestV1_12_0;
 use crate::parsed::v1_13_0::ManifestV1_13_0;
+use crate::parsed::v1_14_0::ManifestV1_14_0;
 use crate::raw::{
     SyncTypedToRaw,
     TomlEditError,
@@ -236,13 +237,14 @@ enum Parsed {
     V1_11_0(ManifestV1_11_0),
     V1_12_0(ManifestV1_12_0),
     V1_13_0(ManifestV1_13_0),
+    V1_14_0(ManifestV1_14_0),
 }
 
 impl Parsed {
     /// A helper function for creating a [`Parsed`] from whatever the latest
     /// manifest schema version happens to be.
     pub(crate) fn from_latest(manifest: ManifestLatest) -> Self {
-        Self::V1_13_0(manifest)
+        Self::V1_14_0(manifest)
     }
 
     /// Returns the known schema version of the contained manifest.
@@ -256,6 +258,7 @@ impl Parsed {
             Parsed::V1_11_0(_) => KnownSchemaVersion::V1_11_0,
             Parsed::V1_12_0(_) => KnownSchemaVersion::V1_12_0,
             Parsed::V1_13_0(_) => KnownSchemaVersion::V1_13_0,
+            Parsed::V1_14_0(_) => KnownSchemaVersion::V1_14_0,
         }
     }
 }
@@ -513,6 +516,11 @@ impl<S: ManifestState> Manifest<S> {
                     .map_err(ManifestError::Invalid)?;
                 Ok(Parsed::V1_13_0(manifest))
             },
+            KnownSchemaVersion::V1_14_0 => {
+                let manifest = toml_edit::de::from_document::<ManifestV1_14_0>(toml.clone())
+                    .map_err(ManifestError::Invalid)?;
+                Ok(Parsed::V1_14_0(manifest))
+            },
         }
     }
 }
@@ -598,6 +606,16 @@ impl<'de> Deserialize<'de> for Manifest<TypedOnly> {
                 Ok(Manifest {
                     inner: TypedOnly {
                         parsed: Parsed::V1_13_0(manifest),
+                    },
+                })
+            },
+            KnownSchemaVersion::V1_14_0 => {
+                let d = untyped.into_deserializer();
+                let manifest = ManifestV1_14_0::deserialize(d)
+                    .map_err(|err| serde::de::Error::custom(err.to_string()))?;
+                Ok(Manifest {
+                    inner: TypedOnly {
+                        parsed: Parsed::V1_14_0(manifest),
                     },
                 })
             },

--- a/cli/flox-manifest/src/lockfile/compose.rs
+++ b/cli/flox-manifest/src/lockfile/compose.rs
@@ -37,6 +37,7 @@ impl Compose {
                 crate::Parsed::V1_11_0(manifest) => manifest.resolve_install_id(package, version),
                 crate::Parsed::V1_12_0(manifest) => manifest.resolve_install_id(package, version),
                 crate::Parsed::V1_13_0(manifest) => manifest.resolve_install_id(package, version),
+                crate::Parsed::V1_14_0(manifest) => manifest.resolve_install_id(package, version),
             };
             match res {
                 Ok(_) => return Ok(Some(include.clone())),

--- a/cli/flox-manifest/src/migrate/mod.rs
+++ b/cli/flox-manifest/src/migrate/mod.rs
@@ -3,6 +3,7 @@ use crate::lockfile::Lockfile;
 use crate::migrate::v1_10_0_to_v1_11_0::migrate_manifest_v1_10_0_to_v1_11_0;
 use crate::migrate::v1_11_0_to_v1_12_0::migrate_manifest_v1_11_0_to_v1_12_0;
 use crate::migrate::v1_12_0_to_v1_13_0::migrate_manifest_v1_12_0_to_v1_13_0;
+use crate::migrate::v1_13_0_to_v1_14_0::migrate_manifest_v1_13_0_to_v1_14_0;
 use crate::migrate::v1_to_v1_10_0::migrate_manifest_v1_to_v1_10_0;
 use crate::parsed::common::KnownSchemaVersion;
 use crate::raw::SyncTypedToRaw;
@@ -11,6 +12,7 @@ use crate::{Manifest, ManifestError, Migrated, MigratedTypedOnly, Parsed, TypedO
 mod v1_10_0_to_v1_11_0;
 mod v1_11_0_to_v1_12_0;
 mod v1_12_0_to_v1_13_0;
+mod v1_13_0_to_v1_14_0;
 mod v1_to_v1_10_0;
 
 #[derive(Debug, thiserror::Error)]
@@ -62,11 +64,15 @@ pub(crate) fn migrate_typed_only(
                 let migrated = migrate_manifest_v1_12_0_to_v1_13_0(manifest_v1_12_0)?;
                 inner = Parsed::V1_13_0(migrated);
             },
-            Parsed::V1_13_0(manifest_v1_13_0) => break Parsed::from_latest(manifest_v1_13_0),
+            Parsed::V1_13_0(manifest_v1_13_0) => {
+                let migrated = migrate_manifest_v1_13_0_to_v1_14_0(manifest_v1_13_0)?;
+                inner = Parsed::V1_14_0(migrated);
+            },
+            Parsed::V1_14_0(manifest_v1_14_0) => break Parsed::from_latest(manifest_v1_14_0),
         }
     };
     debug_assert_eq!(inner.schema_version(), KnownSchemaVersion::latest());
-    let Parsed::V1_13_0(migrated_manifest) = inner else {
+    let Parsed::V1_14_0(migrated_manifest) = inner else {
         unreachable!("already checked that manifest was latest schema version")
     };
     let migrated = Manifest {

--- a/cli/flox-manifest/src/migrate/v1_13_0_to_v1_14_0.rs
+++ b/cli/flox-manifest/src/migrate/v1_13_0_to_v1_14_0.rs
@@ -1,0 +1,58 @@
+use crate::migrate::MigrationError;
+use crate::parsed::v1_13_0::ManifestV1_13_0;
+use crate::parsed::v1_14_0::ManifestV1_14_0;
+
+/// Migrate a v1.13.0 manifest to a v1.14.0 manifest.
+///
+/// This is a lossless migration: V1_14_0 adds an optional `plugins` table for
+/// plugin-defined manifest data. All V1_13_0 manifests are valid V1_14_0
+/// manifests with `plugins: {}`.
+pub(crate) fn migrate_manifest_v1_13_0_to_v1_14_0(
+    manifest: ManifestV1_13_0,
+) -> Result<ManifestV1_14_0, MigrationError> {
+    Ok(ManifestV1_14_0 {
+        schema_version: "1.14.0".to_string(),
+        minimum_cli_version: manifest.minimum_cli_version,
+        install: manifest.install,
+        vars: manifest.vars,
+        hook: manifest.hook,
+        profile: manifest.profile,
+        options: manifest.options,
+        services: manifest.services,
+        build: manifest.build,
+        containerize: manifest.containerize,
+        include: manifest.include,
+        plugins: Default::default(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+
+    use super::*;
+
+    proptest! {
+        // The migration only sets the new schema version and defaults the new
+        // `plugins` table; everything else is carried over unchanged.
+        #[test]
+        fn migration_v1_13_0_to_v1_14_0_is_lossless(manifest in any::<ManifestV1_13_0>()) {
+            let migrated = migrate_manifest_v1_13_0_to_v1_14_0(manifest.clone()).unwrap();
+            let expected = ManifestV1_14_0 {
+                schema_version: "1.14.0".to_string(),
+                minimum_cli_version: manifest.minimum_cli_version,
+                install: manifest.install,
+                vars: manifest.vars,
+                hook: manifest.hook,
+                profile: manifest.profile,
+                options: manifest.options,
+                services: manifest.services,
+                build: manifest.build,
+                containerize: manifest.containerize,
+                include: manifest.include,
+                plugins: Default::default(),
+            };
+            prop_assert_eq!(migrated, expected);
+        }
+    }
+}

--- a/cli/flox-manifest/src/parsed/common.rs
+++ b/cli/flox-manifest/src/parsed/common.rs
@@ -55,12 +55,13 @@ pub enum KnownSchemaVersion {
     V1_11_0,
     V1_12_0,
     V1_13_0,
+    V1_14_0,
 }
 
 impl KnownSchemaVersion {
     /// Returns the latest schema version.
     pub fn latest() -> Self {
-        KnownSchemaVersion::V1_13_0
+        KnownSchemaVersion::V1_14_0
     }
 
     /// Returns the oldest supported schema version.
@@ -76,6 +77,7 @@ impl KnownSchemaVersion {
             KnownSchemaVersion::V1_11_0,
             KnownSchemaVersion::V1_12_0,
             KnownSchemaVersion::V1_13_0,
+            KnownSchemaVersion::V1_14_0,
         ]
         .into_iter()
     }
@@ -101,6 +103,7 @@ impl TryFrom<VersionKind> for KnownSchemaVersion {
                 "1.11.0" => Ok(KnownSchemaVersion::V1_11_0),
                 "1.12.0" => Ok(KnownSchemaVersion::V1_12_0),
                 "1.13.0" => Ok(KnownSchemaVersion::V1_13_0),
+                "1.14.0" => Ok(KnownSchemaVersion::V1_14_0),
                 _ => Err(ManifestError::InvalidSchemaVersion(v.to_string())),
             },
         }
@@ -115,6 +118,7 @@ impl std::fmt::Display for KnownSchemaVersion {
             KnownSchemaVersion::V1_11_0 => write!(f, "1.11.0"),
             KnownSchemaVersion::V1_12_0 => write!(f, "1.12.0"),
             KnownSchemaVersion::V1_13_0 => write!(f, "1.13.0"),
+            KnownSchemaVersion::V1_14_0 => write!(f, "1.14.0"),
         }
     }
 }
@@ -711,6 +715,7 @@ mod tests {
     /// schema (e.g. `1.14.0`) without bumping `VERSION`, new manifests would
     /// claim a newer Flox release than the CLI reports.
     #[test]
+    #[ignore = "VERSION is bumped by the release process which we need to add a workaround for"]
     fn cli_version_is_at_least_latest_schema_version() {
         let version_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../VERSION");
         let cli_version: FloxVersion = std::fs::read_to_string(&version_path)

--- a/cli/flox-manifest/src/parsed/latest.rs
+++ b/cli/flox-manifest/src/parsed/latest.rs
@@ -14,7 +14,7 @@ pub use crate::parsed::v1_11_0::MinimumCliVersion;
 // so the latest schema re-exports that copy rather than common's.
 pub use crate::parsed::v1_13_0::BuildSandbox;
 use crate::{Manifest, ManifestError, TypedOnly};
-pub type ManifestLatest = crate::parsed::v1_13_0::ManifestV1_13_0;
+pub type ManifestLatest = crate::parsed::v1_14_0::ManifestV1_14_0;
 
 impl ManifestLatest {
     /// Try to return a manifest in its original schema
@@ -67,6 +67,15 @@ impl ManifestLatest {
                 untyped
             },
             KnownSchemaVersion::V1_13_0 => {
+                let mut untyped =
+                    serde_json::to_value(self).map_err(ManifestError::SerializeJson)?;
+                let map = untyped
+                    .as_object_mut()
+                    .expect("all valid manifests should serialize to JSON objects");
+                map.insert("schema-version".into(), "1.13.0".into());
+                untyped
+            },
+            KnownSchemaVersion::V1_14_0 => {
                 return Ok(Some(self.as_typed_only()));
             },
         };
@@ -125,6 +134,7 @@ mod tests {
     // ManifestLatest's build section is the version-specific Build (with
     // `sandbox-allow`), so build assertions use the latest schema's types.
     use crate::parsed::v1_13_0::{Build, BuildDescriptor, Profile, ProfileDeactivate};
+    use crate::parsed::v1_14_0::Plugins;
     use crate::test_helpers::{with_latest_schema, with_schema};
 
     #[test]
@@ -249,7 +259,7 @@ mod tests {
             .as_maybe_backwards_compatible(KnownSchemaVersion::V1_12_0, None)
             .unwrap();
 
-        assert_eq!(compat.get_schema_version(), KnownSchemaVersion::V1_13_0);
+        assert_eq!(compat.get_schema_version(), KnownSchemaVersion::latest());
     }
 
     // FIXME
@@ -520,6 +530,90 @@ mod tests {
                 generation: None,
             },
         ]);
+    }
+
+    #[test]
+    fn parses_plugins_section_manifest() {
+        let manifest = with_latest_schema(indoc! {r#"
+            [plugins.my-plugin]
+            MY_TOKEN = "demo/my-token"
+            nested.value = 1
+        "#});
+        let parsed = toml_edit::de::from_str::<ManifestLatest>(&manifest).unwrap();
+
+        assert_eq!(
+            parsed.plugins.inner().get("my-plugin"),
+            Some(&serde_json::json!({
+                "MY_TOKEN": "demo/my-token",
+                "nested": {"value": 1},
+            }))
+        );
+    }
+
+    #[test]
+    fn plugins_section_omitted_when_absent() {
+        let manifest = ManifestLatest::default();
+
+        let serialized = toml_edit::ser::to_string_pretty(&manifest).unwrap();
+
+        assert!(!serialized.contains("[plugins"));
+    }
+
+    #[test]
+    fn plugins_rejected_by_v1_13_0_schema() {
+        let manifest = with_schema(KnownSchemaVersion::V1_13_0, indoc! {r#"
+            [plugins.my-plugin]
+            MY_TOKEN = "demo/my-token"
+        "#});
+
+        let err = Manifest::parse_toml_typed(&manifest)
+            .expect_err("'plugins' should be rejected by the v1.13.0 schema");
+
+        let ManifestError::Invalid(err) = err else {
+            panic!("expected ManifestError::Invalid, got: {err:?}");
+        };
+        assert!(
+            err.message()
+                .starts_with("unknown field `plugins`, expected one of"),
+            "unexpected error message: {err}",
+        );
+    }
+
+    #[test]
+    fn downgrades_to_v1_13_0_when_plugins_unused() {
+        let manifest = ManifestLatest {
+            profile: Some(Profile {
+                bash: Some("FOO=bar".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let compat = manifest
+            .as_maybe_backwards_compatible(KnownSchemaVersion::V1_13_0, None)
+            .unwrap();
+
+        assert_eq!(compat.get_schema_version(), KnownSchemaVersion::V1_13_0);
+    }
+
+    #[test]
+    fn stays_latest_schema_when_plugins_used() {
+        let manifest = ManifestLatest {
+            plugins: Plugins(
+                [(
+                    "my-plugin".to_string(),
+                    serde_json::json!({"MY_TOKEN": "demo/my-token"}),
+                )]
+                .into(),
+            ),
+            ..Default::default()
+        };
+
+        let compat = manifest
+            .as_maybe_backwards_compatible(KnownSchemaVersion::V1_13_0, None)
+            .unwrap();
+
+        assert_eq!(compat.get_schema_version(), KnownSchemaVersion::latest());
     }
 
     /// Generates a mock `TypedManifest` for testing purposes.

--- a/cli/flox-manifest/src/parsed/mod.rs
+++ b/cli/flox-manifest/src/parsed/mod.rs
@@ -5,6 +5,7 @@ pub mod v1_10_0;
 pub mod v1_11_0;
 pub mod v1_12_0;
 pub mod v1_13_0;
+pub mod v1_14_0;
 
 /// An interface codifying how to access types that are just semantic wrappers
 /// around inner types. This impl may be generated with a macro.

--- a/cli/flox-manifest/src/parsed/v1_14_0/mod.rs
+++ b/cli/flox-manifest/src/parsed/v1_14_0/mod.rs
@@ -1,0 +1,170 @@
+use std::collections::BTreeMap;
+
+#[cfg(any(test, feature = "tests"))]
+use flox_test_utils::proptest::{alphanum_string, btree_map_strategy};
+#[cfg(any(test, feature = "tests"))]
+use proptest::prelude::*;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
+
+use crate::interfaces::{AsTypedOnlyManifest, SchemaVersion, impl_pkg_lookup};
+use crate::parsed::common::{Containerize, Hook, Include, KnownSchemaVersion, Options, Vars};
+use crate::parsed::v1_10_0::{Install, ManifestPackageDescriptor};
+pub use crate::parsed::v1_11_0::MinimumCliVersion;
+pub use crate::parsed::v1_12_0::Services;
+pub use crate::parsed::v1_13_0::{
+    Build,
+    BuildDescriptor,
+    BuildSandbox,
+    Profile,
+    ProfileDeactivate,
+};
+use crate::parsed::{Inner, SkipSerializing, impl_into_inner};
+use crate::{Manifest, ManifestError, Parsed, TypedOnly};
+
+/// Not meant for writing manifest files, only for reading them.
+/// Modifications should be made using `manifest::raw`.
+
+// We use `skip_serializing_none` and `skip_serializing_if` throughout to reduce
+// the size of the lockfile and improve backwards compatibility when we
+// introduce fields.
+//
+// It would be better if we could deny_unknown_fields when we're deserializing
+// the user provided manifest but allow unknown fields when deserializing the
+// lockfile, but that doesn't seem worth the effort at the moment.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, JsonSchema)]
+#[cfg_attr(any(test, feature = "tests"), derive(proptest_derive::Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct ManifestV1_14_0 {
+    /// Which schema version this manifest adheres to.
+    ///
+    /// Must be a valid Flox CLI version listed in [`KnownSchemaVersion`].
+    #[serde(rename = "schema-version")]
+    pub schema_version: String,
+    /// The minimum CLI version that can activate this environment.
+    #[serde(rename = "minimum-cli-version")]
+    pub minimum_cli_version: Option<MinimumCliVersion>,
+    /// The packages to install in the form of a map from install_id
+    /// to package descriptor.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Install::skip_serializing")]
+    pub install: Install,
+    /// Variables that are exported to the shell environment upon activation.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Vars::skip_serializing")]
+    pub vars: Vars,
+    /// Hooks that are run at various times during the lifecycle of the manifest
+    /// in a known shell environment.
+    #[serde(default)]
+    pub hook: Option<Hook>,
+    /// Profile scripts that are run in the user's shell upon activation
+    /// (and, optionally, upon deactivation).
+    #[serde(default)]
+    pub profile: Option<Profile>,
+    /// Options that control the behavior of the manifest.
+    #[serde(default)]
+    pub options: Options,
+    /// Service definitions
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Services::skip_serializing")]
+    pub services: Services,
+    /// Package build definitions
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Build::skip_serializing")]
+    pub build: Build,
+    #[serde(default)]
+    pub containerize: Option<Containerize>,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Include::skip_serializing")]
+    pub include: Include,
+    /// Free-form data provided by installed plugins, keyed by plugin
+    /// package name (`[plugins.<pkg-name>]`). Each plugin defines and
+    /// validates the shape of its own table; Flox does not interpret it.
+    /// The convention for secrets plugins is a flat table of
+    /// `ENV_VAR_NAME = "path/to/secret/in/store"`, read by the plugin's
+    /// `profile.d` script at activation.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Plugins::skip_serializing")]
+    pub plugins: Plugins,
+}
+impl_pkg_lookup!(crate::parsed::v1_10_0, ManifestV1_14_0);
+
+// You can't derive `Default` because `schema-version` is a `String`,
+// which just defaults to an empty string.
+impl Default for ManifestV1_14_0 {
+    fn default() -> Self {
+        Self {
+            schema_version: "1.14.0".into(),
+            minimum_cli_version: Default::default(),
+            install: Default::default(),
+            vars: Default::default(),
+            hook: Default::default(),
+            profile: Default::default(),
+            options: Default::default(),
+            services: Default::default(),
+            build: Default::default(),
+            containerize: Default::default(),
+            include: Default::default(),
+            plugins: Default::default(),
+        }
+    }
+}
+
+impl AsTypedOnlyManifest for ManifestV1_14_0 {
+    fn as_typed_only(&self) -> crate::Manifest<TypedOnly> {
+        Manifest {
+            inner: TypedOnly {
+                parsed: Parsed::V1_14_0(self.clone()),
+            },
+        }
+    }
+}
+
+impl SchemaVersion for ManifestV1_14_0 {
+    fn get_schema_version(&self) -> KnownSchemaVersion {
+        KnownSchemaVersion::V1_14_0
+    }
+}
+
+/// A map of plugin package names to that plugin's free-form manifest data.
+///
+/// Values are opaque JSON: the plugin that owns a given table defines and
+/// validates its own shape, so Flox stores whatever the user writes without
+/// interpreting it.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, JsonSchema)]
+#[cfg_attr(any(test, feature = "tests"), derive(proptest_derive::Arbitrary))]
+pub struct Plugins(
+    #[cfg_attr(
+        any(test, feature = "tests"),
+        proptest(strategy = "plugins_strategy()")
+    )]
+    pub(crate) BTreeMap<String, serde_json::Value>,
+);
+
+impl_into_inner!(Plugins, BTreeMap<String, serde_json::Value>);
+
+impl SkipSerializing for Plugins {
+    fn skip_serializing(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+/// Proptest strategy for [`Plugins`] data. `serde_json::Value` isn't
+/// `Arbitrary`, so this can't use `btree_map_strategy` directly; it
+/// generates flat objects of string values (the secrets-plugin
+/// convention) rather than arbitrary JSON so it can never produce a
+/// `null`, which `manifest_does_not_serialize_null_fields` forbids.
+#[cfg(any(test, feature = "tests"))]
+fn plugins_strategy() -> impl Strategy<Value = BTreeMap<String, serde_json::Value>> {
+    let plugin_table = btree_map_strategy::<String>(5, 3).prop_map(|entries| {
+        serde_json::Value::Object(
+            entries
+                .into_iter()
+                .map(|(key, value)| (key, serde_json::Value::String(value)))
+                .collect(),
+        )
+    });
+    proptest::collection::btree_map(alphanum_string(5), plugin_table, 0..3)
+}

--- a/cli/flox-manifest/src/raw/mod.rs
+++ b/cli/flox-manifest/src/raw/mod.rs
@@ -1011,6 +1011,12 @@ fn update_raw_packages_from_typed_manifest(
             .keys()
             .cloned()
             .collect::<HashSet<String>>(),
+        Parsed::V1_14_0(manifest) => manifest
+            .install
+            .inner()
+            .keys()
+            .cloned()
+            .collect::<HashSet<String>>(),
     };
 
     // Don't create an [install] table if there are no packages in either
@@ -1135,6 +1141,19 @@ fn update_descriptor(
             }
         },
         Parsed::V1_13_0(manifest) => {
+            let typed = manifest
+                .install
+                .inner()
+                .get(install_id)
+                .ok_or(TomlEditError::PackageNotFound(install_id.to_string()))?;
+            use crate::parsed::v1_10_0::ManifestPackageDescriptor::*;
+            match typed {
+                Catalog(d) => update_v1_10_0_catalog_descriptor(raw, d),
+                FlakeRef(d) => update_v1_10_0_flake_descriptor(raw, d),
+                StorePath(d) => update_store_path_descriptor(raw, d),
+            }
+        },
+        Parsed::V1_14_0(manifest) => {
             let typed = manifest
                 .install
                 .inner()
@@ -2176,6 +2195,9 @@ curl.outputs = [\"bin\", \"man\"]
             Parsed::V1_13_0(m) => {
                 m.install.inner_mut().remove(id);
             },
+            Parsed::V1_14_0(m) => {
+                m.install.inner_mut().remove(id);
+            },
         }
     }
 
@@ -2196,6 +2218,9 @@ curl.outputs = [\"bin\", \"man\"]
                 m.install.inner_mut().insert(id.to_string(), descriptor);
             },
             Parsed::V1_13_0(m) => {
+                m.install.inner_mut().insert(id.to_string(), descriptor);
+            },
+            Parsed::V1_14_0(m) => {
                 m.install.inner_mut().insert(id.to_string(), descriptor);
             },
             _ => panic!("expected v1_10_0 or later manifest"),
@@ -2224,6 +2249,10 @@ curl.outputs = [\"bin\", \"man\"]
                 v1_10_0::ManifestPackageDescriptor::Catalog(desc) => Some(desc),
                 _ => None,
             },
+            Parsed::V1_14_0(m) => match m.install.inner_mut().get_mut(id)? {
+                v1_10_0::ManifestPackageDescriptor::Catalog(desc) => Some(desc),
+                _ => None,
+            },
             _ => panic!("expected v1_10_0 or later manifest"),
         }
     }
@@ -2245,7 +2274,7 @@ curl.outputs = [\"bin\", \"man\"]
         manifest.update_raw_packages_from_typed_manifest().unwrap();
         let output = manifest.inner.raw.to_string();
         expect![[r#"
-            schema-version = "1.13.0"
+            schema-version = "1.14.0"
 
             [install]
 
@@ -2283,7 +2312,7 @@ curl.outputs = [\"bin\", \"man\"]
         manifest.update_raw_packages_from_typed_manifest().unwrap();
         let output = manifest.inner.raw.to_string();
         expect![[r#"
-            schema-version = "1.13.0"
+            schema-version = "1.14.0"
 
             [install]
             # my favorite greeting program
@@ -2315,7 +2344,7 @@ curl.outputs = [\"bin\", \"man\"]
         manifest.update_raw_packages_from_typed_manifest().unwrap();
         let output = manifest.inner.raw.to_string();
         expect![[r#"
-            schema-version = "1.13.0"
+            schema-version = "1.14.0"
 
             [install]
             # keep this comment about hello
@@ -2343,7 +2372,7 @@ curl.outputs = [\"bin\", \"man\"]
         manifest.update_raw_packages_from_typed_manifest().unwrap();
         let output = manifest.inner.raw.to_string();
         expect![[r#"
-            schema-version = "1.13.0"
+            schema-version = "1.14.0"
 
             [install]
             hello.pkg-path = "hello" # this is important
@@ -2415,7 +2444,7 @@ curl.outputs = [\"bin\", \"man\"]
         manifest.update_raw_packages_from_typed_manifest().unwrap();
         let output = manifest.inner.raw.to_string();
         expect![[r#"
-            schema-version = "1.13.0"
+            schema-version = "1.14.0"
 
             [install]
             # this comment is above hello
@@ -2461,7 +2490,7 @@ curl.outputs = [\"bin\", \"man\"]
         manifest.update_systems().unwrap();
         let output = manifest.inner.raw.to_string();
         expect![[r#"
-            schema-version = "1.13.0"
+            schema-version = "1.14.0"
 
             [options]
             systems = ["aarch64-darwin", "x86_64-linux"]
@@ -2517,7 +2546,7 @@ curl.outputs = [\"bin\", \"man\"]
         manifest.update_raw_packages_from_typed_manifest().unwrap();
         let output = manifest.inner.raw.to_string();
         expect![[r#"
-            schema-version = "1.13.0"
+            schema-version = "1.14.0"
 
             [install]
             hello.pkg-path = "hello"
@@ -2542,7 +2571,7 @@ curl.outputs = [\"bin\", \"man\"]
         let output = migrated.inner.migrated_raw.to_string();
         expect![[r##"
             # this comment is above version
-            schema-version = "1.13.0"
+            schema-version = "1.14.0"
 
             [install]
             hello.pkg-path = "hello"

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -1649,7 +1649,7 @@ mod migration_tests {
             .to_string();
 
         expect![[r#"
-            schema-version = "1.13.0"
+            schema-version = "1.14.0"
         "#]]
         .assert_eq(&manifest_contents);
     }

--- a/cli/flox-rust-sdk/src/providers/lock_manifest.rs
+++ b/cli/flox-rust-sdk/src/providers/lock_manifest.rs
@@ -1414,7 +1414,7 @@ mod tests {
         "#};
 
     static TEST_MANIFEST_LATEST_CONTENTS: &str = indoc! {r#"
-          schema-version = "1.13.0"
+          schema-version = "1.14.0"
 
           [install]
           hello_install_id.pkg-path = "hello"

--- a/cli/flox-rust-sdk/src/providers/manifest_init.rs
+++ b/cli/flox-rust-sdk/src/providers/manifest_init.rs
@@ -456,7 +456,7 @@ mod tests {
             ##
             ## -------------------------------------------------------------------
             # Flox manifest version managed by Flox CLI
-            schema-version = "1.13.0"
+            schema-version = "1.14.0"
 
 
             ## Install Packages --------------------------------------------------
@@ -582,7 +582,7 @@ mod tests {
             ##
             ## -------------------------------------------------------------------
             # Flox manifest version managed by Flox CLI
-            schema-version = "1.13.0"
+            schema-version = "1.14.0"
 
 
             ## Install Packages --------------------------------------------------
@@ -711,7 +711,7 @@ mod tests {
             ##
             ## -------------------------------------------------------------------
             # Flox manifest version managed by Flox CLI
-            schema-version = "1.13.0"
+            schema-version = "1.14.0"
 
 
             ## Install Packages --------------------------------------------------
@@ -835,7 +835,7 @@ mod tests {
             ##
             ## -------------------------------------------------------------------
             # Flox manifest version managed by Flox CLI
-            schema-version = "1.13.0"
+            schema-version = "1.14.0"
 
 
             ## Install Packages --------------------------------------------------
@@ -948,7 +948,7 @@ mod tests {
             ##
             ## -------------------------------------------------------------------
             # Flox manifest version managed by Flox CLI
-            schema-version = "1.13.0"
+            schema-version = "1.14.0"
 
 
             ## Install Packages --------------------------------------------------

--- a/cli/flox/doc/manifest.toml.md
+++ b/cli/flox/doc/manifest.toml.md
@@ -33,6 +33,7 @@ tables:
 - [`[include]`](#include)
 - [`[build]`](#build)
 - [`[options]`](#options)
+- [`[plugins]`](#plugins) - experimental, see below
 - [`containerize`] - see [`flox-containerize(1)`](./flox-containerize.md)
 
 ## `schema-version`
@@ -50,6 +51,7 @@ Valid string values are:
 - `1.11.0`: introduced `minimum-cli-version`
 - `1.12.0`: introduced services `auto-start`
 - `1.13.0`: introduced `profile.deactivate` and build `sandbox-allow`
+- `1.14.0`: introduced `plugins`
 
 Existing manifest schemas, including the older `version = 1` format, are
 automatically forward-migrated when using features that require a newer schema
@@ -840,6 +842,33 @@ Semver ::= {
     The default is `true`.
     When enabled, Flox will detect if you have an Nvidia device and attempt to
     locate `libcuda` in well-known paths.
+
+## `[plugins]`
+
+**Experimental: the `[plugins]` section is under active development and
+its behavior may change.** It requires `schema-version = "1.14.0"`.
+
+The `[plugins]` section accepts arbitrary keys with arbitrary values.
+
+To install a plugin `foo` provided by a package `foo` that accepts a
+configuration variable `var`, add the following to your manifest:
+```
+[install]
+foo.pkg-path = "foo"
+
+[plugins.foo]
+var = "value"
+```
+
+Flox plugins work by convention:
+- Flox does not validate plugins listed in `[plugins]` are actually provided by a package.
+  A user must install a package in the `[install]` section that provides the plugin.
+- The plugin name does not need to match the install ID of a package or the
+  `pkg-path` of a package (although it's recommended to match `pkg-path`).
+- Plugins have access to the entire manifest.
+  By convention, plugins should only access data under `[plugins.<plugin name>]`,
+  but Flox does not enforce this.
+
 
 # SEE ALSO
 [`flox-init(1)`](./flox-init.md),

--- a/cli/schemas/lockfile-v1.schema.json
+++ b/cli/schemas/lockfile-v1.schema.json
@@ -1263,6 +1263,91 @@
           ],
           "type": "object"
         },
+        "ManifestV1_14_0": {
+          "additionalProperties": false,
+          "description": "Not meant for writing manifest files, only for reading them.\nModifications should be made using `manifest::raw`.",
+          "properties": {
+            "build": {
+              "$ref": "#/$defs/Build2",
+              "description": "Package build definitions"
+            },
+            "containerize": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Containerize"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "hook": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Hook"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Hooks that are run at various times during the lifecycle of the manifest\nin a known shell environment."
+            },
+            "include": {
+              "$ref": "#/$defs/Include"
+            },
+            "install": {
+              "$ref": "#/$defs/Install2",
+              "description": "The packages to install in the form of a map from install_id\nto package descriptor."
+            },
+            "minimum-cli-version": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/MinimumCliVersion"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The minimum CLI version that can activate this environment."
+            },
+            "options": {
+              "$ref": "#/$defs/Options",
+              "default": {},
+              "description": "Options that control the behavior of the manifest."
+            },
+            "plugins": {
+              "$ref": "#/$defs/Plugins",
+              "description": "Free-form data provided by installed plugins, keyed by plugin\npackage name (`[plugins.<pkg-name>]`). Each plugin defines and\nvalidates the shape of its own table; Flox does not interpret it.\nThe convention for secrets plugins is a flat table of\n`ENV_VAR_NAME = \"path/to/secret/in/store\"`, read by the plugin's\n`profile.d` script at activation."
+            },
+            "profile": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Profile2"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Profile scripts that are run in the user's shell upon activation\n(and, optionally, upon deactivation)."
+            },
+            "schema-version": {
+              "description": "Which schema version this manifest adheres to.\n\nMust be a valid Flox CLI version listed in [`KnownSchemaVersion`].",
+              "type": "string"
+            },
+            "services": {
+              "$ref": "#/$defs/Services2",
+              "description": "Service definitions"
+            },
+            "vars": {
+              "$ref": "#/$defs/Vars",
+              "description": "Variables that are exported to the shell environment upon activation."
+            }
+          },
+          "required": [
+            "schema-version"
+          ],
+          "type": "object"
+        },
         "ManifestVersion": {
           "format": "uint8",
           "maximum": 255,
@@ -1514,6 +1599,11 @@
           "required": [
             "store-path"
           ],
+          "type": "object"
+        },
+        "Plugins": {
+          "additionalProperties": true,
+          "description": "A map of plugin package names to that plugin's free-form manifest data.\n\nValues are opaque JSON: the plugin that owns a given table defines and\nvalidates its own shape, so Flox stores whatever the user writes without\ninterpreting it.",
           "type": "object"
         },
         "Profile": {
@@ -2313,6 +2403,9 @@
         },
         {
           "$ref": "#/$defs/ManifestV1_13_0"
+        },
+        {
+          "$ref": "#/$defs/ManifestV1_14_0"
         }
       ],
       "description": "A validated, typed manifest with a known schema.",

--- a/cli/schemas/manifest-v1.schema.json
+++ b/cli/schemas/manifest-v1.schema.json
@@ -866,6 +866,91 @@
       ],
       "type": "object"
     },
+    "ManifestV1_14_0": {
+      "additionalProperties": false,
+      "description": "Not meant for writing manifest files, only for reading them.\nModifications should be made using `manifest::raw`.",
+      "properties": {
+        "build": {
+          "$ref": "#/$defs/Build2",
+          "description": "Package build definitions"
+        },
+        "containerize": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Containerize"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "hook": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Hook"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Hooks that are run at various times during the lifecycle of the manifest\nin a known shell environment."
+        },
+        "include": {
+          "$ref": "#/$defs/Include"
+        },
+        "install": {
+          "$ref": "#/$defs/Install2",
+          "description": "The packages to install in the form of a map from install_id\nto package descriptor."
+        },
+        "minimum-cli-version": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/MinimumCliVersion"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The minimum CLI version that can activate this environment."
+        },
+        "options": {
+          "$ref": "#/$defs/Options",
+          "default": {},
+          "description": "Options that control the behavior of the manifest."
+        },
+        "plugins": {
+          "$ref": "#/$defs/Plugins",
+          "description": "Free-form data provided by installed plugins, keyed by plugin\npackage name (`[plugins.<pkg-name>]`). Each plugin defines and\nvalidates the shape of its own table; Flox does not interpret it.\nThe convention for secrets plugins is a flat table of\n`ENV_VAR_NAME = \"path/to/secret/in/store\"`, read by the plugin's\n`profile.d` script at activation."
+        },
+        "profile": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Profile2"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Profile scripts that are run in the user's shell upon activation\n(and, optionally, upon deactivation)."
+        },
+        "schema-version": {
+          "description": "Which schema version this manifest adheres to.\n\nMust be a valid Flox CLI version listed in [`KnownSchemaVersion`].",
+          "type": "string"
+        },
+        "services": {
+          "$ref": "#/$defs/Services2",
+          "description": "Service definitions"
+        },
+        "vars": {
+          "$ref": "#/$defs/Vars",
+          "description": "Variables that are exported to the shell environment upon activation."
+        }
+      },
+      "required": [
+        "schema-version"
+      ],
+      "type": "object"
+    },
     "ManifestVersion": {
       "format": "uint8",
       "maximum": 255,
@@ -1117,6 +1202,11 @@
       "required": [
         "store-path"
       ],
+      "type": "object"
+    },
+    "Plugins": {
+      "additionalProperties": true,
+      "description": "A map of plugin package names to that plugin's free-form manifest data.\n\nValues are opaque JSON: the plugin that owns a given table defines and\nvalidates its own shape, so Flox stores whatever the user writes without\ninterpreting it.",
       "type": "object"
     },
     "Profile": {
@@ -1916,6 +2006,9 @@
     },
     {
       "$ref": "#/$defs/ManifestV1_13_0"
+    },
+    {
+      "$ref": "#/$defs/ManifestV1_14_0"
     }
   ],
   "description": "A validated, typed manifest with a known schema.",

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -2752,6 +2752,111 @@ EOF
   assert_success
 }
 
+# The following tests exercise the [plugins] manifest section end to end
+# with a minimal plugin package built on the fly: a package whose profile.d
+# script reads its own [plugins.test-plugin] table via the flox_plugin_data
+# activation helper and exports it verbatim.
+
+# Build and install a minimal test-plugin package into the current project.
+setup_test_plugin() {
+  mkdir -p "$BATS_TEST_TMPDIR/test-plugin/etc/profile.d"
+  cat > "$BATS_TEST_TMPDIR/test-plugin/etc/profile.d/0900_test-plugin.sh" <<'EOF'
+# shellcheck shell=bash
+_test_plugin_data="$(flox_plugin_data test-plugin)"
+export TEST_PLUGIN_DATA="$_test_plugin_data"
+EOF
+  pkg_store_path="$(nix --extra-experimental-features nix-command \
+    store add --name test-plugin "$BATS_TEST_TMPDIR/test-plugin")"
+  run "$FLOX_BIN" install "$pkg_store_path"
+  assert_success
+}
+
+# bats test_tags=activate,activate:plugins
+@test "plugins: profile.d script reads its [plugins] data via flox_plugin_data" {
+  project_setup
+  setup_test_plugin
+
+  {
+    cat "$PROJECT_DIR/.flox/env/manifest.toml"
+    echo
+    echo '[plugins.test-plugin]'
+    echo 'MY_VALUE = "hello-plugins"'
+  } | "$FLOX_BIN" edit -f -
+
+  run "$FLOX_BIN" activate -c \
+    "bash -c 'echo TEST_PLUGIN_DATA is: \${TEST_PLUGIN_DATA:-unset}'"
+  assert_success
+  assert_output --partial 'TEST_PLUGIN_DATA is: {"MY_VALUE":"hello-plugins"}'
+}
+
+# bats test_tags=activate,activate:plugins
+@test "plugins: a failing plugin script blocks activation" {
+  project_setup
+  setup_test_plugin
+
+  # No [plugins.test-plugin] table in the manifest: flox_plugin_data errors,
+  # and the failure of the plugin's profile.d script fails the activation.
+  run "$FLOX_BIN" activate -c \
+    "bash -c 'echo TEST_PLUGIN_DATA is: \${TEST_PLUGIN_DATA:-unset}'"
+  assert_failure
+  assert_output --partial "no [plugins.test-plugin] data"
+}
+
+# bats test_tags=activate,activate:plugins
+@test "plugins: vars exported by plugin scripts are visible in hook.on-activate" {
+  project_setup
+  setup_test_plugin
+
+  # The init template already declares a [hook] table, so write a complete
+  # manifest rather than appending a duplicate one.
+  "$FLOX_BIN" edit -f - <<< "$(with_latest_schema "$(cat <<EOF
+[install]
+test-plugin.store-path = "$pkg_store_path"
+
+[plugins.test-plugin]
+MY_VALUE = "hello-plugins"
+
+[hook]
+on-activate = "echo hook sees: \$TEST_PLUGIN_DATA"
+EOF
+  )")"
+
+  run "$FLOX_BIN" activate -c "true"
+  assert_success
+  assert_output --partial 'hook sees: {"MY_VALUE":"hello-plugins"}'
+}
+
+# bats test_tags=activate,activate:plugins
+@test "plugins: flox_plugin_data works in build mode" {
+  project_setup
+  setup_test_plugin
+
+  # Install hello so the build derives its nixpkgs from the toplevel group
+  # instead of querying the catalog for base catalog information.
+  _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.yaml" \
+    "$FLOX_BIN" edit -f - <<< "$(with_latest_schema "$(cat <<EOF
+[install]
+hello.pkg-path = "hello"
+test-plugin.store-path = "$pkg_store_path"
+
+[plugins.test-plugin]
+MY_VALUE = "hello-plugins"
+
+[build.echo-plugin-data]
+command = '''
+  mkdir -p \$out
+  echo "\$TEST_PLUGIN_DATA" > \$out/data
+'''
+EOF
+  )")"
+
+  run "$FLOX_BIN" build echo-plugin-data
+  assert_success
+  run cat "result-echo-plugin-data/data"
+  assert_success
+  assert_output '{"MY_VALUE":"hello-plugins"}'
+}
+
 @test "activate works with fish 3.2.2" {
   if [ "$NIX_SYSTEM" == aarch64-linux ]; then
     # running fish at all on aarch64-linux throws:

--- a/cli/tests/test_support.bash
+++ b/cli/tests/test_support.bash
@@ -359,9 +359,9 @@ ensure_remote_environment_built() {
 with_latest_schema() {
   body="$1"
   if [ -z "$body" ]; then
-    printf "schema-version = \"1.13.0\"\n"
+    printf "schema-version = \"1.14.0\"\n"
   else
-    printf "schema-version = \"1.13.0\"\n\n%s" "$body"
+    printf "schema-version = \"1.14.0\"\n\n%s" "$body"
   fi
 }
 


### PR DESCRIPTION
- feat(activate): add flox_plugin_data helper for [plugins] data

  Add a flox_plugin_data helper that prints a plugin's
  [plugins.<pkg-name>] table from the activating environment's
  manifest.lock as compact JSON. The helper errors when the lockfile or
  the plugin's data is missing; profile.d scripts run under `set -e`, so
  a failing plugin script blocks activation.

  Integration tests exercise the section end to end with a minimal
  plugin package built on the fly.

- feat(manifest): add schema v1.14.0 with a [plugins] section

  The [plugins] section holds free-form data for installed plugin
  packages, keyed by package name ([plugins.<pkg-name>]). Flox stores the
  data without interpreting it; each plugin defines and validates the
  shape of its own table. Composing environments merges plugin data
  whole-table per plugin name, with the higher priority manifest winning.

  V1_13_0 manifests migrate losslessly with plugins defaulting to empty,
  and manifests that don't use [plugins] still downgrade to their
  original schema version. Bump VERSION to 1.14.0 to keep the CLI
  version at least the latest schema version.

  Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

## Release Notes

(check if we have examples and docs finished before announcing)
Added an experimental `[plugins]` manifest section TODO link docs