### PR TITLE
feat(extensions): gh-style extension subsystem behind features.beta

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,6 +274,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -573,8 +582,29 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "bpaf",
+ "flate2",
  "flox-rust-sdk",
+ "fslock",
+ "futures",
+ "httpmock",
+ "indicatif",
+ "pretty_assertions",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tar",
+ "temp-env",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "toml",
  "tracing",
+ "url",
+ "uuid",
+ "walkdir",
+ "zip",
 ]
 
 [[package]]
@@ -702,9 +732,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byteorder"
@@ -1020,9 +1050,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.20"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crossterm"
@@ -1190,6 +1220,17 @@ checksum = "d630bccd429a5bb5a64b5e94f693bfc48c9f8566418fda4c494cc94f911f87cc"
 dependencies = [
  "powerfmt",
  "serde",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4947,6 +4988,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
 name = "similar"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6818,10 +6865,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap 2.13.0",
+ "memchr",
+ "thiserror 2.0.18",
+ "zopfli",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f4a4e8e9dc5c62d159f04fcdbe07f4c3fb710415aab4754bf11505501e3251d"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zvariant"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 serde_with = { version = "3.16.1", features = ["time_0_3"] }
 serde_yaml = "0.9"
+sha2 = "0.10"
 shell-escape = "0.1.5"
 slug = "0.1"
 strum = { version = "0.27", features = ["derive"] }
@@ -136,6 +137,7 @@ url-escape = "0.1.1"
 uuid = { version = "1.16", features = ["serde", "v4"] }
 walkdir = "2"
 xdg = "3.0"
+zip = { version = "2", default-features = false, features = ["deflate"] }
 
 
 # dev dependencies

--- a/PROJECTS.md
+++ b/PROJECTS.md
@@ -1431,6 +1431,13 @@ Two upstream changes since `0badcdf59` drove the rework:
       (~80 lines in `cli/flox/src/commands/mod.rs`) that keeps
       `RESERVED_COMMAND_NAMES` in sync with the parser. Guards a real
       invariant, but adds test code to a heavily reviewed file.
+- [x] [P11-T10] Dispatch an external extension for `flox <name> --help`.
+      bpaf routes `--help` to `ParseFailure::Stdout` (its help short-circuit),
+      which returned before the `Stderr` dispatch arm — so an installed
+      extension's own `--help` was never shown. The `Stdout` arm now also
+      calls `try_dispatch_external()`; the reserved-name guard and a lookup
+      miss keep `flox --help`, built-ins, and uninstalled names unchanged.
+      Commit `9435415ed`.
 
 ### Known limitation
 
@@ -1438,7 +1445,17 @@ Two upstream changes since `0badcdf59` drove the rework:
 directly, because it runs in `main()` before the config system loads.
 `flox config --set features.beta true` therefore enables the
 `flox extension …` subcommands but **not** dispatch. Documented in the
-user guide; should be resolved before extensions leave beta.
+user guide; should be resolved before extensions leave beta. Tracked in
+flox/flox#4537.
+
+Nested-bundle extensions (an executable shipped inside a subdirectory
+alongside support files) lose their siblings on install: `locate_executable`
+copies only the executable to the managed root, so `$(dirname "$0")` and
+`$ORIGIN`-relative lookups resolve against the root, not the bundle dir.
+Single-file extensions are unaffected. Fixing it changes the
+layout/dispatch contract, so it is deferred pending a design decision.
+Tracked in Linear CLI-157; a `TODO(CLI-157)` sits at the `fs::copy` site in
+`cli/beta/src/extensions/archive.rs`.
 
 ### Automated Verification
 

--- a/PROJECTS.md
+++ b/PROJECTS.md
@@ -1446,7 +1446,7 @@ directly, because it runs in `main()` before the config system loads.
 `flox config --set features.beta true` therefore enables the
 `flox extension …` subcommands but **not** dispatch. Documented in the
 user guide; should be resolved before extensions leave beta. Tracked in
-flox/flox#4537.
+Linear CLI-158.
 
 Nested-bundle extensions (an executable shipped inside a subdirectory
 alongside support files) lose their siblings on install: `locate_executable`

--- a/PROJECTS.md
+++ b/PROJECTS.md
@@ -1397,6 +1397,11 @@ Two upstream changes since `0badcdf59` drove the rework:
 - Telemetry (still deferred from P07).
 - FloxHub source (P09) and richer UX (P10).
 
+**Linear tracking**: parent tracker **CLI-161** (the branch is the source of
+truth) with sub-issues **CLI-157** (nested-bundle install), **CLI-158**
+(config-vs-env dispatch; moved from closed flox/flox#4537), and **CLI-160**
+(reserved-command drift guard, this P11-T09).
+
 ### Tests & Tasks
 
 - [x] [P11-T01] Fast-forward local `main` to `origin/main` and create the
@@ -1427,10 +1432,11 @@ Two upstream changes since `0badcdf59` drove the rework:
 - [ ] [P11-TS03] `flox --help` does not list `extension`.
 - [ ] [P11-TS04] `just integ-tests extension.bats` passes with the
       converted gating.
-- [ ] [P11-T09] Decide whether to port the `extension_drift_tests` module
+- [>] [P11-T09] Decide whether to port the `extension_drift_tests` module
       (~80 lines in `cli/flox/src/commands/mod.rs`) that keeps
       `RESERVED_COMMAND_NAMES` in sync with the parser. Guards a real
       invariant, but adds test code to a heavily reviewed file.
+      Deferred; tracked in Linear CLI-160.
 - [x] [P11-T10] Dispatch an external extension for `flox <name> --help`.
       bpaf routes `--help` to `ParseFailure::Stdout` (its help short-circuit),
       which returned before the `Stderr` dispatch arm — so an installed

--- a/PROJECTS.md
+++ b/PROJECTS.md
@@ -1,0 +1,1448 @@
+# PROJECTS.md
+
+Tracking doc for the `flox extension` subsystem — porting the `gh extension`
+model to flox. Authoritative design document: [`research/gh_extension_flox.md`](research/gh_extension_flox.md).
+
+## Status Legend
+
+- `[x]` Completed
+- `[-]` In Progress
+- `[ ]` Not Started
+- `[~]` Won't fix / Invalid / False positive
+
+## Branch Discipline
+
+P01–P08 were committed exclusively to `smorin/github-extension-prototype`,
+branched from `main` at `0badcdf59` (2026-04-15).
+
+**P11 supersedes that branch.** Work now happens on
+`smorin/github-extension-prototype-v2`, branched from `origin/main` at
+`dd390e66b` (2026-07-21) — 737 commits later — in a worktree at
+`../flox-gh-plugin-extension-v2`. The v1 branch is retained as the source
+of the port and for its history; it is not the review target.
+
+No merges to `main`, no PR opened until the branch owner decides.
+
+## Design Constraints
+
+The extension subsystem is **purely additive** to the existing flox
+architecture. These rules are binding for all of P01–P07:
+
+1. **No refactors of adjacent code.** Touch an existing file only when a
+   task explicitly requires it; leave everything else alone.
+2. **New variants on the top-level `Commands` enum are permitted and
+   preferred over expanding existing group enums.** Adding
+   `Commands::Extension(ExtensionCommands)` is additive — it touches
+   only the bottom of the enum and the top-level dispatch `match`.
+   Adding under `ManageCommands` would mutate a group that belongs to
+   unrelated commands. No new *sibling* to `Commands` (a separate
+   parser) is introduced. In P01 the variant carries `#[bpaf(hide)]`
+   so it stays out of `flox --help` until the feature leaves prototype
+   status (see P07-T05).
+3. **No new cross-cutting abstractions.** Reuse `GitCommandProvider`,
+   `reqwest::Client`, `fslock::LockFile`, `xdg` paths, `httpmock`,
+   `Features`, `Flox` context, and the existing telemetry infra as-is.
+4. **No modifications to `flox-activations` or `flox-core`.** `Pinned` mode
+   shells out to the existing `FLOX_ACTIVATIONS_BIN` the way
+   `cli/flox/src/commands/activate.rs` already does.
+5. **No new env-var conventions.** Feature flag piggybacks on the existing
+   `FLOX_FEATURES_*` pattern. Activation detection uses
+   `_FLOX_ACTIVE_ENVIRONMENTS` from `cli/flox-core/src/activate/vars.rs`.
+6. **No new dependencies unless unavoidable.** Check `Cargo.lock` first.
+   Known likely-new deps for P04: `flate2` + `tar` + `zip` for archive
+   extraction, `sha2` for checksum (verify these aren't already transitively
+   present).
+7. **Feature flag gates the whole subsystem.** Until P07 flips
+   `Features::extensions` default to `true`, non-flag flox builds are
+   bit-identical to today.
+
+Full rationale and file-by-file impact table:
+[`/Users/stevemorin/.claude/plans/create-a-a-more-velvet-dove.md`](/Users/stevemorin/.claude/plans/create-a-a-more-velvet-dove.md).
+
+## Versioning Note
+
+The versions below (v0.1.0 … v1.0.0) are **feature-internal milestone
+markers** for the extension subsystem behind `FLOX_FEATURES_EXTENSIONS`.
+They are **not** flox git tags — flox ships as a single binary and its
+overall version is independent (already past v1.9). These numbers exist to
+track milestone completion inside this doc and do not drive any release
+process.
+
+## Roadmap at a Glance
+
+| ID  | Title                                                    | Version | Status |
+|-----|----------------------------------------------------------|---------|--------|
+| P01 | Skeleton and dispatch                                    | v0.1.0  | `[x]`  |
+| P02 | Manifest, layout, local install                          | v0.2.0  | `[x]`  |
+| P03 | GitHub source: git/script install                        | v0.3.0  | `[x]`  |
+| P04 | GitHub source: binary release install                    | v0.4.0  | `[x]`  |
+| P05 | `upgrade --all`, table output, lock polish               | v0.5.0  | `[x]`  |
+| P06 | Environment integration (the Flox-unique piece)          | v0.6.0  | `[x]`  |
+| P07 | Docs, telemetry, GA                                      | v1.0.0  | `[ ]`  |
+| P07a | Example repo: flox-hello-script                         | v1.0.0  | `[x]`  |
+| P07b | Example repo: flox-hello-binary (macOS only)            | v1.0.0  | `[x]`  |
+| P07c | Example repo: flox-hello-local                          | v1.0.0  | `[x]`  |
+| P08 | Discovery — search                                       | v1.1.0  | `[x]`  |
+| P09 | Authoring and FloxHub source (v2) — needs more detail    | —       | `[ ]`  |
+| P10 | Richer UX and ecosystem (v3) — needs more detail         | —       | `[ ]`  |
+| P11 | Rebase onto current main; gate behind `features.beta`    | v1.2.0  | `[~]`  |
+
+---
+
+## [x] Project P01: Skeleton and dispatch (v0.1.0)
+
+**Goal**: Land the extension module tree, register the `flox extension`
+subcommand as a stub, and wire the two-phase bpaf parse so that
+`flox <name>` can dispatch to a `flox-<name>` executable in the managed
+directory. Everything behind the `Features::extensions` flag so default
+flox behavior is unchanged.
+
+Maps to research doc §Part 4 M0.
+
+**Out of Scope**
+- Any real install/list/remove/upgrade logic (all handlers are stubs).
+- Manifest parsing or filesystem layout beyond `find`-by-path.
+- Environment-activation modes.
+
+### Tests & Tasks
+
+- [x] [P01-T01] Create the extension provider module tree
+      `cli/flox-rust-sdk/src/providers/extensions/{mod,manager,extension,manifest,dispatch,layout,source,github}.rs`
+      with empty stubs and re-exports from `mod.rs`.
+- [x] [P01-T02] Add `pub mod extensions;` to
+      `cli/flox-rust-sdk/src/providers/mod.rs` (one line).
+- [x] [P01-T03] Add `extensions: bool` (default `false`) to the existing
+      `Features` struct in `cli/flox-rust-sdk/src/flox.rs`; wire the
+      `FLOX_FEATURES_EXTENSIONS` env-var override into the existing
+      features-loading code path.
+- [x] [P01-T04] Create `cli/flox/src/commands/extension/` with
+      `mod.rs`, `install.rs`, `list.rs`, `remove.rs`, `upgrade.rs`.
+      Define `ExtensionCommands` as a `#[derive(Bpaf)]` enum covering the
+      four verbs; handlers are `unimplemented!()` stubs.
+- [x] [P01-T05] Add `Extension(ExtensionCommands)` variant to the
+      top-level `Commands` enum in `cli/flox/src/commands/mod.rs` with
+      `#[bpaf(command, hide)]` (the `hide` keeps it out of
+      `flox --help` during the prototype window) and wire a
+      `Commands::Extension(args) => args.handle(flox).await` arm in
+      the top-level dispatch match.
+- [x] [P01-T06] In `cli/flox/src/main.rs` (around line 131 where
+      `ParseFailure` is matched), add the two-phase-parse fallback: on
+      `ParseFailure::Stderr` where the first positional does not start
+      with `-` **and** `flox.features.extensions` is true, call
+      `dispatch_external(argv)` which looks up `flox-<name>` under
+      `$XDG_DATA_HOME/flox/extensions/flox-<name>/flox-<name>` and then
+      `$PATH`.
+- [x] [P01-T07] Enforce the feature-flag gate in each verb's
+      `handle()` (early-return an error when
+      `flox.features.extensions == false`). Combined with the
+      unconditional `#[bpaf(hide)]` from P01-T05, non-flag builds
+      produce bit-identical help output and behavior to today.
+- [x] [P01-TS01] Unit: `Features::extensions` default is `false`; override
+      via `FLOX_FEATURES_EXTENSIONS=1` sets it to `true`.
+- [x] [P01-TS02] Unit: `dispatch_external` returns `Ok` for a present
+      `flox-<name>` under the managed dir, falls back to `$PATH` correctly,
+      and returns a `NotFound` error when neither contains it.
+- [x] [P01-TS03] Integ bats (new file `cli/tests/extension.bats`): with
+      `FLOX_FEATURES_EXTENSIONS=1` and a pre-placed executable
+      `flox-hello` under the managed dir, `flox hello` prints the expected
+      string.
+- [x] [P01-TS04] Integ bats: `flox extension --help` lists
+      `install`/`list`/`remove`/`upgrade` when the flag is on; the
+      `extension` subcommand is absent from `flox --help` regardless
+      of flag state (the `#[bpaf(hide)]` attribute keeps it off
+      top-level help until P07-T05 removes `hide`).
+
+### Deliverable
+
+```bash
+# With feature flag on and a pre-placed script:
+$ FLOX_FEATURES_EXTENSIONS=1 flox hello world
+Hello, world!
+
+$ FLOX_FEATURES_EXTENSIONS=1 flox extension --help
+Usage: flox extension COMMAND
+  install  Install an extension
+  list     List installed extensions
+  remove   Remove an installed extension
+  upgrade  Upgrade installed extensions
+```
+
+### Automated Verification
+
+- `just build-cli` succeeds.
+- `just unit-tests extensions` passes all P01-TS01/P01-TS02 cases.
+- `just integ-tests extension.bats` passes P01-TS03/P01-TS04.
+
+### Manual Verification
+
+- With flag off, `flox --help` is byte-identical to current output (diff
+  against a pre-branch snapshot).
+- Build without the flag env var set; confirm the `extension` subcommand
+  does not appear in help.
+
+### Exit Criterion
+
+`flox hello` runs a pre-placed `flox-hello` script; `flox extension --help`
+lists the four subcommands. (Research doc §Part 4 M0.)
+
+---
+
+## [x] Project P02: Manifest, layout, local install (v0.2.0)
+
+**Goal**: Introduce the author-facing manifest (`flox-extension.toml`),
+the internal `state.toml`, on-disk layout under `$XDG_DATA_HOME/flox/extensions/`,
+the `.lock` file for concurrency, and end-to-end `install .` / `list` /
+`remove` for local extensions. This is the first user-visible slice.
+
+Maps to research doc §Part 4 M1.
+
+**Out of Scope**
+- Any GitHub fetching (next project).
+- Binary or archive handling.
+- Environment-activation modes.
+
+### Tests & Tasks
+
+- [x] [P02-T01] In `providers/extensions/manifest.rs`, define
+      `AuthorManifest`, `ExtensionMeta`, `BinaryMeta`,
+      `EnvironmentBehavior`, `InheritMode`, `OnActive` per research doc
+      §2.3 with `serde` derives and sensible `Default` impls.
+- [x] [P02-T02] In the same file, define `InstalledState` with fields
+      `schema`, `name`, `kind`, `source`, `owner`, `repo`, `host`, `tag`,
+      `commit`, `pinned`, `asset_sha256`, `installed_at`, `path`.
+- [x] [P02-T03] In `providers/extensions/layout.rs`, implement
+      `extensions_root(&Flox) -> PathBuf` (= `flox.data_dir.join("extensions")`),
+      `install_dir(&Flox, name)`, `state_path(&Flox, name)`,
+      `lock_path(&Flox)` (= `extensions_root/.lock`). Use `flox.data_dir`
+      — do not re-derive XDG paths.
+- [x] [P02-T04] Wrap install/remove in an `fslock::LockFile` on
+      `lock_path`, using the guard pattern from
+      `cli/flox-rust-sdk/src/providers/upgrade_checks.rs`.
+- [x] [P02-T05] Implement `install_local(&Flox, path) -> Result<Extension>`:
+      resolve to absolute path, create a staging dir (`<name>.staging-<uuid>`),
+      verify `flox-<name>` executable exists at `<path>/flox-<name>`,
+      copy `flox-extension.toml` in if present, write `state.toml` with
+      `source = "local"` and `commit = git rev-parse HEAD` if `<path>/.git`
+      exists, then atomic rename staging → final.
+- [x] [P02-T06] Implement `remove(&Flox, name)`: read state, take the
+      lock, `fs::remove_dir_all(install_dir)`.
+- [x] [P02-T07] Implement `list(&Flox) -> Vec<Extension>`: scan
+      `extensions_root` subdirs, parse each `state.toml`, collect results.
+      Lock-free.
+- [x] [P02-T08] Wire `install.rs` to accept `.` (CWD) or
+      `--from-path PATH` and dispatch to `manager::install_local`. Reject
+      `owner/repo`-style specs and other strings with a "GitHub sources
+      land in P03" error. Wire `list.rs` and `remove.rs` to call
+      `manager::list` and `manager::remove`.
+- [x] [P02-T09] Implement the atomic-rename staging helper used by install
+      (and reused by upgrade later).
+- [x] [P02-TS01] Unit: `AuthorManifest` TOML round-trip including all
+      defaults for optional blocks (`[environment]` absent,
+      `[extension.binary]` absent).
+- [x] [P02-TS02] Unit: `InstalledState` TOML round-trip.
+- [x] [P02-TS03] Unit: `layout::extensions_root` returns
+      `flox.data_dir.join("extensions")`, using
+      `flox::test_helpers::flox_instance()` for the fixture (consistent
+      with other SDK provider tests).
+- [x] [P02-TS04] Unit: `install_local` happy path under a `tempfile` dir
+      containing a fake `flox-hello` script.
+- [x] [P02-TS05] Unit: `install_local` rejects if no executable
+      `flox-<name>` exists at the repo root.
+- [x] [P02-TS06] Unit: concurrent `install` + `remove` using the `fslock`
+      guard — the second caller sees `WouldBlock` (or serializes),
+      no corruption.
+- [x] [P02-TS07] Integ bats: init a fake extension directory,
+      `flox extension install .`, `flox extension list` shows it,
+      `flox extension remove <name>`, list is empty again.
+
+### Deliverable
+
+```bash
+$ mkdir -p /tmp/flox-hello && cat > /tmp/flox-hello/flox-hello <<'EOF'
+#!/usr/bin/env bash
+echo "hello from $FLOX_EXTENSION_NAME"
+EOF
+$ chmod +x /tmp/flox-hello/flox-hello
+$ FLOX_FEATURES_EXTENSIONS=1 flox extension install --from-path /tmp/flox-hello
+Installed flox-hello (local) -> ~/.local/share/flox/extensions/flox-hello
+
+$ FLOX_FEATURES_EXTENSIONS=1 flox extension list
+NAME   REPO  VERSION  PINNED
+hello  .     -
+
+$ FLOX_FEATURES_EXTENSIONS=1 flox hello
+hello from hello
+
+$ FLOX_FEATURES_EXTENSIONS=1 flox extension remove hello
+Removed flox-hello
+```
+
+### Automated Verification
+
+- `just unit-tests` passes P02-TS01 through P02-TS06.
+- `just integ-tests extension.bats` passes P02-TS07.
+
+### Manual Verification
+
+- Install the same extension twice without `--force` and confirm a clean
+  "already installed" error.
+- Inspect `$XDG_DATA_HOME/flox/extensions/flox-<name>/state.toml` and
+  confirm all fields are populated and parseable.
+
+### Exit Criterion
+
+Local developer loop works: authors can iterate on an extension locally
+without ever touching GitHub. (Research doc §Part 4 M1.)
+
+---
+
+## [x] Project P03: GitHub source — git/script install (v0.3.0)
+
+**Goal**: First remote-source path. Clone a GitHub repo into the managed
+directory as a script/git extension, with `--pin`, `--force`, and
+`upgrade <name>` support for the clone-based kinds.
+
+Maps to research doc §Part 4 M2.
+
+**Out of Scope**
+- Binary release assets / archive extraction (P04).
+- `upgrade --all` (P05).
+- FloxHub or non-GitHub sources (v2).
+
+### Tests & Tasks
+
+- [x] [P03-T01] In `providers/extensions/github.rs`, define the
+      `GitHubSource` struct holding a `reqwest::Client` (with configurable
+      `base_url`) and a `GitCommandProvider`. The `ExtensionSource` trait
+      is deferred to P04 where a second implementation may justify the
+      abstraction (Design Constraint #3 + CLAUDE.md provider-trait
+      guidance).
+- [x] [P03-T02] In `providers/extensions/github.rs`, implement
+      `GitHubSource` holding a `reqwest::Client` and a
+      `GitCommandProvider` (from `cli/flox-rust-sdk/src/providers/git.rs`).
+      Default host `github.com`; accept GHE host overrides.
+- [x] [P03-T03] `GitHubSource::resolve_latest`: `GET
+      https://api.github.com/repos/:owner/:repo/releases/latest`; fall back
+      to `GET /repos/:owner/:repo` → `default_branch` → `GET
+      /repos/:owner/:repo/commits/<branch>` for the HEAD commit.
+- [x] [P03-T04] `GitHubSource::resolve_pin`: if input matches semver/`v*`,
+      `GET /releases/tags/<pin>`; else treat as commit-SHA prefix and
+      `GET /commits/<prefix>` to expand to a full SHA. Hex pins also
+      fetch `default_branch` so `install_github` has a clonable named
+      ref (`git clone --branch` rejects raw SHAs); the post-clone
+      `git reset --hard <commit>` then pins the worktree exactly.
+- [x] [P03-T05] `GitHubSource::clone_repo`: delegate to
+      `GitCommandProvider::clone_branch_with(url, staging, branch,
+      bare=false)` (single-ref clone, no tags). `--depth=1` is not
+      exposed by the existing API and Design Constraint #3 forbids
+      extending it for the prototype.
+- [x] [P03-T06] Extend `install.rs` with the non-local path: parse
+      `owner/repo` or full URL, normalize (ensure repo suffix is
+      `flox-<name>`, extract `name`), run `checkValidExtension` (core-name
+      collision check + already-installed check), clone into staging,
+      verify `flox-<name>` executable, copy `flox-extension.toml`, write
+      `state.toml` with `kind = Script` or `Git`, atomic rename.
+- [x] [P03-T07] Add `--pin <ref>` flag to `install`; sets `pinned = true`
+      in state.
+- [x] [P03-T08] Add `--force` flag with dual install/upgrade meaning:
+      on `install`, deletes the existing install dir on owner-conflict;
+      on `upgrade`, also overrides the `pinned = true` skip (D4).
+- [x] [P03-T09] Implement `upgrade.rs` for script/git kinds:
+      `GitCommandProvider::fetch_ref(install_dir, "origin", &branch)`
+      (no colon — fetches into FETCH_HEAD without updating the local
+      branch ref, which git would refuse for the currently checked-out
+      branch) then shell out to `git -C <install_dir> reset --hard FETCH_HEAD`
+      (matches the P02-D2 precedent of one-off `git` invocations from
+      manager.rs). Update `commit` in `state.toml`. Skip with
+      `UpgradeStatus::Pinned` if `pinned = true` unless `--force`.
+      Local-kind extensions return `UpgradeError::LocalNotSupported`.
+- [x] [P03-T10] In `providers/extensions/manager.rs`, add a
+      `const RESERVED_COMMAND_NAMES: &[&str]` list of flox's top-level
+      subcommand names (e.g., `install`, `activate`, `search`, `init`, …).
+- [x] [P03-TS01] Unit: `resolve_latest` against a canned
+      `releases/latest` JSON fixture via `httpmock`.
+- [x] [P03-TS02] Unit: `resolve_pin` for a tag name and for a commit-SHA
+      prefix, both against `httpmock` fixtures.
+- [x] [P03-TS03] Unit: `checkValidExtension` rejects a name colliding with
+      `RESERVED_COMMAND_NAMES`.
+- [x] [P03-TS04] Unit: drift test — walk bpaf help output of the top-level
+      `Commands` enum and assert every top-level subcommand is in
+      `RESERVED_COMMAND_NAMES`; fail the build if a new command is added
+      without updating the list.
+- [x] [P03-TS05] Integ bats: init a local bare git repo with a single
+      commit containing an executable `flox-hello`, install from that
+      repo path (as the remote), verify `flox hello` runs.
+- [x] [P03-TS06] Integ bats: `flox extension install --pin <tag>` pins;
+      `flox extension upgrade <name>` is a no-op without `--force` and
+      re-fetches with `--force`.
+- [x] [P03-TS07] Integ bats: `--force` install overwrites a prior install
+      from a different owner.
+
+### Deliverable
+
+```bash
+$ FLOX_FEATURES_EXTENSIONS=1 flox extension install flox-examples/flox-hello-script
+Cloned flox-examples/flox-hello-script at abc1234
+Installed flox-hello (script)
+
+$ FLOX_FEATURES_EXTENSIONS=1 flox extension list
+NAME   REPO                             VERSION   PINNED
+hello  flox-examples/flox-hello-script  abc12345
+
+$ FLOX_FEATURES_EXTENSIONS=1 flox extension upgrade hello
+Upgraded flox-hello: abc12345 -> def67890
+```
+
+### Automated Verification
+
+- `just unit-tests` passes P03-TS01 through P03-TS04.
+- `just integ-tests extension.bats` passes P03-TS05 through P03-TS07.
+
+### Manual Verification
+
+- Install a real public `flox-extension`-topic script repo end-to-end.
+- Attempt to install `flox-examples/flox-activate` (if such a name existed)
+  and confirm the reserved-name rejection kicks in.
+
+### Exit Criterion
+
+`flox extension install <owner>/flox-<name>` works end-to-end for a
+script/git-kind repository. (Research doc §Part 4 M2.)
+
+---
+
+## [x] Project P04: GitHub source — binary release install (v0.4.0)
+
+**Goal**: Precompiled-binary path. Resolve and download a release asset
+matching the host's OS/arch, extract archives as needed, record
+checksums, and support upgrade.
+
+Maps to research doc §Part 4 M3.
+
+**Out of Scope**
+- Checksum *verification* (recorded, not enforced in v1; deferred to v3).
+- Build-provenance / attestation.
+- Non-GitHub sources.
+
+### Tests & Tasks
+
+- [x] [P04-T01] Implement `GitHubSource::list_release_assets`:
+      `GET /releases/tags/<tag>` and parse the `assets[]` array (name,
+      `browser_download_url`, size, content type).
+- [x] [P04-T02] Implement platform-string computation:
+      `format!("{os}-{arch}")` with `os ∈ {linux, darwin, windows}`,
+      `arch ∈ {x86_64|amd64, aarch64|arm64}`. Emit both nomenclatures for
+      substring matching (so `amd64` and `x86_64` both match).
+- [x] [P04-T03] Implement asset resolution in the priority order:
+      (1) author-provided `binary.platforms[<platform>]` map,
+      (2) rendered `asset_template` from the manifest,
+      (3) substring match on asset name,
+      (4) `darwin-arm64` → `darwin-amd64` Rosetta fallback (mirrors
+      `cli/cli#9592`).
+- [x] [P04-T04] Implement `GitHubSource::download_asset`: stream via
+      `reqwest` into staging, compute SHA-256 incrementally, record the
+      hex digest to `state.toml` via `asset_sha256` inside the install dir.
+- [x] [P04-T05] Implement archive extraction for `.tar.gz` (via
+      `flate2` + `tar`) and `.zip` (via `zip`); locate the `flox-<name>`
+      executable inside the extracted tree; `chmod +x`.
+- [x] [P04-T06] Raw-single-file path: if the asset has no archive suffix,
+      copy it directly as `flox-<name>` and `chmod +x`.
+- [x] [P04-T07] Install flow for `kind = Binary`: resolve tag, resolve
+      asset, download to staging, extract/copy, write `state.toml` with
+      `tag` and `asset_sha256`, atomic rename.
+- [x] [P04-T08] Upgrade flow for binary: re-run `resolve_latest`; if
+      `tag == state.tag`, return `UpgradeStatus::AlreadyCurrent`; else
+      re-run the install flow in staging and atomic rename.
+- [x] [P04-T09] Add `InstallError::NoMatchingAsset { owner, repo,
+      platform }` with a hint message directing the user to file an issue
+      against the extension repo. (Per-operation enum rather than an
+      aggregate `ExtensionError`; same pattern as existing install/upgrade
+      errors.)
+- [x] [P04-TS01] Unit: asset-resolver truth table — explicit map beats
+      template beats substring beats Rosetta fallback.
+- [x] [P04-TS02] Unit: platform string generation across
+      Linux/macOS/Windows × amd64/arm64, both nomenclatures accepted.
+- [x] [P04-TS03] Unit: `.tar.gz` extraction fixture, `.zip` extraction
+      fixture, raw single-file fixture.
+- [x] [P04-TS04] Unit: recorded SHA-256 matches a pre-computed fixture
+      checksum.
+- [x] [P04-TS05] Unit: upgrade no-op when `tag == state.tag`.
+- [x] [P04-TS06] Integ bats: serve a fake `releases/latest` JSON and a
+      tarball asset via a local `http.server`; install end-to-end;
+      `flox <name>` runs the extracted binary; upgrade picks up a bumped
+      tag.
+
+### Deliverable
+
+```bash
+$ FLOX_FEATURES_EXTENSIONS=1 flox extension install flox-examples/flox-tool
+Resolved flox-tool v1.0.0
+Downloading flox-tool-linux-x86_64.tar.gz (2.1 MB)
+SHA256: fe14…cafe
+Installed flox-tool v1.0.0 (binary)
+
+$ FLOX_FEATURES_EXTENSIONS=1 flox tool --help
+flox-tool 1.0.0 - a flox extension
+
+$ # after upstream cuts v1.0.1:
+$ FLOX_FEATURES_EXTENSIONS=1 flox extension upgrade tool
+Upgraded flox-tool: v1.0.0 -> v1.0.1
+```
+
+### Automated Verification
+
+- `just unit-tests` passes P04-TS01 through P04-TS05.
+- `just integ-tests extension.bats` passes P04-TS06.
+
+### Manual Verification
+
+- Install a real published `flox-extension`-topic repo that ships Linux +
+  macOS release assets; run its `--help`.
+- On an Apple Silicon host, install an extension that ships only
+  `darwin-amd64` assets and confirm the Rosetta fallback is used with a
+  clear log message.
+
+### Exit Criterion
+
+Install a real published `flox-extension` that ships Linux + macOS
+binaries; upgrade picks up a new tag. (Research doc §Part 4 M3.)
+
+---
+
+## [x] Project P05: `upgrade --all`, table output, lock polish (v0.5.0)
+
+**Goal**: Cross-extension operations and the final UX polish before
+environment integration. Unified table output for `list` and `upgrade`,
+centralized error strings, and a full audit of `.lock` discipline.
+
+Maps to research doc §Part 4 M4.
+
+**Out of Scope**
+- Environment-activation modes (P06).
+- Telemetry (P07).
+
+### Tests & Tasks
+
+- [x] [P05-T01] Implement `upgrade --all`: iterate every installed
+      extension, invoke per-kind upgrade, collect `UpgradeResult { name,
+      from, to, status }`.
+- [x] [P05-T02] Implement `--dry-run`: run only the resolve step for each
+      target and print the would-be plan; no writes to disk.
+- [x] [P05-T03] Unified table formatter with columns NAME / REPO /
+      VERSION (tag if present, else 8-char truncated commit) / PINNED /
+      STATUS. Used by both `list` and `upgrade` (including `--dry-run`).
+- [x] [P05-T04] Centralize the user-facing error strings from research
+      doc §2.9 as `Display` impls on `ExtensionError` variants:
+      - `CommandConflict` → `"error: name '<x>' conflicts with a built-in
+        flox command"`
+      - `AlreadyInstalled` → `"error: flox-<name> is already installed
+        (run with --force to overwrite)"`
+      - `NoMatchingAsset` → `"error: no release asset matches '<os-arch>'
+        for <owner>/<repo>"` + maintainer-issue hint
+      - `ExecutableMissing` → `"error: extension '<name>' has no
+        executable at <path>"`
+      - `PinnedEnvUntrusted` → `"error: extension '<name>' requires the
+        '<env>' environment; trust it with 'flox activate -r <env>
+        --trust' first"`
+      - Pinned-upgrade skip log line: `"skipping '<name>' (pinned to
+        <tag>); pass --force to override"`
+- [x] [P05-T05] Audit and tighten `.lock` usage: every install / upgrade
+      / remove acquires the exclusive lock; `list` and the `find`-for-
+      dispatch path are lock-free; every `state.toml` write is
+      temp-file + rename.
+- [x] [P05-T06] Add progress indication for binary downloads reusing
+      whatever progress infrastructure `publish.rs` / `catalog.rs`
+      already use. Do not add a new progress-bar crate.
+- [x] [P05-TS01] Unit: `UpgradeStatus` enum mapping covers `Upgraded`,
+      `AlreadyCurrent`, `Pinned`, `Failed(reason)`.
+- [x] [P05-TS02] Unit: `--dry-run` across all three kinds performs zero
+      filesystem writes (assert via a read-only temp dir).
+- [x] [P05-TS03] Unit: concurrent `upgrade --all` + `remove` serialize
+      cleanly under the lock; no state-file corruption.
+- [x] [P05-TS04] Integ bats: pre-seed three extensions (local, git,
+      binary), run `flox extension upgrade --all --dry-run`, assert the
+      expected table output.
+- [x] [P05-TS05] Integ bats: trigger every research-doc §2.9 error
+      condition and assert the exact user-facing string.
+
+### Deliverable
+
+```bash
+$ FLOX_FEATURES_EXTENSIONS=1 flox extension list
+NAME    REPO                           VERSION        PINNED  STATUS
+deploy  flox-examples/flox-deploy      v0.3.1         no      update
+report  acme/flox-report               v1.2.3         yes
+tool    flox-examples/flox-tool        def67890       no      up-to-date
+
+$ FLOX_FEATURES_EXTENSIONS=1 flox extension upgrade --all --dry-run
+Plan:
+  deploy:   v0.3.1 -> v0.4.0 (would upgrade)
+  report:   pinned to v1.2.3 (would skip; pass --force to override)
+  tool:     def67890 (already current)
+```
+
+### Automated Verification
+
+- `just unit-tests` passes P05-TS01 through P05-TS03.
+- `just integ-tests extension.bats` passes P05-TS04 and P05-TS05.
+
+### Manual Verification
+
+- Run `upgrade --all` against a real mixed-kind install set and confirm
+  the output matches the designed table format.
+- Run two `flox extension install` commands in parallel shells and
+  confirm the second blocks/errors cleanly rather than racing.
+
+### Exit Criterion
+
+`flox extension upgrade --all --dry-run` produces the expected report
+in a repo with multiple kinds; all §2.9 error strings verified.
+(Research doc §Part 4 M4.)
+
+---
+
+## [x] Project P06: Environment integration (v0.6.0) — the Flox-unique piece
+
+**Goal**: Wire the three activation modes (`Inherit`, `None`,
+`Pinned(ref)`) into the extension dispatch path. This is the single
+substantive divergence of the Flox extension design from `gh extension`.
+
+Maps to research doc §Part 4 M5.
+
+**Out of Scope**
+- `on_active = "layer"` (deferred; research doc §1.11 explicitly defers
+  this pending clarity on composition semantics).
+- Modifying anything inside `cli/flox-activations/` — `Pinned` mode
+  spawns the existing binary, same way `cli/flox/src/commands/activate.rs`
+  already does.
+
+### Tests & Tasks
+
+- [x] [P06-T01] Implement `dispatch::resolve_mode(manifest_env:
+      Option<&EnvironmentBehavior>) -> ActivationMode` per research doc
+      §1.11 rules. `ActivationMode` = `Pinned(String) | Inherit | None`.
+      The `_FLOX_ACTIVE_ENVIRONMENTS` idempotency check is kept out of
+      the SDK (handled at the CLI layer in `try_dispatch_external`) to
+      avoid duplicating the `ActiveEnvironments` JSON parser.
+- [x] [P06-T02] Detect "inside a flox activation" using
+      `_FLOX_ACTIVE_ENVIRONMENTS` (constant
+      `FLOX_ACTIVE_ENVIRONMENTS_VAR` from
+      `cli/flox-core/src/activate/vars.rs`), not `FLOX_ENV`.
+- [x] [P06-T03] `Inherit` mode: spawn the extension child with
+      `std::process::Command::new(&ext.executable).args(argv).envs(std::env::vars_os())`;
+      parent env already carries all `FLOX_*` vars the environment set
+      up.
+- [x] [P06-T04] `None` mode: construct the child env by filtering out
+      every key matching `^FLOX_` or `^_FLOX_` before spawn.
+- [x] [P06-T05] `Pinned(ref)` mode: spawn `FLOX_ACTIVATIONS_BIN` with
+      the equivalent of `flox activate -r <ref> -- <ext.executable>
+      <argv…>`. Use the in-place replacement mechanism from
+      `cli/flox/src/commands/activate.rs` (the same call on line ~502) so
+      PID semantics match a normal `flox activate -- <cmd>` invocation.
+- [x] [P06-T06] In every mode, inject the bookkeeping env vars:
+      `FLOX_EXTENSION_NAME`, `FLOX_EXTENSION_VERSION`,
+      `FLOX_EXTENSION_PATH`, `FLOX_BIN` (= `std::env::current_exe()`).
+- [x] [P06-T07] When `on_active = "error"` and the user is inside a
+      different environment than the one pinned, emit
+      `ExtensionError::PinnedEnvMismatch` with a hint pointing at the
+      offending extension name. `on_active = "override"` (default) just
+      activates.
+- [x] [P06-T08] Replace the P01 `dispatch_external` stub in `main.rs`
+      with a call to `dispatch::spawn_extension(&ext, argv, &flox)`.
+- [x] [P06-T09] Idempotency: if mode is `Pinned(ref)` and the user is
+      already inside `<ref>` (parse `_FLOX_ACTIVE_ENVIRONMENTS` and look
+      for the ref), skip re-activation and launch the extension directly
+      in-place.
+- [x] [P06-TS01] Unit: `resolve_mode` truth table — all combinations of
+      `InheritMode × {_FLOX_ACTIVE_ENVIRONMENTS unset, present with
+      matching ref, present with non-matching ref}` map to the expected
+      `ActivationMode`.
+- [x] [P06-TS02] Unit: `None`-mode env-scrubbing removes every `FLOX_*`
+      and `_FLOX_*` key while preserving others.
+- [x] [P06-TS03] Unit: bookkeeping env vars are set on the child
+      `Command` object for every mode.
+- [x] [P06-TS04] Integ bats: outside any activation, a fixture
+      `flox-echo-env` extension prints `FLOX_ENV is unset`; assert.
+      (Covers research-doc §1.5 user story #4 negative path.)
+- [x] [P06-TS05] Integ bats: inside `flox activate`, the same fixture
+      sees the environment's `$FLOX_ENV` and a known env-supplied tool
+      on `PATH`. (Covers §1.5 user story #4 positive path.)
+- [x] [P06-TS06] Integ bats: pinned-env extension activates the
+      manifest's env even when the user is outside any activation.
+      (Covers §1.5 user story #5.)
+- [x] [P06-TS07] Integ bats: pinned-env extension when user is already
+      inside the same env is a no-op — verify via timing or via probe
+      output that no nested activation happens.
+- [x] [P06-TS08] Integ bats: pinned + `on_active = "error"` + user
+      inside a different env → error message contains the offending
+      extension name + hint.
+- [x] [P06-TS09] Integ bats: `None` mode — extension sees no `FLOX_*`
+      vars even when the parent has them. (Covers §1.5 user story #6.)
+
+### Deliverable
+
+```bash
+# User story #4 (Inherit, inside activation):
+$ flox activate -d ./myproj
+flox [myproj] $ FLOX_FEATURES_EXTENSIONS=1 flox greet
+Hello from myproj — my PATH includes /nix/store/…-myproj/bin
+
+# User story #5 (Pinned, outside activation):
+$ FLOX_FEATURES_EXTENSIONS=1 flox deploy staging
+→ activating acme/prod-tools (pinned by flox-deploy manifest)
+✓ deploy complete
+
+# User story #6 (None):
+$ FLOX_FEATURES_EXTENSIONS=1 flox isolated-extension
+(no FLOX_* vars visible in the child's env)
+```
+
+### Automated Verification
+
+- `just unit-tests` passes P06-TS01 through P06-TS03.
+- `just integ-tests extension.bats` passes P06-TS04 through P06-TS09.
+
+### Manual Verification
+
+- Run `flox deploy` (a fixture extension with a pinned env) from three
+  starting conditions: no activation, same-env activation, different-env
+  activation. Confirm all three behave per §1.11.
+
+### Exit Criterion
+
+Research-doc §1.5 user stories #4, #5, and #6 pass end-to-end.
+(Research doc §Part 4 M5.)
+
+---
+
+## [x] Project P07: Docs, telemetry, GA (v1.0.0)
+
+**Goal**: Ship v1 to users. User + author docs, example repos, telemetry
+wired into the existing metrics pipeline, and flip the feature flag to
+on-by-default.
+
+Maps to research doc §Part 4 M6.
+
+**Out of Scope**
+- `search`, `create`, `browse`, `exec` (v2/v3).
+- FloxHub integration (v2).
+- Example extension repos (moved to P07a/P07b/P07c as separate
+  projects).
+- A `flox/flox-extension-precompile` GitHub Action (parallel workstream;
+  not blocking GA).
+
+### Tests & Tasks
+
+- [x] [P07-T01] Write the user guide at `docs/extensions/user-guide.md`
+      covering install/list/remove/upgrade, pinning, and environment
+      inheritance with the three modes.
+- [x] [P07-T02] Write the author guide at
+      `docs/extensions/author-guide.md` covering repo naming
+      (`flox-<name>`), the `flox-extension.toml` schema, the three kinds,
+      release-asset naming conventions, and the `[environment]` stanza.
+- [~] [P07-T04] Deferred per design review; revisit post-GA. Was:
+      emit telemetry events for `install` / `upgrade` / `remove` /
+      `dispatch`.
+- [x] [P07-T05] Remove the `FLOX_FEATURES_EXTENSIONS` gate by flipping
+      the `Features::extensions` default to `true`; keep the env-var
+      override for opt-out. In the same commit, **remove the
+      `#[bpaf(hide)]` attribute** from the `Commands::Extension`
+      variant in `cli/flox/src/commands/mod.rs` so that
+      `flox --help` now lists `extension` alongside the other
+      subcommands. Delete the handler-side `flox.features.extensions`
+      early-return checks in `cli/flox/src/commands/extension/*.rs`
+      (the flag is the default; no runtime gate needed anymore).
+      Update `cli/tests/extension.bats` P01-TS04 to assert `extension`
+      *is* present in `flox --help` after this change.
+- [x] [P07-TS01] Docs-presence check — a bats block that asserts
+      `docs/extensions/README.md`, `user-guide.md`, and
+      `author-guide.md` exist and that every relative markdown link in
+      them resolves. Replaces the original docs-build check; no docs
+      build exists in-repo.
+- [x] [P07-TS02] Integ bats smoke test — a parity check translating a
+      subset of `gh` integration-test assertions (`install`, `list`,
+      `remove`, `upgrade`) to the `flox extension` surface.
+- [~] [P07-TS03] Deferred per design review; revisit post-GA. Was:
+      telemetry events match the documented schema.
+
+### Deliverable
+
+- Docs pages exist under `docs/extensions/` (`user-guide.md`,
+  `author-guide.md`, `README.md`).
+- `flox extension <verb>` works without `FLOX_FEATURES_EXTENSIONS` set.
+
+### Automated Verification
+
+- `just build-cli` succeeds.
+- `just unit-tests` passes, including the flipped
+  `Features::extensions` default assertion.
+- `just integ-tests extension.bats` passes the flipped help test,
+  the gh-parity smoke block, and the docs-presence block.
+- `grep -r 'flox\.features\.extensions' cli/flox/src/` returns zero
+  hits (all five handler gates removed).
+- `grep -rn 'FLOX_FEATURES_EXTENSIONS' cli/` shows only the
+  deserialization path and the user-guide opt-out reference, not a
+  handler gate.
+
+### Manual Verification
+
+- Fresh install the built flox binary; without any env flags, run
+  `flox extension install flox-examples/flox-hello-script` and confirm
+  end-to-end behavior.
+- Run `FLOX_FEATURES_EXTENSIONS=0 flox extension list` and confirm
+  the subsystem can still be disabled via env override.
+
+### Exit Criterion
+
+v1 GA. Smoke tests translated from `gh extension` all pass.
+(Research doc §Part 4 M6.)
+
+---
+
+## [x] Project P07a: flox-hello-script example repo (v1.0.0)
+
+**Goal**: Publish `flox/flox-hello-script`, the canonical
+script-kind reference extension. Linked from the author guide
+(P07-T02) and used for manual GA verification of the P03 install
+path.
+
+**Out of Scope**
+- Precompiled binary assets (see P07b).
+- Local-only example (see P07c).
+- Use as a fixture for `cli/tests/extension.bats` — those tests use
+  local fixtures; this repo is for users.
+- Telemetry in the example repo (tracks P07-T04, deferred).
+- A flox-binary smoke step in the example repo's CI (avoids a
+  bootstrap cycle against GA artifacts; covered by P07a-TS03 here).
+
+### Tests & Tasks
+
+- [x] [P07a-T01] Create the local working tree at
+      `~/c/flox_repos/flox-hello-script` (`mkdir -p` the parent
+      first) and `git init -b main` inside it.
+- [x] [P07a-T02] Add `LICENSE` (Apache-2.0, matching flox) and an
+      initial empty-tree-free commit on `main`.
+- [x] [P07a-T03] Add `flox-extension.toml` with an `[extension]`
+      table: `name = "hello-script"` (matches the derived
+      extension name from the `flox-hello-script` repo), a
+      one-line `description`, no `[extension.binary]` sub-table
+      (install-time kind derivation in `manager.rs:590` lands on
+      `script` when `binary` is absent — there is no manifest
+      `kind` field), and **no** `[environment]` block — so the
+      default `Inherit` mode applies, exercising the P06-T01
+      resolver default end-to-end.
+- [x] [P07a-T04] Add executable `flox-hello-script` (bash,
+      `#!/usr/bin/env bash`, `set -euo pipefail`) that prints
+      `Hello from $FLOX_EXTENSION_NAME v$FLOX_EXTENSION_VERSION`
+      and echoes any positional args. `chmod +x`. Exercises the
+      P06-T06 bookkeeping env vars.
+- [x] [P07a-T05] Add `README.md`: one-line description, install /
+      upgrade / remove command examples, a link back to the flox
+      author guide (`docs/extensions/author-guide.md`), and a note
+      that this repo is the canonical P03 script-kind reference.
+- [x] [P07a-T06] Add `.github/workflows/ci.yml`: `shellcheck
+      flox-hello-script` + a TOML-parse sanity check on
+      `flox-extension.toml` (tiny Python `tomllib` script is
+      fine). No flox-binary step.
+- [x] [P07a-T07] Create the **public** GitHub repo and push via
+      `gh repo create flox/flox-hello-script --public
+      --source=. --remote=origin --push` from inside
+      `~/c/flox_repos/flox-hello-script`. Verify public visibility
+      with `gh repo view flox/flox-hello-script --json
+      visibility` → `"PUBLIC"`.
+- [x] [P07a-T08] Tag `v0.1.0` on the initial commit and push the
+      tag (`git tag v0.1.0 && git push origin v0.1.0`).
+- [x] [P07a-T09] Apply the `flox-extension` GitHub topic via
+      `gh repo edit flox/flox-hello-script --add-topic
+      flox-extension` so P08 `search` surfaces it. Verify with
+      `gh repo view flox/flox-hello-script --json
+      repositoryTopics`.
+- [x] [P07a-T10] In **this** repo, edit
+      `docs/extensions/author-guide.md` to cross-link the
+      published example repo from the script-kind section.
+- [x] [P07a-TS01] Example repo CI: `shellcheck flox-hello-script`
+      passes.
+- [x] [P07a-TS02] Example repo CI: `flox-extension.toml` parses
+      as valid TOML and deserializes against the documented
+      `AuthorManifest` shape (Python `tomllib` + assertions on
+      the `[extension]` keys).
+- [x] [P07a-TS03] Integ bats (this repo,
+      `cli/tests/extension.bats`): new test case
+      `extension: flox/flox-hello-script mirror installs and
+      dispatches` that mirrors the example repo's layout into a
+      local bare repo via `_setup_hello_script_fixture` and runs
+      `flox extension install flox/flox-hello-script`
+      end-to-end, then `flox hello-script world` and asserts the
+      expected greeting. Guards against schema drift breaking the
+      canonical example.
+
+### Deliverable
+
+`flox extension install flox/flox-hello-script` resolves,
+clones, and runs end-to-end against a GA flox binary.
+
+### Automated Verification
+
+- Example repo CI is green on `main` (P07a-TS01, P07a-TS02).
+- `just integ-tests extension.bats -- --filter hello-script`
+  passes the fixture-mirror test (P07a-TS03).
+
+### Manual Verification
+
+- Fresh checkout of flox with the feature flag on; run
+  `flox extension install flox/flox-hello-script` and confirm
+  `flox hello-script` executes and prints the bookkeeping-env-var
+  greeting.
+- `flox extension upgrade hello-script` is a no-op immediately
+  after install, and picks up a bumped `v0.1.1` tag after one is
+  cut.
+
+### Exit Criterion
+
+Repo is public at `github.com/flox/flox-hello-script`, tagged
+`v0.1.0`, carries the `flox-extension` topic, is linked from the
+author guide, and installs cleanly via `flox extension install
+flox/flox-hello-script`.
+
+---
+
+## [x] Project P07b: flox-hello-binary example repo — macOS (v1.0.0)
+
+**Goal**: Publish `flox/flox-hello-binary`, the canonical
+precompiled-binary reference extension. Linked from the author guide
+(P07-T02) and used for manual GA verification of the P04 install
+path. Initial scope is **macOS only** (x86_64 + aarch64); Linux
+support is tracked inside the example repo's own `PROJECTS.md` as
+its P02 and is out of scope here.
+
+**Out of Scope**
+- Script/git kind (see P07a).
+- Local-only example (see P07c).
+- Linux assets (tracked in the example repo's `PROJECTS.md` P02).
+- Building and publishing via `flox/flox-extension-precompile`
+  (parallel workstream; P07b builds in its own CI).
+- Use as a fixture for `cli/tests/extension.bats` — those tests use
+  local fixtures; this repo is for users.
+- Explicit `[extension.binary].platforms` map — the resolver
+  priority #1 slot is reserved but not implemented in flox today
+  (`github.rs:744`). Install uses priority #2 (`asset` template).
+- Checksum verification of downloaded assets (v1 records but does
+  not enforce; deferred to v3 per P04 scope).
+- Telemetry in the example repo (tracks P07-T04, deferred).
+
+### Tests & Tasks
+
+- [x] [P07b-T01] Create the local working tree at
+      `~/c/flox_repos/flox-hello-binary` and `git init -b main`.
+- [x] [P07b-T02] Add `LICENSE` (Apache-2.0, matching flox) and an
+      initial commit on `main`.
+- [x] [P07b-T03] Author a minimal `flox-hello-binary` source
+      program in Rust (single `main.rs` + `Cargo.toml`) that prints
+      `Hello from $FLOX_EXTENSION_NAME $FLOX_EXTENSION_VERSION`
+      and echoes any positional args. (`FLOX_EXTENSION_VERSION`
+      already carries the `v` prefix, so the literal `v` from the
+      original P07a template was dropped.)
+- [x] [P07b-T04] Add `flox-extension.toml` with an `[extension]`
+      table: `name = "hello-binary"`, a one-line `description`,
+      and no `[environment]` block so the default `Inherit` mode
+      applies. `[extension.binary]` carries `source =
+      "github-release"` and `asset = "flox-hello-binary-{os}-
+      {arch}.tar.gz"`. Assets are named `flox-hello-binary-macos-
+      {aarch64,x86_64}.tar.gz` so the template renders exactly at
+      runtime (`std::env::consts::OS` is `"macos"` on darwin).
+- [x] [P07b-T05] Add `README.md`: install / upgrade / remove
+      examples, platform matrix, and links to the flox author
+      guide and the script-kind sibling repo.
+- [x] [P07b-T06] Add `.github/workflows/release.yml`: on `v*`
+      tag push, build `x86_64-apple-darwin` on `macos-13` and
+      `aarch64-apple-darwin` on `macos-14`, archive each as
+      `flox-hello-binary-macos-<arch>.tar.gz`, upload to a GitHub
+      release via `gh release create`.
+- [x] [P07b-T07] Add `.github/workflows/ci.yml`: `cargo fmt
+      --check`, `cargo clippy --all-targets -- -D warnings`,
+      `cargo test --all-targets` on `macos-14`; Python `tomllib`
+      parse of `flox-extension.toml` on `ubuntu-latest`.
+- [x] [P07b-T08] Create the **public** GitHub repo and push via
+      `gh repo create flox/flox-hello-binary --public
+      --source=. --remote=origin --push`. Verified public:
+      `gh repo view … --json visibility` → `"PUBLIC"`.
+- [x] [P07b-T09] Tag `v0.1.0` on the initial commit and push;
+      release workflow builds and uploads the two macOS assets.
+- [x] [P07b-T10] Apply the `flox-extension` GitHub topic via
+      `gh repo edit flox/flox-hello-binary --add-topic
+      flox-extension`. Verified: `repositoryTopics` includes
+      `flox-extension`.
+- [x] [P07b-T11] Add an example-repo-native `PROJECTS.md` that
+      tracks this milestone as P01 and records cross-platform
+      (Linux) compilation as P02, so future work has a home.
+- [x] [P07b-T12] In **this** repo, edit
+      `docs/extensions/author-guide.md` to point the binary-kind
+      example link at `flox/flox-hello-binary` and note the
+      macOS-only initial scope.
+- [x] [P07b-TS01] Example repo CI: `cargo fmt --check`,
+      `cargo clippy -- -D warnings`, and `cargo test` pass on
+      `macos-14`.
+- [x] [P07b-TS02] Example repo CI: `flox-extension.toml` parses
+      as valid TOML and carries `[extension] name = "hello-
+      binary"` + `[extension.binary] source` + `asset` with
+      `{os}` / `{arch}` placeholders.
+- [x] [P07b-TS03] Example repo release workflow: on `v0.1.0`
+      tag, both macOS archives are built and uploaded. Verified
+      via `gh release view v0.1.0 --json assets`.
+
+### Deliverable
+
+`flox extension install flox/flox-hello-binary` resolves
+`v0.1.0`, downloads the host-matching macOS asset, records its
+SHA-256 in `state.toml`, extracts the executable, and `flox
+hello-binary` runs end-to-end against a GA flox binary on
+macOS.
+
+### Automated Verification
+
+- Example repo CI is green on `main` (P07b-TS01, P07b-TS02).
+- `v0.1.0` release carries the two macOS platform assets
+  (P07b-TS03).
+
+### Manual Verification
+
+- Install on macOS arm64 and macOS x86_64 with a GA flox
+  binary; confirm correct asset selection and that `flox
+  hello-binary world` prints `Hello from hello-binary v0.1.0 /
+  args: world`.
+- On an Apple Silicon host, cut a release without the
+  `aarch64` asset to confirm the `darwin-aarch64 →
+  darwin-x86_64` Rosetta fallback (pairs with the P04 manual
+  check).
+- `flox extension upgrade hello-binary` is a no-op immediately
+  after install, and picks up a bumped `v0.1.1` tag after one
+  is cut.
+
+### Exit Criterion
+
+Repo is public at `github.com/flox/flox-hello-binary`, tagged
+`v0.1.0` with both macOS platform assets attached, carries the
+`flox-extension` topic, is linked from the author guide, and
+installs cleanly via `flox extension install
+flox/flox-hello-binary` on macOS x86_64 and macOS aarch64.
+Cross-platform (Linux) compilation is tracked in the example
+repo's `PROJECTS.md` P02.
+
+---
+
+## [x] Project P07c: flox-hello-local example repo (v1.0.0)
+
+**Goal**: Publish `flox/flox-hello-local`, a template repo
+intended to be cloned locally and installed via
+`flox extension install --from-path`. Demonstrates the P02 local
+dev loop. Linked from the author guide (P07-T02) and used for
+manual GA verification of the P02 local-authoring path.
+
+**Out of Scope**
+- Remote clone-based install (covered by P07a).
+- Binary assets (covered by P07b).
+- Scaffolding automation (`flox extension create`, deferred to P08).
+- Use as a fixture for `cli/tests/extension.bats` — those tests use
+  local fixtures; this repo is for users.
+- Telemetry in the example repo (tracks P07-T04, deferred).
+- `flox extension upgrade` examples: unsupported for local-kind
+  installs (returns `UpgradeError::LocalNotSupported`); the README
+  documents the `--force` reinstall iterate loop instead.
+
+### Tests & Tasks
+
+- [x] [P07c-T01] Create the local working tree at
+      `~/c/flox_repos/flox-hello-local` (`mkdir -p` the parent
+      first) and `git init -b main` inside it.
+- [x] [P07c-T02] Add `LICENSE` (Apache-2.0, matching flox) and an
+      initial commit on `main`.
+- [x] [P07c-T03] Add `flox-extension.toml` with an `[extension]`
+      table: `name = "hello-local"` (matches the derived
+      extension name from the `flox-hello-local` repo), a
+      one-line `description`, no `[extension.binary]` stanza (so
+      kind resolves to `script`), and **no** `[environment]`
+      block — so the default `Inherit` mode applies.
+- [x] [P07c-T04] Add executable `flox-hello-local` (bash,
+      `#!/usr/bin/env bash`, `set -euo pipefail`) that prints
+      `Hello from $FLOX_EXTENSION_NAME v$FLOX_EXTENSION_VERSION`
+      and echoes any positional args. `chmod +x`. Exercises the
+      P06-T06 bookkeeping env vars.
+- [x] [P07c-T05] Add `README.md`: one-line description, a
+      walkthrough for `git clone && flox extension install
+      --from-path ./flox-hello-local`, iterate (`--force`
+      reinstall) / remove command examples — **no** upgrade
+      example, since `upgrade` is unsupported for local-kind —
+      a link back to the flox author guide
+      (`docs/extensions/author-guide.md`), and a note that this
+      repo is the canonical P02 local-authoring reference.
+- [x] [P07c-T06] Add `.github/workflows/ci.yml`: `shellcheck
+      flox-hello-local` + a TOML-parse sanity check on
+      `flox-extension.toml` (tiny Python `tomllib` script is
+      fine). No flox-binary step.
+- [x] [P07c-T07] Create the **public** GitHub repo and push via
+      `gh repo create flox/flox-hello-local --public
+      --source=. --remote=origin --push` from inside
+      `~/c/flox_repos/flox-hello-local`. Verify public visibility
+      with `gh repo view flox/flox-hello-local --json
+      visibility` → `"PUBLIC"`.
+- [x] [P07c-T08] Tag `v0.1.0` on the initial commit and push the
+      tag (`git tag v0.1.0 && git push origin v0.1.0`). Parity
+      with P07a/P07b release cadence; local install does not
+      consume tags, so the tag is not referenced from the
+      README.
+- [x] [P07c-T09] Apply the `flox-extension` GitHub topic via
+      `gh repo edit flox/flox-hello-local --add-topic
+      flox-extension` so P08 `search` surfaces it. Verify with
+      `gh repo view flox/flox-hello-local --json
+      repositoryTopics`.
+- [x] [P07c-T10] In **this** repo, edit
+      `docs/extensions/author-guide.md` to cross-link the
+      published example repo from the local-authoring /
+      `--from-path` section.
+- [x] [P07c-TS01] Example repo CI: `shellcheck flox-hello-local`
+      passes.
+- [x] [P07c-TS02] Example repo CI: `flox-extension.toml` parses
+      as valid TOML and deserializes against the documented
+      `AuthorManifest` shape (Python `tomllib` + assertions on
+      the `[extension]` keys).
+
+### Deliverable
+
+`git clone https://github.com/flox/flox-hello-local &&
+flox extension install --from-path ./flox-hello-local` succeeds and
+`flox hello-local` runs.
+
+### Automated Verification
+
+- Example repo CI is green on `main` (P07c-TS01, P07c-TS02).
+- `gh repo view flox/flox-hello-local --json
+  visibility,repositoryTopics` shows `"PUBLIC"` and the
+  `flox-extension` topic.
+
+### Manual Verification
+
+- Fresh clone + local install on Linux and macOS; confirm the README
+  steps reproduce cleanly and `flox hello-local` prints the
+  bookkeeping-env-var greeting.
+
+### Exit Criterion
+
+Repo is public at `github.com/flox/flox-hello-local`, tagged
+`v0.1.0`, carries the `flox-extension` topic, is linked from the
+author guide's local-authoring section, and the README walkthrough
+reproduces cleanly.
+
+---
+
+## Cross-cutting concerns
+
+Items that don't belong to a single project but are binding for the
+subsystem as a whole.
+
+- **Windows support.** Matches flox's own platform matrix; document as a
+  decision, not a task. Any Windows-specific issues surfaced during
+  P01–P07 are tracked here, not added to prior projects. (Research doc
+  §2.11 #1.)
+- **Git transport.** Shell out through the existing `GitCommandProvider`.
+  No `git2` or `gix` dependency is added at any stage of v1.
+- **Feature flag.** `Features::extensions` (default `false` until P07) is
+  the single source of truth. `FLOX_FEATURES_EXTENSIONS=0/1` is the
+  env-var override, consistent with other `FLOX_FEATURES_*` flags.
+- **v2/v3 re-plan cadence.** After v1 GA (end of P07), run a fresh
+  brainstorming/spec pass for P08, then a separate one for P09, then
+  P10. Do not start P08 tasks without that pass.
+- **Research-doc §2.11 open items.** Revisit each of `#1 Windows`,
+  `#3 git transport`, `#4 archive formats`, `#6 activate re-entrancy`,
+  `#7 telemetry` during P01–P07 and resolve them inside the relevant
+  project rather than in a separate workstream.
+
+---
+
+## [x] Project P08: Extension discovery — search (v1.1.0)
+
+**Goal**: Give users a way to find `flox-extension`-topic GitHub repos
+from the CLI. Single-page `GET /search/repositories?q=topic:flox-
+extension+archived:false+<query>+user:<owner>` against `GitHubSource`;
+mark already-installed rows with `✓`; opportunistically honor
+`GH_TOKEN` / `GITHUB_TOKEN` for a 10→30 req/min rate-limit bump.
+
+The decision to use the GitHub `flox-extension` topic alone (not a
+FloxHub-native index) is locked in for v1.1.0; FloxHub as a source
+lands in P09 alongside the rest of FloxHub work.
+
+**Out of Scope**
+- Pagination (`page=N`, `per_page > 100`).
+- FloxHub-native extension index (P09).
+- `flox extension create` scaffolding (P09).
+- Shell completion (P09).
+- `flox extension browse` TUI (P10).
+- `--json` output, response caching, custom/multiple topics (P10).
+
+### Tests & Tasks
+
+- [x] [P08-T01] In `cli/flox-rust-sdk/src/providers/extensions/github.rs`,
+      add `SearchQuery { query: Option<String>, owner: Option<String>,
+      limit: u8, sort: SearchSort }` and `SearchSort { Stars, Updated }`.
+      Clamp `limit` to `1..=100` at construction.
+- [x] [P08-T02] Same file: add `#[derive(Deserialize)]` response types
+      `SearchResponse { total_count, incomplete_results, items }`,
+      `SearchItem { full_name, owner, name, stargazers_count,
+      description, archived, html_url }`, and `SearchOwner { login }`.
+      Use `#[serde(default)]` on optional scalar fields so minimal
+      fixtures still deserialize.
+- [x] [P08-T03] Same file: extend `GitHubError` with
+      `RateLimited { status: u16 }` (mapped from 403/429) and
+      `AuthFailed { status: u16 }` (mapped from 401). Do not collapse
+      into the existing `HttpStatus` variant — the user-facing message
+      on `RateLimited` should hint at setting `GH_TOKEN` /
+      `GITHUB_TOKEN`.
+- [x] [P08-T04] Same file: add a private `auth_token_from_env()` that
+      reads `GH_TOKEN` then `GITHUB_TOKEN` (first non-empty wins). Add
+      an `auth_token: Option<String>` field on `GitHubSource`; populate
+      in `from_env`. Add a `with_auth_token(self, Option<String>)`
+      builder for tests. Keep the existing `new(client, base_url)`
+      signature unchanged (defaults `auth_token = None`).
+- [x] [P08-T05] Same file: implement `GitHubSource::search_repos(&self,
+      q: &SearchQuery) -> Result<SearchResponse, GitHubError>`. Compose
+      the `q` parameter by space-joining `topic:flox-extension`,
+      `archived:false`, `<query?>`, `user:<owner?>` (no trailing spaces
+      or empty tokens). Attach `per_page=<limit>`, `sort=<stars|updated>`,
+      `order=desc`. Include `Authorization: Bearer <token>` when
+      `auth_token` is set. Map 401→`AuthFailed`, 403/429→`RateLimited`,
+      404→`NotFound`, other non-2xx→`HttpStatus`.
+- [x] [P08-T06] In `cli/flox-rust-sdk/src/providers/extensions/manager.rs`,
+      add `SearchError { Github(GitHubError), List(ListError) }` and
+      `SearchRow { full_name: String, stars: u64, description:
+      Option<String>, installed: bool }`. Implement `pub async fn
+      search(flox: &Flox, q: &SearchQuery) -> Result<(Vec<SearchRow>,
+      bool /* incomplete_results */), SearchError>`: call
+      `GitHubSource::from_env().search_repos(q)`, call
+      `list(flox)` to build a `HashSet<String>` of `"<owner>/<repo>"`
+      (skip `kind == "local"`), mark rows. Re-export `search`,
+      `SearchError`, `SearchQuery`, `SearchSort`, `SearchRow` from
+      `mod.rs`.
+- [x] [P08-T07] Create `cli/flox/src/commands/extension/search.rs` with
+      a `#[derive(Debug, Bpaf, Clone)] pub struct Search { query:
+      Option<String>, owner: Option<String>, limit: u8, sort: SortArg }`
+      and a CLI-level `SortArg { Stars, Updated }`. Defaults: `limit =
+      30`, `sort = Stars`. `handle(self, flox: Flox) -> Result<()>`
+      follows the `list.rs` template: feature-flag early return,
+      `subcommand_metric!("extension::search")`,
+      `#[instrument(name = "extension::search", skip_all)]`, call
+      `manager::search`, format the table, print the
+      `incomplete_results` warning if set.
+- [x] [P08-T08] In `cli/flox/src/commands/extension/mod.rs`: add
+      `mod search;`, add a `Search(#[bpaf(external(search::search))]
+      search::Search)` variant to `ExtensionCommands` between `Remove`
+      and `Upgrade`, and add the matching
+      `ExtensionCommands::Search(args) => args.handle(flox).await`
+      match arm.
+- [x] [P08-T09] Inline table helper in `search.rs` matching `list.rs`
+      style: header `"{:<2}  {:<40}  {:>6}  {}"` over `" "`,
+      `"OWNER/REPO"`, `"STARS"`, `"DESCRIPTION"`; row prefix `"✓ "`
+      when `installed`, `"  "` otherwise. Truncate description to
+      60 chars with an ellipsis. No new formatter crate.
+- [x] [P08-T10] `incomplete_results` handling: after printing the
+      table, if true, `eprintln!("warning: github reported incomplete
+      results; re-run with a narrower query")`. Do not fail.
+- [x] [P08-TS01] Unit (`github.rs`): query-string composition. Given
+      `query = Some("hello")`, `owner = Some("acme")`, `limit = 25`,
+      `sort = Stars`, an `httpmock` server matches
+      `q=topic:flox-extension archived:false hello user:acme`,
+      `per_page=25`, `sort=stars`, `order=desc`.
+- [x] [P08-TS02] Unit: empty `query` + empty `owner` →
+      `q=topic:flox-extension archived:false` (no trailing/empty
+      tokens).
+- [x] [P08-TS03] Unit: canned `/search/repositories` response with
+      `incomplete_results: true`, `total_count: 2`, two items (one with
+      `description: null`) deserializes.
+- [x] [P08-TS04] Unit: mock returning `401` maps to
+      `GitHubError::AuthFailed`; `403` and `429` both map to
+      `GitHubError::RateLimited`; `500` maps to `GitHubError::HttpStatus`.
+- [x] [P08-TS05] Unit: with an auth token set via `with_auth_token`,
+      `search_repos` sends `Authorization: Bearer <token>`; without one,
+      no Authorization header is sent. Uses the builder (not env
+      mutation) to avoid Rust 2024 `unsafe { set_var }` and cross-test
+      races.
+- [x] [P08-TS06] Integ bats (`cli/tests/extension.bats`): extend
+      `_setup_github_fixture`'s Python `http.server` with a
+      `/search/repositories` route returning two items; install
+      `owner/flox-hello` first (reusing the existing fixture install
+      path), then run `flox extension search hello`. Assert stdout
+      contains `✓ owner/flox-hello` and an unchecked row for the
+      other item; exit 0.
+- [x] [P08-TS07] Integ bats: fixture returning `incomplete_results:
+      true` emits `warning: github reported incomplete results` on
+      stderr; exit still 0.
+
+### Deliverable
+
+```bash
+$ FLOX_FEATURES_EXTENSIONS=1 flox extension search hello
+    OWNER/REPO                                STARS  DESCRIPTION
+✓   flox-examples/flox-hello-script              42  canonical script-kind reference extension
+    acme/flox-hello-deploy                       18  deploy helper that prints 'hello <env>'
+    cortex/flox-hello-widget                      7  -
+
+$ FLOX_FEATURES_EXTENSIONS=1 flox extension search --owner flox-examples --sort updated --limit 5
+    OWNER/REPO                                STARS  DESCRIPTION
+✓   flox-examples/flox-hello-script              42  canonical script-kind reference extension
+    flox-examples/flox-hello-binary              31  canonical binary-kind reference extension
+    flox-examples/flox-tool                      12  example multi-platform extension
+```
+
+### Automated Verification
+
+- `just build-cli` succeeds.
+- `just unit-tests` passes P08-TS01 through P08-TS05.
+- `just integ-tests extension.bats` passes P08-TS06 and P08-TS07.
+
+### Manual Verification
+
+- Unauthenticated: `FLOX_FEATURES_EXTENSIONS=1 flox extension search
+  hello` against live `api.github.com`; expect a hit list.
+- Authenticated: `GH_TOKEN=$(gh auth token) FLOX_FEATURES_EXTENSIONS=1
+  flox extension search --limit 100` runs without rate-limit errors
+  under repeated invocations.
+- Installed flag: install a known extension, re-run `search`, confirm
+  the row shows `✓`.
+- Auth error path: `GH_TOKEN=invalid flox extension search x` surfaces
+  a message mentioning `GH_TOKEN` / `GITHUB_TOKEN`.
+
+### Exit Criterion
+
+`flox extension search <query>` returns GitHub repos tagged
+`flox-extension`, marks already-installed ones with `✓`, and honors
+`GH_TOKEN` / `GITHUB_TOKEN` for rate-limit relief.
+
+---
+
+## [ ] Project P09: Authoring and FloxHub source (v2)
+
+> **Needs more detail before work starts — this project requires a
+> separate brainstorming and spec pass. Goal and scope are listed for
+> roadmap visibility only; no tasks are yet defined.**
+
+**Goal** (from research doc §1.6):
+
+- `flox extension create [--kind script|precompiled]`
+- `FloxHubSource` as a second `ExtensionSource` implementation;
+  `floxhub:org/name` install URIs.
+- Shell completion (bpaf already supports generation; wire it in).
+
+### Known open questions (must be resolved before task planning)
+
+- What does a FloxHub "extension" object look like? No such object type
+  exists in FloxHub today. (Research doc §2.11 #5.)
+- Does `create` scaffold a GitHub repo, a local directory, or both?
+- Is a `flox/flox-extension-precompile` GitHub Action a v2 deliverable
+  inside this repo, a parallel workstream, or left to third parties?
+
+### Tests & Tasks
+
+_No task breakdown yet. Re-plan after v1 GA and P08 brainstorming._
+
+---
+
+## [ ] Project P10: Richer UX and ecosystem (v3)
+
+> **Needs more detail before work starts — this project requires a
+> separate brainstorming and spec pass. Goal and scope are listed for
+> roadmap visibility only; no tasks are yet defined.**
+
+**Goal** (from research doc §1.6):
+
+- `flox extension browse` TUI, mirroring `gh extension browse`.
+- `flox extension exec <name> …` as a name-conflict escape hatch.
+- Nested extension commands (e.g., `flox env my-extension`).
+- Optional checksum / build-provenance verification of binary assets.
+- Flox Catalog integration for package dependencies declared by
+  extensions.
+
+### Known open questions
+
+- What TUI framework does the rest of flox use? If none, choosing one is
+  its own decision.
+- Nested-command semantics: how does the parser disambiguate
+  `env my-extension` from a subcommand typo?
+- Does Catalog integration mean extensions declare a whole Flox
+  environment as a dependency, or just pin specific packages?
+
+### Tests & Tasks
+
+_No task breakdown yet. Re-plan after v1 GA, P08, and P09 brainstorming._
+
+---
+
+## [~] Project P11: Rebase onto current main; gate behind `features.beta` (v1.2.0)
+
+**Goal**: Carry P01–P08 forward onto current `origin/main` and change how
+the subsystem is gated: instead of adding a bespoke `Features::extensions`
+flag defaulting to `true`, reuse the existing `features.beta` flag,
+opt-in and off by default.
+
+Two upstream changes since `0badcdf59` drove the rework:
+
+1. `Features` moved from `cli/flox-rust-sdk/src/flox.rs` to a new crate at
+   `cli/flox-core/src/features.rs`, and already carries a `beta: bool`
+   field. No new field is needed, so `flox-core` is untouched.
+2. A `beta` crate (`cli/beta`) and a `BetaCommands` group
+   (`cli/flox/src/commands/beta.rs`) now exist, with a documented
+   convention in `.claude/skills/adding-beta-subcommand`. Beta commands
+   are hidden from `flox --help` and gated once in the `Commands::Beta`
+   arm.
+
+**Out of Scope**
+- Promoting extensions out of beta (that is a separate move, per the skill).
+- Telemetry (still deferred from P07).
+- FloxHub source (P09) and richer UX (P10).
+
+### Tests & Tasks
+
+- [x] [P11-T01] Fast-forward local `main` to `origin/main` and create the
+      `smorin/github-extension-prototype-v2` worktree from it.
+- [x] [P11-T02] Port the 23 new files from
+      `smorin/github-extension-prototype`, including the uncommitted
+      `extension.bats` mirror test.
+- [x] [P11-T03] Relocate the domain module from
+      `cli/flox-rust-sdk/src/providers/extensions/` to
+      `cli/beta/src/extensions/`, so `flox-rust-sdk` is unchanged. Only
+      three `crate::` imports needed rewriting (`Flox`, and the git
+      provider); dependencies moved to `cli/beta/Cargo.toml`.
+- [x] [P11-T04] Register `extension` on `BetaCommands` with
+      `command("extension")` and `hide`, keeping the invocation as
+      `flox extension …` while hiding it from `flox --help`.
+- [x] [P11-T05] Delete the per-handler `ensure_extensions_enabled()` gate
+      from all five verbs. The `Commands::Beta` arm gates once; handlers
+      must not re-check (per the skill).
+- [x] [P11-T06] Replace the opt-out `extensions_enabled()` with the opt-in
+      `beta_enabled_from_env()`, reading `FLOX_FEATURES_BETA`.
+- [x] [P11-T07] Add `sha2` and `zip` to the workspace (`flate2` is now
+      present upstream) and wire `cli/beta/Cargo.toml`.
+- [x] [P11-T08] Add `python3` to `pkgs/flox-cli-tests/default.nix` for the
+      bats fake-GitHub fixture.
+- [ ] [P11-TS01] `cargo build -p flox` succeeds.
+- [ ] [P11-TS02] `flox extension list` without beta fails with the standard
+      beta message; with `FLOX_FEATURES_BETA=true` it runs.
+- [ ] [P11-TS03] `flox --help` does not list `extension`.
+- [ ] [P11-TS04] `just integ-tests extension.bats` passes with the
+      converted gating.
+- [ ] [P11-T09] Decide whether to port the `extension_drift_tests` module
+      (~80 lines in `cli/flox/src/commands/mod.rs`) that keeps
+      `RESERVED_COMMAND_NAMES` in sync with the parser. Guards a real
+      invariant, but adds test code to a heavily reviewed file.
+
+### Known limitation
+
+`flox <name>` dispatch reads `FLOX_FEATURES_BETA` from the environment
+directly, because it runs in `main()` before the config system loads.
+`flox config --set features.beta true` therefore enables the
+`flox extension …` subcommands but **not** dispatch. Documented in the
+user guide; should be resolved before extensions leave beta.
+
+### Automated Verification
+
+- `cargo build -p flox` succeeds.
+- `git status --porcelain cli/flox-rust-sdk/` is empty — the SDK is untouched.
+- `grep -rn 'FLOX_FEATURES_EXTENSIONS' cli/ docs/` returns zero hits.
+- `./target/debug/flox --help` does not mention `extension`.

--- a/cli/beta/Cargo.toml
+++ b/cli/beta/Cargo.toml
@@ -6,5 +6,29 @@ edition.workspace = true
 [dependencies]
 anyhow.workspace = true
 bpaf.workspace = true
+flate2.workspace = true
 flox-rust-sdk.workspace = true
+fslock.workspace = true
+futures.workspace = true
+indicatif.workspace = true
+reqwest.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+sha2.workspace = true
+tar.workspace = true
+thiserror.workspace = true
+time.workspace = true
+tokio.workspace = true
+toml.workspace = true
 tracing.workspace = true
+url.workspace = true
+uuid.workspace = true
+walkdir.workspace = true
+zip.workspace = true
+
+[dev-dependencies]
+flox-rust-sdk = { workspace = true, features = ["tests"] }
+httpmock.workspace = true
+pretty_assertions.workspace = true
+temp-env = { workspace = true, features = ["async_closure"] }
+tempfile.workspace = true

--- a/cli/beta/src/extensions/archive.rs
+++ b/cli/beta/src/extensions/archive.rs
@@ -1,0 +1,497 @@
+//! Archive extraction helpers for P04 binary installs.
+//!
+//! Three shapes are supported:
+//!
+//! * `extract_tar_gz` — `.tar.gz` / `.tgz` via `flate2 + tar`.
+//! * `extract_zip`    — `.zip` via the `zip` crate.
+//! * `install_raw`    — single-file asset (no archive) copied into place.
+//!
+//! After extraction, [`locate_executable`] walks the staging tree and
+//! returns the path of the extension's `flox-<name>` binary, promoting its
+//! mode to include the executable bits on Unix.
+
+use std::path::{Component, Path, PathBuf};
+use std::{fs, io};
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum ArchiveError {
+    #[error("failed to open archive {path}: {source}")]
+    Open {
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+    #[error("tar extraction failed for {path}: {source}")]
+    Tar {
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+    #[error("zip extraction failed for {path}: {detail}")]
+    Zip { path: PathBuf, detail: String },
+    #[error("filesystem error during archive handling: {0}")]
+    Io(#[from] io::Error),
+    #[error(
+        "archive from {archive} did not contain an executable named 'flox-{name}' \
+        (or a file matching '{name}')"
+    )]
+    ExecutableMissing { archive: PathBuf, name: String },
+    #[error("archive {archive} contains unsafe entry path '{entry}'")]
+    UnsafePath { archive: PathBuf, entry: String },
+}
+
+/// Reject absolute paths and any `..` / root / prefix components. Plain
+/// `./foo` / `foo/bar` / empty paths are allowed. This is the sole gate
+/// between a release-asset archive and the staging directory — any entry
+/// that escapes here will unpack outside staging.
+fn is_safe_relative(p: &Path) -> bool {
+    if p.is_absolute() {
+        return false;
+    }
+    p.components()
+        .all(|c| matches!(c, Component::Normal(_) | Component::CurDir))
+}
+
+/// Extract `archive` (a `.tar.gz` or `.tgz`) into `staging`. The staging
+/// directory must already exist.
+///
+/// Entries are iterated manually so that every path can be vetted before
+/// unpacking: any absolute path or `..` component yields
+/// [`ArchiveError::UnsafePath`] and aborts extraction. Non-regular,
+/// non-directory entries (symlinks, hardlinks, devices, fifos) are
+/// silently dropped — extension payloads never need them, and allowing
+/// symlink entries would reopen the tar-slip door by redirecting
+/// subsequent writes outside staging.
+pub fn extract_tar_gz(archive: &Path, staging: &Path) -> Result<(), ArchiveError> {
+    let file = fs::File::open(archive).map_err(|source| ArchiveError::Open {
+        path: archive.to_path_buf(),
+        source,
+    })?;
+    let gz = flate2::read::GzDecoder::new(file);
+    let mut tar = tar::Archive::new(gz);
+
+    let entries = tar.entries().map_err(|source| ArchiveError::Tar {
+        path: archive.to_path_buf(),
+        source,
+    })?;
+
+    for entry in entries {
+        let mut entry = entry.map_err(|source| ArchiveError::Tar {
+            path: archive.to_path_buf(),
+            source,
+        })?;
+
+        let etype = entry.header().entry_type();
+        if !(etype.is_file() || etype.is_dir()) {
+            continue;
+        }
+
+        let entry_path = entry
+            .path()
+            .map_err(|source| ArchiveError::Tar {
+                path: archive.to_path_buf(),
+                source,
+            })?
+            .into_owned();
+
+        if !is_safe_relative(&entry_path) {
+            return Err(ArchiveError::UnsafePath {
+                archive: archive.to_path_buf(),
+                entry: entry_path.display().to_string(),
+            });
+        }
+
+        let dest = staging.join(&entry_path);
+        entry.unpack(&dest).map_err(|source| ArchiveError::Tar {
+            path: archive.to_path_buf(),
+            source,
+        })?;
+    }
+    Ok(())
+}
+
+/// Extract `archive` (a `.zip`) into `staging`. The staging directory must
+/// already exist.
+///
+/// Mirrors [`extract_tar_gz`]: entries are validated via
+/// [`zip::read::ZipFile::enclosed_name`] (which rejects absolute paths and
+/// `..` escapes), symlinks are dropped, and file contents are written with
+/// their recorded unix permissions where present.
+pub fn extract_zip(archive: &Path, staging: &Path) -> Result<(), ArchiveError> {
+    let file = fs::File::open(archive).map_err(|source| ArchiveError::Open {
+        path: archive.to_path_buf(),
+        source,
+    })?;
+    let mut zip = zip::ZipArchive::new(file).map_err(|e| ArchiveError::Zip {
+        path: archive.to_path_buf(),
+        detail: e.to_string(),
+    })?;
+
+    for i in 0..zip.len() {
+        let mut entry = zip.by_index(i).map_err(|e| ArchiveError::Zip {
+            path: archive.to_path_buf(),
+            detail: e.to_string(),
+        })?;
+
+        if entry.is_symlink() {
+            continue;
+        }
+
+        let raw_name = entry.name().to_string();
+        let Some(rel) = entry.enclosed_name() else {
+            return Err(ArchiveError::UnsafePath {
+                archive: archive.to_path_buf(),
+                entry: raw_name,
+            });
+        };
+        if !is_safe_relative(&rel) {
+            return Err(ArchiveError::UnsafePath {
+                archive: archive.to_path_buf(),
+                entry: raw_name,
+            });
+        }
+
+        let dest = staging.join(&rel);
+        if entry.is_dir() {
+            fs::create_dir_all(&dest)?;
+            continue;
+        }
+        if let Some(parent) = dest.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let mut out = fs::File::create(&dest)?;
+        io::copy(&mut entry, &mut out)?;
+
+        #[cfg(unix)]
+        if let Some(mode) = entry.unix_mode() {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&dest, fs::Permissions::from_mode(mode))?;
+        }
+    }
+    Ok(())
+}
+
+/// Copy `src` into `staging` as `flox-<name>` (no archive involved) and
+/// ensure it is executable. Returns the destination path.
+pub fn install_raw(src: &Path, staging: &Path, name: &str) -> Result<PathBuf, ArchiveError> {
+    let dest = staging.join(format!("flox-{name}"));
+    fs::copy(src, &dest)?;
+    chmod_executable(&dest)?;
+    Ok(dest)
+}
+
+/// Walk the extracted tree rooted at `staging` and return the path of the
+/// extension's executable (a file named `flox-<name>` or `<name>` at any
+/// depth). On Unix the file's permissions are promoted to include the
+/// executable bits so the dispatch path can exec it.
+pub fn locate_executable(staging: &Path, name: &str) -> Result<PathBuf, ArchiveError> {
+    let prefixed = format!("flox-{name}");
+    let mut candidate: Option<PathBuf> = None;
+    for entry in walkdir::WalkDir::new(staging)
+        .follow_links(false)
+        .into_iter()
+        .filter_map(|e| e.ok())
+    {
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let file_name = match entry.file_name().to_str() {
+            Some(s) => s,
+            None => continue,
+        };
+        if file_name == prefixed {
+            candidate = Some(entry.path().to_path_buf());
+            break;
+        }
+        if candidate.is_none() && file_name == name {
+            candidate = Some(entry.path().to_path_buf());
+        }
+    }
+    let Some(path) = candidate else {
+        return Err(ArchiveError::ExecutableMissing {
+            archive: staging.to_path_buf(),
+            name: name.to_string(),
+        });
+    };
+    chmod_executable(&path)?;
+    // Ensure the staging-root binary exists at `flox-<name>` so install_dir
+    // can dispatch it without knowing the archive's internal layout. If it's
+    // already at the root with the right name, no move is needed.
+    let root_exe = staging.join(&prefixed);
+    if path != root_exe {
+        // Copy (not rename) so we don't disturb on-disk layout if authors
+        // ship a bundle of support files alongside the binary.
+        fs::copy(&path, &root_exe)?;
+        chmod_executable(&root_exe)?;
+    }
+    Ok(root_exe)
+}
+
+#[cfg(unix)]
+fn chmod_executable(p: &Path) -> io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = fs::metadata(p)?.permissions();
+    let mode = perms.mode() | 0o111;
+    perms.set_mode(mode);
+    fs::set_permissions(p, perms)
+}
+
+#[cfg(not(unix))]
+fn chmod_executable(_p: &Path) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use pretty_assertions::assert_eq;
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn build_tar_gz(dest: &Path, entries: &[(&str, &[u8])]) {
+        let file = fs::File::create(dest).unwrap();
+        let gz = flate2::write::GzEncoder::new(file, flate2::Compression::default());
+        let mut tar = tar::Builder::new(gz);
+        for (name, body) in entries {
+            let mut header = tar::Header::new_gnu();
+            header.set_path(name).unwrap();
+            header.set_size(body.len() as u64);
+            header.set_mode(0o755);
+            header.set_cksum();
+            tar.append(&header, *body).unwrap();
+        }
+        tar.into_inner().unwrap().finish().unwrap();
+    }
+
+    /// Construct a tar.gz with one regular-file entry whose `name` bypasses
+    /// the `tar` crate's path validation (which refuses absolute paths and
+    /// `..` components up-front). We emit the 512-byte ustar header with
+    /// the raw name, then the data, padded to a 512-byte boundary, plus the
+    /// two-empty-record end-of-archive trailer.
+    fn build_tar_gz_raw(dest: &Path, name: &str, body: &[u8]) {
+        let mut record = [0u8; 512];
+        let name_bytes = name.as_bytes();
+        let n = name_bytes.len().min(100);
+        record[..n].copy_from_slice(&name_bytes[..n]);
+        record[100..108].copy_from_slice(b"0000644\0");
+        record[108..116].copy_from_slice(b"0000000\0");
+        record[116..124].copy_from_slice(b"0000000\0");
+        let size_octal = format!("{:011o}\0", body.len());
+        record[124..136].copy_from_slice(size_octal.as_bytes());
+        record[136..148].copy_from_slice(b"00000000000\0");
+        record[148..156].copy_from_slice(b"        ");
+        record[156] = b'0';
+        record[257..263].copy_from_slice(b"ustar\0");
+        record[263..265].copy_from_slice(b"00");
+        let sum: u32 = record.iter().map(|&b| u32::from(b)).sum();
+        let chksum = format!("{sum:06o}\0 ");
+        record[148..156].copy_from_slice(chksum.as_bytes());
+
+        let mut raw = Vec::new();
+        raw.extend_from_slice(&record);
+        raw.extend_from_slice(body);
+        let pad = (512 - (body.len() % 512)) % 512;
+        raw.extend(std::iter::repeat_n(0u8, pad));
+        raw.extend(std::iter::repeat_n(0u8, 1024));
+
+        let file = fs::File::create(dest).unwrap();
+        let mut gz = flate2::write::GzEncoder::new(file, flate2::Compression::default());
+        gz.write_all(&raw).unwrap();
+        gz.finish().unwrap();
+    }
+
+    fn build_tar_gz_with_symlink(dest: &Path, link_name: &str, target: &str) {
+        let file = fs::File::create(dest).unwrap();
+        let gz = flate2::write::GzEncoder::new(file, flate2::Compression::default());
+        let mut tar = tar::Builder::new(gz);
+        let mut header = tar::Header::new_gnu();
+        header.set_size(0);
+        header.set_mode(0o777);
+        header.set_entry_type(tar::EntryType::Symlink);
+        header.set_link_name(target).unwrap();
+        header.set_cksum();
+        tar.append_data(&mut header, link_name, std::io::empty())
+            .unwrap();
+        tar.into_inner().unwrap().finish().unwrap();
+    }
+
+    fn build_zip(dest: &Path, entries: &[(&str, &[u8])]) {
+        let file = fs::File::create(dest).unwrap();
+        let mut zip = zip::ZipWriter::new(file);
+        let options: zip::write::SimpleFileOptions = zip::write::SimpleFileOptions::default()
+            .compression_method(zip::CompressionMethod::Deflated)
+            .unix_permissions(0o755);
+        for (name, body) in entries {
+            zip.start_file(*name, options).unwrap();
+            zip.write_all(body).unwrap();
+        }
+        zip.finish().unwrap();
+    }
+
+    #[test]
+    fn extract_tar_gz_round_trips_entries() {
+        let temp = TempDir::new().unwrap();
+        let archive = temp.path().join("a.tar.gz");
+        let staging = temp.path().join("staging");
+        fs::create_dir(&staging).unwrap();
+        build_tar_gz(&archive, &[
+            ("flox-hello", b"#!/bin/sh\necho hi\n"),
+            ("README.md", b"hello\n"),
+        ]);
+
+        extract_tar_gz(&archive, &staging).unwrap();
+        assert!(staging.join("flox-hello").exists());
+        assert!(staging.join("README.md").exists());
+    }
+
+    #[test]
+    fn extract_zip_round_trips_entries() {
+        let temp = TempDir::new().unwrap();
+        let archive = temp.path().join("a.zip");
+        let staging = temp.path().join("staging");
+        fs::create_dir(&staging).unwrap();
+        build_zip(&archive, &[
+            ("flox-hello", b"#!/bin/sh\necho hi\n"),
+            ("README.md", b"hello\n"),
+        ]);
+
+        extract_zip(&archive, &staging).unwrap();
+        assert!(staging.join("flox-hello").exists());
+        assert!(staging.join("README.md").exists());
+    }
+
+    #[test]
+    fn install_raw_copies_and_chmods() {
+        let temp = TempDir::new().unwrap();
+        let src = temp.path().join("payload");
+        let staging = temp.path().join("staging");
+        fs::create_dir(&staging).unwrap();
+        fs::write(&src, b"#!/bin/sh\necho hi\n").unwrap();
+
+        let dest = install_raw(&src, &staging, "hello").unwrap();
+        assert_eq!(dest, staging.join("flox-hello"));
+        assert_eq!(fs::read(&dest).unwrap(), b"#!/bin/sh\necho hi\n");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = fs::metadata(&dest).unwrap().permissions().mode();
+            assert!(mode & 0o111 != 0, "executable bit not set: mode={mode:o}");
+        }
+    }
+
+    #[test]
+    fn locate_executable_finds_nested_flox_prefixed_file() {
+        let temp = TempDir::new().unwrap();
+        let staging = temp.path().join("s");
+        fs::create_dir_all(staging.join("bin")).unwrap();
+        fs::write(staging.join("bin").join("flox-hello"), b"#!/bin/sh\n").unwrap();
+
+        let exe = locate_executable(&staging, "hello").unwrap();
+        assert_eq!(exe, staging.join("flox-hello"));
+        assert!(exe.exists());
+    }
+
+    #[test]
+    fn locate_executable_falls_back_to_bare_name() {
+        let temp = TempDir::new().unwrap();
+        let staging = temp.path().join("s");
+        fs::create_dir_all(&staging).unwrap();
+        fs::write(staging.join("hello"), b"#!/bin/sh\n").unwrap();
+
+        let exe = locate_executable(&staging, "hello").unwrap();
+        assert_eq!(exe, staging.join("flox-hello"));
+    }
+
+    #[test]
+    fn extract_tar_gz_rejects_dotdot_escape() {
+        let temp = TempDir::new().unwrap();
+        let archive = temp.path().join("evil.tar.gz");
+        let staging = temp.path().join("staging");
+        fs::create_dir(&staging).unwrap();
+        build_tar_gz_raw(&archive, "../escape", b"pwned");
+
+        let err = extract_tar_gz(&archive, &staging).unwrap_err();
+        assert!(
+            matches!(err, ArchiveError::UnsafePath { .. }),
+            "expected UnsafePath, got {err:?}"
+        );
+        assert!(!temp.path().join("escape").exists());
+    }
+
+    #[test]
+    fn extract_tar_gz_rejects_absolute_path() {
+        let temp = TempDir::new().unwrap();
+        let archive = temp.path().join("evil.tar.gz");
+        let staging = temp.path().join("staging");
+        fs::create_dir(&staging).unwrap();
+        build_tar_gz_raw(&archive, "/tmp/flox-absolute-escape", b"pwned");
+
+        let err = extract_tar_gz(&archive, &staging).unwrap_err();
+        assert!(
+            matches!(err, ArchiveError::UnsafePath { .. }),
+            "expected UnsafePath, got {err:?}"
+        );
+        assert!(!PathBuf::from("/tmp/flox-absolute-escape").exists());
+    }
+
+    #[test]
+    fn extract_tar_gz_silently_skips_symlink_entries() {
+        let temp = TempDir::new().unwrap();
+        let archive = temp.path().join("evil.tar.gz");
+        let staging = temp.path().join("staging");
+        fs::create_dir(&staging).unwrap();
+        build_tar_gz_with_symlink(&archive, "flox-hello", "/etc/passwd");
+
+        extract_tar_gz(&archive, &staging).unwrap();
+        assert!(
+            !staging.join("flox-hello").exists(),
+            "symlink must not be materialized"
+        );
+    }
+
+    #[test]
+    fn extract_zip_rejects_dotdot_escape() {
+        let temp = TempDir::new().unwrap();
+        let archive = temp.path().join("evil.zip");
+        let staging = temp.path().join("staging");
+        fs::create_dir(&staging).unwrap();
+        build_zip(&archive, &[("../escape", b"pwned")]);
+
+        let err = extract_zip(&archive, &staging).unwrap_err();
+        assert!(
+            matches!(err, ArchiveError::UnsafePath { .. }),
+            "expected UnsafePath, got {err:?}"
+        );
+        assert!(!temp.path().join("escape").exists());
+    }
+
+    #[test]
+    fn extract_zip_rejects_absolute_path() {
+        let temp = TempDir::new().unwrap();
+        let archive = temp.path().join("evil.zip");
+        let staging = temp.path().join("staging");
+        fs::create_dir(&staging).unwrap();
+        build_zip(&archive, &[("/tmp/flox-absolute-escape-zip", b"pwned")]);
+
+        let err = extract_zip(&archive, &staging).unwrap_err();
+        assert!(
+            matches!(err, ArchiveError::UnsafePath { .. }),
+            "expected UnsafePath, got {err:?}"
+        );
+        assert!(!PathBuf::from("/tmp/flox-absolute-escape-zip").exists());
+    }
+
+    #[test]
+    fn locate_executable_errors_when_no_match() {
+        let temp = TempDir::new().unwrap();
+        let staging = temp.path().join("s");
+        fs::create_dir_all(&staging).unwrap();
+        fs::write(staging.join("something-else"), b"").unwrap();
+        let err = locate_executable(&staging, "hello").unwrap_err();
+        assert!(matches!(err, ArchiveError::ExecutableMissing { .. }));
+    }
+}

--- a/cli/beta/src/extensions/archive.rs
+++ b/cli/beta/src/extensions/archive.rs
@@ -223,6 +223,14 @@ pub fn locate_executable(staging: &Path, name: &str) -> Result<PathBuf, ArchiveE
     if path != root_exe {
         // Copy (not rename) so we don't disturb on-disk layout if authors
         // ship a bundle of support files alongside the binary.
+        //
+        // TODO(CLI-157): a bundled executable copied to the managed root is
+        // detached from its siblings — `$(dirname "$0")/…` and
+        // `$ORIGIN`-relative loads then resolve against the root, not the
+        // bundle directory, so multi-file bundles break. Single-file
+        // extensions are unaffected. The fix needs a layout/dispatch-contract
+        // decision, so it is deferred.
+        // https://linear.app/floxdotdev/issue/CLI-157
         fs::copy(&path, &root_exe)?;
         chmod_executable(&root_exe)?;
     }

--- a/cli/beta/src/extensions/dispatch.rs
+++ b/cli/beta/src/extensions/dispatch.rs
@@ -1,0 +1,363 @@
+//! External-subcommand resolver.
+//!
+//! Given a subcommand name, locate the executable `flox-<name>` that
+//! implements it. Searches the managed extensions directory first, then
+//! `$PATH`. The managed-dir-first order is intentional: the managed dir
+//! is populated only by `flox extension install`, so precedence there
+//! reflects explicit user intent rather than ambient shell state.
+//!
+//! P01 introduced [`find`]. P06 adds [`ActivationMode`] + [`resolve_mode`]
+//! (pure mapping from the author manifest's `[environment]` stanza to
+//! the mode the dispatch layer should apply) and [`scrub_flox_env`]
+//! (helper for None-mode env scrubbing). Process replacement and
+//! bookkeeping-var injection live on the CLI side next to
+//! `try_dispatch_external`.
+
+use std::ffi::{OsStr, OsString};
+use std::path::{Path, PathBuf};
+
+use thiserror::Error;
+use tracing::warn;
+
+use super::manifest::EnvironmentBehavior;
+
+#[derive(Debug, Error)]
+pub enum FindError {
+    #[error("no extension named '{0}' is installed")]
+    NotFound(String),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+}
+
+/// Dispatch-time activation-mode selection derived from the author
+/// manifest's `[environment]` stanza. The CLI layer maps this to a
+/// `Command` before process replacement.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ActivationMode {
+    /// Launch in the caller's current environment (possibly none).
+    Inherit,
+    /// Scrub `FLOX_*` / `_FLOX_*` before launch; no activation wrapper.
+    None,
+    /// Re-invoke `flox activate -r <ref> -- <ext>`. Opaque owner/name.
+    Pinned(String),
+}
+
+/// P06 dispatch-side errors raised before or during process replacement.
+#[derive(Debug, Error)]
+pub enum DispatchError {
+    #[error(
+        "extension '{extension}' requires the '{expected}' environment; trust it with 'flox activate -r {expected} --trust' first"
+    )]
+    PinnedEnvMismatch { extension: String, expected: String },
+}
+
+/// Map an author-manifest `[environment]` stanza to the mode the dispatch
+/// layer should apply.
+///
+/// Rules (research-doc §1.11):
+/// - missing stanza → `Inherit`
+/// - `mode = "none"` → `None`
+/// - `mode = "inherit"` (or empty) → `Inherit`
+/// - `mode = "pinned"` with non-empty `inherit_name` → `Pinned(ref)`
+/// - `mode = "pinned"` with missing/empty `inherit_name` → warn, fall
+///   back to `Inherit` (manifest is malformed; don't hard-fail dispatch)
+/// - any other value → warn, fall back to `Inherit` (lenient
+///   forward-compat)
+///
+/// Idempotency (when the caller is already inside the pinned env) is
+/// handled on the CLI side after this function returns, using
+/// `_FLOX_ACTIVE_ENVIRONMENTS`. Keeping that check out of the SDK avoids
+/// duplicating the `ActiveEnvironments` JSON parser.
+pub fn resolve_mode(manifest_env: Option<&EnvironmentBehavior>) -> ActivationMode {
+    let Some(env) = manifest_env else {
+        return ActivationMode::Inherit;
+    };
+    match env.mode.as_str() {
+        "none" => ActivationMode::None,
+        "inherit" | "" => ActivationMode::Inherit,
+        "pinned" => match env.inherit_name.as_deref() {
+            Some(name) if !name.is_empty() => ActivationMode::Pinned(name.to_owned()),
+            _ => {
+                warn!(
+                    mode = "pinned",
+                    "extension manifest: pinned mode requires non-empty inherit_name; falling back to Inherit"
+                );
+                ActivationMode::Inherit
+            },
+        },
+        other => {
+            warn!(
+                mode = other,
+                "extension manifest: unknown environment.mode; falling back to Inherit"
+            );
+            ActivationMode::Inherit
+        },
+    }
+}
+
+/// Filter `env_vars` down to the set safe to pass in `ActivationMode::None`.
+///
+/// Drops every key whose byte prefix is `FLOX_` or `_FLOX_`. `FLOXHUB_*`
+/// is intentionally preserved: it is not a flox-activation-context
+/// variable, and None-mode is about hiding the enclosing flox
+/// environment, not about scrubbing FloxHub credentials.
+pub fn scrub_flox_env(
+    env_vars: impl IntoIterator<Item = (OsString, OsString)>,
+) -> Vec<(OsString, OsString)> {
+    env_vars
+        .into_iter()
+        .filter(|(key, _)| !is_flox_prefixed(key))
+        .collect()
+}
+
+fn is_flox_prefixed(key: &OsStr) -> bool {
+    let bytes = key.as_encoded_bytes();
+    bytes.starts_with(b"FLOX_") || bytes.starts_with(b"_FLOX_")
+}
+
+/// Resolve `flox-<name>` by searching the managed extensions directory and
+/// then `$PATH`.
+///
+/// `extensions_root` is typically `flox.data_dir.join("extensions")`. The
+/// managed layout is `extensions_root/<flox-name>/<flox-name>` (one
+/// subdirectory per installed extension). `path_env` is the raw value of
+/// `$PATH`; pass `None` to skip the PATH fallback.
+pub fn find(
+    name: &str,
+    extensions_root: &Path,
+    path_env: Option<&OsStr>,
+) -> Result<PathBuf, FindError> {
+    if name.is_empty() || name.contains('/') || name.contains(std::path::MAIN_SEPARATOR) {
+        return Err(FindError::NotFound(name.to_owned()));
+    }
+    let exe_name = format!("flox-{name}");
+
+    let managed = extensions_root.join(&exe_name).join(&exe_name);
+    if is_executable(&managed)? {
+        return Ok(managed);
+    }
+
+    if let Some(path) = path_env {
+        for dir in std::env::split_paths(path) {
+            let candidate = dir.join(&exe_name);
+            if is_executable(&candidate)? {
+                return Ok(candidate);
+            }
+        }
+    }
+
+    Err(FindError::NotFound(name.to_owned()))
+}
+
+#[cfg(unix)]
+fn is_executable(p: &Path) -> std::io::Result<bool> {
+    use std::os::unix::fs::PermissionsExt;
+    match std::fs::metadata(p) {
+        Ok(md) if md.is_file() && md.permissions().mode() & 0o111 != 0 => Ok(true),
+        Ok(_) => Ok(false),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(e) => Err(e),
+    }
+}
+
+#[cfg(not(unix))]
+fn is_executable(p: &Path) -> std::io::Result<bool> {
+    Ok(p.is_file())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsString;
+    use std::fs;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    /// Create `extensions_root/flox-<name>/flox-<name>` as an executable
+    /// file. Returns the full path.
+    fn mk_managed_ext(extensions_root: &Path, name: &str) -> PathBuf {
+        let exe_name = format!("flox-{name}");
+        let dir = extensions_root.join(&exe_name);
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(&exe_name);
+        fs::write(&path, "#!/bin/sh\n").unwrap();
+        #[cfg(unix)]
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();
+        path
+    }
+
+    /// Create `path_dir/flox-<name>` as an executable file. Returns the
+    /// full path.
+    fn mk_path_ext(path_dir: &Path, name: &str) -> PathBuf {
+        let path = path_dir.join(format!("flox-{name}"));
+        fs::write(&path, "#!/bin/sh\n").unwrap();
+        #[cfg(unix)]
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();
+        path
+    }
+
+    #[test]
+    fn find_returns_err_for_missing_name() {
+        let managed = TempDir::new().unwrap();
+        let path_dir = TempDir::new().unwrap();
+        let path_env = OsString::from(path_dir.path());
+
+        let err = find("foo", managed.path(), Some(&path_env)).unwrap_err();
+        assert!(matches!(err, FindError::NotFound(ref n) if n == "foo"));
+    }
+
+    #[test]
+    fn find_picks_managed_dir_over_path() {
+        let managed = TempDir::new().unwrap();
+        let path_dir = TempDir::new().unwrap();
+        let managed_path = mk_managed_ext(managed.path(), "foo");
+        let _path_path = mk_path_ext(path_dir.path(), "foo");
+        let path_env = OsString::from(path_dir.path());
+
+        let got = find("foo", managed.path(), Some(&path_env)).unwrap();
+        assert_eq!(got, managed_path);
+    }
+
+    #[test]
+    fn find_falls_back_to_path() {
+        let managed = TempDir::new().unwrap();
+        let path_dir = TempDir::new().unwrap();
+        let path_path = mk_path_ext(path_dir.path(), "foo");
+        let path_env = OsString::from(path_dir.path());
+
+        let got = find("foo", managed.path(), Some(&path_env)).unwrap();
+        assert_eq!(got, path_path);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn find_rejects_non_executable() {
+        let managed = TempDir::new().unwrap();
+        let exe_name = "flox-foo";
+        let dir = managed.path().join(exe_name);
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(exe_name);
+        fs::write(&path, "#!/bin/sh\n").unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).unwrap();
+
+        let err = find("foo", managed.path(), None).unwrap_err();
+        assert!(matches!(err, FindError::NotFound(ref n) if n == "foo"));
+    }
+
+    #[test]
+    fn find_rejects_names_with_slashes() {
+        let managed = TempDir::new().unwrap();
+        let err = find("../etc/passwd", managed.path(), None).unwrap_err();
+        assert!(matches!(err, FindError::NotFound(ref n) if n == "../etc/passwd"));
+    }
+
+    #[test]
+    fn find_rejects_empty_name() {
+        let managed = TempDir::new().unwrap();
+        let err = find("", managed.path(), None).unwrap_err();
+        assert!(matches!(err, FindError::NotFound(ref n) if n.is_empty()));
+    }
+
+    fn env(mode: &str, inherit_name: Option<&str>) -> EnvironmentBehavior {
+        EnvironmentBehavior {
+            mode: mode.to_string(),
+            inherit: None,
+            inherit_name: inherit_name.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn resolve_mode_none_manifest_returns_inherit() {
+        assert_eq!(resolve_mode(None), ActivationMode::Inherit);
+    }
+
+    #[test]
+    fn resolve_mode_inherit_returns_inherit() {
+        assert_eq!(
+            resolve_mode(Some(&env("inherit", None))),
+            ActivationMode::Inherit
+        );
+    }
+
+    #[test]
+    fn resolve_mode_empty_mode_returns_inherit() {
+        assert_eq!(resolve_mode(Some(&env("", None))), ActivationMode::Inherit);
+    }
+
+    #[test]
+    fn resolve_mode_none_returns_none() {
+        assert_eq!(resolve_mode(Some(&env("none", None))), ActivationMode::None);
+    }
+
+    #[test]
+    fn resolve_mode_pinned_with_name_returns_pinned() {
+        assert_eq!(
+            resolve_mode(Some(&env("pinned", Some("alice/proj")))),
+            ActivationMode::Pinned("alice/proj".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_mode_pinned_without_name_falls_back_to_inherit() {
+        assert_eq!(
+            resolve_mode(Some(&env("pinned", None))),
+            ActivationMode::Inherit
+        );
+    }
+
+    #[test]
+    fn resolve_mode_pinned_with_empty_name_falls_back_to_inherit() {
+        assert_eq!(
+            resolve_mode(Some(&env("pinned", Some("")))),
+            ActivationMode::Inherit
+        );
+    }
+
+    #[test]
+    fn resolve_mode_unknown_mode_falls_back_to_inherit() {
+        assert_eq!(
+            resolve_mode(Some(&env("frobnicate", None))),
+            ActivationMode::Inherit
+        );
+    }
+
+    fn os(s: &str) -> OsString {
+        OsString::from(s)
+    }
+
+    #[test]
+    fn scrub_flox_env_removes_flox_and_underscore_flox_prefixes() {
+        let input = vec![
+            (os("FLOX_ENV"), os("/some/env")),
+            (os("FLOX_PROMPT"), os("foo")),
+            (os("_FLOX_ACTIVE_ENVIRONMENTS"), os("[]")),
+            (os("PATH"), os("/usr/bin")),
+            (os("HOME"), os("/home/u")),
+            (os("FLOXHUB_TOKEN"), os("secret")),
+        ];
+        let out = scrub_flox_env(input);
+        let keys: Vec<OsString> = out.iter().map(|(k, _)| k.clone()).collect();
+        assert_eq!(keys, vec![os("PATH"), os("HOME"), os("FLOXHUB_TOKEN"),]);
+    }
+
+    #[test]
+    fn scrub_flox_env_on_empty_input_returns_empty() {
+        let out: Vec<(OsString, OsString)> = scrub_flox_env(Vec::new());
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn scrub_flox_env_preserves_non_flox_keys_including_floxhub() {
+        let input = vec![
+            (os("FLOXHUB_TOKEN"), os("secret")),
+            (os("FLOXHUB_URL"), os("https://hub.flox.dev")),
+            (os("FLOOR"), os("tile")),
+            (os("FLOX"), os("literal")),
+        ];
+        let out = scrub_flox_env(input.clone());
+        assert_eq!(out, input);
+    }
+}

--- a/cli/beta/src/extensions/extension.rs
+++ b/cli/beta/src/extensions/extension.rs
@@ -1,0 +1,12 @@
+//! In-memory model of an installed extension.
+
+use std::path::PathBuf;
+
+use super::manifest::InstalledState;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Extension {
+    pub name: String,
+    pub install_dir: PathBuf,
+    pub state: InstalledState,
+}

--- a/cli/beta/src/extensions/github.rs
+++ b/cli/beta/src/extensions/github.rs
@@ -842,7 +842,14 @@ pub(crate) fn resolve_asset_for<'a>(
 /// contain a platform substring too (e.g. `flox-x-linux-x86_64.tar.gz.sha256`).
 fn is_sidecar_asset(name: &str) -> bool {
     const SIDECAR_SUFFIXES: &[&str] = &[
-        ".sha256", ".sha512", ".sha1", ".md5", ".sig", ".asc", ".pem", ".sbom",
+        ".sha256",
+        ".sha512",
+        ".sha1",
+        ".md5",
+        ".sig",
+        ".asc",
+        ".pem",
+        ".sbom",
         ".intoto.jsonl",
     ];
     let lower = name.to_ascii_lowercase();

--- a/cli/beta/src/extensions/github.rs
+++ b/cli/beta/src/extensions/github.rs
@@ -98,6 +98,8 @@ pub enum GitHubError {
     Http(#[from] reqwest::Error),
     #[error("github resource not found: {0}")]
     NotFound(String),
+    #[error("invalid git ref '{0}': contains characters not allowed in a ref")]
+    InvalidRef(String),
     #[error("malformed github response from {url}: {detail}")]
     Malformed { url: String, detail: String },
     #[error("failed to write asset to {path}: {source}")]
@@ -232,6 +234,20 @@ impl GitHubSource {
         self
     }
 
+    /// A GET builder for a GitHub **API** URL, carrying
+    /// `Authorization: Bearer <token>` when one is configured. This lifts
+    /// the anonymous rate limit and allows private repos.
+    ///
+    /// It is deliberately NOT used for asset downloads: the token must not
+    /// ride a redirect to an off-`api.github.com` CDN host.
+    fn api_get(&self, url: &str) -> reqwest::RequestBuilder {
+        let req = self.client.get(url);
+        match self.auth_token.as_deref() {
+            Some(token) => req.bearer_auth(token),
+            None => req,
+        }
+    }
+
     /// Clone `https://github.com/<owner>/<repo>.git` into `dest` at
     /// `branch_or_ref` (single-branch, no tags). The clone URL ignores
     /// `base_url` because that override only applies to the API; for
@@ -284,7 +300,7 @@ impl GitHubSource {
         repo: &str,
     ) -> Result<ResolvedRef, GitHubError> {
         let url = format!("{}/repos/{owner}/{repo}/releases/latest", self.base_url);
-        let resp = self.client.get(&url).send().await?;
+        let resp = self.api_get(&url).send().await?;
         let status = resp.status();
         if status.is_success() {
             let body: ReleaseBody = resp.json().await.map_err(|e| GitHubError::Malformed {
@@ -306,7 +322,7 @@ impl GitHubSource {
 
         // Fallback: default branch HEAD.
         let repo_url = format!("{}/repos/{owner}/{repo}", self.base_url);
-        let resp = self.client.get(&repo_url).send().await?;
+        let resp = self.api_get(&repo_url).send().await?;
         let status = resp.status();
         if !status.is_success() {
             if status.as_u16() == 404 {
@@ -338,9 +354,16 @@ impl GitHubSource {
         if pin.is_empty() {
             return Err(GitHubError::NotFound(pin.to_string()));
         }
+        // The pin is interpolated into API URL paths/queries; reject any ref
+        // with characters that could alter the URL structure (spaces, `#`,
+        // `?`, `&`, `%`, control chars) rather than encode them. Real tags,
+        // branches, and SHAs only use `[A-Za-z0-9._/-]`.
+        if !is_url_safe_ref(pin) {
+            return Err(GitHubError::InvalidRef(pin.to_string()));
+        }
         if looks_like_tag(pin) {
             let url = format!("{}/repos/{owner}/{repo}/releases/tags/{pin}", self.base_url);
-            let resp = self.client.get(&url).send().await?;
+            let resp = self.api_get(&url).send().await?;
             let status = resp.status();
             if status.as_u16() == 404 {
                 return Err(GitHubError::NotFound(format!(
@@ -392,7 +415,7 @@ impl GitHubSource {
     /// `GET /repos/:owner/:repo` and extract `default_branch`.
     async fn fetch_default_branch(&self, owner: &str, repo: &str) -> Result<String, GitHubError> {
         let url = format!("{}/repos/{owner}/{repo}", self.base_url);
-        let resp = self.client.get(&url).send().await?;
+        let resp = self.api_get(&url).send().await?;
         let status = resp.status();
         if status.as_u16() == 404 {
             return Err(GitHubError::NotFound(format!("{owner}/{repo}")));
@@ -417,7 +440,7 @@ impl GitHubSource {
         tag: &str,
     ) -> Result<Vec<ReleaseAsset>, GitHubError> {
         let url = format!("{}/repos/{owner}/{repo}/releases/tags/{tag}", self.base_url);
-        let resp = self.client.get(&url).send().await?;
+        let resp = self.api_get(&url).send().await?;
         let status = resp.status();
         if status.as_u16() == 404 {
             return Err(GitHubError::NotFound(format!(
@@ -575,7 +598,7 @@ impl GitHubSource {
         r#ref: &str,
     ) -> Result<String, GitHubError> {
         let url = format!("{}/repos/{owner}/{repo}/commits/{}", self.base_url, r#ref);
-        let resp = self.client.get(&url).send().await?;
+        let resp = self.api_get(&url).send().await?;
         let status = resp.status();
         if status.as_u16() == 404 {
             return Err(GitHubError::NotFound(format!(
@@ -615,8 +638,7 @@ impl GitHubSource {
             self.base_url, r#ref
         );
         let resp = self
-            .client
-            .get(&url)
+            .api_get(&url)
             .header("Accept", "application/vnd.github.raw")
             .send()
             .await?;
@@ -914,6 +936,16 @@ fn looks_like_tag(s: &str) -> bool {
         return chars.next().is_some_and(|c| c.is_ascii_digit());
     }
     first.is_ascii_digit() && s.contains('.')
+}
+
+/// True if `r` contains only characters safe to interpolate into a URL
+/// path or query without encoding: `[A-Za-z0-9._/-]`. Real tags, branches,
+/// and SHAs stay within this set; anything else (spaces, `#`, `?`, `&`,
+/// `%`, control characters) is rejected rather than encoded.
+fn is_url_safe_ref(r: &str) -> bool {
+    !r.is_empty()
+        && r.chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '/' | '-'))
 }
 
 #[cfg(test)]
@@ -1345,6 +1377,56 @@ mod tests {
         assert!(is_sidecar_asset("X.ASC"));
         assert!(!is_sidecar_asset("flox-hi-linux-x86_64.tar.gz"));
         assert!(!is_sidecar_asset("flox-hi-linux-x86_64"));
+    }
+
+    #[test]
+    fn is_url_safe_ref_classifications() {
+        for ok in ["v1.2.3", "main", "feature/x", "abc1234", "v2-rc.1", "1.0.0"] {
+            assert!(is_url_safe_ref(ok), "expected safe: {ok:?}");
+        }
+        for bad in ["", "v1#rc1", "a?b", "a&b", "a b", "a%20b", "a\tb", "a\nb"] {
+            assert!(!is_url_safe_ref(bad), "expected unsafe: {bad:?}");
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_pin_rejects_url_unsafe_ref() {
+        // No server needed: the ref is rejected before any HTTP call.
+        let source = GitHubSource::new(reqwest::Client::new(), "http://127.0.0.1:1/".to_string());
+        let err = source
+            .resolve_pin("owner", "flox-hi", "v1#rc1")
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, GitHubError::InvalidRef(_)),
+            "expected InvalidRef, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_latest_sends_authorization_header_when_token_set() {
+        // Proves the token is attached to non-search API calls, not just
+        // search. Both requests (releases/latest and commits/<tag>) must
+        // carry the header, so the mocks require it.
+        let server = MockServer::start_async().await;
+        let _release = server.mock(|when, then| {
+            when.method(GET)
+                .path("/repos/o/r/releases/latest")
+                .header("authorization", "Bearer tok-123");
+            then.status(200)
+                .json_body(json!({ "tag_name": "v1.0.0", "target_commitish": "main" }));
+        });
+        let _commit = server.mock(|when, then| {
+            when.method(GET)
+                .path("/repos/o/r/commits/v1.0.0")
+                .header("authorization", "Bearer tok-123");
+            then.status(200).json_body(json!({
+                "sha": "abc1234567890abcdef1234567890abcdef123456"
+            }));
+        });
+        let source = fixture_source(&server).with_auth_token(Some("tok-123".to_string()));
+        let resolved = source.resolve_latest("o", "r").await.unwrap();
+        assert_eq!(resolved.tag.as_deref(), Some("v1.0.0"));
     }
 
     #[test]

--- a/cli/beta/src/extensions/github.rs
+++ b/cli/beta/src/extensions/github.rs
@@ -1,0 +1,1802 @@
+//! GitHub release/commit resolver and clone delegate.
+//!
+//! `GitHubSource` is a concrete struct (not a trait) — see Design
+//! Constraint #3 and CLAUDE.md provider-trait guidance. P04 may extract
+//! a trait if a second source materializes.
+//!
+//! **Test-only override:** `FLOX_EXTENSIONS_GITHUB_BASE_URL` overrides the
+//! default `https://api.github.com` for bats fixtures and integration
+//! tests. Not exposed as a CLI flag or config key.
+
+use std::io::Write;
+use std::path::Path;
+use std::time::Duration;
+
+use flox_rust_sdk::providers::git::{GitCommandProvider, GitRemoteCommandError};
+use futures::StreamExt;
+use indicatif::{ProgressBar, ProgressStyle};
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+use tracing::info;
+
+use super::manifest::AuthorManifest;
+
+const DEFAULT_BASE_URL: &str = "https://api.github.com";
+const BASE_URL_ENV_VAR: &str = "FLOX_EXTENSIONS_GITHUB_BASE_URL";
+
+/// Progress template for `download_asset` when Content-Length is known.
+/// `{msg}` is set by the caller to the asset filename so that concurrent
+/// or sequential downloads (e.g. `upgrade --all`) are distinguishable on
+/// the user's terminal.
+pub(super) const PROGRESS_TEMPLATE: &str = "{spinner} {msg} {bytes}/{total_bytes} [{bar:30}] {eta}";
+
+/// Progress template for `download_asset` when Content-Length is absent
+/// (spinner fallback). Omits `{total_bytes}`, `{bar}`, and `{eta}` — none
+/// of which render meaningfully without a known total.
+pub(super) const SPINNER_TEMPLATE: &str = "{spinner} {msg} {bytes} ({bytes_per_sec})";
+
+/// Resolved GitHub reference: a full commit SHA plus the human-readable
+/// tag/branch coordinates that produced it (used to pick the clone ref
+/// and to populate `state.toml`).
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ResolvedRef {
+    pub commit: String,
+    pub tag: Option<String>,
+    pub branch: Option<String>,
+}
+
+/// Sort order for `search_repos`. The GitHub Search API accepts `stars`
+/// or `updated`; both are requested in descending order.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SearchSort {
+    Stars,
+    Updated,
+}
+
+impl SearchSort {
+    fn as_str(self) -> &'static str {
+        match self {
+            SearchSort::Stars => "stars",
+            SearchSort::Updated => "updated",
+        }
+    }
+}
+
+/// Parameters for [`GitHubSource::search_repos`]. The topic filter
+/// `topic:flox-extension archived:false` is implicit; user-supplied
+/// `query` and `owner` are appended as additional qualifiers.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SearchQuery {
+    pub query: Option<String>,
+    pub owner: Option<String>,
+    pub limit: u8,
+    pub sort: SearchSort,
+}
+
+impl SearchQuery {
+    /// Clamp `limit` into `1..=100` (the GitHub Search API maximum
+    /// `per_page`).
+    pub fn new(query: Option<String>, owner: Option<String>, limit: u8, sort: SearchSort) -> Self {
+        let limit = limit.clamp(1, 100);
+        Self {
+            query,
+            owner,
+            limit,
+            sort,
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum GitHubError {
+    #[error("HTTP {status} for {url}")]
+    HttpStatus { status: u16, url: String },
+    #[error("HTTP {status} downloading asset {url}")]
+    AssetHttpStatus { status: u16, url: String },
+    #[error(transparent)]
+    Http(#[from] reqwest::Error),
+    #[error("github resource not found: {0}")]
+    NotFound(String),
+    #[error("malformed github response from {url}: {detail}")]
+    Malformed { url: String, detail: String },
+    #[error("failed to write asset to {path}: {source}")]
+    AssetIo {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("github rate limited ({status}); set GH_TOKEN or GITHUB_TOKEN to raise the limit")]
+    RateLimited { status: u16 },
+    #[error("github auth failed ({status}); check GH_TOKEN / GITHUB_TOKEN")]
+    AuthFailed { status: u16 },
+    #[error("refused to download asset from untrusted host '{host}' ({url})")]
+    UnsafeAssetHost { host: String, url: String },
+    #[error("malformed asset download url '{url}'")]
+    UnparseableAssetUrl { url: String },
+}
+
+/// Owner (user or organization) validation failure for
+/// [`validate_owner`]. Kept separate from [`GitHubError`] because it
+/// describes a client-side input problem, not a transport/API failure.
+#[derive(Debug, Error, PartialEq, Eq)]
+#[error(
+    "invalid owner '{0}': must be 1-39 characters of letters, digits, or hyphens, \
+     with no leading/trailing or consecutive hyphens"
+)]
+pub struct InvalidOwner(pub String);
+
+/// Enforce GitHub login rules on a `--owner` argument so it cannot smuggle
+/// additional search qualifiers (e.g. `x user:attacker`) into the `q=`
+/// parameter. GitHub logins are 1–39 chars of `[A-Za-z0-9-]` with no
+/// leading/trailing or consecutive hyphens.
+pub fn validate_owner(owner: &str) -> Result<(), InvalidOwner> {
+    let len = owner.len();
+    if !(1..=39).contains(&len) {
+        return Err(InvalidOwner(owner.to_string()));
+    }
+    let bytes = owner.as_bytes();
+    if bytes[0] == b'-' || bytes[len - 1] == b'-' {
+        return Err(InvalidOwner(owner.to_string()));
+    }
+    let mut prev_hyphen = false;
+    for &b in bytes {
+        let is_hyphen = b == b'-';
+        let valid = b.is_ascii_alphanumeric() || is_hyphen;
+        if !valid || (is_hyphen && prev_hyphen) {
+            return Err(InvalidOwner(owner.to_string()));
+        }
+        prev_hyphen = is_hyphen;
+    }
+    Ok(())
+}
+
+/// Allow-list check used by [`GitHubSource::check_asset_host`]. Matches
+/// `host` exactly against `github.com` / `githubusercontent.com`, against
+/// any subdomain of either, and against the host component of
+/// `base_url` (to cover the `FLOX_EXTENSIONS_GITHUB_BASE_URL` test
+/// override). Case-insensitive.
+fn host_allowed(host: &str, base_url: &str) -> bool {
+    const APEX: &[&str] = &["github.com", "githubusercontent.com"];
+    let host_lc = host.to_ascii_lowercase();
+    for apex in APEX {
+        if host_lc == *apex || host_lc.ends_with(&format!(".{apex}")) {
+            return true;
+        }
+    }
+    if let Ok(base) = url::Url::parse(base_url)
+        && let Some(base_host) = base.host_str()
+        && host_lc == base_host.to_ascii_lowercase()
+    {
+        return true;
+    }
+    false
+}
+
+/// A single release asset (binary attached to a release).
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
+pub struct ReleaseAsset {
+    pub name: String,
+    pub browser_download_url: String,
+    #[serde(default)]
+    pub size: u64,
+    #[serde(default)]
+    pub content_type: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct GitHubSource {
+    client: reqwest::Client,
+    base_url: String,
+    auth_token: Option<String>,
+}
+
+impl GitHubSource {
+    /// Constructor for tests that supply a mock HTTP client and base URL.
+    /// Production code uses [`Self::from_env`].
+    #[cfg(test)]
+    pub(crate) fn new(client: reqwest::Client, base_url: String) -> Self {
+        Self {
+            client,
+            base_url,
+            auth_token: None,
+        }
+    }
+
+    /// Build a `GitHubSource` with the default reqwest client and the
+    /// `FLOX_EXTENSIONS_GITHUB_BASE_URL` env override (test-only) honored.
+    /// Also reads `GH_TOKEN` / `GITHUB_TOKEN` from the environment so the
+    /// Search API moves from 10 req/min to 30 req/min when a token is set.
+    pub fn from_env() -> Self {
+        let base_url =
+            std::env::var(BASE_URL_ENV_VAR).unwrap_or_else(|_| DEFAULT_BASE_URL.to_string());
+        let client = reqwest::Client::builder()
+            .connect_timeout(Duration::from_secs(15))
+            .timeout(Duration::from_secs(60))
+            .user_agent("flox-extensions")
+            .build()
+            .expect("failed to build reqwest client for GitHubSource");
+        Self {
+            client,
+            base_url,
+            auth_token: auth_token_from_env(),
+        }
+    }
+
+    /// Inject an auth token post-construction (tests bypass env). Empty
+    /// strings are coerced to `None` so the caller can't accidentally
+    /// send `Authorization: Bearer ` and trigger a confusing 401.
+    #[cfg(test)]
+    pub(crate) fn with_auth_token(mut self, token: Option<String>) -> Self {
+        self.auth_token = token.filter(|t| !t.is_empty());
+        self
+    }
+
+    /// Clone `https://github.com/<owner>/<repo>.git` into `dest` at
+    /// `branch_or_ref` (single-branch, no tags). The clone URL ignores
+    /// `base_url` because that override only applies to the API; for
+    /// integration tests, the `git config url.<base>.insteadOf` mechanism
+    /// (set up by the bats fixture) redirects the clone.
+    pub fn clone_repo(
+        &self,
+        owner: &str,
+        repo: &str,
+        branch_or_ref: &str,
+        dest: &Path,
+    ) -> Result<(), GitRemoteCommandError> {
+        let url = format!("https://github.com/{owner}/{repo}.git");
+        GitCommandProvider::clone_branch(&url, dest, branch_or_ref, false)?;
+        Ok(())
+    }
+
+    /// Map an unsuccessful, non-404 HTTP response into the most specific
+    /// `GitHubError` variant the caller should surface. 401 becomes
+    /// `AuthFailed` (user hasn't set a valid `GH_TOKEN`/`GITHUB_TOKEN`);
+    /// 429 and 403-with-`x-ratelimit-remaining: 0` become `RateLimited`;
+    /// any other non-success code falls through to a generic `HttpStatus`.
+    ///
+    /// 404 stays per-site because each call carries its own "not found"
+    /// phrasing (owner/repo vs. tag vs. ref). Callers must handle it
+    /// before invoking this helper.
+    fn classify_http_error(
+        status: reqwest::StatusCode,
+        headers: &reqwest::header::HeaderMap,
+        url: String,
+    ) -> GitHubError {
+        let code = status.as_u16();
+        let rate_limit_exhausted = headers
+            .get("x-ratelimit-remaining")
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.trim() == "0")
+            .unwrap_or(false);
+        match code {
+            401 => GitHubError::AuthFailed { status: code },
+            403 if rate_limit_exhausted => GitHubError::RateLimited { status: code },
+            429 => GitHubError::RateLimited { status: code },
+            _ => GitHubError::HttpStatus { status: code, url },
+        }
+    }
+
+    /// Latest release (preferred) or default-branch HEAD (fallback).
+    pub async fn resolve_latest(
+        &self,
+        owner: &str,
+        repo: &str,
+    ) -> Result<ResolvedRef, GitHubError> {
+        let url = format!("{}/repos/{owner}/{repo}/releases/latest", self.base_url);
+        let resp = self.client.get(&url).send().await?;
+        let status = resp.status();
+        if status.is_success() {
+            let body: ReleaseBody = resp.json().await.map_err(|e| GitHubError::Malformed {
+                url: url.clone(),
+                detail: e.to_string(),
+            })?;
+            // tag_name is the human ref; target_commitish is a branch or commit.
+            // Resolve the tag to a commit SHA via /commits/<tag_name>.
+            let commit = self.resolve_commit(owner, repo, &body.tag_name).await?;
+            return Ok(ResolvedRef {
+                commit,
+                tag: Some(body.tag_name),
+                branch: None,
+            });
+        }
+        if status.as_u16() != 404 {
+            return Err(Self::classify_http_error(status, resp.headers(), url));
+        }
+
+        // Fallback: default branch HEAD.
+        let repo_url = format!("{}/repos/{owner}/{repo}", self.base_url);
+        let resp = self.client.get(&repo_url).send().await?;
+        let status = resp.status();
+        if !status.is_success() {
+            if status.as_u16() == 404 {
+                return Err(GitHubError::NotFound(format!("{owner}/{repo}")));
+            }
+            return Err(Self::classify_http_error(status, resp.headers(), repo_url));
+        }
+        let body: RepoBody = resp.json().await.map_err(|e| GitHubError::Malformed {
+            url: repo_url.clone(),
+            detail: e.to_string(),
+        })?;
+        let commit = self
+            .resolve_commit(owner, repo, &body.default_branch)
+            .await?;
+        Ok(ResolvedRef {
+            commit,
+            tag: None,
+            branch: Some(body.default_branch),
+        })
+    }
+
+    /// Resolve a user-supplied pin: tag (`v*` / semver-ish) or commit-SHA prefix.
+    pub async fn resolve_pin(
+        &self,
+        owner: &str,
+        repo: &str,
+        pin: &str,
+    ) -> Result<ResolvedRef, GitHubError> {
+        if pin.is_empty() {
+            return Err(GitHubError::NotFound(pin.to_string()));
+        }
+        if looks_like_tag(pin) {
+            let url = format!("{}/repos/{owner}/{repo}/releases/tags/{pin}", self.base_url);
+            let resp = self.client.get(&url).send().await?;
+            let status = resp.status();
+            if status.as_u16() == 404 {
+                return Err(GitHubError::NotFound(format!(
+                    "tag '{pin}' on {owner}/{repo}"
+                )));
+            }
+            if !status.is_success() {
+                return Err(Self::classify_http_error(status, resp.headers(), url));
+            }
+            let body: ReleaseBody = resp.json().await.map_err(|e| GitHubError::Malformed {
+                url: url.clone(),
+                detail: e.to_string(),
+            })?;
+            let commit = self.resolve_commit(owner, repo, &body.tag_name).await?;
+            return Ok(ResolvedRef {
+                commit,
+                tag: Some(body.tag_name),
+                branch: None,
+            });
+        }
+        if is_hex_prefix(pin) {
+            // Resolve the commit AND the default branch in parallel: the
+            // commit is what we pin to, but we need a branch name to drive
+            // the `git clone --branch <ref>` step (git won't clone by raw
+            // SHA). The caller resets to `commit` after the clone lands.
+            let commit = self.resolve_commit(owner, repo, pin).await?;
+            let branch = self.fetch_default_branch(owner, repo).await?;
+            return Ok(ResolvedRef {
+                commit,
+                tag: None,
+                branch: Some(branch),
+            });
+        }
+        // Fall back to treating `pin` as a branch (or other ref) name: the
+        // commits endpoint accepts any ref that resolves on the remote.
+        match self.resolve_commit(owner, repo, pin).await {
+            Ok(commit) => Ok(ResolvedRef {
+                commit,
+                tag: None,
+                branch: Some(pin.to_string()),
+            }),
+            Err(GitHubError::NotFound(_)) => Err(GitHubError::NotFound(format!(
+                "pin '{pin}' on {owner}/{repo}; expected a tag (e.g. 'v1.2.3'), a commit SHA prefix, or a branch name"
+            ))),
+            Err(err) => Err(err),
+        }
+    }
+
+    /// `GET /repos/:owner/:repo` and extract `default_branch`.
+    async fn fetch_default_branch(&self, owner: &str, repo: &str) -> Result<String, GitHubError> {
+        let url = format!("{}/repos/{owner}/{repo}", self.base_url);
+        let resp = self.client.get(&url).send().await?;
+        let status = resp.status();
+        if status.as_u16() == 404 {
+            return Err(GitHubError::NotFound(format!("{owner}/{repo}")));
+        }
+        if !status.is_success() {
+            return Err(Self::classify_http_error(status, resp.headers(), url));
+        }
+        let body: RepoBody = resp.json().await.map_err(|e| GitHubError::Malformed {
+            url: url.clone(),
+            detail: e.to_string(),
+        })?;
+        Ok(body.default_branch)
+    }
+
+    /// `GET /repos/:owner/:repo/releases/tags/:tag` and return the `assets[]`
+    /// array. Returns an empty vec if the release exists but has no assets;
+    /// returns `NotFound` if the tag is not a published release.
+    pub async fn list_release_assets(
+        &self,
+        owner: &str,
+        repo: &str,
+        tag: &str,
+    ) -> Result<Vec<ReleaseAsset>, GitHubError> {
+        let url = format!("{}/repos/{owner}/{repo}/releases/tags/{tag}", self.base_url);
+        let resp = self.client.get(&url).send().await?;
+        let status = resp.status();
+        if status.as_u16() == 404 {
+            return Err(GitHubError::NotFound(format!(
+                "tag '{tag}' on {owner}/{repo}"
+            )));
+        }
+        if !status.is_success() {
+            return Err(Self::classify_http_error(status, resp.headers(), url));
+        }
+        let body: ReleaseAssetsBody = resp.json().await.map_err(|e| GitHubError::Malformed {
+            url: url.clone(),
+            detail: e.to_string(),
+        })?;
+        Ok(body.assets)
+    }
+
+    /// Reject asset download URLs whose host is not on the allowlist.
+    ///
+    /// `browser_download_url` is server-supplied (via the GitHub releases
+    /// API JSON) and could in principle point at any host. We restrict to:
+    ///
+    /// * `github.com` and subdomains of `github.com` — release-asset
+    ///   redirect origin.
+    /// * `githubusercontent.com` and subdomains (e.g.
+    ///   `objects.githubusercontent.com`) — signed-URL CDN GitHub redirects
+    ///   real downloads through.
+    /// * The host of `self.base_url` — covers the test override where
+    ///   `FLOX_EXTENSIONS_GITHUB_BASE_URL` points at a local mock server.
+    fn check_asset_host(&self, asset_url: &str) -> Result<(), GitHubError> {
+        let parsed = url::Url::parse(asset_url).map_err(|_| GitHubError::UnparseableAssetUrl {
+            url: asset_url.to_string(),
+        })?;
+        let host = parsed
+            .host_str()
+            .ok_or_else(|| GitHubError::UnparseableAssetUrl {
+                url: asset_url.to_string(),
+            })?;
+        if host_allowed(host, &self.base_url) {
+            return Ok(());
+        }
+        Err(GitHubError::UnsafeAssetHost {
+            host: host.to_string(),
+            url: asset_url.to_string(),
+        })
+    }
+
+    /// Stream `asset.browser_download_url` into `dest`, computing a SHA-256
+    /// digest along the way. Returns the hex-encoded digest.
+    ///
+    /// Uses `reqwest::Response::bytes_stream()` so the full body is never
+    /// held in memory and the checksum is computed in the same pass that
+    /// writes to disk.
+    pub async fn download_asset(
+        &self,
+        asset: &ReleaseAsset,
+        dest: &Path,
+    ) -> Result<String, GitHubError> {
+        let url = &asset.browser_download_url;
+        self.check_asset_host(url)?;
+        let resp = self.client.get(url).send().await?;
+        let status = resp.status();
+        if !status.is_success() {
+            return Err(GitHubError::AssetHttpStatus {
+                status: status.as_u16(),
+                url: url.clone(),
+            });
+        }
+        let total = resp.content_length();
+        let bar = match total {
+            Some(n) if n > 0 => {
+                let bar = ProgressBar::new(n);
+                bar.set_style(
+                    ProgressStyle::with_template(PROGRESS_TEMPLATE)
+                        .unwrap_or_else(|_| ProgressStyle::default_bar()),
+                );
+                bar
+            },
+            _ => {
+                let bar = ProgressBar::new_spinner();
+                bar.set_style(
+                    ProgressStyle::with_template(SPINNER_TEMPLATE)
+                        .unwrap_or_else(|_| ProgressStyle::default_spinner()),
+                );
+                bar
+            },
+        };
+        bar.set_message(asset.name.clone());
+        let mut file = std::fs::File::create(dest).map_err(|source| GitHubError::AssetIo {
+            path: dest.display().to_string(),
+            source,
+        })?;
+        let mut hasher = Sha256::new();
+        let mut stream = resp.bytes_stream();
+        while let Some(chunk) = stream.next().await {
+            let bytes = chunk?;
+            hasher.update(&bytes);
+            file.write_all(&bytes)
+                .map_err(|source| GitHubError::AssetIo {
+                    path: dest.display().to_string(),
+                    source,
+                })?;
+            bar.inc(bytes.len() as u64);
+        }
+        bar.finish_and_clear();
+        file.flush().map_err(|source| GitHubError::AssetIo {
+            path: dest.display().to_string(),
+            source,
+        })?;
+        let digest = hasher.finalize();
+        Ok(hex_encode(&digest))
+    }
+
+    /// `GET /search/repositories?q=topic:flox-extension ...` — used by
+    /// `flox extension search`. The topic filter and `archived:false`
+    /// qualifier are always included; user-supplied `query` and `owner`
+    /// are appended. When [`Self::auth_token`] is set the request carries
+    /// `Authorization: Bearer <token>`, lifting the anonymous Search API
+    /// quota from 10 req/min to 30 req/min.
+    pub async fn search_repos(&self, q: &SearchQuery) -> Result<SearchResponse, GitHubError> {
+        let url = format!("{}/search/repositories", self.base_url);
+        let q_param = build_search_query(q);
+        let mut req = self
+            .client
+            .get(&url)
+            .query(&[
+                ("q", q_param.as_str()),
+                ("sort", q.sort.as_str()),
+                ("order", "desc"),
+            ])
+            .query(&[("per_page", q.limit)]);
+        if let Some(token) = self.auth_token.as_deref() {
+            req = req.bearer_auth(token);
+        }
+        let resp = req.send().await?;
+        let status = resp.status();
+        let code = status.as_u16();
+        if status.is_success() {
+            let body: SearchResponse = resp.json().await.map_err(|e| GitHubError::Malformed {
+                url: url.clone(),
+                detail: e.to_string(),
+            })?;
+            return Ok(body);
+        }
+        if code == 404 {
+            return Err(GitHubError::NotFound(url));
+        }
+        Err(Self::classify_http_error(status, resp.headers(), url))
+    }
+
+    /// `GET /repos/:owner/:repo/commits/:ref` and extract the full SHA.
+    async fn resolve_commit(
+        &self,
+        owner: &str,
+        repo: &str,
+        r#ref: &str,
+    ) -> Result<String, GitHubError> {
+        let url = format!("{}/repos/{owner}/{repo}/commits/{}", self.base_url, r#ref);
+        let resp = self.client.get(&url).send().await?;
+        let status = resp.status();
+        if status.as_u16() == 404 {
+            return Err(GitHubError::NotFound(format!(
+                "ref '{}' on {owner}/{repo}",
+                r#ref
+            )));
+        }
+        if !status.is_success() {
+            return Err(Self::classify_http_error(status, resp.headers(), url));
+        }
+        let body: CommitBody = resp.json().await.map_err(|e| GitHubError::Malformed {
+            url: url.clone(),
+            detail: e.to_string(),
+        })?;
+        if body.sha.is_empty() {
+            return Err(GitHubError::Malformed {
+                url,
+                detail: "empty sha".to_string(),
+            });
+        }
+        Ok(body.sha)
+    }
+
+    /// `GET /repos/:owner/:repo/contents/flox-extension.toml?ref=<ref>` with
+    /// `Accept: application/vnd.github.raw` to fetch the author manifest at
+    /// a specific commit/tag. Returns `Ok(None)` when the file doesn't
+    /// exist (manifest is optional); parse failures bubble as
+    /// `GitHubError::Malformed`.
+    pub async fn fetch_author_manifest(
+        &self,
+        owner: &str,
+        repo: &str,
+        r#ref: &str,
+    ) -> Result<Option<AuthorManifest>, GitHubError> {
+        let url = format!(
+            "{}/repos/{owner}/{repo}/contents/flox-extension.toml?ref={}",
+            self.base_url, r#ref
+        );
+        let resp = self
+            .client
+            .get(&url)
+            .header("Accept", "application/vnd.github.raw")
+            .send()
+            .await?;
+        let status = resp.status();
+        if status.as_u16() == 404 {
+            return Ok(None);
+        }
+        if !status.is_success() {
+            return Err(GitHubError::HttpStatus {
+                status: status.as_u16(),
+                url,
+            });
+        }
+        let body = resp.text().await.map_err(|e| GitHubError::Malformed {
+            url: url.clone(),
+            detail: e.to_string(),
+        })?;
+        let manifest =
+            super::manifest::parse_author_manifest(&body).map_err(|e| GitHubError::Malformed {
+                url,
+                detail: e.to_string(),
+            })?;
+        Ok(Some(manifest))
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct ReleaseBody {
+    tag_name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct RepoBody {
+    default_branch: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct CommitBody {
+    sha: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReleaseAssetsBody {
+    #[serde(default)]
+    assets: Vec<ReleaseAsset>,
+}
+
+/// Raw GitHub Search API response. `incomplete_results` flips to `true`
+/// when the server truncates the result set (usually due to rate-limit or
+/// time-budget pressure); surfaced to the user as a stderr warning.
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+pub struct SearchResponse {
+    #[serde(default)]
+    pub total_count: u64,
+    #[serde(default)]
+    pub incomplete_results: bool,
+    #[serde(default)]
+    pub items: Vec<SearchItem>,
+}
+
+/// One repository in a search response.
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+pub struct SearchItem {
+    pub full_name: String,
+    pub owner: SearchOwner,
+    pub name: String,
+    #[serde(default)]
+    pub stargazers_count: u64,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub archived: bool,
+    #[serde(default)]
+    pub html_url: String,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+pub struct SearchOwner {
+    pub login: String,
+}
+
+/// Error returned by [`resolve_asset`] when no asset matches the host's
+/// platform. The caller converts this into an `InstallError::NoMatchingAsset`
+/// so the user-facing hint (mentioning the repo) lives with the other
+/// install errors.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NoMatchingAssetError {
+    pub platform: String,
+}
+
+/// Return the list of lowercase substrings that indicate a release asset
+/// matches the current host. `os` is one of `linux`/`darwin`/`windows`;
+/// `arch` is one of `x86_64`/`aarch64` (other targets fall back to the
+/// arch name as-is).
+///
+/// Authors ship assets under a variety of conventions (`x86_64` vs `amd64`,
+/// `aarch64` vs `arm64`, `darwin` vs `macos`), so both aliases are emitted
+/// and the matcher walks them in priority order.
+pub(crate) fn platform_matchers_for(os: &str, arch: &str) -> Vec<String> {
+    let os_aliases: &[&str] = match os {
+        "macos" | "darwin" => &["darwin", "macos"],
+        "linux" => &["linux"],
+        "windows" => &["windows"],
+        _ => return Vec::new(),
+    };
+    let arch_aliases: &[&str] = match arch {
+        "x86_64" | "amd64" => &["x86_64", "amd64"],
+        "aarch64" | "arm64" => &["aarch64", "arm64"],
+        other => {
+            // Best effort: emit just the single token so odd archs still match
+            // `flox-<name>-<os>-<arch>.tar.gz` when authors follow the naming
+            // convention directly.
+            let mut out = Vec::with_capacity(os_aliases.len());
+            for o in os_aliases {
+                out.push(format!("{o}-{other}"));
+            }
+            return out;
+        },
+    };
+    let mut out = Vec::with_capacity(os_aliases.len() * arch_aliases.len());
+    for o in os_aliases {
+        for a in arch_aliases {
+            out.push(format!("{o}-{a}"));
+        }
+    }
+    out
+}
+
+/// Resolve which release asset to download for the host running flox, given
+/// a list of release assets, an optional author manifest (for template /
+/// explicit mapping), and the extension `name`. Priority order:
+///
+/// 1. *(Reserved for future `BinaryMeta.platforms`)* — not yet implemented.
+/// 2. `manifest.extension.binary.asset` rendered with `{name}`, `{os}`,
+///    `{arch}` placeholders; exact asset-name match.
+/// 3. Substring match against [`platform_matchers_for`] on the asset name.
+/// 4. Rosetta fallback: on `darwin-aarch64`, retry as `darwin-x86_64`; if
+///    matched, emit `tracing::info!` noting the fallback.
+///
+/// On exhaustion returns the host's matcher string so the caller can
+/// produce a helpful `no release asset matches ...` error.
+pub(crate) fn resolve_asset<'a>(
+    assets: &'a [ReleaseAsset],
+    manifest: Option<&AuthorManifest>,
+    name: &str,
+) -> Result<&'a ReleaseAsset, NoMatchingAssetError> {
+    resolve_asset_for(
+        assets,
+        manifest,
+        name,
+        std::env::consts::OS,
+        std::env::consts::ARCH,
+    )
+}
+
+/// Host-aware variant of [`resolve_asset`] for unit tests.
+pub(crate) fn resolve_asset_for<'a>(
+    assets: &'a [ReleaseAsset],
+    manifest: Option<&AuthorManifest>,
+    name: &str,
+    os: &str,
+    arch: &str,
+) -> Result<&'a ReleaseAsset, NoMatchingAssetError> {
+    if let Some(binary) = manifest.and_then(|m| m.extension.binary.as_ref()) {
+        let tmpl = binary.asset.trim();
+        if !tmpl.is_empty() {
+            let rendered = render_asset_template(tmpl, name, os, arch);
+            if let Some(a) = assets.iter().find(|a| a.name == rendered) {
+                return Ok(a);
+            }
+        }
+    }
+
+    let matchers = platform_matchers_for(os, arch);
+    if let Some(a) = substring_match(assets, &matchers) {
+        return Ok(a);
+    }
+
+    // Rosetta fallback: apple silicon can run x86_64 darwin binaries.
+    if (os == "macos" || os == "darwin") && (arch == "aarch64" || arch == "arm64") {
+        let fallback = platform_matchers_for(os, "x86_64");
+        if let Some(a) = substring_match(assets, &fallback) {
+            info!(
+                asset = %a.name,
+                "no arm64 release asset; falling back to x86_64 under Rosetta"
+            );
+            return Ok(a);
+        }
+    }
+
+    Err(NoMatchingAssetError {
+        platform: matchers
+            .into_iter()
+            .next()
+            .unwrap_or_else(|| format!("{os}-{arch}")),
+    })
+}
+
+fn substring_match<'a>(
+    assets: &'a [ReleaseAsset],
+    matchers: &[String],
+) -> Option<&'a ReleaseAsset> {
+    for needle in matchers {
+        if let Some(a) = assets.iter().find(|a| a.name.contains(needle)) {
+            return Some(a);
+        }
+    }
+    None
+}
+
+fn render_asset_template(tmpl: &str, name: &str, os: &str, arch: &str) -> String {
+    let ext = if os == "windows" { "zip" } else { "tar.gz" };
+    tmpl.replace("{name}", name)
+        .replace("{os}", os)
+        .replace("{arch}", arch)
+        .replace("{ext}", ext)
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        out.push(HEX[(b >> 4) as usize] as char);
+        out.push(HEX[(b & 0x0f) as usize] as char);
+    }
+    out
+}
+
+/// Read `GH_TOKEN` then `GITHUB_TOKEN` from the environment, returning the
+/// first non-empty value. Empty strings are treated as unset so users can
+/// clear the token with `GH_TOKEN=`.
+fn auth_token_from_env() -> Option<String> {
+    for var in ["GH_TOKEN", "GITHUB_TOKEN"] {
+        if let Ok(v) = std::env::var(var)
+            && !v.is_empty()
+        {
+            return Some(v);
+        }
+    }
+    None
+}
+
+/// Compose the `q=` parameter for `search_repos`. Always prefixes
+/// `topic:flox-extension archived:false`; appends user-supplied query
+/// text (free-form) and a `user:<owner>` qualifier when present. Empty
+/// tokens are dropped so trailing whitespace never leaks into the URL.
+fn build_search_query(q: &SearchQuery) -> String {
+    let mut parts: Vec<String> = Vec::with_capacity(4);
+    parts.push("topic:flox-extension".to_string());
+    parts.push("archived:false".to_string());
+    if let Some(text) = q.query.as_deref() {
+        let trimmed = text.trim();
+        if !trimmed.is_empty() {
+            parts.push(trimmed.to_string());
+        }
+    }
+    if let Some(owner) = q.owner.as_deref() {
+        let trimmed = owner.trim();
+        if !trimmed.is_empty() {
+            parts.push(format!("user:{trimmed}"));
+        }
+    }
+    parts.join(" ")
+}
+
+fn is_hex_prefix(s: &str) -> bool {
+    !s.is_empty() && s.len() <= 40 && s.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+/// Heuristic: tag-like if it starts with `v` followed by a digit, or if
+/// the first char is a digit (e.g. `1.2.3`) AND it contains a `.`.
+/// Otherwise treat as a commit prefix.
+fn looks_like_tag(s: &str) -> bool {
+    let mut chars = s.chars();
+    let first = match chars.next() {
+        Some(c) => c,
+        None => return false,
+    };
+    if first == 'v' {
+        return chars.next().is_some_and(|c| c.is_ascii_digit());
+    }
+    first.is_ascii_digit() && s.contains('.')
+}
+
+#[cfg(test)]
+mod tests {
+    use httpmock::Method::GET;
+    use httpmock::MockServer;
+    use pretty_assertions::assert_eq;
+    use serde_json::json;
+
+    use super::*;
+
+    fn fixture_source(server: &MockServer) -> GitHubSource {
+        GitHubSource::new(reqwest::Client::new(), server.base_url())
+    }
+
+    #[tokio::test]
+    async fn resolve_latest_returns_release_tag_when_release_exists() {
+        let server = MockServer::start_async().await;
+        let release_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/repos/owner/flox-hello/releases/latest");
+            then.status(200).json_body(json!({
+                "tag_name": "v1.2.3",
+                "target_commitish": "main"
+            }));
+        });
+        let commit_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/repos/owner/flox-hello/commits/v1.2.3");
+            then.status(200).json_body(json!({
+                "sha": "abc1234567890abcdef1234567890abcdef123456"
+            }));
+        });
+
+        let source = fixture_source(&server);
+        let resolved = source.resolve_latest("owner", "flox-hello").await.unwrap();
+
+        assert_eq!(resolved, ResolvedRef {
+            commit: "abc1234567890abcdef1234567890abcdef123456".to_string(),
+            tag: Some("v1.2.3".to_string()),
+            branch: None,
+        });
+        release_mock.assert_async().await;
+        commit_mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn resolve_latest_falls_back_to_default_branch_head_when_no_release() {
+        let server = MockServer::start_async().await;
+        let _release_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/repos/owner/flox-hello/releases/latest");
+            then.status(404);
+        });
+        let _repo_mock = server.mock(|when, then| {
+            when.method(GET).path("/repos/owner/flox-hello");
+            then.status(200).json_body(json!({
+                "default_branch": "trunk"
+            }));
+        });
+        let _commit_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/repos/owner/flox-hello/commits/trunk");
+            then.status(200).json_body(json!({
+                "sha": "deadbeefcafef00d0000000000000000feedface"
+            }));
+        });
+
+        let source = fixture_source(&server);
+        let resolved = source.resolve_latest("owner", "flox-hello").await.unwrap();
+
+        assert_eq!(resolved, ResolvedRef {
+            commit: "deadbeefcafef00d0000000000000000feedface".to_string(),
+            tag: None,
+            branch: Some("trunk".to_string()),
+        });
+    }
+
+    #[tokio::test]
+    async fn resolve_latest_returns_not_found_when_repo_missing() {
+        let server = MockServer::start_async().await;
+        let _release_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/repos/owner/flox-hello/releases/latest");
+            then.status(404);
+        });
+        let _repo_mock = server.mock(|when, then| {
+            when.method(GET).path("/repos/owner/flox-hello");
+            then.status(404);
+        });
+
+        let source = fixture_source(&server);
+        let err = source
+            .resolve_latest("owner", "flox-hello")
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, GitHubError::NotFound(_)),
+            "expected NotFound, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_pin_treats_v_prefix_as_tag() {
+        let server = MockServer::start_async().await;
+        let _tag_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/repos/owner/flox-hello/releases/tags/v1.0.0");
+            then.status(200).json_body(json!({ "tag_name": "v1.0.0" }));
+        });
+        let _commit_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/repos/owner/flox-hello/commits/v1.0.0");
+            then.status(200).json_body(json!({
+                "sha": "1111111111111111111111111111111111111111"
+            }));
+        });
+
+        let source = fixture_source(&server);
+        let resolved = source
+            .resolve_pin("owner", "flox-hello", "v1.0.0")
+            .await
+            .unwrap();
+        assert_eq!(resolved, ResolvedRef {
+            commit: "1111111111111111111111111111111111111111".to_string(),
+            tag: Some("v1.0.0".to_string()),
+            branch: None,
+        });
+    }
+
+    #[tokio::test]
+    async fn resolve_pin_treats_hex_as_commit_prefix() {
+        let server = MockServer::start_async().await;
+        let _commit_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/repos/owner/flox-hello/commits/abc1234");
+            then.status(200).json_body(json!({
+                "sha": "abc1234567890abcdef1234567890abcdef123456"
+            }));
+        });
+        // Hex pins also fetch the default branch so install_github has a
+        // clonable ref name.
+        let _repo_mock = server.mock(|when, then| {
+            when.method(GET).path("/repos/owner/flox-hello");
+            then.status(200)
+                .json_body(json!({ "default_branch": "main" }));
+        });
+
+        let source = fixture_source(&server);
+        let resolved = source
+            .resolve_pin("owner", "flox-hello", "abc1234")
+            .await
+            .unwrap();
+        assert_eq!(resolved, ResolvedRef {
+            commit: "abc1234567890abcdef1234567890abcdef123456".to_string(),
+            tag: None,
+            branch: Some("main".to_string()),
+        });
+    }
+
+    #[tokio::test]
+    async fn resolve_pin_returns_err_when_tag_not_found() {
+        let server = MockServer::start_async().await;
+        let _tag_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/repos/owner/flox-hello/releases/tags/v9.9.9");
+            then.status(404);
+        });
+
+        let source = fixture_source(&server);
+        let err = source
+            .resolve_pin("owner", "flox-hello", "v9.9.9")
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, GitHubError::NotFound(_)),
+            "expected NotFound, got {err:?}"
+        );
+    }
+
+    /// BUG-14 regression: a pin that is neither tag-like nor a hex SHA
+    /// should fall back to resolving as a branch (or other ref) name via
+    /// the commits endpoint.
+    #[tokio::test]
+    async fn resolve_pin_resolves_branch_name_via_commits() {
+        let server = MockServer::start_async().await;
+        let _commit_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/repos/owner/flox-hello/commits/main");
+            then.status(200).json_body(json!({
+                "sha": "2222222222222222222222222222222222222222"
+            }));
+        });
+
+        let source = fixture_source(&server);
+        let resolved = source
+            .resolve_pin("owner", "flox-hello", "main")
+            .await
+            .unwrap();
+        assert_eq!(resolved, ResolvedRef {
+            commit: "2222222222222222222222222222222222222222".to_string(),
+            tag: None,
+            branch: Some("main".to_string()),
+        });
+    }
+
+    /// BUG-14 regression: an unresolvable pin should surface the error
+    /// with a hint listing the three supported pin shapes.
+    #[tokio::test]
+    async fn resolve_pin_unknown_ref_returns_hint_with_supported_shapes() {
+        let server = MockServer::start_async().await;
+        let _commit_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/repos/owner/flox-hello/commits/does-not-exist");
+            then.status(404);
+        });
+
+        let source = fixture_source(&server);
+        let err = source
+            .resolve_pin("owner", "flox-hello", "does-not-exist")
+            .await
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            matches!(err, GitHubError::NotFound(_)),
+            "expected NotFound, got {err:?}"
+        );
+        assert!(
+            msg.contains("tag") && msg.contains("commit") && msg.contains("branch"),
+            "error message should mention all three pin shapes: {msg}"
+        );
+    }
+
+    #[test]
+    fn looks_like_tag_classifications() {
+        assert!(looks_like_tag("v1.0.0"));
+        assert!(looks_like_tag("v2"));
+        assert!(looks_like_tag("1.2.3"));
+        assert!(!looks_like_tag("abc1234"));
+        assert!(!looks_like_tag(""));
+        assert!(!looks_like_tag("vfoo"));
+        assert!(!looks_like_tag("123abc")); // hex-like, not a tag
+    }
+
+    #[test]
+    fn is_hex_prefix_classifications() {
+        assert!(is_hex_prefix("abc"));
+        assert!(is_hex_prefix("0123456789abcdef"));
+        assert!(!is_hex_prefix(""));
+        assert!(!is_hex_prefix("xyz"));
+        assert!(!is_hex_prefix("abc-def"));
+        // Exactly 40 chars: ok; 41: rejected.
+        assert!(is_hex_prefix(&"a".repeat(40)));
+        assert!(!is_hex_prefix(&"a".repeat(41)));
+    }
+
+    fn mk_asset(name: &str) -> ReleaseAsset {
+        ReleaseAsset {
+            name: name.to_string(),
+            browser_download_url: format!("https://example.invalid/{name}"),
+            size: 0,
+            content_type: "application/octet-stream".to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn list_release_assets_returns_assets_for_tag() {
+        let server = MockServer::start_async().await;
+        let _tag_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/repos/owner/flox-hello/releases/tags/v1.0.0");
+            then.status(200).json_body(json!({
+                "tag_name": "v1.0.0",
+                "assets": [
+                    {
+                        "name": "flox-hello-linux-x86_64.tar.gz",
+                        "browser_download_url": "https://example.invalid/1.tar.gz",
+                        "size": 100,
+                        "content_type": "application/gzip"
+                    },
+                    {
+                        "name": "flox-hello-darwin-aarch64.tar.gz",
+                        "browser_download_url": "https://example.invalid/2.tar.gz",
+                        "size": 200,
+                        "content_type": "application/gzip"
+                    }
+                ]
+            }));
+        });
+        let source = fixture_source(&server);
+        let assets = source
+            .list_release_assets("owner", "flox-hello", "v1.0.0")
+            .await
+            .unwrap();
+        assert_eq!(assets.len(), 2);
+        assert_eq!(assets[0].name, "flox-hello-linux-x86_64.tar.gz");
+        assert_eq!(assets[1].name, "flox-hello-darwin-aarch64.tar.gz");
+    }
+
+    #[tokio::test]
+    async fn list_release_assets_empty_when_release_has_no_assets() {
+        let server = MockServer::start_async().await;
+        let _tag_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/repos/owner/flox-hello/releases/tags/v1.0.0");
+            then.status(200).json_body(json!({
+                "tag_name": "v1.0.0"
+            }));
+        });
+        let source = fixture_source(&server);
+        let assets = source
+            .list_release_assets("owner", "flox-hello", "v1.0.0")
+            .await
+            .unwrap();
+        assert!(assets.is_empty());
+    }
+
+    #[tokio::test]
+    async fn list_release_assets_not_found_when_tag_missing() {
+        let server = MockServer::start_async().await;
+        let _tag_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/repos/owner/flox-hello/releases/tags/v9.9.9");
+            then.status(404);
+        });
+        let source = fixture_source(&server);
+        let err = source
+            .list_release_assets("owner", "flox-hello", "v9.9.9")
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, GitHubError::NotFound(_)),
+            "expected NotFound, got {err:?}"
+        );
+    }
+
+    // TS01 — resolve_asset priority table: manifest template beats substring,
+    // substring beats Rosetta, Rosetta fallback on darwin-aarch64.
+    #[test]
+    fn resolve_asset_template_beats_substring() {
+        let assets = vec![
+            mk_asset("flox-hello-linux-x86_64.tar.gz"),
+            mk_asset("custom-linux-x86_64.tar.gz"),
+        ];
+        let manifest = AuthorManifest {
+            schema: "1".to_string(),
+            extension: super::super::manifest::ExtensionMeta {
+                name: "hello".to_string(),
+                description: None,
+                binary: Some(super::super::manifest::BinaryMeta {
+                    source: "github-release".to_string(),
+                    asset: "custom-{os}-{arch}.tar.gz".to_string(),
+                    sha256: None,
+                }),
+            },
+            environment: None,
+            on_active: None,
+        };
+        let chosen =
+            resolve_asset_for(&assets, Some(&manifest), "hello", "linux", "x86_64").unwrap();
+        assert_eq!(chosen.name, "custom-linux-x86_64.tar.gz");
+    }
+
+    #[test]
+    fn resolve_asset_substring_match_when_no_template() {
+        let assets = vec![
+            mk_asset("flox-hello-darwin-x86_64.tar.gz"),
+            mk_asset("flox-hello-linux-x86_64.tar.gz"),
+        ];
+        let chosen = resolve_asset_for(&assets, None, "hello", "linux", "x86_64").unwrap();
+        assert_eq!(chosen.name, "flox-hello-linux-x86_64.tar.gz");
+    }
+
+    #[test]
+    fn resolve_asset_substring_accepts_amd64_alias() {
+        let assets = vec![mk_asset("flox-hello-linux-amd64.tar.gz")];
+        let chosen = resolve_asset_for(&assets, None, "hello", "linux", "x86_64").unwrap();
+        assert_eq!(chosen.name, "flox-hello-linux-amd64.tar.gz");
+    }
+
+    #[test]
+    fn resolve_asset_substring_accepts_arm64_alias() {
+        let assets = vec![mk_asset("flox-hello-darwin-arm64.tar.gz")];
+        let chosen = resolve_asset_for(&assets, None, "hello", "darwin", "aarch64").unwrap();
+        assert_eq!(chosen.name, "flox-hello-darwin-arm64.tar.gz");
+    }
+
+    #[test]
+    fn resolve_asset_rosetta_fallback_on_darwin_arm64() {
+        let assets = vec![mk_asset("flox-hello-darwin-x86_64.tar.gz")];
+        let chosen = resolve_asset_for(&assets, None, "hello", "darwin", "aarch64").unwrap();
+        assert_eq!(chosen.name, "flox-hello-darwin-x86_64.tar.gz");
+    }
+
+    #[test]
+    fn resolve_asset_no_match_on_unavailable_platform() {
+        let assets = vec![mk_asset("flox-hello-windows-x86_64.zip")];
+        let err = resolve_asset_for(&assets, None, "hello", "linux", "x86_64").unwrap_err();
+        assert_eq!(err, NoMatchingAssetError {
+            platform: "linux-x86_64".to_string(),
+        });
+    }
+
+    // TS02 — platform_matchers_for returns the expected strings.
+    #[test]
+    fn platform_matchers_for_linux_x86_64() {
+        assert_eq!(platform_matchers_for("linux", "x86_64"), vec![
+            "linux-x86_64".to_string(),
+            "linux-amd64".to_string()
+        ],);
+    }
+
+    #[test]
+    fn platform_matchers_for_darwin_aarch64() {
+        assert_eq!(platform_matchers_for("darwin", "aarch64"), vec![
+            "darwin-aarch64".to_string(),
+            "darwin-arm64".to_string(),
+            "macos-aarch64".to_string(),
+            "macos-arm64".to_string(),
+        ],);
+    }
+
+    #[test]
+    fn platform_matchers_for_unknown_os_is_empty() {
+        assert_eq!(
+            platform_matchers_for("plan9", "x86_64"),
+            Vec::<String>::new()
+        );
+    }
+
+    // TS04 — download_asset streams bytes and computes a matching SHA-256.
+    #[tokio::test]
+    async fn download_asset_streams_and_computes_sha256() {
+        let payload: Vec<u8> = (0u8..=63u8).collect();
+        let expected_sha = {
+            let mut h = Sha256::new();
+            h.update(&payload);
+            hex_encode(&h.finalize())
+        };
+
+        let server = MockServer::start_async().await;
+        let _asset_mock = server.mock(|when, then| {
+            when.method(GET).path("/asset/file.bin");
+            then.status(200)
+                .header("Content-Type", "application/octet-stream")
+                .body(&payload);
+        });
+
+        let asset = ReleaseAsset {
+            name: "file.bin".to_string(),
+            browser_download_url: format!("{}/asset/file.bin", server.base_url()),
+            size: payload.len() as u64,
+            content_type: "application/octet-stream".to_string(),
+        };
+
+        let source = fixture_source(&server);
+        let temp = tempfile::TempDir::new().unwrap();
+        let dest = temp.path().join("file.bin");
+        let sha = source.download_asset(&asset, &dest).await.unwrap();
+        assert_eq!(sha, expected_sha);
+        assert_eq!(std::fs::read(&dest).unwrap(), payload);
+    }
+
+    #[tokio::test]
+    async fn download_asset_refuses_off_allowlist_host() {
+        let server = MockServer::start_async().await;
+        let source = fixture_source(&server);
+        let asset = ReleaseAsset {
+            name: "evil.bin".to_string(),
+            browser_download_url: "http://169.254.169.254/evil.bin".to_string(),
+            size: 0,
+            content_type: "application/octet-stream".to_string(),
+        };
+        let temp = tempfile::TempDir::new().unwrap();
+        let dest = temp.path().join("evil.bin");
+        let err = source.download_asset(&asset, &dest).await.unwrap_err();
+        assert!(
+            matches!(err, GitHubError::UnsafeAssetHost { .. }),
+            "expected UnsafeAssetHost, got {err:?}"
+        );
+        assert!(!dest.exists());
+    }
+
+    #[test]
+    fn host_allowed_matches_apex_subdomains_and_base_url() {
+        assert!(host_allowed("github.com", "https://example.test/"));
+        assert!(host_allowed("objects.githubusercontent.com", "https://x/"));
+        assert!(host_allowed("raw.githubusercontent.com", "https://x/"));
+        // Case-insensitive.
+        assert!(host_allowed("GitHub.COM", "https://x/"));
+        // Subdomain confusion must not slip through.
+        assert!(!host_allowed("github.com.evil.corp", "https://x/"));
+        assert!(!host_allowed("notgithub.com", "https://x/"));
+        // Matches base_url host for test overrides (e.g. mock servers).
+        assert!(host_allowed("127.0.0.1", "http://127.0.0.1:12345/"));
+    }
+
+    #[test]
+    fn progress_bar_template_includes_message_placeholder() {
+        // Both templates must carry a `{msg}` placeholder so callers can
+        // inject the asset name. Without this, `upgrade --all` prints
+        // indistinguishable progress lines for each binary.
+        for tpl in [PROGRESS_TEMPLATE, SPINNER_TEMPLATE] {
+            assert!(tpl.contains("{msg}"), "template missing {{msg}}: {tpl}");
+        }
+    }
+
+    // TS01 — query-string composition with user-supplied query + owner.
+    #[tokio::test]
+    async fn search_repos_composes_topic_query_and_owner_filter() {
+        let server = MockServer::start_async().await;
+        let _mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/search/repositories")
+                .query_param("q", "topic:flox-extension archived:false hello user:acme")
+                .query_param("sort", "stars")
+                .query_param("order", "desc")
+                .query_param("per_page", "25");
+            then.status(200).json_body(json!({
+                "total_count": 0,
+                "incomplete_results": false,
+                "items": []
+            }));
+        });
+        let source = fixture_source(&server);
+        let q = SearchQuery::new(
+            Some("hello".to_string()),
+            Some("acme".to_string()),
+            25,
+            SearchSort::Stars,
+        );
+        let _resp = source.search_repos(&q).await.unwrap();
+    }
+
+    // TS02 — empty query and owner produce only the topic + archived
+    // qualifiers (no trailing tokens).
+    #[tokio::test]
+    async fn search_repos_omits_empty_tokens() {
+        let server = MockServer::start_async().await;
+        let _mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/search/repositories")
+                .query_param("q", "topic:flox-extension archived:false")
+                .query_param("sort", "updated")
+                .query_param("per_page", "50");
+            then.status(200).json_body(json!({
+                "total_count": 0,
+                "incomplete_results": false,
+                "items": []
+            }));
+        });
+        let source = fixture_source(&server);
+        let q = SearchQuery::new(None, None, 50, SearchSort::Updated);
+        let _resp = source.search_repos(&q).await.unwrap();
+    }
+
+    // TS03 — canned response with incomplete_results and a null description
+    // deserializes into typed fields.
+    #[tokio::test]
+    async fn search_repos_parses_incomplete_results_and_null_description() {
+        let server = MockServer::start_async().await;
+        let _mock = server.mock(|when, then| {
+            when.method(GET).path("/search/repositories");
+            then.status(200).json_body(json!({
+                "total_count": 2,
+                "incomplete_results": true,
+                "items": [
+                    {
+                        "full_name": "alpha/flox-one",
+                        "owner": { "login": "alpha" },
+                        "name": "flox-one",
+                        "stargazers_count": 42,
+                        "description": "canonical reference",
+                        "archived": false,
+                        "html_url": "https://github.com/alpha/flox-one"
+                    },
+                    {
+                        "full_name": "beta/flox-two",
+                        "owner": { "login": "beta" },
+                        "name": "flox-two",
+                        "stargazers_count": 7,
+                        "description": null,
+                        "archived": false,
+                        "html_url": "https://github.com/beta/flox-two"
+                    }
+                ]
+            }));
+        });
+        let source = fixture_source(&server);
+        let q = SearchQuery::new(None, None, 30, SearchSort::Stars);
+        let resp = source.search_repos(&q).await.unwrap();
+        assert_eq!(resp, SearchResponse {
+            total_count: 2,
+            incomplete_results: true,
+            items: vec![
+                SearchItem {
+                    full_name: "alpha/flox-one".to_string(),
+                    owner: SearchOwner {
+                        login: "alpha".to_string(),
+                    },
+                    name: "flox-one".to_string(),
+                    stargazers_count: 42,
+                    description: Some("canonical reference".to_string()),
+                    archived: false,
+                    html_url: "https://github.com/alpha/flox-one".to_string(),
+                },
+                SearchItem {
+                    full_name: "beta/flox-two".to_string(),
+                    owner: SearchOwner {
+                        login: "beta".to_string(),
+                    },
+                    name: "flox-two".to_string(),
+                    stargazers_count: 7,
+                    description: None,
+                    archived: false,
+                    html_url: "https://github.com/beta/flox-two".to_string(),
+                },
+            ],
+        });
+    }
+
+    // TS04 — HTTP status mapping: 401→AuthFailed, 403/429→RateLimited,
+    // 500→HttpStatus.
+    #[tokio::test]
+    async fn search_repos_maps_401_to_auth_failed() {
+        let server = MockServer::start_async().await;
+        let _mock = server.mock(|when, then| {
+            when.method(GET).path("/search/repositories");
+            then.status(401)
+                .json_body(json!({ "message": "Bad credentials" }));
+        });
+        let source = fixture_source(&server);
+        let q = SearchQuery::new(None, None, 30, SearchSort::Stars);
+        let err = source.search_repos(&q).await.unwrap_err();
+        assert!(
+            matches!(err, GitHubError::AuthFailed { status: 401 }),
+            "expected AuthFailed(401), got {err:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn search_repos_maps_403_with_exhausted_quota_to_rate_limited() {
+        let server = MockServer::start_async().await;
+        let _mock = server.mock(|when, then| {
+            when.method(GET).path("/search/repositories");
+            then.status(403)
+                .header("x-ratelimit-remaining", "0")
+                .json_body(json!({ "message": "API rate limit exceeded" }));
+        });
+        let source = fixture_source(&server);
+        let q = SearchQuery::new(None, None, 30, SearchSort::Stars);
+        let err = source.search_repos(&q).await.unwrap_err();
+        assert!(
+            matches!(err, GitHubError::RateLimited { status: 403 }),
+            "expected RateLimited(403), got {err:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn search_repos_maps_403_without_quota_header_to_http_status() {
+        let server = MockServer::start_async().await;
+        let _mock = server.mock(|when, then| {
+            when.method(GET).path("/search/repositories");
+            then.status(403)
+                .json_body(json!({ "message": "Resource protected by SSO" }));
+        });
+        let source = fixture_source(&server);
+        let q = SearchQuery::new(None, None, 30, SearchSort::Stars);
+        let err = source.search_repos(&q).await.unwrap_err();
+        assert!(
+            matches!(err, GitHubError::HttpStatus { status: 403, .. }),
+            "expected HttpStatus(403) (non-rate-limit 403), got {err:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn search_repos_maps_429_to_rate_limited() {
+        let server = MockServer::start_async().await;
+        let _mock = server.mock(|when, then| {
+            when.method(GET).path("/search/repositories");
+            then.status(429);
+        });
+        let source = fixture_source(&server);
+        let q = SearchQuery::new(None, None, 30, SearchSort::Stars);
+        let err = source.search_repos(&q).await.unwrap_err();
+        assert!(
+            matches!(err, GitHubError::RateLimited { status: 429 }),
+            "expected RateLimited(429), got {err:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn search_repos_maps_500_to_http_status() {
+        let server = MockServer::start_async().await;
+        let _mock = server.mock(|when, then| {
+            when.method(GET).path("/search/repositories");
+            then.status(500);
+        });
+        let source = fixture_source(&server);
+        let q = SearchQuery::new(None, None, 30, SearchSort::Stars);
+        let err = source.search_repos(&q).await.unwrap_err();
+        assert!(
+            matches!(err, GitHubError::HttpStatus { status: 500, .. }),
+            "expected HttpStatus(500), got {err:?}",
+        );
+    }
+
+    // BUG-10 regression: every GitHub API call (not just search_repos)
+    // must map 401 → AuthFailed, 403+x-ratelimit-remaining:0 → RateLimited,
+    // 429 → RateLimited. Exercise this through `resolve_latest` and
+    // `list_release_assets` so the unified classifier is demonstrably
+    // wired into all sites.
+    #[tokio::test]
+    async fn resolve_latest_maps_401_to_auth_failed() {
+        let server = MockServer::start_async().await;
+        let _mock = server.mock(|when, then| {
+            when.method(GET).path("/repos/o/r/releases/latest");
+            then.status(401);
+        });
+        let source = fixture_source(&server);
+        let err = source.resolve_latest("o", "r").await.unwrap_err();
+        assert!(
+            matches!(err, GitHubError::AuthFailed { status: 401 }),
+            "expected AuthFailed(401), got {err:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_latest_maps_429_to_rate_limited() {
+        let server = MockServer::start_async().await;
+        let _mock = server.mock(|when, then| {
+            when.method(GET).path("/repos/o/r/releases/latest");
+            then.status(429);
+        });
+        let source = fixture_source(&server);
+        let err = source.resolve_latest("o", "r").await.unwrap_err();
+        assert!(
+            matches!(err, GitHubError::RateLimited { status: 429 }),
+            "expected RateLimited(429), got {err:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn list_release_assets_maps_403_with_exhausted_quota_to_rate_limited() {
+        let server = MockServer::start_async().await;
+        let _mock = server.mock(|when, then| {
+            when.method(GET).path("/repos/o/r/releases/tags/v1");
+            then.status(403)
+                .header("x-ratelimit-remaining", "0")
+                .json_body(json!({ "message": "API rate limit exceeded" }));
+        });
+        let source = fixture_source(&server);
+        let err = source
+            .list_release_assets("o", "r", "v1")
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, GitHubError::RateLimited { status: 403 }),
+            "expected RateLimited(403), got {err:?}",
+        );
+    }
+
+    // TS05 — when an auth token is set via `with_auth_token`, the request
+    // carries `Authorization: Bearer <token>`. Uses the builder rather than
+    // env mutation to avoid Rust 2024 `unsafe { set_var }` and inter-test
+    // races.
+    #[tokio::test]
+    async fn search_repos_sends_authorization_header_when_token_set() {
+        let server = MockServer::start_async().await;
+        let _mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/search/repositories")
+                .header("authorization", "Bearer test-token-xyz");
+            then.status(200).json_body(json!({
+                "total_count": 0,
+                "incomplete_results": false,
+                "items": []
+            }));
+        });
+        let source = fixture_source(&server).with_auth_token(Some("test-token-xyz".to_string()));
+        let q = SearchQuery::new(None, None, 30, SearchSort::Stars);
+        let _resp = source.search_repos(&q).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn search_repos_omits_authorization_header_when_unset() {
+        let server = MockServer::start_async().await;
+        // Two mocks: a strict "with Authorization header" that must NOT fire,
+        // and a default "no such header required" that must fire.
+        let strict = server.mock(|when, then| {
+            when.method(GET)
+                .path("/search/repositories")
+                .header_exists("authorization");
+            then.status(500);
+        });
+        let fallback = server.mock(|when, then| {
+            when.method(GET).path("/search/repositories");
+            then.status(200).json_body(json!({
+                "total_count": 0,
+                "incomplete_results": false,
+                "items": []
+            }));
+        });
+        let source = fixture_source(&server);
+        let q = SearchQuery::new(None, None, 30, SearchSort::Stars);
+        let _resp = source.search_repos(&q).await.unwrap();
+        strict.assert_calls_async(0).await;
+        fallback.assert_async().await;
+    }
+
+    #[test]
+    fn build_search_query_joins_tokens_with_spaces() {
+        let q = SearchQuery::new(
+            Some("  hello  ".to_string()),
+            Some(" acme ".to_string()),
+            10,
+            SearchSort::Stars,
+        );
+        assert_eq!(
+            build_search_query(&q),
+            "topic:flox-extension archived:false hello user:acme"
+        );
+    }
+
+    #[test]
+    fn build_search_query_drops_empty_or_whitespace_tokens() {
+        let q = SearchQuery::new(
+            Some("   ".to_string()),
+            Some(String::new()),
+            10,
+            SearchSort::Stars,
+        );
+        assert_eq!(
+            build_search_query(&q),
+            "topic:flox-extension archived:false"
+        );
+    }
+
+    #[test]
+    fn search_query_clamps_limit_to_max_100() {
+        let q = SearchQuery::new(None, None, 250, SearchSort::Stars);
+        assert_eq!(q.limit, 100);
+        let q = SearchQuery::new(None, None, 0, SearchSort::Stars);
+        assert_eq!(q.limit, 1);
+    }
+
+    #[test]
+    fn validate_owner_accepts_normal_logins() {
+        for ok in ["a", "acme", "flox-examples", "Acme-Org-99", &"a".repeat(39)] {
+            validate_owner(ok).unwrap_or_else(|e| panic!("expected Ok for {ok:?}: {e}"));
+        }
+    }
+
+    #[test]
+    fn validate_owner_rejects_injection_and_edge_cases() {
+        let bad = [
+            "",                // empty
+            "-lead",           // leading hyphen
+            "trail-",          // trailing hyphen
+            "double--hyphen",  // consecutive hyphens
+            "x user:attacker", // injection attempt (space)
+            "a/b",             // path component
+            "acme\ttab",       // tab
+            &"a".repeat(40),   // too long
+            "dot.separated",   // dot not allowed
+        ];
+        for s in bad {
+            assert_eq!(validate_owner(s), Err(InvalidOwner(s.to_string())));
+        }
+    }
+
+    #[test]
+    fn with_auth_token_filters_empty_string() {
+        let src = GitHubSource::new(reqwest::Client::new(), "http://x".to_string())
+            .with_auth_token(Some(String::new()));
+        assert!(src.auth_token.is_none(), "empty token must be dropped");
+        let src = GitHubSource::new(reqwest::Client::new(), "http://x".to_string())
+            .with_auth_token(Some("abc".to_string()));
+        assert_eq!(src.auth_token.as_deref(), Some("abc"));
+    }
+
+    #[test]
+    fn spinner_template_omits_unknown_total_placeholders() {
+        // Without a known Content-Length the bar/eta/total_bytes fields
+        // would render as empty or zero, so the spinner template must not
+        // reference them.
+        let tpl = SPINNER_TEMPLATE;
+        assert!(
+            !tpl.contains("{total_bytes}"),
+            "spinner template should not use total_bytes: {tpl}"
+        );
+        assert!(
+            !tpl.contains("{bar"),
+            "spinner template should not use a bar: {tpl}"
+        );
+        assert!(
+            !tpl.contains("{eta"),
+            "spinner template should not use eta: {tpl}"
+        );
+    }
+}

--- a/cli/beta/src/extensions/github.rs
+++ b/cli/beta/src/extensions/github.rs
@@ -815,12 +815,27 @@ pub(crate) fn resolve_asset_for<'a>(
     })
 }
 
+/// Checksum / signature / provenance sidecars that sit next to a real
+/// release binary and must never be selected as the executable — they
+/// contain a platform substring too (e.g. `flox-x-linux-x86_64.tar.gz.sha256`).
+fn is_sidecar_asset(name: &str) -> bool {
+    const SIDECAR_SUFFIXES: &[&str] = &[
+        ".sha256", ".sha512", ".sha1", ".md5", ".sig", ".asc", ".pem", ".sbom",
+        ".intoto.jsonl",
+    ];
+    let lower = name.to_ascii_lowercase();
+    SIDECAR_SUFFIXES.iter().any(|s| lower.ends_with(s))
+}
+
 fn substring_match<'a>(
     assets: &'a [ReleaseAsset],
     matchers: &[String],
 ) -> Option<&'a ReleaseAsset> {
     for needle in matchers {
-        if let Some(a) = assets.iter().find(|a| a.name.contains(needle)) {
+        if let Some(a) = assets
+            .iter()
+            .find(|a| a.name.contains(needle) && !is_sidecar_asset(&a.name))
+        {
             return Some(a);
         }
     }
@@ -1309,6 +1324,27 @@ mod tests {
             "linux-x86_64".to_string(),
             "linux-amd64".to_string()
         ],);
+    }
+
+    #[test]
+    fn resolve_asset_skips_checksum_sidecar() {
+        // The sidecar sorts first and also contains the platform substring;
+        // selection must skip it and choose the real archive.
+        let assets = vec![
+            mk_asset("flox-hi-linux-x86_64.tar.gz.sha256"),
+            mk_asset("flox-hi-linux-x86_64.tar.gz"),
+        ];
+        let chosen = resolve_asset_for(&assets, None, "hi", "linux", "x86_64").unwrap();
+        assert_eq!(chosen.name, "flox-hi-linux-x86_64.tar.gz");
+    }
+
+    #[test]
+    fn is_sidecar_asset_matches_common_suffixes() {
+        assert!(is_sidecar_asset("x-linux-x86_64.tar.gz.sha256"));
+        assert!(is_sidecar_asset("x.sig"));
+        assert!(is_sidecar_asset("X.ASC"));
+        assert!(!is_sidecar_asset("flox-hi-linux-x86_64.tar.gz"));
+        assert!(!is_sidecar_asset("flox-hi-linux-x86_64"));
     }
 
     #[test]

--- a/cli/beta/src/extensions/layout.rs
+++ b/cli/beta/src/extensions/layout.rs
@@ -1,0 +1,63 @@
+//! On-disk layout under `$XDG_DATA_HOME/flox/extensions/`.
+//!
+//! The managed directory is rooted at `flox.data_dir.join("extensions")`.
+//! Each installed extension lives in its own `flox-<name>/` subdirectory
+//! containing the `flox-<name>` executable, the optional copied
+//! `flox-extension.toml` author manifest, and a `state.toml` describing
+//! the install. A single `.lock` file at the root serializes mutating
+//! operations (install / remove / upgrade); `list` and the dispatch
+//! `find` are lock-free.
+
+use std::path::PathBuf;
+
+use flox_rust_sdk::flox::Flox;
+
+pub fn extensions_root(flox: &Flox) -> PathBuf {
+    flox.data_dir.join("extensions")
+}
+
+pub fn install_dir(flox: &Flox, name: &str) -> PathBuf {
+    extensions_root(flox).join(format!("flox-{name}"))
+}
+
+pub fn state_path(flox: &Flox, name: &str) -> PathBuf {
+    install_dir(flox, name).join("state.toml")
+}
+
+pub fn lock_path(flox: &Flox) -> PathBuf {
+    extensions_root(flox).join(".lock")
+}
+
+#[cfg(test)]
+mod tests {
+    use flox_rust_sdk::flox::test_helpers::flox_instance;
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    #[test]
+    fn extensions_root_is_under_data_dir() {
+        let (flox, _tempdir) = flox_instance();
+        assert_eq!(extensions_root(&flox), flox.data_dir.join("extensions"));
+    }
+
+    #[test]
+    fn install_dir_prefixes_flox() {
+        let (flox, _tempdir) = flox_instance();
+        assert_eq!(
+            install_dir(&flox, "hello"),
+            flox.data_dir.join("extensions").join("flox-hello"),
+        );
+    }
+
+    #[test]
+    fn state_and_lock_paths() {
+        let (flox, _tempdir) = flox_instance();
+        let root = flox.data_dir.join("extensions");
+        assert_eq!(
+            state_path(&flox, "hello"),
+            root.join("flox-hello").join("state.toml")
+        );
+        assert_eq!(lock_path(&flox), root.join(".lock"));
+    }
+}

--- a/cli/beta/src/extensions/manager.rs
+++ b/cli/beta/src/extensions/manager.rs
@@ -1,0 +1,2429 @@
+//! `ExtensionManager` — install / remove / list operations.
+//!
+//! P02 wires up `install_local`, `remove`, and `list` on top of the
+//! [`super::layout`] paths and the [`super::manifest`] types. A small
+//! [`LockGuard`] RAII wrapper around `fslock::LockFile` serializes
+//! mutating operations against the same managed directory; `list` is
+//! deliberately lock-free.
+//!
+//! P03 reuses [`atomic_install`] for the GitHub-source install path and
+//! the upgrade flow, so the helper lives here from the start.
+//!
+//! # Lock discipline (P05-T05 audit)
+//!
+//! - `install_local`, `install_github`, `upgrade` (all kinds, including
+//!   `binary`), `upgrade_all` (per-item via `upgrade`), and `remove` each
+//!   acquire the extensions lock with [`LockGuard::acquire`].
+//! - `list`, `upgrade_dry_run`, `upgrade_all_dry_run`, and
+//!   `dispatch::find` are lock-free on purpose — they are pure reads.
+//! - Every write to `state.toml` goes through `render_installed_state`
+//!   and `fs::write` inside a staging dir; the atomic rename
+//!   ([`atomic_install`]) is the only visible transition from "missing"
+//!   to "installed".
+//! - `install_github_binary` does not acquire the lock itself because
+//!   fslock is non-reentrant; its callers (`install_github` and
+//!   `upgrade`, via `upgrade_binary`) hold the lock for its duration.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::{fs, io};
+
+use flox_rust_sdk::flox::Flox;
+use fslock::LockFile;
+use thiserror::Error;
+use time::OffsetDateTime;
+use time::format_description::well_known::Rfc3339;
+use tracing::debug;
+use uuid::Uuid;
+
+use super::extension::Extension;
+use super::github::{GitHubError, GitHubSource, SearchQuery, SearchResponse};
+use super::layout;
+use super::manifest::{
+    AuthorManifest,
+    InstalledState,
+    ManifestError,
+    parse_author_manifest,
+    parse_installed_state,
+    render_installed_state,
+};
+use super::reserved::RESERVED_COMMAND_NAMES;
+
+#[derive(Debug, Error)]
+pub enum LockError {
+    #[error("failed to open lock file at {path}: {source}")]
+    Open {
+        path: PathBuf,
+        #[source]
+        source: fslock::Error,
+    },
+    #[error("failed to acquire lock at {path}: {source}")]
+    Acquire {
+        path: PathBuf,
+        #[source]
+        source: fslock::Error,
+    },
+    #[error("another extensions operation is already in progress (lock at {path} is held)")]
+    WouldBlock { path: PathBuf },
+}
+
+#[derive(Debug, Error)]
+pub enum InstallError {
+    #[error("source path '{0}' does not exist")]
+    SourceMissing(PathBuf),
+    #[error("source path '{0}' is not a directory")]
+    SourceNotDirectory(PathBuf),
+    #[error(
+        "could not derive an extension name from source path '{0}' (expected directory name like 'flox-<name>')"
+    )]
+    NameUnderivable(PathBuf),
+    #[error(
+        "manifest extension name '{manifest}' does not match source directory name 'flox-{dirname}' \
+        — fix one or the other"
+    )]
+    NameMismatch { manifest: String, dirname: String },
+    #[error("{}", fmt_executable_missing(.name, .path))]
+    ExecutableMissing { name: String, path: PathBuf },
+    #[error(
+        "derived extension name '{0}' is not valid: must match '^[a-z0-9][a-z0-9_-]*$' \
+        (rename the source directory, or set '[extension] name' in flox-extension.toml)"
+    )]
+    InvalidName(String),
+    #[error("flox-{0} is already installed (run with --force to overwrite)")]
+    AlreadyInstalled(String),
+    #[error(
+        "repo name '{0}' is not a valid extension repo: must be 'flox-<name>' \
+        where <name> matches '^[a-z0-9][a-z0-9_-]*$'"
+    )]
+    InvalidRepoName(String),
+    #[error("name '{0}' conflicts with a built-in flox command")]
+    ReservedName(String),
+    #[error(
+        "spec '{0}' is not a valid GitHub source — use 'owner/repo' \
+        (or '--from-path PATH' for local sources)"
+    )]
+    InvalidSpec(String),
+    #[error(transparent)]
+    Lock(#[from] LockError),
+    #[error(transparent)]
+    Manifest(#[from] ManifestError),
+    #[error(transparent)]
+    GitHub(#[from] super::github::GitHubError),
+    #[error(transparent)]
+    Git(#[from] flox_rust_sdk::providers::git::GitRemoteCommandError),
+    #[error("filesystem error during install: {0}")]
+    Io(#[from] io::Error),
+    #[error("failed to format installation timestamp: {0}")]
+    Time(#[from] time::error::Format),
+    #[error("no release asset matches '{platform}' for {owner}/{repo}")]
+    NoMatchingAsset {
+        owner: String,
+        repo: String,
+        platform: String,
+    },
+    #[error("archive extraction failed: {0}")]
+    Archive(#[from] super::archive::ArchiveError),
+    #[error(
+        "binary asset integrity check failed — flox-extension.toml declared \
+        sha256={expected} but the downloaded asset hashed to {actual}"
+    )]
+    Sha256Mismatch { expected: String, actual: String },
+}
+
+#[derive(Debug, Error)]
+pub enum RemoveError {
+    #[error("extension 'flox-{0}' is not installed")]
+    NotFound(String),
+    #[error(transparent)]
+    Lock(#[from] LockError),
+    #[error("filesystem error during remove: {0}")]
+    Io(#[from] io::Error),
+}
+
+#[derive(Debug, Error)]
+pub enum ListError {
+    #[error("filesystem error during list: {0}")]
+    Io(#[from] io::Error),
+}
+
+#[derive(Debug, Error)]
+pub enum SearchError {
+    #[error(transparent)]
+    Github(#[from] GitHubError),
+    #[error(transparent)]
+    List(#[from] ListError),
+}
+
+/// One row in a search result, decorated with whether the repo is already
+/// installed locally. `full_name` is `<owner>/<repo>` (matches GitHub
+/// terminology and what we key installed state by).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SearchRow {
+    pub full_name: String,
+    pub stars: u64,
+    pub description: Option<String>,
+    pub installed: bool,
+}
+
+/// Outcome of a successful `upgrade` call (the `Err` arm of the result
+/// type covers true failures).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum UpgradeStatus {
+    /// Re-fetch produced a new commit; `state.toml` was rewritten.
+    Upgraded { from: String, to: String },
+    /// Remote HEAD already matched the recorded commit; no write.
+    AlreadyCurrent,
+    /// `state.pinned` is true and `--force` was not passed; no fetch.
+    Pinned,
+}
+
+/// Outcome of a read-only dry-run upgrade resolve. Distinct from
+/// `UpgradeStatus` because the dry-run path never mutates disk:
+/// `WouldUpgrade` is the *planned* action, not a performed one.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DryRunStatus {
+    WouldUpgrade { from: String, to: String },
+    AlreadyCurrent,
+    Pinned,
+}
+
+/// Per-extension outcome inside an `upgrade_all_dry_run` run.
+/// Mirrors `UpgradeResult` for ergonomic parity across the dry-run and
+/// upgrade paths.
+#[derive(Debug)]
+pub struct DryRunResult {
+    pub name: String,
+    pub outcome: Result<DryRunStatus, UpgradeError>,
+}
+
+/// Per-extension outcome inside an `upgrade_all` / `upgrade --dry-run` run.
+/// Wraps either `UpgradeStatus` (success, including no-op skip) or a
+/// per-extension error surfaced without aborting the overall loop.
+#[derive(Debug)]
+pub struct UpgradeResult {
+    pub name: String,
+    pub outcome: Result<UpgradeStatus, UpgradeError>,
+}
+
+#[derive(Debug, Error)]
+pub enum UpgradeError {
+    #[error("extension 'flox-{0}' is not installed")]
+    NotInstalled(String),
+    #[error(
+        "local extensions cannot be upgraded; reinstall with \
+        'flox extension install --from-path <dir>'"
+    )]
+    LocalNotSupported,
+    #[error(
+        "extension 'flox-{0}' has no recorded branch — upgrade requires a tracked branch \
+        (reinstall to refresh)"
+    )]
+    NoBranch(String),
+    #[error("'git ls-remote origin {branch}' failed in {dir} (exit {code})")]
+    LsRemoteFailed {
+        dir: PathBuf,
+        branch: String,
+        code: i32,
+    },
+    #[error("git reset --hard FETCH_HEAD failed in {dir}: exit {code}")]
+    ResetFailed { dir: PathBuf, code: i32 },
+    #[error("git rev-parse HEAD failed in {dir}: exit {code}")]
+    RevParseFailed { dir: PathBuf, code: i32 },
+    #[error("repo {owner}/{repo} has no releases; cannot upgrade binary extension")]
+    NoRelease { owner: String, repo: String },
+    #[error(transparent)]
+    Lock(#[from] LockError),
+    #[error(transparent)]
+    Manifest(#[from] ManifestError),
+    #[error(transparent)]
+    Git(#[from] flox_rust_sdk::providers::git::GitRemoteCommandError),
+    #[error("filesystem error during upgrade: {0}")]
+    Io(#[from] io::Error),
+    #[error("failed to format upgrade timestamp: {0}")]
+    Time(#[from] time::error::Format),
+    #[error(transparent)]
+    Install(#[from] Box<InstallError>),
+}
+
+/// RAII guard around an `fslock::LockFile`. Drops the lock when dropped.
+///
+/// The full type-state guard pattern in
+/// [`flox_rust_sdk::providers::upgrade_checks`] is overkill for our use case —
+/// extensions only ever mutate while holding the lock, and we don't
+/// need separate read/write capabilities at the type level.
+#[derive(Debug)]
+pub struct LockGuard {
+    _lock: LockFile,
+    path: PathBuf,
+}
+
+impl LockGuard {
+    /// Acquire the lock at `path`, blocking until available. Creates the
+    /// lock file (and parent directories) if missing.
+    pub fn acquire(path: &Path) -> Result<Self, LockError> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).map_err(|source| LockError::Open {
+                path: path.to_path_buf(),
+                source: fslock::Error::from(source),
+            })?;
+        }
+        let mut lock = LockFile::open(path).map_err(|source| LockError::Open {
+            path: path.to_path_buf(),
+            source,
+        })?;
+        lock.lock().map_err(|source| LockError::Acquire {
+            path: path.to_path_buf(),
+            source,
+        })?;
+        debug!(?path, "acquired extensions lock");
+        Ok(Self {
+            _lock: lock,
+            path: path.to_path_buf(),
+        })
+    }
+
+    /// Try to acquire the lock at `path`; return `WouldBlock` immediately
+    /// if another holder has it.
+    #[allow(dead_code)] // P05 will use this for upgrade --all skip-on-busy
+    pub fn try_acquire(path: &Path) -> Result<Self, LockError> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).map_err(|source| LockError::Open {
+                path: path.to_path_buf(),
+                source: fslock::Error::from(source),
+            })?;
+        }
+        let mut lock = LockFile::open(path).map_err(|source| LockError::Open {
+            path: path.to_path_buf(),
+            source,
+        })?;
+        let acquired = lock.try_lock().map_err(|source| LockError::Acquire {
+            path: path.to_path_buf(),
+            source,
+        })?;
+        if !acquired {
+            return Err(LockError::WouldBlock {
+                path: path.to_path_buf(),
+            });
+        }
+        debug!(?path, "acquired extensions lock (try)");
+        Ok(Self {
+            _lock: lock,
+            path: path.to_path_buf(),
+        })
+    }
+}
+
+impl Drop for LockGuard {
+    fn drop(&mut self) {
+        debug!(path = ?self.path, "released extensions lock");
+    }
+}
+
+/// Atomically promote `staging` to `final_dir` via `rename`. Both must
+/// be on the same filesystem (the caller arranges this by placing the
+/// staging dir under the same `extensions_root`). P05 may reuse this
+/// helper for the upgrade path.
+pub fn atomic_install(staging: &Path, final_dir: &Path) -> io::Result<()> {
+    fs::rename(staging, final_dir)
+}
+
+/// Install an extension from a local directory.
+///
+/// `source` must be a directory containing an executable `flox-<name>`.
+/// An optional `flox-extension.toml` at the source root supplies metadata;
+/// if it sets `[extension] name`, that name wins (and must match the
+/// `flox-<name>` directory naming if both exist). If the source is a
+/// git checkout, `commit` is populated from `git rev-parse HEAD` —
+/// best-effort, empty string on failure.
+pub fn install_local(flox: &Flox, source: &Path, force: bool) -> Result<Extension, InstallError> {
+    let source = match source.canonicalize() {
+        Ok(p) => p,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {
+            return Err(InstallError::SourceMissing(source.to_path_buf()));
+        },
+        Err(e) => return Err(InstallError::Io(e)),
+    };
+    if !source.is_dir() {
+        return Err(InstallError::SourceNotDirectory(source));
+    }
+
+    let manifest = read_author_manifest(&source)?;
+    let name = derive_name(&source, manifest.as_ref())?;
+    validate_local_name(&name)?;
+    let exe_name = format!("flox-{name}");
+
+    let exe_path = source.join(&exe_name);
+    if !is_executable(&exe_path) {
+        return Err(InstallError::ExecutableMissing {
+            name: name.clone(),
+            path: exe_path,
+        });
+    }
+
+    let extensions_root = layout::extensions_root(flox);
+    fs::create_dir_all(&extensions_root)?;
+
+    let _guard = LockGuard::acquire(&layout::lock_path(flox))?;
+
+    let install_dir = layout::install_dir(flox, &name);
+    if install_dir.exists() && !force {
+        return Err(InstallError::AlreadyInstalled(name));
+    }
+
+    let staging = extensions_root.join(format!(".staging-{}", Uuid::new_v4()));
+    fs::create_dir(&staging)?;
+
+    let state = match populate_local_staging(
+        &staging,
+        &source,
+        &name,
+        &exe_name,
+        &exe_path,
+        &install_dir,
+    ) {
+        Ok(s) => s,
+        Err(err) => {
+            let _ = fs::remove_dir_all(&staging);
+            return Err(err);
+        },
+    };
+
+    if install_dir.exists() {
+        fs::remove_dir_all(&install_dir)?;
+    }
+    if let Err(err) = atomic_install(&staging, &install_dir) {
+        let _ = fs::remove_dir_all(&staging);
+        return Err(err.into());
+    }
+
+    Ok(Extension {
+        name,
+        install_dir,
+        state,
+    })
+}
+
+fn populate_local_staging(
+    staging: &Path,
+    source: &Path,
+    name: &str,
+    exe_name: &str,
+    exe_path: &Path,
+    install_dir: &Path,
+) -> Result<InstalledState, InstallError> {
+    let staged_exe = staging.join(exe_name);
+    fs::copy(exe_path, &staged_exe)?;
+    let manifest_src = source.join("flox-extension.toml");
+    if manifest_src.exists() {
+        fs::copy(&manifest_src, staging.join("flox-extension.toml"))?;
+    }
+
+    let commit = git_head_commit(source).unwrap_or_default();
+    let now = OffsetDateTime::now_utc().format(&Rfc3339)?;
+
+    let state = InstalledState {
+        schema: "1".to_string(),
+        name: name.to_string(),
+        kind: "local".to_string(),
+        source: source.display().to_string(),
+        owner: String::new(),
+        repo: String::new(),
+        host: String::new(),
+        tag: String::new(),
+        branch: String::new(),
+        commit,
+        pinned: false,
+        asset_sha256: String::new(),
+        installed_at: now,
+        path: install_dir.display().to_string(),
+    };
+    let state_str = render_installed_state(&state)?;
+    fs::write(staging.join("state.toml"), state_str)?;
+    Ok(state)
+}
+
+/// Enforce the same name rules as GitHub-source installs so the two paths
+/// don't diverge: `[a-z0-9][a-z0-9_-]*` with no reserved subcommand names.
+/// Without this, a source dir like `flox-` (empty name) or
+/// `flox-foo bar` (space) installs silently and is then undispatchable.
+fn validate_local_name(name: &str) -> Result<(), InstallError> {
+    let repo = format!("flox-{name}");
+    match extract_extension_name(&repo) {
+        Some(n) if n == name => {},
+        _ => return Err(InstallError::InvalidName(name.to_string())),
+    }
+    check_not_reserved(name)?;
+    Ok(())
+}
+
+/// Install an extension from a GitHub source spec.
+///
+/// `spec` is `owner/repo` (e.g. `floxhub/flox-hello`). The repo segment
+/// must be `flox-<name>` per [`extract_extension_name`]; `<name>` must
+/// not collide with a built-in subcommand per [`check_not_reserved`].
+///
+/// When `pin` is `Some`, the install is recorded as `pinned = true`
+/// (upgrade will skip it without `--force`). When `force` is true and an
+/// install dir already exists for the same name, it is removed before the
+/// atomic swap.
+pub async fn install_github(
+    flox: &Flox,
+    spec: &str,
+    pin: Option<&str>,
+    force: bool,
+) -> Result<Extension, InstallError> {
+    let (owner, repo) = parse_owner_repo(spec)?;
+    let name = extract_extension_name(&repo)
+        .ok_or_else(|| InstallError::InvalidRepoName(repo.clone()))?
+        .to_string();
+    check_not_reserved(&name)?;
+
+    let extensions_root = layout::extensions_root(flox);
+    fs::create_dir_all(&extensions_root)?;
+
+    let _guard = LockGuard::acquire(&layout::lock_path(flox))?;
+
+    let install_dir = layout::install_dir(flox, &name);
+    if install_dir.exists() && !force {
+        return Err(InstallError::AlreadyInstalled(name));
+    }
+
+    let source = super::github::GitHubSource::from_env();
+    let resolved = match pin {
+        Some(p) => source.resolve_pin(&owner, &repo, p).await?,
+        None => source.resolve_latest(&owner, &repo).await?,
+    };
+
+    // Binary install: if the release has assets and one matches the host
+    // platform, download + extract instead of cloning.
+    if let Some(tag) = resolved.tag.as_deref() {
+        let assets = match source.list_release_assets(&owner, &repo, tag).await {
+            Ok(a) => a,
+            Err(super::github::GitHubError::NotFound(_)) => Vec::new(),
+            Err(err) => return Err(err.into()),
+        };
+        if !assets.is_empty()
+            && let Some(asset) = try_resolve_asset(&assets, None, &name)
+        {
+            let asset = asset.clone();
+            let manifest_ref = resolved.tag.as_deref().unwrap_or(&resolved.commit);
+            let manifest = source
+                .fetch_author_manifest(&owner, &repo, manifest_ref)
+                .await?;
+            return install_github_binary(
+                flox,
+                &owner,
+                &repo,
+                &name,
+                &resolved,
+                &asset,
+                pin.is_some(),
+                &source,
+                manifest.as_ref(),
+            )
+            .await;
+        }
+    }
+
+    let staging = extensions_root.join(format!(".staging-{}", Uuid::new_v4()));
+    // git clone --branch only accepts named refs (branch or tag), so SHA
+    // pins still need a branch to clone by — `resolve_pin` returns the
+    // default branch in that case. Post-clone, we reset to the resolved
+    // commit so the working tree pins the exact SHA the caller asked for
+    // (a no-op for tag/branch installs where the clone already lands
+    // there).
+    let clone_ref = resolved
+        .tag
+        .clone()
+        .or_else(|| resolved.branch.clone())
+        .unwrap_or_else(|| resolved.commit.clone());
+    if let Err(err) = source.clone_repo(&owner, &repo, &clone_ref, &staging) {
+        let _ = fs::remove_dir_all(&staging);
+        return Err(err.into());
+    }
+    if !resolved.commit.is_empty() {
+        let reset_status = Command::new("git")
+            .arg("-C")
+            .arg(&staging)
+            .args(["reset", "--hard", &resolved.commit])
+            .status();
+        match reset_status {
+            Ok(s) if s.success() => {},
+            Ok(s) => {
+                let _ = fs::remove_dir_all(&staging);
+                return Err(InstallError::Io(io::Error::other(format!(
+                    "git reset --hard {} failed in staging: exit {}",
+                    resolved.commit,
+                    s.code().unwrap_or(-1)
+                ))));
+            },
+            Err(err) => {
+                let _ = fs::remove_dir_all(&staging);
+                return Err(err.into());
+            },
+        }
+    }
+
+    let exe_name = format!("flox-{name}");
+    let exe_path = staging.join(&exe_name);
+    if !is_executable(&exe_path) {
+        let _ = fs::remove_dir_all(&staging);
+        return Err(InstallError::ExecutableMissing {
+            name: name.clone(),
+            path: exe_path,
+        });
+    }
+
+    let manifest_path = staging.join("flox-extension.toml");
+    let manifest = if manifest_path.exists() {
+        Some(parse_author_manifest(&fs::read_to_string(&manifest_path)?)?)
+    } else {
+        None
+    };
+
+    // At this point no matching release asset was found (or there were no
+    // assets at all), so the extension is either a pure script or a git
+    // checkout. The `[extension.binary]` section is advisory here: it
+    // *declares* a binary distribution but we couldn't find one, so the
+    // install is treated as a source clone with kind=git/script.
+    let kind = match manifest.as_ref().and_then(|m| m.extension.binary.as_ref()) {
+        Some(_) => "git",
+        None => "script",
+    };
+
+    let now = OffsetDateTime::now_utc().format(&Rfc3339)?;
+    let state = InstalledState {
+        schema: "1".to_string(),
+        name: name.clone(),
+        kind: kind.to_string(),
+        source: format!("https://github.com/{owner}/{repo}"),
+        owner: owner.clone(),
+        repo: repo.clone(),
+        host: "github.com".to_string(),
+        tag: resolved.tag.clone().unwrap_or_default(),
+        branch: resolved.branch.clone().unwrap_or_default(),
+        commit: resolved.commit.clone(),
+        pinned: pin.is_some(),
+        asset_sha256: String::new(),
+        installed_at: now,
+        path: install_dir.display().to_string(),
+    };
+    let state_str = render_installed_state(&state)?;
+    fs::write(staging.join("state.toml"), state_str)?;
+
+    if install_dir.exists() {
+        // --force path: remove the prior install before the atomic rename.
+        fs::remove_dir_all(&install_dir)?;
+    }
+    if let Err(err) = atomic_install(&staging, &install_dir) {
+        let _ = fs::remove_dir_all(&staging);
+        return Err(err.into());
+    }
+
+    Ok(Extension {
+        name,
+        install_dir,
+        state,
+    })
+}
+
+/// Try to resolve an asset using [`super::github::resolve_asset`]. Returns
+/// `None` when no asset matches (the caller then falls through to the
+/// clone-based flow).
+fn try_resolve_asset<'a>(
+    assets: &'a [super::github::ReleaseAsset],
+    manifest: Option<&AuthorManifest>,
+    name: &str,
+) -> Option<&'a super::github::ReleaseAsset> {
+    super::github::resolve_asset(assets, manifest, name).ok()
+}
+
+/// Install a precompiled binary extension: download the release asset,
+/// extract it (or copy it as-is for bare binaries), locate the
+/// `flox-<name>` executable, and write `state.toml` with
+/// `kind="binary"`. The caller has already acquired the extensions lock.
+#[allow(clippy::too_many_arguments)]
+async fn install_github_binary(
+    flox: &Flox,
+    owner: &str,
+    repo: &str,
+    name: &str,
+    resolved: &super::github::ResolvedRef,
+    asset: &super::github::ReleaseAsset,
+    pinned: bool,
+    source: &super::github::GitHubSource,
+    manifest: Option<&super::manifest::AuthorManifest>,
+) -> Result<Extension, InstallError> {
+    // The two callers (`install_github` and `upgrade_binary`) hold the
+    // extensions lock and have already decided whether to proceed past an
+    // existing install_dir, so re-checking `install_dir.exists() && !force`
+    // here is redundant and would race against the lock anyway.
+    let extensions_root = layout::extensions_root(flox);
+    let install_dir = layout::install_dir(flox, name);
+
+    let staging = extensions_root.join(format!(".staging-{}", Uuid::new_v4()));
+    fs::create_dir(&staging)?;
+
+    let result = populate_binary_staging(
+        source,
+        asset,
+        &staging,
+        name,
+        owner,
+        repo,
+        resolved,
+        pinned,
+        &install_dir,
+        manifest,
+    )
+    .await;
+    let state = match result {
+        Ok(s) => s,
+        Err(err) => {
+            let _ = fs::remove_dir_all(&staging);
+            return Err(err);
+        },
+    };
+
+    if install_dir.exists() {
+        fs::remove_dir_all(&install_dir)?;
+    }
+    if let Err(err) = atomic_install(&staging, &install_dir) {
+        let _ = fs::remove_dir_all(&staging);
+        return Err(err.into());
+    }
+
+    Ok(Extension {
+        name: name.to_string(),
+        install_dir,
+        state,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn populate_binary_staging(
+    source: &super::github::GitHubSource,
+    asset: &super::github::ReleaseAsset,
+    staging: &Path,
+    name: &str,
+    owner: &str,
+    repo: &str,
+    resolved: &super::github::ResolvedRef,
+    pinned: bool,
+    install_dir: &Path,
+    manifest: Option<&super::manifest::AuthorManifest>,
+) -> Result<InstalledState, InstallError> {
+    let asset_path = staging.join(".tmp-asset");
+    let sha = source.download_asset(asset, &asset_path).await?;
+
+    if let Some(expected) = manifest
+        .and_then(|m| m.extension.binary.as_ref())
+        .and_then(|b| b.sha256.as_deref())
+    {
+        let expected_lc = expected.to_ascii_lowercase();
+        let actual_lc = sha.to_ascii_lowercase();
+        if expected_lc != actual_lc {
+            return Err(InstallError::Sha256Mismatch {
+                expected: expected_lc,
+                actual: actual_lc,
+            });
+        }
+    }
+
+    extract_asset(&asset_path, staging, &asset.name, name)?;
+    // Drop the raw asset once extraction has finished.
+    let _ = fs::remove_file(&asset_path);
+
+    let staged_exe = staging.join(format!("flox-{name}"));
+    if !is_executable(&staged_exe) {
+        return Err(InstallError::ExecutableMissing {
+            name: name.to_string(),
+            path: staged_exe,
+        });
+    }
+
+    let now = OffsetDateTime::now_utc().format(&Rfc3339)?;
+    let state = InstalledState {
+        schema: "1".to_string(),
+        name: name.to_string(),
+        kind: "binary".to_string(),
+        source: format!("https://github.com/{owner}/{repo}"),
+        owner: owner.to_string(),
+        repo: repo.to_string(),
+        host: "github.com".to_string(),
+        tag: resolved.tag.clone().unwrap_or_default(),
+        branch: resolved.branch.clone().unwrap_or_default(),
+        commit: resolved.commit.clone(),
+        pinned,
+        asset_sha256: sha,
+        installed_at: now,
+        path: install_dir.display().to_string(),
+    };
+    let state_str = render_installed_state(&state)?;
+    fs::write(staging.join("state.toml"), state_str)?;
+    Ok(state)
+}
+
+fn extract_asset(
+    asset_path: &Path,
+    staging: &Path,
+    asset_name: &str,
+    extension_name: &str,
+) -> Result<(), InstallError> {
+    let lower = asset_name.to_ascii_lowercase();
+    if lower.ends_with(".tar.gz") || lower.ends_with(".tgz") {
+        super::archive::extract_tar_gz(asset_path, staging)?;
+        super::archive::locate_executable(staging, extension_name)?;
+        return Ok(());
+    }
+    if lower.ends_with(".zip") {
+        super::archive::extract_zip(asset_path, staging)?;
+        super::archive::locate_executable(staging, extension_name)?;
+        return Ok(());
+    }
+    // Raw single-file asset: copy into place as `flox-<name>`.
+    super::archive::install_raw(asset_path, staging, extension_name)?;
+    Ok(())
+}
+
+/// Re-fetch the recorded branch and reset the install dir to FETCH_HEAD,
+/// updating `state.toml` if the commit changed.
+///
+/// Local-kind extensions cannot be upgraded (they were copied without a
+/// remote). Pinned installs are skipped unless `force` is true. The fetch
+/// uses [`flox_rust_sdk::providers::git::GitCommandProvider::fetch_branch`]; the
+/// reset shells out to `git -C <dir> reset --hard FETCH_HEAD` because no
+/// trait wrapper exists for `reset` (P02-D2 precedent).
+pub async fn upgrade(flox: &Flox, name: &str, force: bool) -> Result<UpgradeStatus, UpgradeError> {
+    // Acquire the lock BEFORE reading state.toml so a concurrent `install`
+    // / `remove` / `upgrade` can't swap the file between the read here and
+    // any subsequent write. The `local` / pinned early-returns stay, but
+    // execute under the lock — no mutation happens on those paths, so
+    // holding the lock is cost-free.
+    let _guard = LockGuard::acquire(&layout::lock_path(flox))?;
+
+    let install_dir = layout::install_dir(flox, name);
+    let state_path = layout::state_path(flox, name);
+    let state_str = fs::read_to_string(&state_path).map_err(|err| {
+        if err.kind() == io::ErrorKind::NotFound {
+            UpgradeError::NotInstalled(name.to_string())
+        } else {
+            UpgradeError::Io(err)
+        }
+    })?;
+    let state = parse_installed_state(&state_str)?;
+
+    if state.kind == "local" {
+        return Err(UpgradeError::LocalNotSupported);
+    }
+    if state.pinned && !force {
+        return Ok(UpgradeStatus::Pinned);
+    }
+
+    if state.kind == "binary" {
+        return upgrade_binary(flox, name, &state).await;
+    }
+
+    if state.branch.is_empty() {
+        return Err(UpgradeError::NoBranch(name.to_string()));
+    }
+
+    let git = flox_rust_sdk::providers::git::GitCommandProvider::open(&install_dir)
+        .map_err(|err| UpgradeError::Io(io::Error::other(err.to_string())))?;
+    // Fetch the source ref without updating any local branch (no colon in
+    // the refspec). Updating `refs/heads/<branch>` directly would be
+    // refused by git because that branch is the current checkout.
+    // FETCH_HEAD is always written and is what `reset --hard` consumes.
+    git.fetch_ref("origin", &state.branch)?;
+
+    let reset_status = Command::new("git")
+        .arg("-C")
+        .arg(&install_dir)
+        .args(["reset", "--hard", "FETCH_HEAD"])
+        .status()?;
+    if !reset_status.success() {
+        return Err(UpgradeError::ResetFailed {
+            dir: install_dir.clone(),
+            code: reset_status.code().unwrap_or(-1),
+        });
+    }
+
+    let head_out = Command::new("git")
+        .arg("-C")
+        .arg(&install_dir)
+        .args(["rev-parse", "HEAD"])
+        .output()?;
+    if !head_out.status.success() {
+        return Err(UpgradeError::RevParseFailed {
+            dir: install_dir.clone(),
+            code: head_out.status.code().unwrap_or(-1),
+        });
+    }
+    let new_commit = String::from_utf8_lossy(&head_out.stdout).trim().to_string();
+
+    if new_commit == state.commit {
+        return Ok(UpgradeStatus::AlreadyCurrent);
+    }
+
+    let from = state.commit.clone();
+    let now = OffsetDateTime::now_utc().format(&Rfc3339)?;
+    let new_state = InstalledState {
+        commit: new_commit.clone(),
+        installed_at: now,
+        ..state
+    };
+    let new_state_str = render_installed_state(&new_state)?;
+    atomic_write_state(&state_path, &new_state_str)?;
+
+    Ok(UpgradeStatus::Upgraded {
+        from,
+        to: new_commit,
+    })
+}
+
+/// Write `state.toml` atomically via a sibling `.tmp` + `rename`. If the
+/// caller process crashes mid-write, the next `upgrade` sees the prior
+/// file unchanged rather than a truncated one.
+fn atomic_write_state(state_path: &Path, contents: &str) -> io::Result<()> {
+    let tmp = state_path.with_extension("toml.tmp");
+    fs::write(&tmp, contents)?;
+    fs::rename(&tmp, state_path)?;
+    Ok(())
+}
+
+/// Binary-kind upgrade: re-run `resolve_latest` for the recorded
+/// owner/repo, compare tags, and re-install from the fresh release asset
+/// if it has advanced. Does not acquire the extensions lock itself —
+/// the caller (`upgrade`) holds it for the full mutator, because fslock
+/// is non-reentrant and `install_github_binary` assumes the lock is
+/// already held.
+async fn upgrade_binary(
+    flox: &Flox,
+    name: &str,
+    state: &InstalledState,
+) -> Result<UpgradeStatus, UpgradeError> {
+    let source = super::github::GitHubSource::from_env();
+    let resolved = source
+        .resolve_latest(&state.owner, &state.repo)
+        .await
+        .map_err(|err| UpgradeError::Install(Box::new(InstallError::GitHub(err))))?;
+
+    let new_tag = resolved.tag.clone().unwrap_or_default();
+    if !new_tag.is_empty() && new_tag == state.tag {
+        return Ok(UpgradeStatus::AlreadyCurrent);
+    }
+
+    let tag_for_lookup = match resolved.tag.as_deref() {
+        Some(t) if !t.is_empty() => t,
+        _ => {
+            return Err(UpgradeError::NoRelease {
+                owner: state.owner.clone(),
+                repo: state.repo.clone(),
+            });
+        },
+    };
+    let assets = source
+        .list_release_assets(&state.owner, &state.repo, tag_for_lookup)
+        .await
+        .map_err(|err| UpgradeError::Install(Box::new(InstallError::GitHub(err))))?;
+    let asset = match super::github::resolve_asset(&assets, None, name) {
+        Ok(a) => a.clone(),
+        Err(err) => {
+            return Err(UpgradeError::Install(Box::new(
+                InstallError::NoMatchingAsset {
+                    owner: state.owner.clone(),
+                    repo: state.repo.clone(),
+                    platform: err.platform,
+                },
+            )));
+        },
+    };
+
+    let from = if !state.tag.is_empty() {
+        state.tag.clone()
+    } else {
+        state.commit.clone()
+    };
+
+    let manifest_ref = resolved.tag.as_deref().unwrap_or(&resolved.commit);
+    let manifest = source
+        .fetch_author_manifest(&state.owner, &state.repo, manifest_ref)
+        .await
+        .map_err(|err| UpgradeError::Install(Box::new(InstallError::GitHub(err))))?;
+
+    install_github_binary(
+        flox,
+        &state.owner,
+        &state.repo,
+        name,
+        &resolved,
+        &asset,
+        state.pinned,
+        &source,
+        manifest.as_ref(),
+    )
+    .await
+    .map_err(|e| UpgradeError::Install(Box::new(e)))?;
+
+    let to = if new_tag.is_empty() {
+        resolved.commit.clone()
+    } else {
+        new_tag
+    };
+    Ok(UpgradeStatus::Upgraded { from, to })
+}
+
+/// Upgrade every installed extension, collecting per-item results.
+///
+/// Design note: per D4 in the P05 plan, each call to the inner `upgrade()`
+/// acquires and releases the extensions lock independently. `list` stays
+/// lock-free; other operations may interleave between items. The
+/// alternative (one lock across the whole loop) was rejected to keep
+/// blast radius small and to preserve the existing per-mutator locking
+/// pattern.
+pub async fn upgrade_all(flox: &Flox, force: bool) -> Result<Vec<UpgradeResult>, ListError> {
+    let extensions = list(flox)?;
+    let mut out = Vec::with_capacity(extensions.len());
+    for ext in extensions {
+        let outcome = upgrade(flox, &ext.name, force).await;
+        out.push(UpgradeResult {
+            name: ext.name,
+            outcome,
+        });
+    }
+    Ok(out)
+}
+
+/// Read-only dry-run of `upgrade` for a single extension. Never writes
+/// `state.toml`; never writes `FETCH_HEAD`; never downloads an asset.
+///
+/// - `kind = local` → `UpgradeError::LocalNotSupported` (same as `upgrade`).
+/// - `state.pinned` → `DryRunStatus::Pinned` (no remote I/O).
+/// - `kind = binary` → `GitHubSource::resolve_latest`; compare tag.
+/// - `kind = script|git` → `git ls-remote <origin-url> <branch>`; compare sha.
+pub async fn upgrade_dry_run(flox: &Flox, name: &str) -> Result<DryRunStatus, UpgradeError> {
+    let state_path = layout::state_path(flox, name);
+    let state_str = fs::read_to_string(&state_path).map_err(|err| {
+        if err.kind() == io::ErrorKind::NotFound {
+            UpgradeError::NotInstalled(name.to_string())
+        } else {
+            UpgradeError::Io(err)
+        }
+    })?;
+    let state = parse_installed_state(&state_str)?;
+
+    if state.kind == "local" {
+        return Err(UpgradeError::LocalNotSupported);
+    }
+    if state.pinned {
+        return Ok(DryRunStatus::Pinned);
+    }
+
+    if state.kind == "binary" {
+        let source = super::github::GitHubSource::from_env();
+        let resolved = source
+            .resolve_latest(&state.owner, &state.repo)
+            .await
+            .map_err(|err| UpgradeError::Install(Box::new(InstallError::GitHub(err))))?;
+        let new_tag = resolved.tag.clone().unwrap_or_default();
+        if !new_tag.is_empty() && new_tag == state.tag {
+            return Ok(DryRunStatus::AlreadyCurrent);
+        }
+        // Match `upgrade_binary`'s gate: if there's no published release on
+        // the remote, report NoRelease rather than offering to "upgrade" to
+        // whatever the default branch HEAD happens to be. A real `upgrade`
+        // would bail with the same error.
+        if new_tag.is_empty() {
+            return Err(UpgradeError::NoRelease {
+                owner: state.owner.clone(),
+                repo: state.repo.clone(),
+            });
+        }
+        let from = if !state.tag.is_empty() {
+            state.tag.clone()
+        } else {
+            state.commit.clone()
+        };
+        return Ok(DryRunStatus::WouldUpgrade { from, to: new_tag });
+    }
+
+    if state.branch.is_empty() {
+        return Err(UpgradeError::NoBranch(name.to_string()));
+    }
+
+    // script / git: `git ls-remote origin <branch>` — read-only.
+    let install_dir = layout::install_dir(flox, name);
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(&install_dir)
+        .args(["ls-remote", "origin", &state.branch])
+        .output()?;
+    if !out.status.success() {
+        return Err(UpgradeError::LsRemoteFailed {
+            dir: install_dir.clone(),
+            branch: state.branch.clone(),
+            code: out.status.code().unwrap_or(-1),
+        });
+    }
+    let remote_sha = String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .next()
+        .and_then(|l| l.split_whitespace().next())
+        .unwrap_or("")
+        .to_string();
+    if remote_sha.is_empty() {
+        return Err(UpgradeError::NoBranch(name.to_string()));
+    }
+    if remote_sha == state.commit {
+        return Ok(DryRunStatus::AlreadyCurrent);
+    }
+    Ok(DryRunStatus::WouldUpgrade {
+        from: state.commit.clone(),
+        to: remote_sha,
+    })
+}
+
+/// `upgrade_all` analogue for dry-run mode. Mirrors `upgrade_all`'s
+/// `Result<Vec<...>, ListError>` shape so the outer `list` failure is
+/// propagated cleanly rather than swallowed per-item.
+pub async fn upgrade_all_dry_run(flox: &Flox) -> Result<Vec<DryRunResult>, ListError> {
+    let extensions = list(flox)?;
+    let mut out = Vec::with_capacity(extensions.len());
+    for ext in extensions {
+        let outcome = upgrade_dry_run(flox, &ext.name).await;
+        out.push(DryRunResult {
+            name: ext.name,
+            outcome,
+        });
+    }
+    Ok(out)
+}
+
+/// Search GitHub for repositories tagged `flox-extension` and mark any
+/// that are already installed locally. Returns the decorated rows plus
+/// the Search API's `incomplete_results` flag so the caller can warn.
+///
+/// Wraps `GitHubSource::from_env().search_repos()` (so `GH_TOKEN` /
+/// `GITHUB_TOKEN` and `FLOX_EXTENSIONS_GITHUB_BASE_URL` flow through)
+/// and cross-references `list(flox)` for the ✓ column. Local-only
+/// extensions (kind = "local") have no remote identity and are skipped.
+pub async fn search(flox: &Flox, q: &SearchQuery) -> Result<(Vec<SearchRow>, bool), SearchError> {
+    let source = GitHubSource::from_env();
+    let SearchResponse {
+        incomplete_results,
+        items,
+        ..
+    } = source.search_repos(q).await?;
+
+    let installed = list(flox)?;
+    // GitHub owner/repo handles are case-insensitive but preserve the
+    // registered casing in API payloads. Installed state preserves
+    // whatever case the user typed at install time. Compare lowercased
+    // on both sides so `Vercel/foo` locally matches `vercel/foo` from
+    // the API.
+    let installed_keys: HashSet<String> = installed
+        .into_iter()
+        .filter(|e| e.state.kind != "local")
+        .map(|e| format!("{}/{}", e.state.owner, e.state.repo).to_ascii_lowercase())
+        .collect();
+
+    let rows = items
+        .into_iter()
+        .map(|item| {
+            let installed = installed_keys.contains(&item.full_name.to_ascii_lowercase());
+            SearchRow {
+                full_name: item.full_name,
+                stars: item.stargazers_count,
+                description: item.description,
+                installed,
+            }
+        })
+        .collect();
+
+    Ok((rows, incomplete_results))
+}
+
+/// Parse `owner/repo` strictly: exactly two non-empty segments, no extra
+/// `/` or whitespace.
+fn parse_owner_repo(spec: &str) -> Result<(String, String), InstallError> {
+    let trimmed = spec.trim();
+    let parts: Vec<&str> = trimmed.split('/').collect();
+    if parts.len() != 2 || parts[0].is_empty() || parts[1].is_empty() {
+        return Err(InstallError::InvalidSpec(spec.to_string()));
+    }
+    Ok((parts[0].to_string(), parts[1].to_string()))
+}
+
+/// Remove an installed extension by name.
+pub fn remove(flox: &Flox, name: &str) -> Result<(), RemoveError> {
+    let install_dir = layout::install_dir(flox, name);
+    if !install_dir.exists() {
+        return Err(RemoveError::NotFound(name.to_string()));
+    }
+
+    let _guard = LockGuard::acquire(&layout::lock_path(flox))?;
+
+    if !install_dir.exists() {
+        return Err(RemoveError::NotFound(name.to_string()));
+    }
+
+    fs::remove_dir_all(&install_dir)?;
+    Ok(())
+}
+
+/// List installed extensions. Lock-free — entries with unparseable
+/// `state.toml` (e.g., a crashed install left behind) are skipped with a
+/// debug log rather than failing the whole listing.
+pub fn list(flox: &Flox) -> Result<Vec<Extension>, ListError> {
+    let root = layout::extensions_root(flox);
+    if !root.exists() {
+        return Ok(vec![]);
+    }
+
+    let mut out = vec![];
+    for entry in fs::read_dir(&root)? {
+        let entry = entry?;
+        let dir_name = entry.file_name();
+        let Some(dir_name_str) = dir_name.to_str() else {
+            continue;
+        };
+        let Some(name) = dir_name_str.strip_prefix("flox-") else {
+            continue;
+        };
+        let install_dir = entry.path();
+        if !install_dir.is_dir() {
+            continue;
+        }
+        let state_path = layout::state_path(flox, name);
+        let state_str = match fs::read_to_string(&state_path) {
+            Ok(s) => s,
+            Err(err) => {
+                debug!(
+                    ?install_dir,
+                    ?err,
+                    "skipping entry with missing/unreadable state.toml"
+                );
+                continue;
+            },
+        };
+        let state = match parse_installed_state(&state_str) {
+            Ok(s) => s,
+            Err(err) => {
+                debug!(
+                    ?install_dir,
+                    ?err,
+                    "skipping entry with unparseable state.toml"
+                );
+                continue;
+            },
+        };
+        out.push(Extension {
+            name: name.to_string(),
+            install_dir,
+            state,
+        });
+    }
+    out.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(out)
+}
+
+fn read_author_manifest(source: &Path) -> Result<Option<AuthorManifest>, InstallError> {
+    let path = source.join("flox-extension.toml");
+    if !path.exists() {
+        return Ok(None);
+    }
+    let s = fs::read_to_string(&path)?;
+    Ok(Some(parse_author_manifest(&s).map_err(InstallError::from)?))
+}
+
+fn derive_name(source: &Path, manifest: Option<&AuthorManifest>) -> Result<String, InstallError> {
+    let dirname_name = source
+        .file_name()
+        .and_then(|s| s.to_str())
+        .and_then(|s| s.strip_prefix("flox-"))
+        .map(str::to_string);
+
+    let manifest_name = manifest.and_then(|m| {
+        let n = m.extension.name.trim();
+        if n.is_empty() {
+            None
+        } else {
+            Some(n.to_string())
+        }
+    });
+
+    match (manifest_name, dirname_name) {
+        (Some(m), Some(d)) if m == d => Ok(m),
+        (Some(m), Some(d)) => Err(InstallError::NameMismatch {
+            manifest: m,
+            dirname: d,
+        }),
+        (Some(m), None) => Ok(m),
+        (None, Some(d)) => Ok(d),
+        (None, None) => Err(InstallError::NameUnderivable(source.to_path_buf())),
+    }
+}
+
+#[cfg(unix)]
+fn is_executable(p: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    fs::metadata(p)
+        .map(|md| md.is_file() && md.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
+}
+
+#[cfg(not(unix))]
+fn is_executable(p: &Path) -> bool {
+    p.is_file()
+}
+
+/// Strip the `flox-` prefix from a repo name and return the bare extension
+/// `<name>`, or `None` if the prefix is missing or `<name>` doesn't match
+/// `^[a-z0-9][a-z0-9_-]*$`.
+///
+/// Used by `install_github` to derive the on-disk extension name from a
+/// `<owner>/<repo>` spec. Lives here next to the other manager validators
+/// so it shares the InstallError surface.
+pub fn extract_extension_name(repo: &str) -> Option<&str> {
+    let name = repo.strip_prefix("flox-")?;
+    if name.is_empty() {
+        return None;
+    }
+    let mut chars = name.chars();
+    let first = chars.next()?;
+    if !(first.is_ascii_lowercase() || first.is_ascii_digit()) {
+        return None;
+    }
+    if !chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-' || c == '_') {
+        return None;
+    }
+    Some(name)
+}
+
+/// Reject extension names that collide with a built-in `flox` subcommand
+/// (see [`RESERVED_COMMAND_NAMES`]).
+///
+/// `try_dispatch_external` only fires when bpaf fails to parse the first
+/// positional, so a reserved name would never dispatch to the extension
+/// even if installed. Catching the conflict at install time gives a much
+/// better error than a silent shadowing.
+pub fn check_not_reserved(name: &str) -> Result<(), InstallError> {
+    let lowered = name.to_ascii_lowercase();
+    if RESERVED_COMMAND_NAMES.contains(&lowered.as_str()) {
+        return Err(InstallError::ReservedName(name.to_string()));
+    }
+    Ok(())
+}
+
+fn git_head_commit(source: &Path) -> Option<String> {
+    if !source.join(".git").exists() {
+        return None;
+    }
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(source)
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        debug!(?source, status = ?out.status, "git rev-parse HEAD failed");
+        return None;
+    }
+    let s = String::from_utf8(out.stdout).ok()?.trim().to_string();
+    if s.is_empty() { None } else { Some(s) }
+}
+
+fn fmt_executable_missing(name: &str, path: &Path) -> String {
+    format!("extension '{name}' has no executable at {}", path.display())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    use flox_rust_sdk::flox::test_helpers::flox_instance;
+    use pretty_assertions::assert_eq;
+    use tempfile::TempDir;
+
+    use super::*;
+
+    #[cfg(unix)]
+    fn write_exe(path: &Path, body: &str) {
+        use std::os::unix::fs::PermissionsExt;
+        fs::write(path, body).unwrap();
+        fs::set_permissions(path, fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    #[cfg(not(unix))]
+    fn write_exe(path: &Path, body: &str) {
+        fs::write(path, body).unwrap();
+    }
+
+    fn make_source(parent: &Path, name: &str) -> PathBuf {
+        let dir = parent.join(format!("flox-{name}"));
+        fs::create_dir(&dir).unwrap();
+        write_exe(&dir.join(format!("flox-{name}")), "#!/bin/sh\necho hi\n");
+        dir
+    }
+
+    #[test]
+    fn lock_guard_blocks_second_try_acquire() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join(".lock");
+
+        std::thread::scope(|scope| {
+            let (held, hold_rx) = mpsc::sync_channel::<()>(0);
+            let (release, release_rx) = mpsc::sync_channel::<()>(0);
+            let path_a = path.clone();
+            let path_b = path.clone();
+
+            scope.spawn(move || {
+                let _guard = LockGuard::acquire(&path_a).unwrap();
+                held.send(()).unwrap();
+                release_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+            });
+
+            scope.spawn(move || {
+                hold_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+                let err = LockGuard::try_acquire(&path_b).unwrap_err();
+                assert!(matches!(err, LockError::WouldBlock { .. }));
+                release.send(()).unwrap();
+            });
+        });
+    }
+
+    #[test]
+    fn atomic_install_renames() {
+        let temp = TempDir::new().unwrap();
+        let staging = temp.path().join(".staging-x");
+        let final_dir = temp.path().join("flox-foo");
+        fs::create_dir(&staging).unwrap();
+        write_exe(&staging.join("flox-foo"), "#!/bin/sh\n");
+
+        atomic_install(&staging, &final_dir).unwrap();
+
+        assert!(!staging.exists());
+        assert!(final_dir.join("flox-foo").exists());
+    }
+
+    #[test]
+    fn install_local_happy_path() {
+        let (flox, _tempdir) = flox_instance();
+        let src_root = TempDir::new().unwrap();
+        let src = make_source(src_root.path(), "hello");
+
+        let ext = install_local(&flox, &src, false).unwrap();
+        assert_eq!(ext.name, "hello");
+        assert_eq!(ext.install_dir, layout::install_dir(&flox, "hello"));
+        assert!(ext.install_dir.join("flox-hello").exists());
+        assert!(is_executable(&ext.install_dir.join("flox-hello")));
+
+        let state_str = fs::read_to_string(ext.install_dir.join("state.toml")).unwrap();
+        let state = parse_installed_state(&state_str).unwrap();
+        assert_eq!(state.name, "hello");
+        assert_eq!(state.kind, "local");
+        assert_eq!(state.path, ext.install_dir.display().to_string());
+    }
+
+    #[test]
+    fn install_local_rejects_when_no_executable() {
+        let (flox, _tempdir) = flox_instance();
+        let src_root = TempDir::new().unwrap();
+        let src = src_root.path().join("flox-hello");
+        fs::create_dir(&src).unwrap();
+        // intentionally no flox-hello executable
+
+        let err = install_local(&flox, &src, false).unwrap_err();
+        assert!(matches!(err, InstallError::ExecutableMissing { .. }));
+    }
+
+    #[test]
+    fn install_local_rejects_when_already_installed() {
+        let (flox, _tempdir) = flox_instance();
+        let src_root = TempDir::new().unwrap();
+        let src = make_source(src_root.path(), "hello");
+
+        install_local(&flox, &src, false).unwrap();
+        let err = install_local(&flox, &src, false).unwrap_err();
+        assert!(matches!(err, InstallError::AlreadyInstalled(ref n) if n == "hello"));
+    }
+
+    #[test]
+    fn install_local_force_overwrites_existing_install() {
+        let (flox, _tempdir) = flox_instance();
+        let src_root = TempDir::new().unwrap();
+        let src = make_source(src_root.path(), "hello");
+
+        install_local(&flox, &src, false).unwrap();
+        // Second install with `force=true` must succeed where `force=false`
+        // returns `AlreadyInstalled`. This keeps the CLI `--force` flag's
+        // promise for the local install path.
+        let ext = install_local(&flox, &src, true).unwrap();
+        assert_eq!(ext.name, "hello");
+    }
+
+    #[test]
+    fn install_local_rejects_empty_name() {
+        let (flox, _tempdir) = flox_instance();
+        let src_root = TempDir::new().unwrap();
+        let src = src_root.path().join("flox-");
+        fs::create_dir(&src).unwrap();
+        write_exe(&src.join("flox-"), "#!/bin/sh\n");
+
+        let err = install_local(&flox, &src, false).unwrap_err();
+        assert!(matches!(err, InstallError::InvalidName(ref n) if n.is_empty()));
+    }
+
+    #[test]
+    fn install_local_rejects_invalid_name_chars() {
+        let (flox, _tempdir) = flox_instance();
+        let src_root = TempDir::new().unwrap();
+        let src = src_root.path().join("flox-foo bar");
+        fs::create_dir(&src).unwrap();
+        write_exe(&src.join("flox-foo bar"), "#!/bin/sh\n");
+
+        let err = install_local(&flox, &src, false).unwrap_err();
+        assert!(matches!(err, InstallError::InvalidName(ref n) if n == "foo bar"));
+    }
+
+    #[test]
+    fn install_local_rejects_uppercase_name() {
+        let (flox, _tempdir) = flox_instance();
+        let src_root = TempDir::new().unwrap();
+        let src = src_root.path().join("flox-Hello");
+        fs::create_dir(&src).unwrap();
+        write_exe(&src.join("flox-Hello"), "#!/bin/sh\n");
+
+        let err = install_local(&flox, &src, false).unwrap_err();
+        assert!(matches!(err, InstallError::InvalidName(ref n) if n == "Hello"));
+    }
+
+    #[test]
+    fn install_local_rejects_reserved_name() {
+        let (flox, _tempdir) = flox_instance();
+        let src_root = TempDir::new().unwrap();
+        let src = make_source(src_root.path(), "install");
+
+        let err = install_local(&flox, &src, false).unwrap_err();
+        assert!(matches!(err, InstallError::ReservedName(ref n) if n == "install"));
+    }
+
+    #[test]
+    fn install_local_reports_not_found_when_source_missing() {
+        let (flox, _tempdir) = flox_instance();
+        let missing = PathBuf::from("/definitely/does/not/exist/flox-ghost");
+
+        let err = install_local(&flox, &missing, false).unwrap_err();
+        assert!(matches!(err, InstallError::SourceMissing(_)));
+    }
+
+    /// BUG-01 regression: the staging directory must not leak after a
+    /// failure between `create_dir(&staging)` and `atomic_install`. We
+    /// trigger the failure by pre-creating the final install dir so
+    /// `atomic_install` gets `EEXIST`/`ENOTEMPTY`. The same staging-cleanup
+    /// path also covers any earlier failure inside `populate_local_staging`.
+    #[test]
+    fn install_local_cleans_staging_on_atomic_install_failure() {
+        let (flox, _tempdir) = flox_instance();
+        let src_root = TempDir::new().unwrap();
+        let src = make_source(src_root.path(), "hello");
+
+        // Pre-populate install_dir so atomic_install cannot rename onto it.
+        let install_dir = layout::install_dir(&flox, "hello");
+        fs::create_dir_all(&install_dir).unwrap();
+        fs::write(install_dir.join("marker"), "pre-existing").unwrap();
+
+        let _ = install_local(&flox, &src, false).unwrap_err();
+
+        let leftover_staging: Vec<_> = fs::read_dir(layout::extensions_root(&flox))
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                e.file_name()
+                    .to_str()
+                    .is_some_and(|n| n.starts_with(".staging-"))
+            })
+            .collect();
+        assert!(
+            leftover_staging.is_empty(),
+            "expected no .staging-* dirs after failed install, found {leftover_staging:?}"
+        );
+    }
+
+    #[test]
+    fn install_local_name_mismatch_is_error() {
+        let (flox, _tempdir) = flox_instance();
+        let src_root = TempDir::new().unwrap();
+        let src = src_root.path().join("flox-hello");
+        fs::create_dir(&src).unwrap();
+        write_exe(&src.join("flox-hello"), "#!/bin/sh\n");
+        fs::write(
+            src.join("flox-extension.toml"),
+            "schema = \"1\"\n[extension]\nname = \"goodbye\"\n",
+        )
+        .unwrap();
+
+        let err = install_local(&flox, &src, false).unwrap_err();
+        assert!(matches!(err, InstallError::NameMismatch { .. }));
+    }
+
+    #[test]
+    fn list_returns_installed_extensions_sorted() {
+        let (flox, _tempdir) = flox_instance();
+        let src_root = TempDir::new().unwrap();
+        let beta = make_source(src_root.path(), "beta");
+        let alpha = make_source(src_root.path(), "alpha");
+
+        install_local(&flox, &beta, false).unwrap();
+        install_local(&flox, &alpha, false).unwrap();
+
+        let listed = list(&flox).unwrap();
+        let names: Vec<_> = listed.iter().map(|e| e.name.as_str()).collect();
+        assert_eq!(names, vec!["alpha", "beta"]);
+    }
+
+    #[test]
+    fn list_returns_empty_when_root_missing() {
+        let (flox, _tempdir) = flox_instance();
+        // extensions_root never created
+        let listed = list(&flox).unwrap();
+        assert_eq!(listed, vec![]);
+    }
+
+    #[test]
+    fn list_skips_unparseable_state() {
+        let (flox, _tempdir) = flox_instance();
+        let root = layout::extensions_root(&flox);
+        fs::create_dir_all(&root).unwrap();
+        let bad = root.join("flox-broken");
+        fs::create_dir(&bad).unwrap();
+        fs::write(bad.join("state.toml"), "this is not toml = =").unwrap();
+
+        let listed = list(&flox).unwrap();
+        assert_eq!(listed, vec![]);
+    }
+
+    #[test]
+    fn remove_deletes_install_dir() {
+        let (flox, _tempdir) = flox_instance();
+        let src_root = TempDir::new().unwrap();
+        let src = make_source(src_root.path(), "hello");
+
+        install_local(&flox, &src, false).unwrap();
+        assert!(layout::install_dir(&flox, "hello").exists());
+
+        remove(&flox, "hello").unwrap();
+        assert!(!layout::install_dir(&flox, "hello").exists());
+    }
+
+    #[test]
+    fn remove_errors_when_not_installed() {
+        let (flox, _tempdir) = flox_instance();
+        let err = remove(&flox, "missing").unwrap_err();
+        assert!(matches!(err, RemoveError::NotFound(ref n) if n == "missing"));
+    }
+
+    #[test]
+    fn extract_extension_name_strips_flox_prefix() {
+        assert_eq!(extract_extension_name("flox-hello"), Some("hello"));
+        assert_eq!(extract_extension_name("flox-foo-bar"), Some("foo-bar"));
+        assert_eq!(extract_extension_name("flox-foo_bar"), Some("foo_bar"));
+        assert_eq!(extract_extension_name("flox-h"), Some("h"));
+        assert_eq!(extract_extension_name("flox-2nd"), Some("2nd"));
+    }
+
+    #[test]
+    fn extract_extension_name_rejects_no_prefix() {
+        assert_eq!(extract_extension_name("hello"), None);
+        assert_eq!(extract_extension_name("FLOX-hello"), None);
+        assert_eq!(extract_extension_name("my-flox-hello"), None);
+    }
+
+    #[test]
+    fn extract_extension_name_rejects_uppercase() {
+        assert_eq!(extract_extension_name("flox-Hello"), None);
+        assert_eq!(extract_extension_name("flox-HELLO"), None);
+        assert_eq!(extract_extension_name("flox-hElLo"), None);
+    }
+
+    #[test]
+    fn extract_extension_name_rejects_leading_separator() {
+        assert_eq!(extract_extension_name("flox--foo"), None);
+        assert_eq!(extract_extension_name("flox-_foo"), None);
+        assert_eq!(extract_extension_name("flox-"), None);
+    }
+
+    #[test]
+    fn check_not_reserved_rejects_install() {
+        let err = check_not_reserved("install").unwrap_err();
+        assert!(matches!(err, InstallError::ReservedName(ref n) if n == "install"));
+    }
+
+    #[test]
+    fn check_not_reserved_rejects_short_aliases() {
+        // 'i' and 'l' are short aliases for install/list and must be reserved.
+        assert!(check_not_reserved("i").is_err());
+        assert!(check_not_reserved("l").is_err());
+    }
+
+    #[test]
+    fn check_not_reserved_accepts_unique_name() {
+        check_not_reserved("hello").unwrap();
+        check_not_reserved("my-extension").unwrap();
+    }
+
+    /// BUG-12 regression: reserved-name check must be case-insensitive so
+    /// that `Install` and `INSTALL` collide with the built-in `install`.
+    #[test]
+    fn check_not_reserved_is_case_insensitive() {
+        for name in ["Install", "INSTALL", "InStAlL"] {
+            let err = check_not_reserved(name).unwrap_err();
+            assert!(
+                matches!(err, InstallError::ReservedName(ref n) if n == name),
+                "expected ReservedName for {name}, got {err:?}"
+            );
+        }
+    }
+
+    /// TS06: under the lock, a concurrent second install of the same
+    /// name must not corrupt the install dir. Without the lock the two
+    /// threads would race past the AlreadyInstalled check and both try
+    /// to atomic_install into the same final dir; with the lock, they
+    /// serialize and the loser sees AlreadyInstalled cleanly.
+    #[test]
+    fn concurrent_install_serializes_via_lock() {
+        let (flox, _tempdir) = flox_instance();
+        let src_root = TempDir::new().unwrap();
+        let src = make_source(src_root.path(), "twin");
+        let flox_ref = &flox;
+        let src_ref = &src;
+
+        let (r1, r2) = std::thread::scope(|scope| {
+            let h1 = scope.spawn(move || install_local(flox_ref, src_ref, false));
+            let h2 = scope.spawn(move || install_local(flox_ref, src_ref, false));
+            (h1.join().unwrap(), h2.join().unwrap())
+        });
+
+        let outcomes = [r1.is_ok(), r2.is_ok()];
+        assert_eq!(
+            outcomes.iter().filter(|x| **x).count(),
+            1,
+            "exactly one install must succeed"
+        );
+
+        // The install dir is intact and parseable.
+        let install_dir = layout::install_dir(&flox, "twin");
+        assert!(install_dir.join("flox-twin").exists());
+        let state_str = fs::read_to_string(install_dir.join("state.toml")).unwrap();
+        let _state = parse_installed_state(&state_str).unwrap();
+    }
+
+    /// Build a bare git repo with a single commit containing an executable
+    /// `flox-<name>` script, returning `(bare_repo_path, head_sha)`.
+    fn build_bare_repo_with_extension(
+        parent: &Path,
+        name: &str,
+        script_body: &str,
+    ) -> (PathBuf, String) {
+        let work = parent.join(format!("work-flox-{name}"));
+        let bare = parent.join(format!("bare-flox-{name}.git"));
+        fs::create_dir(&work).unwrap();
+        Command::new("git")
+            .arg("init")
+            .arg("--bare")
+            .arg(&bare)
+            .status()
+            .unwrap();
+        Command::new("git")
+            .arg("init")
+            .arg("-b")
+            .arg("main")
+            .arg(&work)
+            .status()
+            .unwrap();
+        write_exe(&work.join(format!("flox-{name}")), script_body);
+        for (k, v) in [
+            ("user.email", "t@e"),
+            ("user.name", "t"),
+            ("commit.gpgsign", "false"),
+        ] {
+            Command::new("git")
+                .arg("-C")
+                .arg(&work)
+                .args(["config", k, v])
+                .status()
+                .unwrap();
+        }
+        Command::new("git")
+            .arg("-C")
+            .arg(&work)
+            .args(["add", "-A"])
+            .status()
+            .unwrap();
+        Command::new("git")
+            .arg("-C")
+            .arg(&work)
+            .args(["commit", "-q", "-m", "initial"])
+            .status()
+            .unwrap();
+        Command::new("git")
+            .arg("-C")
+            .arg(&work)
+            .args(["remote", "add", "origin"])
+            .arg(&bare)
+            .status()
+            .unwrap();
+        Command::new("git")
+            .arg("-C")
+            .arg(&work)
+            .args(["push", "-q", "origin", "main"])
+            .status()
+            .unwrap();
+        let head = Command::new("git")
+            .arg("-C")
+            .arg(&work)
+            .args(["rev-parse", "HEAD"])
+            .output()
+            .unwrap();
+        let sha = String::from_utf8(head.stdout).unwrap().trim().to_string();
+        (bare, sha)
+    }
+
+    /// Clone a bare repo as if `install_github` had done it: copy the worktree
+    /// shape into `extensions_root/flox-<name>` and write a matching `state.toml`.
+    fn install_from_bare_repo(
+        flox: &Flox,
+        name: &str,
+        bare: &Path,
+        sha: &str,
+        branch: &str,
+    ) -> PathBuf {
+        let install_dir = layout::install_dir(flox, name);
+        let parent = install_dir.parent().unwrap();
+        fs::create_dir_all(parent).unwrap();
+        let bare_url = format!("file://{}", bare.display());
+        Command::new("git")
+            .args([
+                "clone",
+                "--quiet",
+                "--single-branch",
+                "--no-tags",
+                "--branch",
+                branch,
+                &bare_url,
+            ])
+            .arg(&install_dir)
+            .status()
+            .unwrap();
+
+        let state = InstalledState {
+            schema: "1".to_string(),
+            name: name.to_string(),
+            kind: "script".to_string(),
+            source: bare_url,
+            owner: "owner".to_string(),
+            repo: format!("flox-{name}"),
+            host: "github.com".to_string(),
+            tag: String::new(),
+            branch: branch.to_string(),
+            commit: sha.to_string(),
+            pinned: false,
+            asset_sha256: String::new(),
+            installed_at: "2026-04-17T00:00:00Z".to_string(),
+            path: install_dir.display().to_string(),
+        };
+        let state_str = render_installed_state(&state).unwrap();
+        fs::write(layout::state_path(flox, name), state_str).unwrap();
+        install_dir
+    }
+
+    #[tokio::test]
+    async fn upgrade_errors_when_not_installed() {
+        let (flox, _tempdir) = flox_instance();
+        let err = upgrade(&flox, "missing", false).await.unwrap_err();
+        assert!(matches!(err, UpgradeError::NotInstalled(ref n) if n == "missing"));
+    }
+
+    #[tokio::test]
+    async fn upgrade_errors_for_local_kind() {
+        let (flox, _tempdir) = flox_instance();
+        let src_root = TempDir::new().unwrap();
+        let src = make_source(src_root.path(), "hello");
+        install_local(&flox, &src, false).unwrap();
+
+        let err = upgrade(&flox, "hello", false).await.unwrap_err();
+        assert!(matches!(err, UpgradeError::LocalNotSupported));
+    }
+
+    #[tokio::test]
+    async fn upgrade_returns_pinned_when_pinned_and_no_force() {
+        let (flox, _tempdir) = flox_instance();
+        let parent = TempDir::new().unwrap();
+        let (bare, sha) =
+            build_bare_repo_with_extension(parent.path(), "hello", "#!/bin/sh\necho v1\n");
+        let install_dir = install_from_bare_repo(&flox, "hello", &bare, &sha, "main");
+
+        // Mark the install as pinned.
+        let mut state =
+            parse_installed_state(&fs::read_to_string(install_dir.join("state.toml")).unwrap())
+                .unwrap();
+        state.pinned = true;
+        fs::write(
+            install_dir.join("state.toml"),
+            render_installed_state(&state).unwrap(),
+        )
+        .unwrap();
+
+        let result = upgrade(&flox, "hello", false).await.unwrap();
+        assert_eq!(result, UpgradeStatus::Pinned);
+    }
+
+    #[tokio::test]
+    async fn upgrade_returns_already_current_when_remote_unchanged() {
+        let (flox, _tempdir) = flox_instance();
+        let parent = TempDir::new().unwrap();
+        let (bare, sha) =
+            build_bare_repo_with_extension(parent.path(), "hello", "#!/bin/sh\necho v1\n");
+        install_from_bare_repo(&flox, "hello", &bare, &sha, "main");
+
+        let result = upgrade(&flox, "hello", false).await.unwrap();
+        assert_eq!(result, UpgradeStatus::AlreadyCurrent);
+    }
+
+    #[tokio::test]
+    async fn upgrade_advances_commit_when_remote_changed() {
+        let (flox, _tempdir) = flox_instance();
+        let parent = TempDir::new().unwrap();
+        let (bare, sha_v1) =
+            build_bare_repo_with_extension(parent.path(), "hello", "#!/bin/sh\necho v1\n");
+        let install_dir = install_from_bare_repo(&flox, "hello", &bare, &sha_v1, "main");
+
+        // Push a new commit to the bare repo by re-using its working clone.
+        let work = parent.path().join("work-flox-hello");
+        write_exe(&work.join("flox-hello"), "#!/bin/sh\necho v2\n");
+        Command::new("git")
+            .arg("-C")
+            .arg(&work)
+            .args(["add", "-A"])
+            .status()
+            .unwrap();
+        Command::new("git")
+            .arg("-C")
+            .arg(&work)
+            .args(["commit", "-q", "-m", "v2"])
+            .status()
+            .unwrap();
+        Command::new("git")
+            .arg("-C")
+            .arg(&work)
+            .args(["push", "-q", "origin", "main"])
+            .status()
+            .unwrap();
+        let sha_v2 = String::from_utf8(
+            Command::new("git")
+                .arg("-C")
+                .arg(&work)
+                .args(["rev-parse", "HEAD"])
+                .output()
+                .unwrap()
+                .stdout,
+        )
+        .unwrap()
+        .trim()
+        .to_string();
+        assert_ne!(sha_v1, sha_v2);
+
+        let result = upgrade(&flox, "hello", false).await.unwrap();
+        match result {
+            UpgradeStatus::Upgraded { from, to } => {
+                assert_eq!(from, sha_v1);
+                assert_eq!(to, sha_v2);
+            },
+            other => panic!("expected Upgraded, got {other:?}"),
+        }
+
+        // state.toml now records the new commit.
+        let state =
+            parse_installed_state(&fs::read_to_string(install_dir.join("state.toml")).unwrap())
+                .unwrap();
+        assert_eq!(state.commit, sha_v2);
+    }
+
+    /// TS05: binary upgrade short-circuits to `AlreadyCurrent` when the
+    /// remote tag matches the recorded tag. Uses httpmock to simulate the
+    /// GitHub API and `FLOX_EXTENSIONS_GITHUB_BASE_URL` to point the
+    /// `GitHubSource::from_env()` client at it. No file-system writes are
+    /// expected beyond the pre-seeded state.
+    #[tokio::test]
+    async fn upgrade_binary_returns_already_current_when_tag_unchanged() {
+        use httpmock::Method::GET;
+        use httpmock::MockServer;
+        use serde_json::json;
+
+        let server = MockServer::start_async().await;
+        let _release_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/repos/owner/flox-hello/releases/latest");
+            then.status(200).json_body(json!({
+                "tag_name": "v1.0.0",
+                "target_commitish": "main"
+            }));
+        });
+        let _commit_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/repos/owner/flox-hello/commits/v1.0.0");
+            then.status(200).json_body(json!({
+                "sha": "cafef00d00000000000000000000000000000000"
+            }));
+        });
+
+        let (flox, _tempdir) = flox_instance();
+
+        // Seed install_dir and state.toml as if `install_github_binary`
+        // had already run for v1.0.0.
+        let install_dir = layout::install_dir(&flox, "hello");
+        fs::create_dir_all(&install_dir).unwrap();
+        write_exe(&install_dir.join("flox-hello"), "#!/bin/sh\necho v1\n");
+        let seeded = InstalledState {
+            schema: "1".to_string(),
+            name: "hello".to_string(),
+            kind: "binary".to_string(),
+            source: "https://github.com/owner/flox-hello".to_string(),
+            owner: "owner".to_string(),
+            repo: "flox-hello".to_string(),
+            host: "github.com".to_string(),
+            tag: "v1.0.0".to_string(),
+            branch: String::new(),
+            commit: "cafef00d00000000000000000000000000000000".to_string(),
+            pinned: false,
+            asset_sha256: "deadbeef".to_string(),
+            installed_at: "2026-04-17T00:00:00Z".to_string(),
+            path: install_dir.display().to_string(),
+        };
+        fs::write(
+            layout::state_path(&flox, "hello"),
+            render_installed_state(&seeded).unwrap(),
+        )
+        .unwrap();
+
+        let prior_mtime = fs::metadata(install_dir.join("flox-hello"))
+            .unwrap()
+            .modified()
+            .ok();
+
+        let status = temp_env::async_with_vars(
+            [("FLOX_EXTENSIONS_GITHUB_BASE_URL", Some(server.base_url()))],
+            upgrade(&flox, "hello", false),
+        )
+        .await
+        .unwrap();
+        assert_eq!(status, UpgradeStatus::AlreadyCurrent);
+
+        // The executable file has not been rewritten.
+        let post_mtime = fs::metadata(install_dir.join("flox-hello"))
+            .unwrap()
+            .modified()
+            .ok();
+        assert_eq!(prior_mtime, post_mtime);
+    }
+
+    /// BUG-05/08/16 regression: `atomic_write_state` must write via a
+    /// sibling `.tmp` file and rename, so a crash mid-write leaves the
+    /// previous `state.toml` intact and `upgrade` doesn't read a partially
+    /// written file. We observe the tmp file is cleaned up on success.
+    #[test]
+    fn atomic_write_state_renames_tmp_onto_target() {
+        use tempfile::TempDir;
+
+        let dir = TempDir::new().unwrap();
+        let state_path = dir.path().join("state.toml");
+        fs::write(&state_path, "schema = \"1\"\nold = true\n").unwrap();
+        atomic_write_state(&state_path, "schema = \"1\"\nnew = true\n").unwrap();
+        assert_eq!(
+            fs::read_to_string(&state_path).unwrap(),
+            "schema = \"1\"\nnew = true\n"
+        );
+        assert!(!state_path.with_extension("toml.tmp").exists());
+    }
+
+    /// BUG-13 regression: `upgrade` must distinguish "state.toml does not
+    /// exist" (extension not installed) from other I/O failures — a
+    /// blanket `|_| NotInstalled` hides permission/disk errors behind a
+    /// confusing "not installed" message. Here we write a state.toml that
+    /// is a directory (so `read_to_string` fails with IsADirectory /
+    /// InvalidInput, not NotFound) and assert we get `Io`.
+    #[tokio::test]
+    async fn upgrade_surfaces_non_notfound_io_errors() {
+        let (flox, _tempdir) = flox_instance();
+        let state_path = layout::state_path(&flox, "hello");
+        fs::create_dir_all(state_path.parent().unwrap()).unwrap();
+        fs::create_dir(&state_path).unwrap();
+
+        let err = upgrade(&flox, "hello", false).await.unwrap_err();
+        assert!(
+            matches!(err, UpgradeError::Io(_)),
+            "expected Io, got {err:?}"
+        );
+    }
+
+    /// BUG-13 regression (dry-run): `upgrade_dry_run` must mirror
+    /// `upgrade`'s classifier — non-NotFound I/O errors surface as
+    /// `Io` rather than masquerading as `NotInstalled`.
+    #[tokio::test]
+    async fn upgrade_dry_run_surfaces_non_notfound_io_errors() {
+        let (flox, _tempdir) = flox_instance();
+        let state_path = layout::state_path(&flox, "hello");
+        fs::create_dir_all(state_path.parent().unwrap()).unwrap();
+        fs::create_dir(&state_path).unwrap();
+
+        let err = upgrade_dry_run(&flox, "hello").await.unwrap_err();
+        assert!(
+            matches!(err, UpgradeError::Io(_)),
+            "expected Io, got {err:?}"
+        );
+    }
+
+    /// BUG-04 regression: `populate_binary_staging` must compare the
+    /// downloaded asset's SHA-256 against the digest declared in the author
+    /// manifest's `[extension.binary]` block and surface a
+    /// `Sha256Mismatch` when they disagree. A matching digest (and the
+    /// no-digest case) must pass through silently.
+    #[tokio::test]
+    async fn populate_binary_staging_rejects_sha256_mismatch() {
+        use httpmock::Method::GET;
+        use httpmock::MockServer;
+        use sha2::{Digest, Sha256};
+        use tempfile::TempDir;
+
+        use crate::extensions::github as github_mod;
+        use crate::extensions::manifest::{BinaryMeta, ExtensionMeta};
+
+        let payload: Vec<u8> = b"#!/bin/sh\necho hello\n".to_vec();
+        let actual_sha = {
+            let mut h = Sha256::new();
+            h.update(&payload);
+            format!("{:x}", h.finalize())
+        };
+
+        let server = MockServer::start_async().await;
+        let _asset_mock = server.mock(|when, then| {
+            when.method(GET).path("/asset/flox-hello");
+            then.status(200)
+                .header("Content-Type", "application/octet-stream")
+                .body(&payload);
+        });
+
+        let asset = github_mod::ReleaseAsset {
+            name: "flox-hello".to_string(),
+            browser_download_url: format!("{}/asset/flox-hello", server.base_url()),
+            size: payload.len() as u64,
+            content_type: "application/octet-stream".to_string(),
+        };
+        let source = github_mod::GitHubSource::new(reqwest::Client::new(), server.base_url());
+        let staging = TempDir::new().unwrap();
+        let install_dir = staging.path().join("install");
+        let resolved = github_mod::ResolvedRef {
+            commit: "deadbeef".to_string(),
+            tag: Some("v1.0.0".to_string()),
+            branch: None,
+        };
+
+        let manifest = AuthorManifest {
+            schema: "1".to_string(),
+            extension: ExtensionMeta {
+                name: "hello".to_string(),
+                description: None,
+                binary: Some(BinaryMeta {
+                    source: "github-release".to_string(),
+                    asset: "flox-hello".to_string(),
+                    sha256: Some(
+                        "0000000000000000000000000000000000000000000000000000000000000000"
+                            .to_string(),
+                    ),
+                }),
+            },
+            environment: None,
+            on_active: None,
+        };
+
+        let err = populate_binary_staging(
+            &source,
+            &asset,
+            staging.path(),
+            "hello",
+            "owner",
+            "flox-hello",
+            &resolved,
+            false,
+            &install_dir,
+            Some(&manifest),
+        )
+        .await
+        .unwrap_err();
+        match err {
+            InstallError::Sha256Mismatch { expected, actual } => {
+                assert_eq!(
+                    expected,
+                    "0000000000000000000000000000000000000000000000000000000000000000"
+                );
+                assert_eq!(actual, actual_sha);
+            },
+            other => panic!("expected Sha256Mismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn upgrade_result_carries_name_and_outcome() {
+        let ok = UpgradeResult {
+            name: "hello".to_string(),
+            outcome: Ok(UpgradeStatus::AlreadyCurrent),
+        };
+        let err = UpgradeResult {
+            name: "ghost".to_string(),
+            outcome: Err(UpgradeError::NotInstalled("ghost".to_string())),
+        };
+        assert_eq!(ok.name, "hello");
+        assert!(matches!(ok.outcome, Ok(UpgradeStatus::AlreadyCurrent)));
+        assert!(matches!(err.outcome, Err(UpgradeError::NotInstalled(_))));
+    }
+
+    #[tokio::test]
+    async fn upgrade_all_returns_one_result_per_installed_extension() {
+        let (flox, _tempdir) = flox_instance();
+        let src_root = TempDir::new().unwrap();
+        let a = make_source(src_root.path(), "alpha");
+        let b = make_source(src_root.path(), "beta");
+        install_local(&flox, &a, false).unwrap();
+        install_local(&flox, &b, false).unwrap();
+
+        let results = upgrade_all(&flox, false).await.unwrap();
+
+        let names: Vec<_> = results.iter().map(|r| r.name.as_str()).collect();
+        assert_eq!(names, vec!["alpha", "beta"]);
+        for r in &results {
+            assert!(matches!(r.outcome, Err(UpgradeError::LocalNotSupported)));
+        }
+    }
+
+    #[tokio::test]
+    async fn upgrade_all_on_empty_root_returns_empty_vec() {
+        let (flox, _tempdir) = flox_instance();
+        let results = upgrade_all(&flox, false).await.unwrap();
+        assert!(results.is_empty());
+    }
+
+    /// P05-TS03: concurrent `upgrade_all` + `remove` must not corrupt
+    /// state. Because each upgrade item acquires its own lock (D4), a
+    /// concurrent `remove` either (a) runs before upgrade takes the lock
+    /// and the upgrade of that item returns `NotInstalled`, or
+    /// (b) runs after upgrade completes that item. The test asserts both
+    /// threads terminate without panic and that `list` is parseable after.
+    ///
+    /// Note: `Flox` does not implement `Clone`, so this test shares the
+    /// fixture across tasks via `Arc<Flox>` rather than cloning the
+    /// spec-literal way. Same observable behaviour — both tasks hit the
+    /// same on-disk extensions root.
+    #[tokio::test]
+    async fn upgrade_all_and_remove_serialize_cleanly() {
+        use std::sync::Arc;
+
+        let (flox, _tempdir) = flox_instance();
+        let src_root = TempDir::new().unwrap();
+        let a = make_source(src_root.path(), "alpha");
+        let b = make_source(src_root.path(), "beta");
+        install_local(&flox, &a, false).unwrap();
+        install_local(&flox, &b, false).unwrap();
+
+        let flox = Arc::new(flox);
+        let flox_c = Arc::clone(&flox);
+        let h1 = tokio::spawn(async move { upgrade_all(&flox_c, false).await });
+        let flox_c = Arc::clone(&flox);
+        let h2 = tokio::task::spawn_blocking(move || {
+            // Small sleep so upgrade has a chance to hold the lock at least once.
+            std::thread::sleep(std::time::Duration::from_millis(10));
+            remove(&flox_c, "beta")
+        });
+
+        let _ = h1.await.unwrap();
+        let _ = h2.await.unwrap();
+
+        // Post-condition: state is parseable (no crash inside list).
+        let _ = list(&flox).unwrap();
+    }
+
+    #[tokio::test]
+    async fn upgrade_dry_run_reports_would_upgrade_for_advanced_remote() {
+        let (flox, _tempdir) = flox_instance();
+        let parent = TempDir::new().unwrap();
+        let (bare, sha_v1) =
+            build_bare_repo_with_extension(parent.path(), "hello", "#!/bin/sh\necho v1\n");
+        let install_dir = install_from_bare_repo(&flox, "hello", &bare, &sha_v1, "main");
+
+        // Advance the remote.
+        let work = parent.path().join("work-flox-hello");
+        write_exe(&work.join("flox-hello"), "#!/bin/sh\necho v2\n");
+        Command::new("git")
+            .arg("-C")
+            .arg(&work)
+            .args(["add", "-A"])
+            .status()
+            .unwrap();
+        Command::new("git")
+            .arg("-C")
+            .arg(&work)
+            .args(["commit", "-q", "-m", "v2"])
+            .status()
+            .unwrap();
+        Command::new("git")
+            .arg("-C")
+            .arg(&work)
+            .args(["push", "-q", "origin", "main"])
+            .status()
+            .unwrap();
+
+        // Snapshot state.toml mtime BEFORE the dry-run.
+        let marker = install_dir.join("state.toml");
+        let before = fs::metadata(&marker).unwrap().modified().unwrap();
+
+        let status = upgrade_dry_run(&flox, "hello").await.unwrap();
+        match status {
+            DryRunStatus::WouldUpgrade { from, to } => {
+                assert_eq!(from, sha_v1);
+                assert_ne!(to, sha_v1);
+            },
+            other => panic!("expected WouldUpgrade, got {other:?}"),
+        }
+
+        // Dry-run must not touch state.toml.
+        let after = fs::metadata(&marker).unwrap().modified().unwrap();
+        assert_eq!(before, after);
+    }
+
+    /// BUG-09 regression: `upgrade_dry_run`'s binary branch must report
+    /// `NoRelease` when the remote has no published tag, matching
+    /// `upgrade_binary`'s real-upgrade gate. Previously it fell through
+    /// to `WouldUpgrade { to: <default-branch-commit> }`, which lied to
+    /// the user — a subsequent non-dry-run `upgrade` would immediately
+    /// fail with `NoRelease`.
+    #[tokio::test]
+    async fn upgrade_dry_run_binary_returns_no_release_when_remote_has_no_tag() {
+        use httpmock::Method::GET;
+        use httpmock::MockServer;
+        use serde_json::json;
+
+        let server = MockServer::start_async().await;
+        // /releases/latest 404 triggers default-branch fallback.
+        let _release_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/repos/owner/flox-hello/releases/latest");
+            then.status(404);
+        });
+        let _repo_mock = server.mock(|when, then| {
+            when.method(GET).path("/repos/owner/flox-hello");
+            then.status(200)
+                .json_body(json!({ "default_branch": "main" }));
+        });
+        let _commit_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/repos/owner/flox-hello/commits/main");
+            then.status(200)
+                .json_body(json!({ "sha": "cafef00d00000000000000000000000000000000" }));
+        });
+
+        let (flox, _tempdir) = flox_instance();
+        let install_dir = layout::install_dir(&flox, "hello");
+        fs::create_dir_all(&install_dir).unwrap();
+        write_exe(&install_dir.join("flox-hello"), "#!/bin/sh\necho v1\n");
+        let seeded = InstalledState {
+            schema: "1".to_string(),
+            name: "hello".to_string(),
+            kind: "binary".to_string(),
+            source: "https://github.com/owner/flox-hello".to_string(),
+            owner: "owner".to_string(),
+            repo: "flox-hello".to_string(),
+            host: "github.com".to_string(),
+            tag: "v1.0.0".to_string(),
+            branch: String::new(),
+            commit: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string(),
+            pinned: false,
+            asset_sha256: "deadbeef".to_string(),
+            installed_at: "2026-04-17T00:00:00Z".to_string(),
+            path: install_dir.display().to_string(),
+        };
+        fs::write(
+            layout::state_path(&flox, "hello"),
+            render_installed_state(&seeded).unwrap(),
+        )
+        .unwrap();
+
+        let err = temp_env::async_with_vars(
+            [("FLOX_EXTENSIONS_GITHUB_BASE_URL", Some(server.base_url()))],
+            upgrade_dry_run(&flox, "hello"),
+        )
+        .await
+        .unwrap_err();
+        match err {
+            UpgradeError::NoRelease { owner, repo } => {
+                assert_eq!(owner, "owner");
+                assert_eq!(repo, "flox-hello");
+            },
+            other => panic!("expected NoRelease, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn upgrade_dry_run_reports_pinned_without_resolving() {
+        let (flox, _tempdir) = flox_instance();
+        let parent = TempDir::new().unwrap();
+        let (bare, sha) =
+            build_bare_repo_with_extension(parent.path(), "hello", "#!/bin/sh\necho v1\n");
+        let install_dir = install_from_bare_repo(&flox, "hello", &bare, &sha, "main");
+        let mut state =
+            parse_installed_state(&fs::read_to_string(install_dir.join("state.toml")).unwrap())
+                .unwrap();
+        state.pinned = true;
+        fs::write(
+            install_dir.join("state.toml"),
+            render_installed_state(&state).unwrap(),
+        )
+        .unwrap();
+
+        let status = upgrade_dry_run(&flox, "hello").await.unwrap();
+        assert_eq!(status, DryRunStatus::Pinned);
+    }
+
+    #[test]
+    fn install_error_display_matches_spec_strings() {
+        let e = InstallError::ReservedName("activate".to_string());
+        assert_eq!(
+            e.to_string(),
+            "name 'activate' conflicts with a built-in flox command"
+        );
+
+        let e = InstallError::AlreadyInstalled("deploy".to_string());
+        assert_eq!(
+            e.to_string(),
+            "flox-deploy is already installed (run with --force to overwrite)"
+        );
+
+        let e = InstallError::NoMatchingAsset {
+            owner: "flox-examples".to_string(),
+            repo: "flox-deploy".to_string(),
+            platform: "linux-x86_64".to_string(),
+        };
+        assert_eq!(
+            e.to_string(),
+            "no release asset matches 'linux-x86_64' for flox-examples/flox-deploy"
+        );
+
+        let e = InstallError::ExecutableMissing {
+            name: "deploy".to_string(),
+            path: std::path::PathBuf::from("/tmp/flox-deploy/flox-deploy"),
+        };
+        assert_eq!(
+            e.to_string(),
+            "extension 'deploy' has no executable at /tmp/flox-deploy/flox-deploy"
+        );
+    }
+}

--- a/cli/beta/src/extensions/manager.rs
+++ b/cli/beta/src/extensions/manager.rs
@@ -512,20 +512,39 @@ pub async fn install_github(
             let manifest = source
                 .fetch_author_manifest(&owner, &repo, manifest_ref)
                 .await?;
-            if let Some(asset) = try_resolve_asset(&assets, manifest.as_ref(), &name) {
-                let asset = asset.clone();
-                return install_github_binary(
-                    flox,
-                    &owner,
-                    &repo,
-                    &name,
-                    &resolved,
-                    &asset,
-                    pin.is_some(),
-                    &source,
-                    manifest.as_ref(),
-                )
-                .await;
+            match super::github::resolve_asset(&assets, manifest.as_ref(), &name) {
+                Ok(asset) => {
+                    let asset = asset.clone();
+                    return install_github_binary(
+                        flox,
+                        &owner,
+                        &repo,
+                        &name,
+                        &resolved,
+                        &asset,
+                        pin.is_some(),
+                        &source,
+                        manifest.as_ref(),
+                    )
+                    .await;
+                },
+                Err(e) => {
+                    // A release exists but no asset matches this host. If the
+                    // manifest declares a binary distribution, the author
+                    // intends a binary install, so surface a clear
+                    // NoMatchingAsset rather than falling through to a source
+                    // clone that would later fail with ExecutableMissing.
+                    if manifest
+                        .as_ref()
+                        .is_some_and(|m| m.extension.binary.is_some())
+                    {
+                        return Err(InstallError::NoMatchingAsset {
+                            owner: owner.clone(),
+                            repo: repo.clone(),
+                            platform: e.platform,
+                        });
+                    }
+                },
             }
         }
     }
@@ -632,17 +651,6 @@ pub async fn install_github(
     })
 }
 
-/// Try to resolve an asset using [`super::github::resolve_asset`]. Returns
-/// `None` when no asset matches (the caller then falls through to the
-/// clone-based flow).
-fn try_resolve_asset<'a>(
-    assets: &'a [super::github::ReleaseAsset],
-    manifest: Option<&AuthorManifest>,
-    name: &str,
-) -> Option<&'a super::github::ReleaseAsset> {
-    super::github::resolve_asset(assets, manifest, name).ok()
-}
-
 /// Install a precompiled binary extension: download the release asset,
 /// extract it (or copy it as-is for bare binaries), locate the
 /// `flox-<name>` executable, and write `state.toml` with
@@ -741,6 +749,15 @@ async fn populate_binary_staging(
 
     let staged_exe = staging.join(format!("flox-{name}"));
     if !is_executable(&staged_exe) {
+        return Err(InstallError::ExecutableMissing {
+            name: name.to_string(),
+            path: staged_exe,
+        });
+    }
+    // A zero-byte asset (e.g. an empty raw download) is +x but not a usable
+    // executable; reject it here rather than "installing" a binary that
+    // fails at exec.
+    if fs::metadata(&staged_exe).map(|m| m.len()).unwrap_or(0) == 0 {
         return Err(InstallError::ExecutableMissing {
             name: name.to_string(),
             path: staged_exe,
@@ -1066,7 +1083,11 @@ pub async fn upgrade_all(flox: &Flox, force: bool) -> Result<Vec<UpgradeResult>,
 /// - `state.pinned` → `DryRunStatus::Pinned` (no remote I/O).
 /// - `kind = binary` → `GitHubSource::resolve_latest`; compare tag.
 /// - `kind = script|git` → `git ls-remote <origin-url> <branch>`; compare sha.
-pub async fn upgrade_dry_run(flox: &Flox, name: &str) -> Result<DryRunStatus, UpgradeError> {
+pub async fn upgrade_dry_run(
+    flox: &Flox,
+    name: &str,
+    force: bool,
+) -> Result<DryRunStatus, UpgradeError> {
     let state_path = layout::state_path(flox, name);
     let state_str = fs::read_to_string(&state_path).map_err(|err| {
         if err.kind() == io::ErrorKind::NotFound {
@@ -1080,7 +1101,7 @@ pub async fn upgrade_dry_run(flox: &Flox, name: &str) -> Result<DryRunStatus, Up
     if state.kind == "local" {
         return Err(UpgradeError::LocalNotSupported);
     }
-    if state.pinned {
+    if state.pinned && !force {
         return Ok(DryRunStatus::Pinned);
     }
 
@@ -1151,11 +1172,14 @@ pub async fn upgrade_dry_run(flox: &Flox, name: &str) -> Result<DryRunStatus, Up
 /// `upgrade_all` analogue for dry-run mode. Mirrors `upgrade_all`'s
 /// `Result<Vec<...>, ListError>` shape so the outer `list` failure is
 /// propagated cleanly rather than swallowed per-item.
-pub async fn upgrade_all_dry_run(flox: &Flox) -> Result<Vec<DryRunResult>, ListError> {
+pub async fn upgrade_all_dry_run(
+    flox: &Flox,
+    force: bool,
+) -> Result<Vec<DryRunResult>, ListError> {
     let extensions = list(flox)?;
     let mut out = Vec::with_capacity(extensions.len());
     for ext in extensions {
-        let outcome = upgrade_dry_run(flox, &ext.name).await;
+        let outcome = upgrade_dry_run(flox, &ext.name, force).await;
         out.push(DryRunResult {
             name: ext.name,
             outcome,
@@ -1214,6 +1238,13 @@ fn parse_owner_repo(spec: &str) -> Result<(String, String), InstallError> {
     let trimmed = spec.trim();
     let parts: Vec<&str> = trimmed.split('/').collect();
     if parts.len() != 2 || parts[0].is_empty() || parts[1].is_empty() {
+        return Err(InstallError::InvalidSpec(spec.to_string()));
+    }
+    // Validate the owner charset so odd input (`owner /repo`, control
+    // characters) is rejected cleanly here rather than flowing into a clone
+    // URL / API path and producing a confusing downstream 404. The repo
+    // segment is validated separately by `extract_extension_name`.
+    if super::github::validate_owner(parts[0]).is_err() {
         return Err(InstallError::InvalidSpec(spec.to_string()));
     }
     Ok((parts[0].to_string(), parts[1].to_string()))
@@ -1754,6 +1785,16 @@ mod tests {
     }
 
     #[test]
+    fn parse_owner_repo_rejects_invalid_owner_and_shape() {
+        assert!(parse_owner_repo("good-owner/flox-hi").is_ok());
+        assert!(parse_owner_repo("owner /flox-hi").is_err());
+        assert!(parse_owner_repo("ow ner/flox-hi").is_err());
+        assert!(parse_owner_repo("a/b/c").is_err());
+        assert!(parse_owner_repo("/flox-hi").is_err());
+        assert!(parse_owner_repo("owner/").is_err());
+    }
+
+    #[test]
     fn extract_extension_name_rejects_no_prefix() {
         assert_eq!(extract_extension_name("hello"), None);
         assert_eq!(extract_extension_name("FLOX-hello"), None);
@@ -2197,7 +2238,7 @@ mod tests {
         fs::create_dir_all(state_path.parent().unwrap()).unwrap();
         fs::create_dir(&state_path).unwrap();
 
-        let err = upgrade_dry_run(&flox, "hello").await.unwrap_err();
+        let err = upgrade_dry_run(&flox, "hello", false).await.unwrap_err();
         assert!(
             matches!(err, UpgradeError::Io(_)),
             "expected Io, got {err:?}"
@@ -2406,7 +2447,7 @@ mod tests {
         let marker = install_dir.join("state.toml");
         let before = fs::metadata(&marker).unwrap().modified().unwrap();
 
-        let status = upgrade_dry_run(&flox, "hello").await.unwrap();
+        let status = upgrade_dry_run(&flox, "hello", false).await.unwrap();
         match status {
             DryRunStatus::WouldUpgrade { from, to } => {
                 assert_eq!(from, sha_v1);
@@ -2479,7 +2520,7 @@ mod tests {
 
         let err = temp_env::async_with_vars(
             [("FLOX_EXTENSIONS_GITHUB_BASE_URL", Some(server.base_url()))],
-            upgrade_dry_run(&flox, "hello"),
+            upgrade_dry_run(&flox, "hello", false),
         )
         .await
         .unwrap_err();
@@ -2509,7 +2550,7 @@ mod tests {
         )
         .unwrap();
 
-        let status = upgrade_dry_run(&flox, "hello").await.unwrap();
+        let status = upgrade_dry_run(&flox, "hello", false).await.unwrap();
         assert_eq!(status, DryRunStatus::Pinned);
     }
 

--- a/cli/beta/src/extensions/manager.rs
+++ b/cli/beta/src/extensions/manager.rs
@@ -1125,6 +1125,26 @@ pub async fn upgrade_dry_run(
                 repo: state.repo.clone(),
             });
         }
+        // Verify the new release actually has a host-matching asset, so the
+        // dry-run doesn't report "would upgrade" for a release the real
+        // upgrade would abort on with NoMatchingAsset.
+        let assets = source
+            .list_release_assets(&state.owner, &state.repo, &new_tag)
+            .await
+            .map_err(|err| UpgradeError::Install(Box::new(InstallError::GitHub(err))))?;
+        let manifest = source
+            .fetch_author_manifest(&state.owner, &state.repo, &new_tag)
+            .await
+            .map_err(|err| UpgradeError::Install(Box::new(InstallError::GitHub(err))))?;
+        if let Err(e) = super::github::resolve_asset(&assets, manifest.as_ref(), name) {
+            return Err(UpgradeError::Install(Box::new(
+                InstallError::NoMatchingAsset {
+                    owner: state.owner.clone(),
+                    repo: state.repo.clone(),
+                    platform: e.platform,
+                },
+            )));
+        }
         let from = if !state.tag.is_empty() {
             state.tag.clone()
         } else {

--- a/cli/beta/src/extensions/manager.rs
+++ b/cli/beta/src/extensions/manager.rs
@@ -503,26 +503,30 @@ pub async fn install_github(
             Err(super::github::GitHubError::NotFound(_)) => Vec::new(),
             Err(err) => return Err(err.into()),
         };
-        if !assets.is_empty()
-            && let Some(asset) = try_resolve_asset(&assets, None, &name)
-        {
-            let asset = asset.clone();
+        if !assets.is_empty() {
+            // Fetch the author manifest *before* asset resolution so the
+            // `[extension.binary].asset` template can influence selection —
+            // otherwise the template is dead code and selection is
+            // substring-only.
             let manifest_ref = resolved.tag.as_deref().unwrap_or(&resolved.commit);
             let manifest = source
                 .fetch_author_manifest(&owner, &repo, manifest_ref)
                 .await?;
-            return install_github_binary(
-                flox,
-                &owner,
-                &repo,
-                &name,
-                &resolved,
-                &asset,
-                pin.is_some(),
-                &source,
-                manifest.as_ref(),
-            )
-            .await;
+            if let Some(asset) = try_resolve_asset(&assets, manifest.as_ref(), &name) {
+                let asset = asset.clone();
+                return install_github_binary(
+                    flox,
+                    &owner,
+                    &repo,
+                    &name,
+                    &resolved,
+                    &asset,
+                    pin.is_some(),
+                    &source,
+                    manifest.as_ref(),
+                )
+                .await;
+            }
         }
     }
 
@@ -762,6 +766,16 @@ async fn populate_binary_staging(
     };
     let state_str = render_installed_state(&state)?;
     fs::write(staging.join("state.toml"), state_str)?;
+
+    // Persist the fetched author manifest so dispatch can honor the
+    // extension's [environment] / [on_active] policy. A binary extension's
+    // archive usually contains only the executable, so without this the
+    // manifest would be lost and dispatch would default to Inherit.
+    if let Some(manifest) = manifest {
+        let manifest_str = super::manifest::render_author_manifest(manifest)?;
+        fs::write(staging.join("flox-extension.toml"), manifest_str)?;
+    }
+
     Ok(state)
 }
 
@@ -796,6 +810,11 @@ fn extract_asset(
 /// reset shells out to `git -C <dir> reset --hard FETCH_HEAD` because no
 /// trait wrapper exists for `reset` (P02-D2 precedent).
 pub async fn upgrade(flox: &Flox, name: &str, force: bool) -> Result<UpgradeStatus, UpgradeError> {
+    // Reject path-traversal / invalid names before composing any path
+    // (upgrade builds `flox-<name>` for the install dir and state path).
+    if !is_valid_extension_name(name) {
+        return Err(UpgradeError::NotInstalled(name.to_string()));
+    }
     // Acquire the lock BEFORE reading state.toml so a concurrent `install`
     // / `remove` / `upgrade` can't swap the file between the read here and
     // any subsequent write. The `local` / pinned early-returns stay, but
@@ -826,7 +845,19 @@ pub async fn upgrade(flox: &Flox, name: &str, force: bool) -> Result<UpgradeStat
     }
 
     if state.branch.is_empty() {
-        return Err(UpgradeError::NoBranch(name.to_string()));
+        // No tracked branch. A source extension installed from a release
+        // tag records a tag but no branch; upgrade it by re-resolving and
+        // re-cloning at the newest tag (mirrors the binary path). Only a
+        // genuinely branchless *and* tagless install is unupgradeable.
+        if state.tag.is_empty() {
+            return Err(UpgradeError::NoBranch(name.to_string()));
+        }
+        // Release the lock before delegating: `install_github` re-acquires
+        // it, and `LockGuard` is non-reentrant. `install_github` is
+        // self-contained (re-resolves and force-installs atomically under
+        // its own lock), so nothing here needs protecting across the gap.
+        drop(_guard);
+        return upgrade_source_tag(flox, &state).await;
     }
 
     let git = flox_rust_sdk::providers::git::GitCommandProvider::open(&install_dir)
@@ -927,7 +958,16 @@ async fn upgrade_binary(
         .list_release_assets(&state.owner, &state.repo, tag_for_lookup)
         .await
         .map_err(|err| UpgradeError::Install(Box::new(InstallError::GitHub(err))))?;
-    let asset = match super::github::resolve_asset(&assets, None, name) {
+
+    // Fetch the manifest before resolving the asset so its `asset` template
+    // can influence selection (see the matching reorder in `install_github`).
+    let manifest_ref = resolved.tag.as_deref().unwrap_or(&resolved.commit);
+    let manifest = source
+        .fetch_author_manifest(&state.owner, &state.repo, manifest_ref)
+        .await
+        .map_err(|err| UpgradeError::Install(Box::new(InstallError::GitHub(err))))?;
+
+    let asset = match super::github::resolve_asset(&assets, manifest.as_ref(), name) {
         Ok(a) => a.clone(),
         Err(err) => {
             return Err(UpgradeError::Install(Box::new(
@@ -945,12 +985,6 @@ async fn upgrade_binary(
     } else {
         state.commit.clone()
     };
-
-    let manifest_ref = resolved.tag.as_deref().unwrap_or(&resolved.commit);
-    let manifest = source
-        .fetch_author_manifest(&state.owner, &state.repo, manifest_ref)
-        .await
-        .map_err(|err| UpgradeError::Install(Box::new(InstallError::GitHub(err))))?;
 
     install_github_binary(
         flox,
@@ -972,6 +1006,36 @@ async fn upgrade_binary(
         new_tag
     };
     Ok(UpgradeStatus::Upgraded { from, to })
+}
+
+/// Upgrade a source (`script`/`git`) extension that was installed from a
+/// release tag and therefore has no tracked branch: re-resolve the latest
+/// tag and, if it advanced, re-clone at it via the install flow.
+async fn upgrade_source_tag(
+    flox: &Flox,
+    state: &InstalledState,
+) -> Result<UpgradeStatus, UpgradeError> {
+    let source = super::github::GitHubSource::from_env();
+    let resolved = source
+        .resolve_latest(&state.owner, &state.repo)
+        .await
+        .map_err(|err| UpgradeError::Install(Box::new(InstallError::GitHub(err))))?;
+    let new_tag = resolved.tag.clone().unwrap_or_default();
+    if new_tag.is_empty() || new_tag == state.tag {
+        return Ok(UpgradeStatus::AlreadyCurrent);
+    }
+
+    // Re-clone at the newest tag. `install_github` re-resolves latest and
+    // overwrites the existing install under `force`.
+    let spec = format!("{}/{}", state.owner, state.repo);
+    install_github(flox, &spec, None, true)
+        .await
+        .map_err(|err| UpgradeError::Install(Box::new(err)))?;
+
+    Ok(UpgradeStatus::Upgraded {
+        from: state.tag.clone(),
+        to: new_tag,
+    })
 }
 
 /// Upgrade every installed extension, collecting per-item results.
@@ -1157,6 +1221,13 @@ fn parse_owner_repo(spec: &str) -> Result<(String, String), InstallError> {
 
 /// Remove an installed extension by name.
 pub fn remove(flox: &Flox, name: &str) -> Result<(), RemoveError> {
+    // Reject path-traversal / invalid names before composing any path.
+    // Without this, `remove "x/../../../dir"` would build
+    // `<root>/flox-x/../../../dir` and `remove_dir_all` a directory outside
+    // the extensions root.
+    if !is_valid_extension_name(name) {
+        return Err(RemoveError::NotFound(name.to_string()));
+    }
     let install_dir = layout::install_dir(flox, name);
     if !install_dir.exists() {
         return Err(RemoveError::NotFound(name.to_string()));
@@ -1314,6 +1385,18 @@ pub fn check_not_reserved(name: &str) -> Result<(), InstallError> {
         return Err(InstallError::ReservedName(name.to_string()));
     }
     Ok(())
+}
+
+/// Whether `name` is a syntactically valid extension name — the same
+/// `[a-z0-9][a-z0-9_-]*` rule install enforces via [`extract_extension_name`].
+///
+/// This is the guard `remove` and `upgrade` use before composing a
+/// `flox-<name>` path. A name containing `/`, a path separator, or `..`
+/// fails the charset check, which is what prevents those operations from
+/// building a path that escapes the extensions root and, in `remove`'s
+/// case, recursively deleting it.
+pub fn is_valid_extension_name(name: &str) -> bool {
+    extract_extension_name(&format!("flox-{name}")) == Some(name)
 }
 
 fn git_head_commit(source: &Path) -> Option<String> {
@@ -1622,6 +1705,43 @@ mod tests {
         let (flox, _tempdir) = flox_instance();
         let err = remove(&flox, "missing").unwrap_err();
         assert!(matches!(err, RemoveError::NotFound(ref n) if n == "missing"));
+    }
+
+    #[test]
+    fn is_valid_extension_name_rejects_traversal_and_separators() {
+        assert!(is_valid_extension_name("hello"));
+        assert!(is_valid_extension_name("hello-world"));
+        assert!(is_valid_extension_name("h"));
+        assert!(!is_valid_extension_name(""));
+        assert!(!is_valid_extension_name("a/b"));
+        assert!(!is_valid_extension_name("hello/../../../etc"));
+        assert!(!is_valid_extension_name("../victim"));
+        assert!(!is_valid_extension_name("a b"));
+        assert!(!is_valid_extension_name("Hello"));
+    }
+
+    #[test]
+    fn remove_rejects_traversal_name_without_deleting_outside() {
+        let (flox, _tempdir) = flox_instance();
+        let src_root = TempDir::new().unwrap();
+        let src = make_source(src_root.path(), "hello");
+        install_local(&flox, &src, false).unwrap();
+
+        // A directory just outside the extensions root that a naive
+        // `flox-{name}` join + remove_dir_all could otherwise reach.
+        let victim = layout::extensions_root(&flox)
+            .parent()
+            .unwrap()
+            .join("victim");
+        fs::create_dir_all(&victim).unwrap();
+
+        let err = remove(&flox, "hello/../../victim").unwrap_err();
+        assert!(matches!(err, RemoveError::NotFound(_)));
+        assert!(
+            victim.exists(),
+            "a traversal name must not delete a directory outside the extensions root"
+        );
+        assert!(layout::install_dir(&flox, "hello").exists());
     }
 
     #[test]

--- a/cli/beta/src/extensions/manager.rs
+++ b/cli/beta/src/extensions/manager.rs
@@ -1192,10 +1192,7 @@ pub async fn upgrade_dry_run(
 /// `upgrade_all` analogue for dry-run mode. Mirrors `upgrade_all`'s
 /// `Result<Vec<...>, ListError>` shape so the outer `list` failure is
 /// propagated cleanly rather than swallowed per-item.
-pub async fn upgrade_all_dry_run(
-    flox: &Flox,
-    force: bool,
-) -> Result<Vec<DryRunResult>, ListError> {
+pub async fn upgrade_all_dry_run(flox: &Flox, force: bool) -> Result<Vec<DryRunResult>, ListError> {
     let extensions = list(flox)?;
     let mut out = Vec::with_capacity(extensions.len());
     for ext in extensions {

--- a/cli/beta/src/extensions/manifest.rs
+++ b/cli/beta/src/extensions/manifest.rs
@@ -120,6 +120,10 @@ pub fn render_installed_state(state: &InstalledState) -> Result<String, Manifest
     Ok(toml::to_string(state)?)
 }
 
+pub fn render_author_manifest(manifest: &AuthorManifest) -> Result<String, ManifestError> {
+    Ok(toml::to_string(manifest)?)
+}
+
 #[cfg(test)]
 mod tests {
     use pretty_assertions::assert_eq;

--- a/cli/beta/src/extensions/manifest.rs
+++ b/cli/beta/src/extensions/manifest.rs
@@ -1,0 +1,204 @@
+//! Author manifest (`flox-extension.toml`) and installed-state record
+//! (`state.toml`).
+//!
+//! Plain `serde` structs with a `schema = "1"` string field. The
+//! type-state pattern from `flox-manifest::Manifest<S>` is deliberately
+//! not used here: there is one schema version and no migration history.
+//!
+//! P02 reads `[extension] name`. The other fields (`[extension.binary]`,
+//! `[environment]`, `[on_active]`) are parsed into typed structs so the
+//! schema is locked in now and round-tripped by tests; P03/P04/P06 wire
+//! them into behavior without a schema bump.
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum ManifestError {
+    #[error("failed to parse manifest TOML: {0}")]
+    Parse(#[from] toml::de::Error),
+    #[error("failed to serialize manifest TOML: {0}")]
+    Serialize(#[from] toml::ser::Error),
+}
+
+/// `flox-extension.toml` — author-supplied, optional in the source tree.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuthorManifest {
+    #[serde(default = "default_schema")]
+    pub schema: String,
+    pub extension: ExtensionMeta,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub environment: Option<EnvironmentBehavior>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_active: Option<OnActive>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExtensionMeta {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub binary: Option<BinaryMeta>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BinaryMeta {
+    pub source: String,
+    pub asset: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sha256: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EnvironmentBehavior {
+    pub mode: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub inherit: Option<InheritMode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub inherit_name: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum InheritMode {
+    Current,
+    Default,
+    Named,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OnActive {
+    pub inside: String,
+}
+
+/// `state.toml` — written by `install`, consumed by `list` / `remove` /
+/// `upgrade`.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InstalledState {
+    #[serde(default = "default_schema")]
+    pub schema: String,
+    pub name: String,
+    pub kind: String,
+    pub source: String,
+    #[serde(default)]
+    pub owner: String,
+    #[serde(default)]
+    pub repo: String,
+    #[serde(default)]
+    pub host: String,
+    #[serde(default)]
+    pub tag: String,
+    /// Default branch name as observed at install time (used by `upgrade`
+    /// to know which ref to fetch). Empty for tag-pinned and commit-pinned
+    /// installs that didn't go through the default-branch fallback.
+    #[serde(default)]
+    pub branch: String,
+    #[serde(default)]
+    pub commit: String,
+    #[serde(default)]
+    pub pinned: bool,
+    #[serde(default)]
+    pub asset_sha256: String,
+    pub installed_at: String,
+    pub path: String,
+}
+
+fn default_schema() -> String {
+    "1".to_string()
+}
+
+pub fn parse_author_manifest(s: &str) -> Result<AuthorManifest, ManifestError> {
+    Ok(toml::from_str(s)?)
+}
+
+pub fn parse_installed_state(s: &str) -> Result<InstalledState, ManifestError> {
+    Ok(toml::from_str(s)?)
+}
+
+pub fn render_installed_state(state: &InstalledState) -> Result<String, ManifestError> {
+    Ok(toml::to_string(state)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    #[test]
+    fn author_manifest_minimal_round_trip() {
+        let src = r#"
+schema = "1"
+
+[extension]
+name = "hello"
+"#;
+        let parsed = parse_author_manifest(src).unwrap();
+        let expected = AuthorManifest {
+            schema: "1".to_string(),
+            extension: ExtensionMeta {
+                name: "hello".to_string(),
+                description: None,
+                binary: None,
+            },
+            environment: None,
+            on_active: None,
+        };
+        assert_eq!(parsed, expected);
+
+        let rendered = toml::to_string(&parsed).unwrap();
+        let reparsed = parse_author_manifest(&rendered).unwrap();
+        assert_eq!(reparsed, expected);
+    }
+
+    #[test]
+    fn author_manifest_full_round_trip() {
+        let src = AuthorManifest {
+            schema: "1".to_string(),
+            extension: ExtensionMeta {
+                name: "deploy".to_string(),
+                description: Some("Deploys things".to_string()),
+                binary: Some(BinaryMeta {
+                    source: "github-release".to_string(),
+                    asset: "flox-deploy-{platform}.tar.gz".to_string(),
+                    sha256: Some("cafe".to_string()),
+                }),
+            },
+            environment: Some(EnvironmentBehavior {
+                mode: "pinned".to_string(),
+                inherit: Some(InheritMode::Named),
+                inherit_name: Some("dev".to_string()),
+            }),
+            on_active: Some(OnActive {
+                inside: "use-active".to_string(),
+            }),
+        };
+        let rendered = toml::to_string(&src).unwrap();
+        let reparsed = parse_author_manifest(&rendered).unwrap();
+        assert_eq!(reparsed, src);
+    }
+
+    #[test]
+    fn installed_state_round_trip() {
+        let src = InstalledState {
+            schema: "1".to_string(),
+            name: "hello".to_string(),
+            kind: "local".to_string(),
+            source: ".".to_string(),
+            owner: String::new(),
+            repo: String::new(),
+            host: String::new(),
+            tag: String::new(),
+            branch: String::new(),
+            commit: "abc123".to_string(),
+            pinned: false,
+            asset_sha256: String::new(),
+            installed_at: "2026-04-17T12:34:56Z".to_string(),
+            path: "/tmp/x/flox-hello".to_string(),
+        };
+        let rendered = render_installed_state(&src).unwrap();
+        let reparsed = parse_installed_state(&rendered).unwrap();
+        assert_eq!(reparsed, src);
+    }
+}

--- a/cli/beta/src/extensions/mod.rs
+++ b/cli/beta/src/extensions/mod.rs
@@ -1,0 +1,63 @@
+//! External-subcommand extension subsystem.
+//!
+//! See [`research/gh_extension_flox.md`](../../../../research/gh_extension_flox.md)
+//! for the full PRD and design.
+//!
+//! This lives in the `beta` crate rather than `flox-rust-sdk` because the
+//! whole subsystem is gated behind `features.beta`: keeping it here leaves
+//! the SDK untouched, so promoting or dropping the feature does not churn a
+//! reviewed crate. It depends on `flox-rust-sdk` only for [`Flox`] and the
+//! git provider.
+//!
+//! [`Flox`]: flox_rust_sdk::flox::Flox
+
+pub mod dispatch;
+
+pub(crate) mod archive;
+pub(crate) mod extension;
+pub(crate) mod github;
+pub(crate) mod layout;
+pub(crate) mod manager;
+pub(crate) mod manifest;
+pub mod reserved;
+pub(crate) mod source;
+
+pub use extension::Extension;
+pub use github::{InvalidOwner, SearchQuery, SearchSort, validate_owner};
+pub use manager::{
+    DryRunResult,
+    DryRunStatus,
+    InstallError,
+    ListError,
+    LockError,
+    RemoveError,
+    SearchError,
+    SearchRow,
+    UpgradeError,
+    UpgradeResult,
+    UpgradeStatus,
+    check_not_reserved,
+    extract_extension_name,
+    install_github,
+    install_local,
+    list,
+    remove,
+    search,
+    upgrade,
+    upgrade_all,
+    upgrade_all_dry_run,
+    upgrade_dry_run,
+};
+pub use manifest::{
+    AuthorManifest,
+    BinaryMeta,
+    EnvironmentBehavior,
+    ExtensionMeta,
+    InheritMode,
+    InstalledState,
+    ManifestError,
+    OnActive,
+    parse_author_manifest,
+    parse_installed_state,
+};
+pub use reserved::RESERVED_COMMAND_NAMES;

--- a/cli/beta/src/extensions/reserved.rs
+++ b/cli/beta/src/extensions/reserved.rs
@@ -1,0 +1,61 @@
+//! Top-level subcommand names that conflict with the `flox <name>`
+//! external-extension dispatch.
+//!
+//! `try_dispatch_external` only fires when bpaf fails to parse the first
+//! positional as a known subcommand, so any subcommand name shadows an
+//! extension of the same name. To prevent surprises like
+//! `flox install` silently dispatching to a user's `flox-install`
+//! extension if bpaf's parser ever changes, `install_github` rejects any
+//! repo whose `<name>` segment is in this list.
+//!
+//! This list is verified by a drift test in `cli/tests/extension.bats`
+//! ("reserved-name list covers every visible top-level command"), which
+//! parses `flox --help` and asserts each command is refused at install
+//! time. If a new visible top-level command is added, that test fails and
+//! points here.
+//!
+//! Hidden commands are invisible to `--help` and so cannot be caught by
+//! that test; they must be added here by hand. As of the rebase onto
+//! `dd390e66b` those are `extension`, `help`, `beta-enabled`, and
+//! `factory`.
+
+pub const RESERVED_COMMAND_NAMES: &[&str] = &[
+    // Manage
+    "init",
+    "envs",
+    "delete",
+    // Use
+    "activate",
+    "deactivate",
+    "run",
+    "services",
+    // Discover
+    "search",
+    "show",
+    // Modify
+    "install",
+    "i",
+    "list",
+    "l",
+    "edit",
+    "include",
+    "upgrade",
+    "uninstall",
+    "generations",
+    // Share
+    "build",
+    "publish",
+    "push",
+    "pull",
+    "containerize",
+    // Administration
+    "auth",
+    "config",
+    "gc",
+    // Hidden / internal (not in --help output, so not covered by the
+    // bats drift test — keep this section current by hand)
+    "extension",
+    "help",
+    "beta-enabled",
+    "factory",
+];

--- a/cli/beta/src/extensions/source.rs
+++ b/cli/beta/src/extensions/source.rs
@@ -1,0 +1,1 @@
+//! `ExtensionSource` trait — stub for P03.

--- a/cli/beta/src/lib.rs
+++ b/cli/beta/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod beta_enabled;
+pub mod extensions;

--- a/cli/flox/src/commands/beta.rs
+++ b/cli/flox/src/commands/beta.rs
@@ -3,23 +3,31 @@ use beta::beta_enabled;
 use bpaf::Bpaf;
 use flox_rust_sdk::flox::Flox;
 
+use crate::commands::extension;
+
 #[derive(Bpaf, Clone)]
 #[bpaf(hide)]
 pub enum BetaCommands {
     #[bpaf(command("beta-enabled"), hide)]
     BetaEnabled(#[bpaf(external(beta_enabled::beta_enabled))] beta_enabled::BetaEnabled),
+
+    /// Manage flox extensions
+    #[bpaf(command("extension"), hide)]
+    Extension(#[bpaf(external(extension::extension_commands))] extension::ExtensionCommands),
 }
 
 impl BetaCommands {
     pub async fn handle(self, flox: Flox) -> Result<()> {
         match self {
             BetaCommands::BetaEnabled(args) => args.handle(flox).await,
+            BetaCommands::Extension(args) => args.handle(flox).await,
         }
     }
 
     pub fn subcommand_name(&self) -> &'static str {
         match self {
             BetaCommands::BetaEnabled(_) => "beta-enabled",
+            BetaCommands::Extension(_) => "extension",
         }
     }
 }

--- a/cli/flox/src/commands/extension/format.rs
+++ b/cli/flox/src/commands/extension/format.rs
@@ -1,0 +1,144 @@
+use beta::extensions::Extension;
+
+/// Render a single row of the `flox extension list` / `upgrade` table.
+/// Column widths match the existing `list` handler (20 / 32 / 14 / 6 / _)
+/// with a trailing STATUS column. STATUS is `None` for rows produced by
+/// `list` (column omitted), `Some("...")` for rows produced by `upgrade`
+/// and `upgrade --dry-run`.
+pub(super) struct TableRow {
+    pub name: String,
+    pub repo: String,
+    pub version: String,
+    pub pinned: bool,
+    pub status: Option<String>,
+}
+
+pub(super) fn render_header() -> String {
+    format!(
+        "{:<20}  {:<32}  {:<14}  {:<6}  {}",
+        "NAME", "REPO", "VERSION", "PINNED", "STATUS"
+    )
+}
+
+pub(super) fn render_row(row: &TableRow) -> String {
+    let version = short_sha(&row.version);
+    let pinned = if row.pinned { "yes" } else { "" };
+    let status = row.status.as_deref().unwrap_or("");
+    format!(
+        "{:<20}  {:<32}  {:<14}  {:<6}  {}",
+        row.name, row.repo, version, pinned, status
+    )
+}
+
+/// Convert an `Extension` to a `TableRow`. Reused by list and upgrade
+/// handlers. `status` is left `None`; the caller fills it.
+pub(super) fn row_from_extension(ext: &Extension) -> TableRow {
+    let repo = if ext.state.kind == "local" {
+        ".".to_string()
+    } else if !ext.state.owner.is_empty() && !ext.state.repo.is_empty() {
+        format!("{}/{}", ext.state.owner, ext.state.repo)
+    } else {
+        ext.state.source.clone()
+    };
+    let version = if !ext.state.tag.is_empty() {
+        ext.state.tag.clone()
+    } else {
+        ext.state.commit.clone()
+    };
+    TableRow {
+        name: ext.name.clone(),
+        repo,
+        version,
+        pinned: ext.state.pinned,
+        status: None,
+    }
+}
+
+/// Synthesize a `TableRow` for an extension whose name is not present in
+/// the `list` snapshot. Used by `upgrade --all` so that an outcome (often
+/// an error) reported by the SDK still surfaces on stdout instead of
+/// being silently dropped when the on-disk state disagrees with the
+/// snapshot we took before the upgrade loop started.
+pub(super) fn row_for_unknown(name: &str) -> TableRow {
+    TableRow {
+        name: name.to_string(),
+        repo: "-".to_string(),
+        version: "-".to_string(),
+        pinned: false,
+        status: None,
+    }
+}
+
+/// Truncate a commit SHA to 8 chars; leave tag-shaped strings untouched.
+pub(super) fn short_sha(v: &str) -> String {
+    let is_sha = v.len() >= 40 && v.chars().all(|c| c.is_ascii_hexdigit());
+    if is_sha {
+        v.chars().take(8).collect()
+    } else {
+        v.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn render_row_for_installed_script_includes_short_sha_as_version() {
+        let row = TableRow {
+            name: "deploy".to_string(),
+            repo: "flox-examples/flox-deploy".to_string(),
+            version: "abcdef1234567890abcdef1234567890abcdef12".to_string(),
+            pinned: false,
+            status: Some("up-to-date".to_string()),
+        };
+        let out = render_row(&row);
+        assert!(out.contains("deploy"));
+        assert!(out.contains("flox-examples/flox-deploy"));
+        // version column truncates commit SHAs to 8 chars.
+        assert!(out.contains("abcdef12"));
+        assert!(!out.contains("abcdef1234567890abcdef1234567890abcdef12"));
+        assert!(out.contains("up-to-date"));
+    }
+
+    #[test]
+    fn render_row_pinned_shows_yes() {
+        let row = TableRow {
+            name: "report".to_string(),
+            repo: "acme/flox-report".to_string(),
+            version: "v1.2.3".to_string(),
+            pinned: true,
+            status: None,
+        };
+        let out = render_row(&row);
+        assert!(out.contains("yes"));
+        assert!(out.contains("v1.2.3"));
+    }
+
+    /// BUG-15 regression: `row_for_unknown` must produce a renderable row
+    /// that surfaces a name reported by `upgrade_all` but missing from the
+    /// pre-loop snapshot — otherwise error outcomes are silently dropped.
+    #[test]
+    fn row_for_unknown_renders_name_with_placeholders() {
+        let row = row_for_unknown("ghost");
+        let out = render_row(&row);
+        assert!(out.contains("ghost"));
+        // repo and version placeholders are '-' so the row is obviously
+        // partial; pinned/status columns are empty-by-default.
+        assert!(out.contains('-'));
+    }
+
+    #[test]
+    fn render_header_matches_column_order() {
+        let h = render_header();
+        let name_idx = h.find("NAME").unwrap();
+        let repo_idx = h.find("REPO").unwrap();
+        let version_idx = h.find("VERSION").unwrap();
+        let pinned_idx = h.find("PINNED").unwrap();
+        let status_idx = h.find("STATUS").unwrap();
+        assert!(name_idx < repo_idx);
+        assert!(repo_idx < version_idx);
+        assert!(version_idx < pinned_idx);
+        assert!(pinned_idx < status_idx);
+    }
+}

--- a/cli/flox/src/commands/extension/install.rs
+++ b/cli/flox/src/commands/extension/install.rs
@@ -1,0 +1,90 @@
+use std::path::PathBuf;
+
+use anyhow::{Result, bail};
+use beta::extensions;
+use bpaf::Bpaf;
+use flox_rust_sdk::flox::Flox;
+use tracing::instrument;
+
+use crate::commands::SHELL_COMPLETION_DIR;
+use crate::subcommand_metric;
+use crate::utils::message;
+
+#[derive(Debug, Bpaf, Clone)]
+pub struct Install {
+    /// Install from an explicit local path (alternative to '.')
+    #[bpaf(long, argument("PATH"), complete_shell(SHELL_COMPLETION_DIR))]
+    from_path: Option<PathBuf>,
+
+    /// Pin to a specific git ref (tag like 'v1.2.3' or commit SHA prefix)
+    #[bpaf(long, argument("REF"))]
+    pin: Option<String>,
+
+    /// Overwrite an existing install (install) or override pin and re-fetch (upgrade)
+    #[bpaf(long, switch)]
+    force: bool,
+
+    /// Spec to install — '.' for the current directory, or 'owner/repo'
+    /// for a GitHub source. Use --from-path PATH for an explicit local path.
+    #[bpaf(positional("SPEC"), fallback(String::new()))]
+    spec: String,
+}
+
+impl Install {
+    #[instrument(name = "extensions::install", skip_all)]
+    pub async fn handle(self, flox: Flox) -> Result<()> {
+        subcommand_metric!("extensions::install");
+
+        match (self.spec.as_str(), self.from_path.as_ref()) {
+            (".", None) => {
+                if self.pin.is_some() {
+                    bail!("--pin only applies to GitHub sources, not '.'");
+                }
+                let cwd = std::env::current_dir()?;
+                let ext = extensions::install_local(&flox, &cwd, self.force)?;
+                message::updated(format!(
+                    "Installed flox-{} (local) -> {}",
+                    ext.name,
+                    ext.install_dir.display()
+                ));
+            },
+            ("", Some(p)) => {
+                if self.pin.is_some() {
+                    bail!("--pin only applies to GitHub sources, not --from-path");
+                }
+                let ext = extensions::install_local(&flox, p, self.force)?;
+                message::updated(format!(
+                    "Installed flox-{} (local) -> {}",
+                    ext.name,
+                    ext.install_dir.display()
+                ));
+            },
+            (".", Some(_)) => bail!("specify either '.' or --from-path, not both"),
+            ("", None) => {
+                bail!("usage: flox extension install . | --from-path PATH | OWNER/REPO")
+            },
+            (spec, Some(_)) => bail!("--from-path is mutually exclusive with SPEC '{spec}'"),
+            (spec, None) if looks_like_github_spec(spec) => {
+                let ext = extensions::install_github(&flox, spec, self.pin.as_deref(), self.force)
+                    .await?;
+                let suffix = match (ext.state.tag.as_str(), ext.state.commit.get(..8)) {
+                    (tag, _) if !tag.is_empty() => format!("@{tag}"),
+                    (_, Some(sha)) => format!("@{sha}"),
+                    _ => String::new(),
+                };
+                message::updated(format!(
+                    "Installed flox-{} ({}{})",
+                    ext.name, ext.state.kind, suffix
+                ));
+            },
+            (spec, None) => {
+                bail!("unsupported spec: '{spec}' — use '.', --from-path PATH, or 'owner/repo'")
+            },
+        }
+        Ok(())
+    }
+}
+
+fn looks_like_github_spec(s: &str) -> bool {
+    s.contains('/') && !s.starts_with('.') && !s.starts_with('/')
+}

--- a/cli/flox/src/commands/extension/list.rs
+++ b/cli/flox/src/commands/extension/list.rs
@@ -1,0 +1,31 @@
+use anyhow::Result;
+use beta::extensions;
+use bpaf::Bpaf;
+use flox_rust_sdk::flox::Flox;
+use tracing::instrument;
+
+use crate::subcommand_metric;
+use crate::utils::message;
+
+#[derive(Debug, Bpaf, Clone)]
+pub struct List {}
+
+impl List {
+    #[instrument(name = "extensions::list", skip_all)]
+    pub async fn handle(self, flox: Flox) -> Result<()> {
+        subcommand_metric!("extensions::list");
+
+        let extensions = extensions::list(&flox)?;
+        if extensions.is_empty() {
+            message::plain("No extensions installed.");
+            return Ok(());
+        }
+
+        println!("{}", super::format::render_header());
+        for ext in &extensions {
+            let row = super::format::row_from_extension(ext);
+            println!("{}", super::format::render_row(&row));
+        }
+        Ok(())
+    }
+}

--- a/cli/flox/src/commands/extension/mod.rs
+++ b/cli/flox/src/commands/extension/mod.rs
@@ -92,6 +92,12 @@ impl ExtensionCommands {
 /// `FLOX_FEATURES_BETA=true` for dispatch to work. This is documented in
 /// the user guide.
 pub fn try_dispatch_external() -> Option<ExitCode> {
+    // TODO(flox/flox#4537): dispatch runs before config loads, so it reads
+    // FLOX_FEATURES_BETA and reconstructs the extensions root from XDG
+    // instead of the resolved `features.beta` / `flox.data_dir`. This
+    // diverges from the `flox extension …` subcommands (config-enabled beta
+    // and a config-set data_dir are not honored here). Fix deferred; load
+    // the effective config lazily on this path. See the issue for repros.
     if !beta_enabled_from_env() {
         return None;
     }

--- a/cli/flox/src/commands/extension/mod.rs
+++ b/cli/flox/src/commands/extension/mod.rs
@@ -92,12 +92,13 @@ impl ExtensionCommands {
 /// `FLOX_FEATURES_BETA=true` for dispatch to work. This is documented in
 /// the user guide.
 pub fn try_dispatch_external() -> Option<ExitCode> {
-    // TODO(flox/flox#4537): dispatch runs before config loads, so it reads
+    // TODO(CLI-158): dispatch runs before config loads, so it reads
     // FLOX_FEATURES_BETA and reconstructs the extensions root from XDG
     // instead of the resolved `features.beta` / `flox.data_dir`. This
     // diverges from the `flox extension …` subcommands (config-enabled beta
     // and a config-set data_dir are not honored here). Fix deferred; load
     // the effective config lazily on this path. See the issue for repros.
+    // https://linear.app/floxdotdev/issue/CLI-158
     if !beta_enabled_from_env() {
         return None;
     }

--- a/cli/flox/src/commands/extension/mod.rs
+++ b/cli/flox/src/commands/extension/mod.rs
@@ -1,0 +1,350 @@
+//! `flox extension` subcommand group.
+
+use std::ffi::OsString;
+use std::os::unix::process::CommandExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitCode};
+
+use anyhow::Result;
+use beta::extensions::dispatch::{
+    self,
+    ActivationMode,
+    DispatchError,
+    resolve_mode,
+    scrub_flox_env,
+};
+use beta::extensions::{
+    AuthorManifest,
+    InstalledState,
+    parse_author_manifest,
+    parse_installed_state,
+};
+use bpaf::Bpaf;
+use flox_rust_sdk::flox::Flox;
+use tracing::{debug, warn};
+
+use crate::utils::active_environments::activated_environments;
+
+mod format;
+mod install;
+mod list;
+mod remove;
+mod search;
+mod upgrade;
+
+/// Manage flox extensions
+#[derive(Debug, Bpaf, Clone)]
+pub enum ExtensionCommands {
+    /// Install an extension
+    #[bpaf(command)]
+    Install(#[bpaf(external(install::install))] install::Install),
+
+    /// List installed extensions
+    #[bpaf(command)]
+    List(#[bpaf(external(list::list))] list::List),
+
+    /// Remove an installed extension
+    #[bpaf(command)]
+    Remove(#[bpaf(external(remove::remove))] remove::Remove),
+
+    /// Search GitHub for flox extensions
+    #[bpaf(command)]
+    Search(#[bpaf(external(search::search))] search::Search),
+
+    /// Upgrade one or all installed extensions
+    #[bpaf(command)]
+    Upgrade(#[bpaf(external(upgrade::upgrade))] upgrade::Upgrade),
+}
+
+impl ExtensionCommands {
+    pub async fn handle(self, flox: Flox) -> Result<()> {
+        match self {
+            ExtensionCommands::Install(args) => args.handle(flox).await,
+            ExtensionCommands::List(args) => args.handle(flox).await,
+            ExtensionCommands::Remove(args) => args.handle(flox).await,
+            ExtensionCommands::Search(args) => args.handle(flox).await,
+            ExtensionCommands::Upgrade(args) => args.handle(flox).await,
+        }
+    }
+}
+
+/// Two-phase parse fallback: when the top-level bpaf parse fails (because
+/// `flox <name>` doesn't match a known subcommand), check whether `<name>`
+/// resolves to a managed or PATH-installed `flox-<name>` and exec it.
+///
+/// Returns `Some(exit_code)` when the dispatch happens (success or failure
+/// of the child process), or `None` when no extension matched and the
+/// caller should fall back to its existing parse-error path.
+///
+/// Extensions are a beta feature and are **off** by default. Dispatch only
+/// fires when `FLOX_FEATURES_BETA` is set to `true` (or `1`) in the
+/// environment.
+///
+/// # Known limitation
+///
+/// This reads the environment variable directly rather than consulting
+/// [`Flox::features`], because `Flox` is not yet initialized at the
+/// parse-failure point in `main()` where this is called. Consequently
+/// `flox config --set features.beta true` — which writes the config file
+/// and does *not* set the environment variable — enables the
+/// `flox extension …` subcommands but **not** `flox <name>` dispatch.
+/// Users who enable beta via config must also export
+/// `FLOX_FEATURES_BETA=true` for dispatch to work. This is documented in
+/// the user guide.
+pub fn try_dispatch_external() -> Option<ExitCode> {
+    if !beta_enabled_from_env() {
+        return None;
+    }
+
+    let mut argv: Vec<OsString> = std::env::args_os().collect();
+    if argv.is_empty() {
+        return None;
+    }
+    argv.remove(0);
+
+    // Skip leading global flags (e.g. `flox -v myext`). They were not
+    // applied to flox itself — we only reach this path on parse failure —
+    // and are not forwarded to the extension. A flag placed after the name
+    // (`flox myext -v`) falls into `rest` and reaches the child.
+    let mut iter = argv.into_iter();
+    let mut name: Option<OsString> = None;
+    for arg in iter.by_ref() {
+        if arg.as_encoded_bytes().first() == Some(&b'-') {
+            continue;
+        }
+        name = Some(arg);
+        break;
+    }
+    let rest: Vec<OsString> = iter.collect();
+    let name = name?;
+    let name_str = name.to_str()?;
+
+    let extensions_root = extensions_root();
+    let path_env = std::env::var_os("PATH");
+    let path = match dispatch::find(name_str, &extensions_root, path_env.as_deref()) {
+        Ok(p) => p,
+        Err(dispatch::FindError::NotFound(_)) => return None,
+        Err(e) => {
+            warn!(extension = name_str, error = %e, "extension lookup failed");
+            return None;
+        },
+    };
+
+    debug!(extension = name_str, path = ?path, "dispatching to external extension");
+
+    let install_dir = managed_install_dir(&path, &extensions_root);
+    let author_manifest = install_dir.as_deref().and_then(load_author_manifest);
+    let installed_state = install_dir.as_deref().and_then(load_installed_state);
+
+    let mode = resolve_mode(
+        author_manifest
+            .as_ref()
+            .and_then(|m| m.environment.as_ref()),
+    );
+    let on_active_inside = author_manifest
+        .as_ref()
+        .and_then(|m| m.on_active.as_ref())
+        .map(|o| o.inside.as_str())
+        .unwrap_or_default();
+
+    let extension_name = installed_state
+        .as_ref()
+        .map(|s| s.name.clone())
+        .unwrap_or_else(|| name_str.to_string());
+    let extension_version = installed_state
+        .as_ref()
+        .map(version_from_state)
+        .unwrap_or_else(|| "-".to_string());
+    let extension_path = install_dir
+        .as_ref()
+        .map(|p| p.as_os_str().to_owned())
+        .unwrap_or_else(|| path.as_os_str().to_owned());
+    let flox_bin = std::env::current_exe().unwrap_or_else(|_| PathBuf::from("flox"));
+
+    let mut command = match build_dispatch_command(
+        &mode,
+        &path,
+        &rest,
+        &flox_bin,
+        &extension_name,
+        on_active_inside,
+    ) {
+        Ok(cmd) => cmd,
+        Err(e) => {
+            eprintln!("flox: {e}");
+            return Some(ExitCode::from(1));
+        },
+    };
+    command
+        .env("FLOX_EXTENSION_NAME", &extension_name)
+        .env("FLOX_EXTENSION_VERSION", &extension_version)
+        .env("FLOX_EXTENSION_PATH", &extension_path)
+        .env("FLOX_BIN", &flox_bin);
+
+    let err = replace_process(&mut command);
+    eprintln!("flox: failed to execute '{}': {}", path.display(), err);
+    Some(ExitCode::from(1))
+}
+
+/// Wrapper around `<Command as CommandExt>::exec` — replaces the current
+/// process in place via the `execvp(2)` syscall. Never returns on success.
+/// Args are passed as a separate vector; no shell is spawned.
+fn replace_process(command: &mut Command) -> std::io::Error {
+    <Command as CommandExt>::exec(command)
+}
+
+/// The install directory for a managed extension, if `exe_path` lives
+/// under `extensions_root` in the expected `<root>/<flox-name>/<flox-name>`
+/// layout. Returns `None` for PATH-fallback extensions (which have no
+/// managed install_dir) or when `exe_path` is in an unexpected shape.
+fn managed_install_dir(exe_path: &Path, extensions_root: &Path) -> Option<PathBuf> {
+    let parent = exe_path.parent()?;
+    if !parent.starts_with(extensions_root) {
+        return None;
+    }
+    Some(parent.to_path_buf())
+}
+
+fn load_author_manifest(install_dir: &Path) -> Option<AuthorManifest> {
+    let path = install_dir.join("flox-extension.toml");
+    let contents = std::fs::read_to_string(&path).ok()?;
+    match parse_author_manifest(&contents) {
+        Ok(m) => Some(m),
+        Err(e) => {
+            warn!(path = %path.display(), error = %e, "failed to parse extension author manifest");
+            None
+        },
+    }
+}
+
+fn load_installed_state(install_dir: &Path) -> Option<InstalledState> {
+    let path = install_dir.join("state.toml");
+    let contents = std::fs::read_to_string(&path).ok()?;
+    match parse_installed_state(&contents) {
+        Ok(s) => Some(s),
+        Err(e) => {
+            warn!(path = %path.display(), error = %e, "failed to parse extension installed state");
+            None
+        },
+    }
+}
+
+fn version_from_state(state: &InstalledState) -> String {
+    if !state.tag.is_empty() {
+        return state.tag.clone();
+    }
+    if state.commit.len() >= 8 {
+        return state.commit[..8].to_string();
+    }
+    "-".to_string()
+}
+
+/// Build the `Command` for a given activation mode. Does not inject the
+/// `FLOX_EXTENSION_*` bookkeeping vars; the caller overlays those on all
+/// three modes.
+fn build_dispatch_command(
+    mode: &ActivationMode,
+    ext_path: &Path,
+    rest: &[OsString],
+    flox_bin: &Path,
+    extension_name: &str,
+    on_active_inside: &str,
+) -> Result<Command, DispatchError> {
+    match mode {
+        ActivationMode::Inherit => {
+            let mut cmd = Command::new(ext_path);
+            cmd.args(rest);
+            Ok(cmd)
+        },
+        ActivationMode::None => {
+            let mut cmd = Command::new(ext_path);
+            cmd.args(rest);
+            cmd.env_clear();
+            cmd.envs(scrub_flox_env(std::env::vars_os()));
+            Ok(cmd)
+        },
+        ActivationMode::Pinned(pinned_ref) => {
+            let active = activated_environments();
+            if ref_matches_active(pinned_ref, &active) {
+                let mut cmd = Command::new(ext_path);
+                cmd.args(rest);
+                return Ok(cmd);
+            }
+            if on_active_inside == "error" && active.iter().next().is_some() {
+                return Err(DispatchError::PinnedEnvMismatch {
+                    extension: extension_name.to_string(),
+                    expected: pinned_ref.clone(),
+                });
+            }
+            let mut cmd = Command::new(flox_bin);
+            cmd.arg("activate").arg("-r").arg(pinned_ref).arg("--");
+            cmd.arg(ext_path);
+            cmd.args(rest);
+            Ok(cmd)
+        },
+    }
+}
+
+/// Return true when the caller is already activated in the environment
+/// referenced by `pinned_ref` (an opaque `owner/name` string). Non-matching
+/// or malformed refs degrade to `false` (the caller will wrap with `flox
+/// activate -r`).
+fn ref_matches_active(
+    pinned_ref: &str,
+    active: &crate::utils::active_environments::ActiveEnvironments,
+) -> bool {
+    let Some((owner, name)) = pinned_ref.split_once('/') else {
+        return false;
+    };
+    active.iter().any(|env| {
+        env.owner_if_managed().map(|o| o.as_str()) == Some(owner) && env.name().as_ref() == name
+    })
+}
+
+/// Whether beta features are enabled, according to the environment alone.
+///
+/// The `Commands::Beta` arm gates every beta subcommand on
+/// [`Flox::features`] before dispatching, so the `flox extension …`
+/// handlers must not re-check. This exists solely for
+/// [`try_dispatch_external`], which runs before `Flox` is initialized —
+/// see the limitation documented there.
+///
+/// Accepts the spelling the docs use (`true`) plus `1`. Anything else,
+/// including unset, leaves the feature off.
+fn beta_enabled_from_env() -> bool {
+    matches!(
+        std::env::var("FLOX_FEATURES_BETA")
+            .ok()
+            .as_deref()
+            .map(str::to_ascii_lowercase)
+            .as_deref(),
+        Some("true") | Some("1")
+    )
+}
+
+/// Compute the extensions root the same way `flox.data_dir` resolves:
+///   1. `FLOX_DATA_DIR` env var (matches the config-system override that
+///      `Flox::data_dir` would pick up after `Flox::init`), then
+///   2. `XDG_DATA_HOME/flox`, then
+///   3. `$HOME/.local/share/flox`.
+///
+/// Empty-string values are treated as unset, matching the `xdg` crate used
+/// by `BaseDirectories::with_prefix("flox")` in the config system.
+///
+/// This must agree with `beta::extensions::layout::extensions_root`,
+/// which derives from `flox.data_dir`. If they diverge, `flox extension install`
+/// writes to one path and `flox <name>` looks in another.
+fn extensions_root() -> PathBuf {
+    if let Some(d) = non_empty_env("FLOX_DATA_DIR") {
+        return PathBuf::from(d).join("extensions");
+    }
+    let base = non_empty_env("XDG_DATA_HOME")
+        .map(PathBuf::from)
+        .or_else(|| non_empty_env("HOME").map(|h| PathBuf::from(h).join(".local/share")))
+        .unwrap_or_else(|| PathBuf::from("."));
+    base.join("flox").join("extensions")
+}
+
+fn non_empty_env(key: &str) -> Option<OsString> {
+    std::env::var_os(key).filter(|v| !v.is_empty())
+}

--- a/cli/flox/src/commands/extension/mod.rs
+++ b/cli/flox/src/commands/extension/mod.rs
@@ -133,7 +133,16 @@ pub fn try_dispatch_external() -> Option<ExitCode> {
     debug!(extension = name_str, path = ?path, "dispatching to external extension");
 
     let install_dir = managed_install_dir(&path, &extensions_root);
-    let author_manifest = install_dir.as_deref().and_then(load_author_manifest);
+    let author_manifest = match install_dir.as_deref().map(load_author_manifest) {
+        None => None,
+        Some(Ok(m)) => m,
+        Some(Err(msg)) => {
+            // Fail closed: a present-but-unreadable manifest may declare a
+            // restrictive activation policy we must not silently ignore.
+            eprintln!("flox: {msg}");
+            return Some(ExitCode::from(1));
+        },
+    };
     let installed_state = install_dir.as_deref().and_then(load_installed_state);
 
     let mode = resolve_mode(
@@ -205,16 +214,24 @@ fn managed_install_dir(exe_path: &Path, extensions_root: &Path) -> Option<PathBu
     Some(parent.to_path_buf())
 }
 
-fn load_author_manifest(install_dir: &Path) -> Option<AuthorManifest> {
+/// Load the author manifest for dispatch.
+///
+/// `Ok(None)` means no manifest is present (no declared policy → the
+/// caller's default applies). `Err` means a manifest *is* present but
+/// could not be read or parsed: dispatch must fail closed rather than
+/// silently defaulting to `Inherit`, because the unreadable manifest may
+/// have declared `mode = "none"` (a scrubbed environment) or a pinned
+/// environment.
+fn load_author_manifest(install_dir: &Path) -> Result<Option<AuthorManifest>, String> {
     let path = install_dir.join("flox-extension.toml");
-    let contents = std::fs::read_to_string(&path).ok()?;
-    match parse_author_manifest(&contents) {
-        Ok(m) => Some(m),
-        Err(e) => {
-            warn!(path = %path.display(), error = %e, "failed to parse extension author manifest");
-            None
-        },
+    if !path.exists() {
+        return Ok(None);
     }
+    let contents = std::fs::read_to_string(&path)
+        .map_err(|e| format!("cannot read extension manifest {}: {e}", path.display()))?;
+    parse_author_manifest(&contents)
+        .map(Some)
+        .map_err(|e| format!("invalid extension manifest {}: {e}", path.display()))
 }
 
 fn load_installed_state(install_dir: &Path) -> Option<InstalledState> {
@@ -233,8 +250,12 @@ fn version_from_state(state: &InstalledState) -> String {
     if !state.tag.is_empty() {
         return state.tag.clone();
     }
-    if state.commit.len() >= 8 {
-        return state.commit[..8].to_string();
+    // Truncate by characters, not bytes: a byte slice at offset 8 can land
+    // inside a multibyte codepoint and panic on a non-ASCII (corrupt)
+    // commit value.
+    let short: String = state.commit.chars().take(8).collect();
+    if short.chars().count() == 8 {
+        return short;
     }
     "-".to_string()
 }

--- a/cli/flox/src/commands/extension/mod.rs
+++ b/cli/flox/src/commands/extension/mod.rs
@@ -119,6 +119,18 @@ pub fn try_dispatch_external() -> Option<ExitCode> {
     let name = name?;
     let name_str = name.to_str()?;
 
+    // Never let the external fallback shadow a built-in command. If the
+    // first token names a reserved (built-in) command, the parse failure
+    // was a bad invocation of that command — e.g. `flox init --badflag` —
+    // not an extension. Fall through to the parser's error instead of
+    // exec'ing a `flox-init` that happens to be on $PATH.
+    if beta::extensions::RESERVED_COMMAND_NAMES
+        .iter()
+        .any(|r| r.eq_ignore_ascii_case(name_str))
+    {
+        return None;
+    }
+
     let extensions_root = extensions_root();
     let path_env = std::env::var_os("PATH");
     let path = match dispatch::find(name_str, &extensions_root, path_env.as_deref()) {

--- a/cli/flox/src/commands/extension/remove.rs
+++ b/cli/flox/src/commands/extension/remove.rs
@@ -1,0 +1,26 @@
+use anyhow::Result;
+use beta::extensions;
+use bpaf::Bpaf;
+use flox_rust_sdk::flox::Flox;
+use tracing::instrument;
+
+use crate::subcommand_metric;
+use crate::utils::message;
+
+#[derive(Debug, Bpaf, Clone)]
+pub struct Remove {
+    /// Name of the installed extension to remove
+    #[bpaf(positional("NAME"))]
+    name: String,
+}
+
+impl Remove {
+    #[instrument(name = "extensions::remove", skip_all)]
+    pub async fn handle(self, flox: Flox) -> Result<()> {
+        subcommand_metric!("extensions::remove");
+
+        extensions::remove(&flox, &self.name)?;
+        message::updated(format!("Removed flox-{}", self.name));
+        Ok(())
+    }
+}

--- a/cli/flox/src/commands/extension/search.rs
+++ b/cli/flox/src/commands/extension/search.rs
@@ -1,0 +1,202 @@
+use std::str::FromStr;
+
+use anyhow::{Result, bail};
+use beta::extensions::{self, SearchQuery, SearchRow, SearchSort, validate_owner};
+use bpaf::Bpaf;
+use flox_rust_sdk::flox::Flox;
+use tracing::instrument;
+
+use crate::subcommand_metric;
+use crate::utils::message;
+
+/// `--sort <stars|updated>` — single flag with a value, matching the P08
+/// deliverable. `FromStr` gates the input so bpaf produces a type error
+/// instead of silently accepting an unknown mode.
+#[derive(Debug, Clone, Copy)]
+pub enum SortArg {
+    Stars,
+    Updated,
+}
+
+impl FromStr for SortArg {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "stars" => Ok(SortArg::Stars),
+            "updated" => Ok(SortArg::Updated),
+            other => Err(format!(
+                "unknown sort '{other}'; expected 'stars' or 'updated'"
+            )),
+        }
+    }
+}
+
+impl SortArg {
+    fn into_search_sort(self) -> SearchSort {
+        match self {
+            SortArg::Stars => SearchSort::Stars,
+            SortArg::Updated => SearchSort::Updated,
+        }
+    }
+}
+
+#[derive(Debug, Bpaf, Clone)]
+pub struct Search {
+    /// Limit results to a specific owner/organization
+    #[bpaf(long, argument("OWNER"))]
+    owner: Option<String>,
+
+    /// Maximum number of results to return (1–100)
+    #[bpaf(long, argument("N"), fallback(30))]
+    limit: u8,
+
+    /// Sort order: 'stars' (default) or 'updated'
+    #[bpaf(long, argument("MODE"), fallback(SortArg::Stars))]
+    sort: SortArg,
+
+    /// Free-form search term matched against repo name/description
+    #[bpaf(positional("QUERY"))]
+    query: Option<String>,
+}
+
+impl Search {
+    #[instrument(name = "extensions::search", skip_all)]
+    pub async fn handle(self, flox: Flox) -> Result<()> {
+        subcommand_metric!("extensions::search");
+
+        if let Some(owner) = self.owner.as_deref()
+            && let Err(e) = validate_owner(owner)
+        {
+            bail!("{e}");
+        }
+
+        let q = SearchQuery::new(
+            self.query.clone(),
+            self.owner.clone(),
+            self.limit,
+            self.sort.into_search_sort(),
+        );
+
+        let (rows, incomplete) = extensions::search(&flox, &q).await?;
+        if rows.is_empty() {
+            message::plain("No matching extensions found.");
+            return Ok(());
+        }
+
+        println!("{}", render_header());
+        for row in &rows {
+            println!("{}", render_row(row));
+        }
+
+        if incomplete {
+            message::warning("github reported incomplete results; re-run with a narrower query");
+        }
+
+        Ok(())
+    }
+}
+
+fn render_header() -> String {
+    format!(
+        "{:<2}  {:<40}  {:>6}  {}",
+        " ", "OWNER/REPO", "STARS", "DESCRIPTION"
+    )
+}
+
+fn render_row(row: &SearchRow) -> String {
+    let mark = if row.installed { "\u{2713}" } else { " " };
+    let desc = row.description.as_deref().unwrap_or("-");
+    let desc = truncate_description(desc, 60);
+    format!(
+        "{:<2}  {:<40}  {:>6}  {}",
+        mark, row.full_name, row.stars, desc
+    )
+}
+
+fn truncate_description(s: &str, max: usize) -> String {
+    if max == 0 {
+        return String::new();
+    }
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    let mut out: String = s.chars().take(max.saturating_sub(1)).collect();
+    out.push('\u{2026}');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use beta::extensions::SearchRow;
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    #[test]
+    fn row_marks_installed_with_check() {
+        let row = SearchRow {
+            full_name: "acme/flox-hello".to_string(),
+            stars: 42,
+            description: Some("hello world extension".to_string()),
+            installed: true,
+        };
+        let rendered = render_row(&row);
+        assert!(rendered.starts_with('\u{2713}'), "row: {rendered}");
+        assert!(rendered.contains("acme/flox-hello"));
+        assert!(rendered.contains("42"));
+    }
+
+    #[test]
+    fn row_without_install_has_no_check() {
+        let row = SearchRow {
+            full_name: "acme/flox-hello".to_string(),
+            stars: 1,
+            description: None,
+            installed: false,
+        };
+        let rendered = render_row(&row);
+        assert!(!rendered.contains('\u{2713}'), "row: {rendered}");
+        assert!(
+            rendered.contains('-'),
+            "missing description fallback: {rendered}"
+        );
+    }
+
+    #[test]
+    fn truncate_description_appends_ellipsis() {
+        let s: String = "a".repeat(80);
+        let out = truncate_description(&s, 10);
+        assert_eq!(out.chars().count(), 10);
+        assert!(out.ends_with('\u{2026}'));
+    }
+
+    #[test]
+    fn truncate_description_passthrough_when_short() {
+        assert_eq!(truncate_description("short", 60), "short");
+    }
+
+    #[test]
+    fn truncate_description_with_zero_max_returns_empty() {
+        // Guards against a subtle off-by-one: `max.saturating_sub(1)` is 0
+        // when `max == 0`, and without the early return we would still push
+        // an ellipsis, yielding a 1-char output exceeding the requested max.
+        assert_eq!(truncate_description("anything", 0), "");
+    }
+
+    #[test]
+    fn sort_arg_from_str_accepts_known_modes() {
+        assert!(matches!("stars".parse::<SortArg>(), Ok(SortArg::Stars)));
+        assert!(matches!("updated".parse::<SortArg>(), Ok(SortArg::Updated)));
+    }
+
+    #[test]
+    fn sort_arg_from_str_rejects_unknown_modes() {
+        let err = "random".parse::<SortArg>().unwrap_err();
+        assert!(err.contains("random"), "message missing input: {err}");
+        assert!(
+            err.contains("stars") && err.contains("updated"),
+            "message should list valid modes: {err}"
+        );
+    }
+}

--- a/cli/flox/src/commands/extension/upgrade.rs
+++ b/cli/flox/src/commands/extension/upgrade.rs
@@ -1,0 +1,162 @@
+use anyhow::{Result, bail};
+use beta::extensions::{self, DryRunStatus, UpgradeStatus};
+use bpaf::Bpaf;
+use flox_rust_sdk::flox::Flox;
+use tracing::instrument;
+
+use crate::subcommand_metric;
+use crate::utils::message;
+
+#[derive(Debug, Bpaf, Clone)]
+pub struct Upgrade {
+    /// Upgrade every installed extension instead of one
+    #[bpaf(long, switch)]
+    all: bool,
+
+    /// Resolve but don't mutate state.toml or the install dir
+    #[bpaf(long, switch)]
+    dry_run: bool,
+
+    /// Override pin and re-fetch (single-item or --all)
+    #[bpaf(long, switch)]
+    force: bool,
+
+    /// Name of the extension to upgrade (omit when --all is given)
+    #[bpaf(positional("NAME"), fallback(String::new()))]
+    name: String,
+}
+
+impl Upgrade {
+    #[instrument(name = "extensions::upgrade", skip_all)]
+    pub async fn handle(self, flox: Flox) -> Result<()> {
+        subcommand_metric!("extensions::upgrade");
+
+        match (self.all, self.name.is_empty()) {
+            // --all with NAME — ambiguous, reject.
+            (true, false) => bail!("--all and NAME are mutually exclusive"),
+            // Neither flag nor NAME — nothing to do.
+            (false, true) => {
+                bail!("usage: flox extension upgrade [--all] [--dry-run] [--force] [NAME]")
+            },
+            // --all without NAME — iterate every installed extension.
+            (true, true) => self.run_all(flox).await,
+            // NAME without --all — single-item path.
+            (false, false) => self.run_one(flox).await,
+        }
+    }
+
+    async fn run_one(&self, flox: Flox) -> Result<()> {
+        if self.dry_run {
+            match extensions::upgrade_dry_run(&flox, &self.name).await? {
+                DryRunStatus::WouldUpgrade { from, to } => {
+                    message::info(format!(
+                        "flox-{}: would upgrade {} -> {}",
+                        self.name,
+                        super::format::short_sha(&from),
+                        super::format::short_sha(&to)
+                    ));
+                },
+                DryRunStatus::AlreadyCurrent => {
+                    message::info(format!("flox-{} is already current", self.name));
+                },
+                DryRunStatus::Pinned => {
+                    message::info(format!(
+                        "flox-{} is pinned; pass --force to override",
+                        self.name
+                    ));
+                },
+            }
+            return Ok(());
+        }
+
+        match extensions::upgrade(&flox, &self.name, self.force).await? {
+            UpgradeStatus::Upgraded { from, to } => {
+                message::updated(format!(
+                    "Upgraded flox-{}: {} -> {}",
+                    self.name,
+                    super::format::short_sha(&from),
+                    super::format::short_sha(&to)
+                ));
+            },
+            UpgradeStatus::AlreadyCurrent => {
+                message::info(format!(
+                    "flox-{} is already at the latest commit",
+                    self.name
+                ));
+            },
+            UpgradeStatus::Pinned => {
+                bail!(
+                    "flox-{} is pinned; pass --force to override and re-fetch",
+                    self.name
+                );
+            },
+        }
+        Ok(())
+    }
+
+    async fn run_all(&self, flox: Flox) -> Result<()> {
+        let extensions_listed = extensions::list(&flox)?;
+        if extensions_listed.is_empty() {
+            message::plain("No extensions installed.");
+            return Ok(());
+        }
+        println!("{}", super::format::render_header());
+
+        if self.dry_run {
+            for result in extensions::upgrade_all_dry_run(&flox).await? {
+                let ext = extensions_listed.iter().find(|e| e.name == result.name);
+                let mut row = match ext {
+                    Some(e) => super::format::row_from_extension(e),
+                    None => super::format::row_for_unknown(&result.name),
+                };
+                row.status = Some(match &result.outcome {
+                    Ok(DryRunStatus::WouldUpgrade { from, to }) => {
+                        format!(
+                            "would upgrade {} -> {}",
+                            super::format::short_sha(from.as_str()),
+                            super::format::short_sha(to.as_str())
+                        )
+                    },
+                    Ok(DryRunStatus::AlreadyCurrent) => "up-to-date".to_string(),
+                    Ok(DryRunStatus::Pinned) => "pinned (skip)".to_string(),
+                    Err(e) => format!("error: {e}"),
+                });
+                println!("{}", super::format::render_row(&row));
+            }
+            return Ok(());
+        }
+
+        for result in extensions::upgrade_all(&flox, self.force).await? {
+            let ext = extensions_listed.iter().find(|e| e.name == result.name);
+            let mut row = match ext {
+                Some(e) => super::format::row_from_extension(e),
+                None => super::format::row_for_unknown(&result.name),
+            };
+            row.status = Some(match &result.outcome {
+                Ok(UpgradeStatus::Upgraded { from, to }) => {
+                    format!(
+                        "upgraded {} -> {}",
+                        super::format::short_sha(from.as_str()),
+                        super::format::short_sha(to.as_str())
+                    )
+                },
+                Ok(UpgradeStatus::AlreadyCurrent) => "up-to-date".to_string(),
+                Ok(UpgradeStatus::Pinned) => "pinned (skip)".to_string(),
+                Err(e) => format!("error: {e}"),
+            });
+            println!("{}", super::format::render_row(&row));
+
+            // Pinned-skip log line per research doc §2.9.
+            if let Ok(UpgradeStatus::Pinned) = &result.outcome {
+                let tag = ext
+                    .and_then(|e| (!e.state.tag.is_empty()).then(|| e.state.tag.clone()))
+                    .unwrap_or_else(|| "<unknown>".to_string());
+                message::info(format!(
+                    "skipping '{}' (pinned to {}); pass --force to override",
+                    result.name, tag
+                ));
+            }
+        }
+        Ok(())
+    }
+}

--- a/cli/flox/src/commands/extension/upgrade.rs
+++ b/cli/flox/src/commands/extension/upgrade.rs
@@ -47,7 +47,7 @@ impl Upgrade {
 
     async fn run_one(&self, flox: Flox) -> Result<()> {
         if self.dry_run {
-            match extensions::upgrade_dry_run(&flox, &self.name).await? {
+            match extensions::upgrade_dry_run(&flox, &self.name, self.force).await? {
                 DryRunStatus::WouldUpgrade { from, to } => {
                     message::info(format!(
                         "flox-{}: would upgrade {} -> {}",
@@ -103,7 +103,7 @@ impl Upgrade {
         println!("{}", super::format::render_header());
 
         if self.dry_run {
-            for result in extensions::upgrade_all_dry_run(&flox).await? {
+            for result in extensions::upgrade_all_dry_run(&flox, self.force).await? {
                 let ext = extensions_listed.iter().find(|e| e.name == result.name);
                 let mut row = match ext {
                     Some(e) => super::format::row_from_extension(e),

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -9,6 +9,7 @@ mod deactivate;
 mod delete;
 mod edit;
 mod envs;
+pub mod extension;
 mod factory;
 mod gc;
 pub(crate) mod general;

--- a/cli/flox/src/main.rs
+++ b/cli/flox/src/main.rs
@@ -148,6 +148,12 @@ fn main() -> ExitCode {
                 return ExitCode::from(0);
             },
             bpaf::ParseFailure::Stderr(m) => {
+                // `flox <name>` may be an installed beta extension rather than a
+                // typo. Only reached once the parse has already failed, and a
+                // miss falls through to the unchanged error below.
+                if let Some(exit) = commands::extension::try_dispatch_external() {
+                    return exit;
+                }
                 message::error(format!("{m:80}"));
                 return ExitCode::from(1);
             },

--- a/cli/flox/src/main.rs
+++ b/cli/flox/src/main.rs
@@ -144,6 +144,15 @@ fn main() -> ExitCode {
     if let Some(parse_err) = args.as_ref().err() {
         match parse_err {
             bpaf::ParseFailure::Stdout(m, _) => {
+                // `flox <name> --help` lands here, not in the `Stderr` arm:
+                // bpaf treats `--help` as a global short-circuit that fires
+                // before it decides `<name>` is unknown, so the help text is
+                // produced instead of a parse error. Attempt dispatch first so
+                // an installed extension's own `--help` is shown; the reserved
+                // guard and a lookup miss both fall through to flox's help.
+                if let Some(exit) = commands::extension::try_dispatch_external() {
+                    return exit;
+                }
                 print!("{m:80}");
                 return ExitCode::from(0);
             },

--- a/cli/tests/extension.bats
+++ b/cli/tests/extension.bats
@@ -1,0 +1,1066 @@
+#! /usr/bin/env bats
+# -*- mode: bats; -*-
+# ============================================================================ #
+#
+# Tests for the `flox extension` subcommand and the `flox <name>` two-phase
+# parse fallback that dispatches to a `flox-<name>` external executable.
+#
+# Covers P01 (skeleton + dispatch) and P02 (local install / list / remove
+# lifecycle). GitHub sources are P03+.
+#
+# ---------------------------------------------------------------------------- #
+
+load test_support.bash
+
+# bats file_tags=extension
+
+# ---------------------------------------------------------------------------- #
+
+setup() {
+  common_test_setup
+  setup_isolated_flox
+  # setup_isolated_flox exports FLOX_DATA_DIR; the dispatch path resolves
+  # the extensions root the same way `flox.data_dir` does (FLOX_DATA_DIR
+  # first, then XDG_DATA_HOME), so fixtures live under FLOX_DATA_DIR.
+  export EXT_ROOT="${FLOX_DATA_DIR?}/extensions"
+  mkdir -p "$EXT_ROOT"
+  # Extensions are a beta feature and off by default. Enable for every test
+  # here; the two tests that assert the disabled behavior `unset` it in
+  # their own body, which runs after setup.
+  export FLOX_FEATURES_BETA=true
+}
+
+teardown() {
+  common_test_teardown
+}
+
+# ---------------------------------------------------------------------------- #
+
+@test "extension: 'flox <name>' dispatches to flox-<name> when extensions enabled" {
+  export FLOX_FEATURES_BETA=true
+  local ext_dir="$EXT_ROOT/flox-hello"
+  mkdir -p "$ext_dir"
+  cat > "$ext_dir/flox-hello" <<'EOF'
+#!/usr/bin/env bash
+echo "hello from extension"
+EOF
+  chmod +x "$ext_dir/flox-hello"
+
+  run "$FLOX_BIN" hello
+  assert_success
+  assert_output --partial "hello from extension"
+}
+
+@test "extension: 'flox <name>' dispatch is off unless FLOX_FEATURES_BETA is set" {
+  unset FLOX_FEATURES_BETA
+  local ext_dir="$EXT_ROOT/flox-hello"
+  mkdir -p "$ext_dir"
+  cat > "$ext_dir/flox-hello" <<'EOF'
+#!/usr/bin/env bash
+echo "hello from extension"
+EOF
+  chmod +x "$ext_dir/flox-hello"
+
+  run "$FLOX_BIN" hello
+  assert_failure
+  refute_output --partial "hello from extension"
+}
+
+@test "extension: 'flox extension --help' lists install/list/remove/search/upgrade" {
+  run "$FLOX_BIN" extension --help
+  assert_success
+  assert_output --partial "install"
+  assert_output --partial "list"
+  assert_output --partial "remove"
+  assert_output --partial "search"
+  assert_output --partial "upgrade"
+}
+
+@test "extension: 'flox --help' does not list extension (beta commands are hidden)" {
+  run "$FLOX_BIN" --help
+  assert_success
+  # bats-assert `--regexp` matches the entire `$output` as a single
+  # string, so `^` only anchors to the very start. Match the line by
+  # requiring a newline (or string start) before the leading spaces.
+  refute_output --regexp '(^|'$'\n'')[[:space:]]*extension[[:space:]]+Manage flox extensions'
+}
+
+@test "extension: subcommands refuse to run when beta is disabled" {
+  unset FLOX_FEATURES_BETA
+  run "$FLOX_BIN" extension list
+  assert_failure
+  assert_output --partial "flox config --set features.beta true"
+}
+
+# P02-TS07: full install -> list -> dispatch -> remove -> list-empty lifecycle
+# against a local source.
+@test "extension: install/list/dispatch/remove lifecycle (local source via --from-path)" {
+  export FLOX_FEATURES_BETA=true
+
+  # Author a tiny local extension at $BATS_TEST_TMPDIR/flox-hello.
+  local src="$BATS_TEST_TMPDIR/flox-hello"
+  mkdir -p "$src"
+  cat > "$src/flox-hello" <<'EOF'
+#!/usr/bin/env bash
+echo "hello from extension"
+EOF
+  chmod +x "$src/flox-hello"
+
+  # Install — name derived from source dirname (no manifest).
+  run "$FLOX_BIN" extension install --from-path "$src"
+  assert_success
+  assert_output --partial "Installed flox-hello"
+
+  # List — table includes hello, repo column shows '.', version is '-'.
+  run "$FLOX_BIN" extension list
+  assert_success
+  assert_output --partial "hello"
+  assert_output --partial "."
+
+  # Dispatch — `flox hello` should now resolve to the installed executable.
+  run "$FLOX_BIN" hello
+  assert_success
+  assert_output --partial "hello from extension"
+
+  # Remove.
+  run "$FLOX_BIN" extension remove hello
+  assert_success
+  assert_output --partial "Removed flox-hello"
+
+  # List again — empty.
+  run "$FLOX_BIN" extension list
+  assert_success
+  assert_output --partial "No extensions installed."
+}
+
+# ---------------------------------------------------------------------------- #
+# P03 — GitHub source helpers
+#
+# These tests exercise the real `install_github` / `upgrade` code paths
+# without needing live network. The trick is twofold:
+#
+#   1. A local bare git repo stands in for github.com/<owner>/<repo>.git.
+#      `GIT_CONFIG_COUNT` / `GIT_CONFIG_KEY_0` / `GIT_CONFIG_VALUE_0`
+#      env vars inject a `url.<file://bare>.insteadOf` entry into the
+#      git process spawned by `GitHubSource::clone_repo`, redirecting
+#      the `https://github.com/owner/flox-hello.git` URL to the local
+#      bare repo. Using env vars rather than `git config --global`
+#      avoids contention on the suite-wide `gitconfig.global` file when
+#      multiple bats files run in parallel.
+#
+#   2. A tiny Python `http.server` returns canned JSON for the GitHub API
+#      endpoints `install_github` hits. `FLOX_EXTENSIONS_GITHUB_BASE_URL`
+#      points `GitHubSource::from_env()` at it.
+#
+# `_setup_github_fixture` builds both and exports `FIXTURE_SHA`.
+# `_teardown_github_fixture` kills the server and unsets the redirect.
+# ---------------------------------------------------------------------------- #
+
+_setup_github_fixture() {
+  local work="$BATS_TEST_TMPDIR/work-flox-hello"
+  local bare="$BATS_TEST_TMPDIR/bare/flox-hello.git"
+  mkdir -p "$work" "$(dirname "$bare")"
+  git init -q --bare "$bare"
+  git init -q -b main "$work"
+  cat > "$work/flox-hello" <<'EOF'
+#!/usr/bin/env bash
+echo "hello from gh"
+EOF
+  chmod +x "$work/flox-hello"
+  git -C "$work" -c user.email=t@e -c user.name=t -c commit.gpgsign=false add -A
+  git -C "$work" -c user.email=t@e -c user.name=t -c commit.gpgsign=false commit -q -m initial
+  git -C "$work" remote add origin "$bare"
+  git -C "$work" push -q origin main
+
+  export FIXTURE_WORK="$work"
+  export FIXTURE_BARE="$bare"
+  export FIXTURE_SHA
+  FIXTURE_SHA="$(git -C "$work" rev-parse HEAD)"
+
+  cat > "$BATS_TEST_TMPDIR/api.py" <<EOF
+import json, sys, http.server
+SHA = "$FIXTURE_SHA"
+class H(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        # Strip query string before routing.
+        path = self.path.split("?", 1)[0]
+        query = self.path.split("?", 1)[1] if "?" in self.path else ""
+        if path == "/repos/owner/flox-hello/releases/latest":
+            self.send_response(404); self.end_headers(); return
+        if path == "/search/repositories":
+            # TS07: trigger incomplete_results when the query contains
+            # the literal token 'incomplete'.
+            incomplete = "incomplete" in query
+            body = json.dumps({
+                "total_count": 2,
+                "incomplete_results": incomplete,
+                "items": [
+                    {
+                        "full_name": "owner/flox-hello",
+                        "owner": {"login": "owner"},
+                        "name": "flox-hello",
+                        "stargazers_count": 42,
+                        "description": "canonical hello extension",
+                        "archived": False,
+                        "html_url": "https://github.com/owner/flox-hello"
+                    },
+                    {
+                        "full_name": "acme/flox-world",
+                        "owner": {"login": "acme"},
+                        "name": "flox-world",
+                        "stargazers_count": 7,
+                        "description": "another extension",
+                        "archived": False,
+                        "html_url": "https://github.com/acme/flox-world"
+                    }
+                ]
+            }).encode()
+        elif path == "/repos/owner/flox-hello":
+            body = json.dumps({"default_branch": "main"}).encode()
+        elif path.startswith("/repos/owner/flox-hello/commits/"):
+            body = json.dumps({"sha": SHA}).encode()
+        elif path.startswith("/repos/owner/flox-hello/releases/tags/"):
+            tag = path.rsplit("/", 1)[-1]
+            body = json.dumps({"tag_name": tag}).encode()
+        else:
+            self.send_response(404); self.end_headers(); return
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+    def log_message(self, *a, **k):
+        pass
+s = http.server.HTTPServer(("127.0.0.1", 0), H)
+print(s.server_address[1], flush=True)
+s.serve_forever()
+EOF
+  # Use `python3` if available; else fall back to `python`. Skip the
+  # test cleanly if neither is on PATH — the `flox-cli-tests` Nix
+  # wrapper controls the PATH and is the source of truth for whether
+  # python is available in CI.
+  local py
+  if command -v python3 > /dev/null 2>&1; then
+    py=python3
+  elif command -v python > /dev/null 2>&1; then
+    py=python
+  else
+    skip "python3 not available in test environment"
+  fi
+
+  $py "$BATS_TEST_TMPDIR/api.py" > "$BATS_TEST_TMPDIR/port.txt" &
+  echo $! > "$BATS_TEST_TMPDIR/api.pid"
+  local i
+  for i in $(seq 1 50); do
+    [ -s "$BATS_TEST_TMPDIR/port.txt" ] && break
+    sleep 0.1
+  done
+  local port
+  port="$(cat "$BATS_TEST_TMPDIR/port.txt")"
+  export FLOX_EXTENSIONS_GITHUB_BASE_URL="http://127.0.0.1:$port"
+
+  # Redirect the github clone URL to the local bare repo via git's
+  # GIT_CONFIG_COUNT env-var interface. This avoids contending for the
+  # suite-wide `gitconfig.global` file (which other parallel bats files
+  # also write to) and gives this test its own private config entries
+  # without a lockfile.
+  export GIT_CONFIG_COUNT=1
+  export GIT_CONFIG_KEY_0="url.file://$bare.insteadOf"
+  export GIT_CONFIG_VALUE_0="https://github.com/owner/flox-hello.git"
+}
+
+_teardown_github_fixture() {
+  if [ -f "$BATS_TEST_TMPDIR/api.pid" ]; then
+    kill "$(cat "$BATS_TEST_TMPDIR/api.pid")" 2>/dev/null || true
+  fi
+  unset GIT_CONFIG_COUNT GIT_CONFIG_KEY_0 GIT_CONFIG_VALUE_0
+}
+
+# P04 fixture: release body with assets[] + a tarball served from the same
+# Python http.server. No git redirect is needed because the binary-install
+# flow skips `git clone` entirely in favor of downloading the asset.
+#
+# Args: $1=tag (default v1.0.0)
+_setup_github_binary_fixture() {
+  local tag="${1:-v1.0.0}"
+  local py
+  if command -v python3 > /dev/null 2>&1; then
+    py=python3
+  elif command -v python > /dev/null 2>&1; then
+    py=python
+  else
+    skip "python3 not available in test environment"
+  fi
+
+  # Detect host OS/arch using the same names the Rust resolver emits.
+  local host_os host_arch
+  case "$(uname -s)" in
+    Darwin) host_os=darwin ;;
+    Linux)  host_os=linux ;;
+    *)      skip "unsupported host OS for P04 bats fixture: $(uname -s)" ;;
+  esac
+  case "$(uname -m)" in
+    x86_64|amd64)   host_arch=x86_64 ;;
+    arm64|aarch64)  host_arch=aarch64 ;;
+    *)              skip "unsupported host arch for P04 bats fixture: $(uname -m)" ;;
+  esac
+
+  local asset_name="flox-hello-${host_os}-${host_arch}.tar.gz"
+  local asset_path="$BATS_TEST_TMPDIR/$asset_name"
+  local stage="$BATS_TEST_TMPDIR/stage-$tag"
+  mkdir -p "$stage"
+  cat > "$stage/flox-hello" <<EOF
+#!/usr/bin/env bash
+echo "hello from binary ${tag}"
+EOF
+  chmod +x "$stage/flox-hello"
+  # Build the tarball via Python's stdlib so the test does not depend on an
+  # external `gzip` binary being on PATH (the bats env only has gnutar +
+  # coreutils, and gnutar's `-z` shells out to `gzip`).
+  "$py" - "$stage/flox-hello" "$asset_path" <<'PYEOF'
+import os, sys, tarfile
+src, dest = sys.argv[1], sys.argv[2]
+with tarfile.open(dest, "w:gz") as tf:
+    ti = tf.gettarinfo(src, arcname="flox-hello")
+    ti.mode = 0o755
+    with open(src, "rb") as f:
+        tf.addfile(ti, f)
+PYEOF
+
+  # Fake a commit SHA — the binary-install flow records this verbatim but
+  # does not otherwise use it for verification.
+  local sha="cafef00d00000000000000000000000000000000"
+  export FIXTURE_SHA="$sha"
+  export FIXTURE_TAG="$tag"
+  export FIXTURE_ASSET_NAME="$asset_name"
+  export FIXTURE_ASSET_PATH="$asset_path"
+
+  cat > "$BATS_TEST_TMPDIR/api.py" <<EOF
+import json, os, sys, http.server
+SHA = "$sha"
+TAG = "$tag"
+ASSET_NAME = "$asset_name"
+ASSET_PATH = "$asset_path"
+class H(http.server.BaseHTTPRequestHandler):
+    def _release_body(self, port):
+        url = f"http://127.0.0.1:{port}/asset/{ASSET_NAME}"
+        return json.dumps({
+            "tag_name": TAG,
+            "target_commitish": "main",
+            "assets": [{
+                "name": ASSET_NAME,
+                "browser_download_url": url,
+                "size": os.path.getsize(ASSET_PATH),
+                "content_type": "application/gzip",
+            }],
+        }).encode()
+    def do_GET(self):
+        port = self.server.server_address[1]
+        if self.path == "/repos/owner/flox-hello/releases/latest":
+            body = self._release_body(port)
+        elif self.path == f"/repos/owner/flox-hello/releases/tags/{TAG}":
+            body = self._release_body(port)
+        elif self.path == "/repos/owner/flox-hello":
+            body = json.dumps({"default_branch": "main"}).encode()
+        elif self.path.startswith("/repos/owner/flox-hello/commits/"):
+            body = json.dumps({"sha": SHA}).encode()
+        elif self.path == f"/asset/{ASSET_NAME}":
+            with open(ASSET_PATH, "rb") as f:
+                data = f.read()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/gzip")
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+            return
+        else:
+            self.send_response(404); self.end_headers(); return
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+    def log_message(self, *a, **k):
+        pass
+s = http.server.HTTPServer(("127.0.0.1", 0), H)
+print(s.server_address[1], flush=True)
+s.serve_forever()
+EOF
+
+  $py "$BATS_TEST_TMPDIR/api.py" > "$BATS_TEST_TMPDIR/port.txt" &
+  echo $! > "$BATS_TEST_TMPDIR/api.pid"
+  local i
+  for i in $(seq 1 50); do
+    [ -s "$BATS_TEST_TMPDIR/port.txt" ] && break
+    sleep 0.1
+  done
+  local port
+  port="$(cat "$BATS_TEST_TMPDIR/port.txt")"
+  export FLOX_EXTENSIONS_GITHUB_BASE_URL="http://127.0.0.1:$port"
+}
+
+_teardown_github_binary_fixture() {
+  if [ -f "$BATS_TEST_TMPDIR/api.pid" ]; then
+    kill "$(cat "$BATS_TEST_TMPDIR/api.pid")" 2>/dev/null || true
+  fi
+  unset FLOX_EXTENSIONS_GITHUB_BASE_URL FIXTURE_SHA FIXTURE_TAG FIXTURE_ASSET_NAME FIXTURE_ASSET_PATH
+}
+
+# P03-TS05: clone-from-bare-repo install + dispatch
+@test "extension: install owner/flox-hello from a local bare repo" {
+  export FLOX_FEATURES_BETA=true
+  _setup_github_fixture
+
+  run "$FLOX_BIN" extension install owner/flox-hello
+  assert_success
+  assert_output --partial "Installed flox-hello"
+
+  run "$FLOX_BIN" hello
+  assert_success
+  assert_output --partial "hello from gh"
+
+  _teardown_github_fixture
+}
+
+# P03-TS06: --pin pins; upgrade is no-op without --force, refetches with --force
+@test "extension: --pin and upgrade --force lifecycle" {
+  export FLOX_FEATURES_BETA=true
+  _setup_github_fixture
+
+  run "$FLOX_BIN" extension install --pin "$FIXTURE_SHA" owner/flox-hello
+  assert_success
+  assert_output --partial "Installed flox-hello"
+
+  run "$FLOX_BIN" extension upgrade hello
+  assert_failure
+  assert_output --partial "pinned"
+
+  run "$FLOX_BIN" extension upgrade --force hello
+  assert_success
+
+  _teardown_github_fixture
+}
+
+# P03-TS07: --force install overwrites a prior install at the same name
+@test "extension: --force install overwrites prior install" {
+  export FLOX_FEATURES_BETA=true
+  _setup_github_fixture
+
+  run "$FLOX_BIN" extension install owner/flox-hello
+  assert_success
+
+  # Re-install without --force fails.
+  run "$FLOX_BIN" extension install owner/flox-hello
+  assert_failure
+  assert_output --partial "already installed"
+
+  # With --force it succeeds.
+  run "$FLOX_BIN" extension install --force owner/flox-hello
+  assert_success
+
+  _teardown_github_fixture
+}
+
+# P04-TS06: install a precompiled-binary release asset, dispatch, then
+# upgrade to a newer tag and verify the executable changed.
+@test "extension: install binary release asset and upgrade" {
+  export FLOX_FEATURES_BETA=true
+  _setup_github_binary_fixture "v1.0.0"
+
+  run "$FLOX_BIN" extension install owner/flox-hello
+  assert_success
+  assert_output --partial "Installed flox-hello"
+
+  run "$FLOX_BIN" hello
+  assert_success
+  assert_output --partial "hello from binary v1.0.0"
+
+  # state.toml should record kind=binary and the asset sha.
+  run cat "$EXT_ROOT/flox-hello/state.toml"
+  assert_success
+  assert_output --partial "kind = \"binary\""
+  assert_output --partial "tag = \"v1.0.0\""
+  assert_output --partial "asset_sha256"
+
+  # Bounce the fixture onto a newer tag with a different asset body.
+  _teardown_github_binary_fixture
+  _setup_github_binary_fixture "v1.0.1"
+
+  run "$FLOX_BIN" extension upgrade hello
+  assert_success
+
+  run "$FLOX_BIN" hello
+  assert_success
+  assert_output --partial "hello from binary v1.0.1"
+
+  _teardown_github_binary_fixture
+}
+
+# P05-TS04: pre-seed one pinned-git + one local extension and assert
+# `upgrade --all --dry-run` prints a row per extension, exercising both
+# the pinned-skip path and a non-upgradable kind in the same table.
+@test "extension: upgrade --all --dry-run prints a row per installed extension" {
+  export FLOX_FEATURES_BETA=true
+  _setup_github_fixture
+
+  # Pinned script install — exercises the DryRunStatus::Pinned branch.
+  run "$FLOX_BIN" extension install --pin "$FIXTURE_SHA" owner/flox-hello
+  assert_success
+
+  # Local extension — exercises the per-row error branch (LocalNotSupported).
+  local local_src="$BATS_TEST_TMPDIR/flox-local"
+  mkdir -p "$local_src"
+  cat > "$local_src/flox-local" <<'EOF'
+#!/usr/bin/env bash
+echo "hi"
+EOF
+  chmod +x "$local_src/flox-local"
+  run "$FLOX_BIN" extension install --from-path "$local_src"
+  assert_success
+
+  run "$FLOX_BIN" extension upgrade --all --dry-run
+  assert_success
+  assert_output --partial "NAME"
+  assert_output --partial "STATUS"
+  assert_output --partial "hello"
+  assert_output --partial "local"
+  assert_output --partial "pinned"
+
+  _teardown_github_fixture
+}
+
+# P05-TS05: error strings from research-doc §2.9 must match verbatim.
+@test "extension: install rejects reserved name with the §2.9 message" {
+  export FLOX_FEATURES_BETA=true
+  local src="$BATS_TEST_TMPDIR/flox-install"
+  mkdir -p "$src"
+  echo '#!/bin/sh' > "$src/flox-install"
+  chmod +x "$src/flox-install"
+
+  run "$FLOX_BIN" extension install --from-path "$src"
+  assert_failure
+  assert_output --partial "name 'install' conflicts with a built-in flox command"
+}
+
+# P11-TS05: drift guard for RESERVED_COMMAND_NAMES.
+#
+# `try_dispatch_external` only fires when bpaf fails to parse the first
+# positional, so a built-in always shadows a same-named extension. The
+# installer refuses reserved names to stop users installing something that
+# could never dispatch — but that list is hand-maintained in
+# `cli/beta/src/extensions/reserved.rs` and silently rots when flox gains a
+# command. This walks every visible top-level command and asserts the
+# installer refuses it.
+#
+# Black-box on purpose: it exercises the shipped parser and the real
+# installer, so it needs no test code in the `flox` crate.
+#
+# Parsing note: command rows are indented exactly four spaces. Options are
+# also four-space indented but begin with `-`, and wrapped description text
+# is indented far deeper — matching that by accident is how a previous
+# version of this check mistook the wrapped word "invocation" for a
+# command. Stopping at "Available options:" and requiring `[a-z]` after
+# exactly four spaces excludes both.
+#
+# Hidden commands (`extension`, `help`, `beta-enabled`, `factory`) never
+# appear in --help and cannot be covered here; they are listed by hand in
+# reserved.rs.
+@test "extension: reserved-name list covers every visible top-level command" {
+  export FLOX_FEATURES_BETA=true
+
+  run "$FLOX_BIN" --help
+  assert_success
+  local commands
+  commands="$(printf '%s\n' "$output" \
+    | awk '/^Available options:/ {exit} /^    [a-z]/ {print $1}' \
+    | tr -d ',' | sort -u)"
+
+  # Guard the guard: if the help layout changes and we scrape nothing,
+  # every assertion below would vacuously pass.
+  local count
+  count="$(printf '%s\n' "$commands" | grep -c .)"
+  [ "$count" -ge 10 ] || {
+    echo "expected >=10 top-level commands, parsed $count -- help layout changed?" >&2
+    return 1
+  }
+
+  # `--from-path` derives the extension name from the *directory* basename,
+  # which must be `flox-<name>`; give each candidate its own parent so the
+  # directories don't collide.
+  local cmd dir
+  for cmd in $commands; do
+    dir="$BATS_TEST_TMPDIR/reserved/$cmd/flox-$cmd"
+    mkdir -p "$dir"
+    echo '#!/bin/sh' > "$dir/flox-$cmd"
+    chmod +x "$dir/flox-$cmd"
+
+    run "$FLOX_BIN" extension install --from-path "$dir"
+    assert_failure
+    assert_output --partial "name '$cmd' conflicts with a built-in flox command"
+  done
+}
+
+@test "extension: second install without --force emits the §2.9 message" {
+  export FLOX_FEATURES_BETA=true
+  _setup_github_fixture
+
+  run "$FLOX_BIN" extension install owner/flox-hello
+  assert_success
+
+  run "$FLOX_BIN" extension install owner/flox-hello
+  assert_failure
+  assert_output --partial "flox-hello is already installed (run with --force to overwrite)"
+
+  _teardown_github_fixture
+}
+
+@test "extension: missing executable emits the §2.9 message" {
+  export FLOX_FEATURES_BETA=true
+  local src="$BATS_TEST_TMPDIR/flox-noexe"
+  mkdir -p "$src"
+  # Intentionally no flox-noexe executable inside.
+
+  run "$FLOX_BIN" extension install --from-path "$src"
+  assert_failure
+  assert_output --partial "has no executable"
+}
+
+@test "extension: upgrade on pinned without --force emits the pinned-skip hint" {
+  export FLOX_FEATURES_BETA=true
+  _setup_github_fixture
+
+  run "$FLOX_BIN" extension install --pin "$FIXTURE_SHA" owner/flox-hello
+  assert_success
+
+  run "$FLOX_BIN" extension upgrade hello
+  assert_failure
+  assert_output --partial "pinned"
+
+  _teardown_github_fixture
+}
+
+# P08-TS06: `flox extension search` decorates installed repos with a ✓
+# and leaves uninstalled repos unmarked.
+@test "extension: search marks installed repos with check and leaves others unmarked" {
+  export FLOX_FEATURES_BETA=true
+  _setup_github_fixture
+
+  run "$FLOX_BIN" extension install owner/flox-hello
+  assert_success
+
+  run "$FLOX_BIN" extension search hello
+  assert_success
+  assert_output --partial "OWNER/REPO"
+  assert_output --partial "STARS"
+  assert_output --regexp '✓[[:space:]]+owner/flox-hello'
+  assert_output --regexp '[[:space:]]+acme/flox-world'
+  refute_output --regexp '✓[[:space:]]+acme/flox-world'
+
+  _teardown_github_fixture
+}
+
+# P08-TS07: when the Search API sets `incomplete_results: true`, a stderr
+# warning is emitted and the exit code is still 0.
+@test "extension: search warns on incomplete_results without failing" {
+  export FLOX_FEATURES_BETA=true
+  _setup_github_fixture
+
+  # The fixture flips incomplete_results on when the query string
+  # contains the literal token 'incomplete'.
+  run "$FLOX_BIN" extension search incomplete
+  assert_success
+  assert_output --partial "incomplete results"
+
+  _teardown_github_fixture
+}
+
+# ---------------------------------------------------------------------------- #
+# P06 — Environment integration (Inherit / None / Pinned)
+#
+# The managed-extension layout is `$EXT_ROOT/flox-<name>/flox-<name>`; P06
+# also reads `flox-extension.toml` (optional `[environment]` stanza) and
+# `state.toml` (for `FLOX_EXTENSION_VERSION`) from the same directory. These
+# helpers write a managed extension with a user-supplied script body and an
+# optional author manifest.
+# ---------------------------------------------------------------------------- #
+
+# Write a managed extension at $EXT_ROOT/flox-<name>/flox-<name>.
+# Args: $1=name, $2=script_body (stdin body after shebang).
+_p06_mk_managed_ext() {
+  local name="$1"
+  local body="$2"
+  local ext_dir="$EXT_ROOT/flox-$name"
+  mkdir -p "$ext_dir"
+  printf '%s\n' '#!/usr/bin/env bash' "$body" > "$ext_dir/flox-$name"
+  chmod +x "$ext_dir/flox-$name"
+  # Minimal state.toml — supplies `FLOX_EXTENSION_NAME` / `_VERSION`.
+  cat > "$ext_dir/state.toml" <<EOF
+schema = "1"
+name = "$name"
+kind = "local"
+source = "."
+installed_at = "1970-01-01T00:00:00Z"
+path = "$ext_dir/flox-$name"
+EOF
+}
+
+# Write flox-extension.toml with a `[environment]` stanza.
+# Args: $1=name, $2=mode ("inherit"|"none"|"pinned"),
+#       $3=inherit_name (for pinned, else ""),
+#       $4=on_active_inside ("error"|""|skip).
+_p06_write_author_manifest() {
+  local name="$1"
+  local mode="$2"
+  local inherit_name="$3"
+  local on_active="$4"
+  local path="$EXT_ROOT/flox-$name/flox-extension.toml"
+  {
+    echo 'schema = "1"'
+    echo
+    echo '[extension]'
+    echo "name = \"$name\""
+    echo
+    echo '[environment]'
+    echo "mode = \"$mode\""
+    [ -n "$inherit_name" ] && echo "inherit_name = \"$inherit_name\""
+    if [ -n "$on_active" ]; then
+      echo
+      echo '[on_active]'
+      echo "inside = \"$on_active\""
+    fi
+  } > "$path"
+}
+
+# P06-TS04: Inherit mode, outside any activation. `FLOX_ENV` is unset in
+# the parent shell, so the extension sees it unset too. Bookkeeping vars
+# are present on all three modes.
+@test "extension: P06 Inherit mode outside activation sees no FLOX_ENV" {
+  export FLOX_FEATURES_BETA=true
+  _p06_mk_managed_ext "probe" \
+    'echo "FLOX_ENV=${FLOX_ENV:-unset}"
+echo "EXT_NAME=${FLOX_EXTENSION_NAME:-unset}"'
+  # No author manifest → default Inherit mode.
+  unset FLOX_ENV
+  unset _FLOX_ACTIVE_ENVIRONMENTS
+
+  run "$FLOX_BIN" probe
+  assert_success
+  assert_output --partial "FLOX_ENV=unset"
+  assert_output --partial "EXT_NAME=probe"
+}
+
+# P06-TS05: Inherit mode, inside an activation. The ambient `flox activate`
+# sets FLOX_ENV; the extension inherits it.
+@test "extension: P06 Inherit mode inside activation sees ambient FLOX_ENV" {
+  export FLOX_FEATURES_BETA=true
+  _p06_mk_managed_ext "probe" 'echo "FLOX_ENV=${FLOX_ENV:-unset}"'
+  # No author manifest → default Inherit mode.
+
+  local proj="$BATS_TEST_TMPDIR/p06-inherit-inside"
+  mkdir -p "$proj"
+  pushd "$proj" > /dev/null
+  "$FLOX_BIN" init -d "$proj" > /dev/null
+
+  run "$FLOX_BIN" activate -d "$proj" -- "$FLOX_BIN" probe
+  popd > /dev/null
+  assert_success
+  refute_output --partial "FLOX_ENV=unset"
+  assert_output --partial "FLOX_ENV="
+}
+
+# P06-TS06: Pinned mode, no matching active env. The dispatcher wraps the
+# call in `flox activate -r owner/<name> --`. Without a real FloxHub ref
+# the activation fails — but we can verify the pinned-ref activation code
+# path was attempted by looking for the FloxHub-resolution error.
+@test "extension: P06 Pinned mode outside activation attempts flox activate -r" {
+  export FLOX_FEATURES_BETA=true
+  _p06_mk_managed_ext "probe" 'echo PROBE_RAN_OUTSIDE_ACTIVATION'
+  _p06_write_author_manifest "probe" "pinned" "owner/no-such-env" ""
+  unset _FLOX_ACTIVE_ENVIRONMENTS
+
+  run "$FLOX_BIN" probe
+  # Expected to fail because owner/no-such-env does not exist, but the
+  # failure must come from the activation attempt (not from a silent fall
+  # through to direct execution of the extension).
+  assert_failure
+  refute_output --partial "PROBE_RAN_OUTSIDE_ACTIVATION"
+}
+
+# P06-TS07: Pinned mode where the caller is already activated in the
+# pinned env (same owner/name). The dispatcher short-circuits the wrapper
+# and runs the extension directly — exactly once.
+@test "extension: P06 Pinned mode short-circuits when caller is already in the pinned env" {
+  export FLOX_FEATURES_BETA=true
+  _p06_mk_managed_ext "probe" 'echo "ran=$RANDOM-$$"'
+
+  # Create a managed env at owner/<name> by pushing a path env. The
+  # `floxhub_setup` helper wires up a fake FloxHub at FLOXHUB_URL so we
+  # can push.
+  floxhub_setup owner
+  local proj="$BATS_TEST_TMPDIR/p06-pinned-inside"
+  mkdir -p "$proj"
+  pushd "$proj" > /dev/null
+  "$FLOX_BIN" init -d "$proj" -n inner > /dev/null
+  "$FLOX_BIN" push --owner owner -d "$proj" > /dev/null || skip "floxhub push fixture unavailable"
+  popd > /dev/null
+
+  _p06_write_author_manifest "probe" "pinned" "owner/inner" ""
+
+  # Inside the activation, the dispatcher should see _FLOX_ACTIVE_ENVIRONMENTS
+  # containing owner/inner and skip re-activation. Script runs once.
+  run "$FLOX_BIN" activate -d "$proj" -- "$FLOX_BIN" probe
+  assert_success
+  assert_output --partial "ran="
+}
+
+# P06-TS08: on_active="error" and the caller is active in a *different*
+# env than the pinned one → dispatcher emits the §2.9 mismatch error.
+@test "extension: P06 on_active=error mismatch emits the §2.9 trust-prompt error" {
+  export FLOX_FEATURES_BETA=true
+  _p06_mk_managed_ext "probe" 'echo ran'
+  _p06_write_author_manifest "probe" "pinned" "owner/right-env" "error"
+
+  local proj="$BATS_TEST_TMPDIR/p06-on-active-error"
+  mkdir -p "$proj"
+  pushd "$proj" > /dev/null
+  "$FLOX_BIN" init -d "$proj" > /dev/null
+  popd > /dev/null
+
+  # Caller is in some other env; on_active=error forbids launching here.
+  run "$FLOX_BIN" activate -d "$proj" -- "$FLOX_BIN" probe
+  assert_failure
+  assert_output --partial "requires the 'owner/right-env' environment"
+  refute_output --partial "ran"
+}
+
+# P06-TS09: None mode scrubs FLOX_ / _FLOX_ prefixed vars before launch
+# and keeps the four bookkeeping vars. Non-FLOX vars (PATH, HOME) pass
+# through unchanged.
+@test "extension: P06 None mode scrubs FLOX_* and keeps only bookkeeping vars" {
+  export FLOX_FEATURES_BETA=true
+  _p06_mk_managed_ext "probe" \
+    'env | grep -E "^_?FLOX" | sort'
+  _p06_write_author_manifest "probe" "none" "" ""
+
+  # Set a fake FLOX_ var to confirm it gets scrubbed. Also set a
+  # _FLOX_ACTIVE_ENVIRONMENTS to confirm the underscore-prefixed form
+  # is scrubbed too.
+  export FLOX_SHOULD_BE_SCRUBBED=yes
+  export _FLOX_ACTIVE_ENVIRONMENTS='[]'
+
+  run "$FLOX_BIN" probe
+  assert_success
+  refute_output --partial "FLOX_SHOULD_BE_SCRUBBED"
+  refute_output --partial "_FLOX_ACTIVE_ENVIRONMENTS"
+  # Bookkeeping vars are overlaid *after* env_clear, so they appear.
+  assert_output --partial "FLOX_EXTENSION_NAME=probe"
+  assert_output --partial "FLOX_EXTENSION_PATH="
+  assert_output --partial "FLOX_BIN="
+}
+
+# ---------------------------------------------------------------------------- #
+# P07-TS02: gh-parity smoke — install/list/upgrade/remove
+#
+# Mirrors the upstream `cli/cli` extension integ flow against our
+# local bare-git fixture: end-to-end install, list, dispatch,
+# upgrade-with-no-new-commits, remove.
+# ---------------------------------------------------------------------------- #
+
+@test "extension: gh-parity smoke — install/list/upgrade/remove" {
+  _setup_github_fixture
+
+  # install
+  run "$FLOX_BIN" extension install owner/flox-hello
+  assert_success
+  assert_output --partial "Installed flox-hello"
+
+  # list contains the name and repo
+  run "$FLOX_BIN" extension list
+  assert_success
+  assert_output --partial "hello"
+  assert_output --partial "owner/flox-hello"
+
+  # dispatch resolves
+  run "$FLOX_BIN" hello
+  assert_success
+  assert_output --partial "hello from gh"
+
+  # upgrade with no new commits on main → already-current
+  run "$FLOX_BIN" extension upgrade hello
+  assert_success
+  assert_output --partial "already at the latest commit"
+
+  # remove deletes the install dir
+  run "$FLOX_BIN" extension remove hello
+  assert_success
+  assert_output --partial "Removed flox-hello"
+  [ ! -d "$EXT_ROOT/flox-hello" ]
+
+  # dispatch now fails (flox has no 'hello' subcommand and no managed exe)
+  run "$FLOX_BIN" hello
+  assert_failure
+
+  _teardown_github_fixture
+}
+
+# ---------------------------------------------------------------------------- #
+# P07-TS01: docs pages present and relative links resolve
+#
+# Reduced scope replacement for the original docs-build check. No docs
+# build tooling exists yet, so this asserts source presence and that
+# relative `](./...)` / `](../...)` links resolve to real paths in the
+# tree.
+# ---------------------------------------------------------------------------- #
+
+@test "extension: docs pages present and links resolve" {
+  # The flox-cli-tests harness exports PROJECT_ROOT_DIR when running
+  # against a real source checkout (the common `just integ-tests` path).
+  # When the harness is launched from a /nix/store copy (the pure-Nix
+  # `nix-integ-tests` path) there's no source tree to inspect, so the
+  # presence check doesn't apply and we skip cleanly.
+  if [ -z "${PROJECT_ROOT_DIR:-}" ]; then
+    skip "PROJECT_ROOT_DIR not set (tests running from a Nix-built copy)"
+  fi
+
+  local docs="$PROJECT_ROOT_DIR/docs/extensions"
+  [ -f "$docs/README.md" ]
+  [ -f "$docs/user-guide.md" ]
+  [ -f "$docs/author-guide.md" ]
+
+  # For each doc file, extract relative markdown links and assert
+  # each target resolves against the file's directory. External
+  # http(s) and anchor-only links are ignored.
+  local f target abs rel
+  for f in "$docs/README.md" "$docs/user-guide.md" "$docs/author-guide.md"; do
+    while IFS= read -r target; do
+      [ -z "$target" ] && continue
+      # Strip any "#anchor" fragment.
+      rel="${target%%#*}"
+      [ -z "$rel" ] && continue
+      abs="$(cd "$(dirname "$f")" && cd "$(dirname "$rel")" 2>/dev/null && pwd)/$(basename "$rel")" \
+        || { echo "unresolved dir for link '$target' in $f" >&2; return 1; }
+      if [ ! -e "$abs" ]; then
+        echo "broken relative link '$target' in $f (resolved to $abs)" >&2
+        return 1
+      fi
+    done < <(grep -oE '\]\((\./|\.\./)[^)]+\)' "$f" | sed -E 's/^\]\(//; s/\)$//')
+  done
+}
+
+# ---------------------------------------------------------------------------- #
+# P07a-TS03: schema-drift guard for the canonical flox/flox-hello-script
+# example repo.
+#
+# Mirrors the published repo's file layout (minimal `flox-extension.toml`,
+# no `[extension.binary]` so install-time kind derivation lands on script,
+# an executable `flox-hello-script` that prints the P06 bookkeeping env
+# vars) into a local bare repo, redirects the github clone URL and the
+# API base URL at it, and asserts the real `flox extension install
+# flox/flox-hello-script` + `flox hello-script` path produces the
+# expected greeting.
+# ---------------------------------------------------------------------------- #
+
+_setup_hello_script_fixture() {
+  local work="$BATS_TEST_TMPDIR/work-hello-script"
+  local bare="$BATS_TEST_TMPDIR/bare/flox-hello-script.git"
+  mkdir -p "$work" "$(dirname "$bare")"
+  git init -q --bare "$bare"
+  git init -q -b main "$work"
+  cat > "$work/flox-extension.toml" <<'EOF'
+[extension]
+name = "hello-script"
+description = "Canonical script-kind reference extension for flox."
+EOF
+  cat > "$work/flox-hello-script" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+name="${FLOX_EXTENSION_NAME:-hello-script}"
+version="${FLOX_EXTENSION_VERSION:-unknown}"
+echo "Hello from ${name} v${version}"
+if [ "$#" -gt 0 ]; then
+  echo "args: $*"
+fi
+EOF
+  chmod +x "$work/flox-hello-script"
+  git -C "$work" -c user.email=t@e -c user.name=t -c commit.gpgsign=false add -A
+  git -C "$work" -c user.email=t@e -c user.name=t -c commit.gpgsign=false commit -q -m initial
+  git -C "$work" remote add origin "$bare"
+  git -C "$work" push -q origin main
+
+  export HELLO_SCRIPT_SHA
+  HELLO_SCRIPT_SHA="$(git -C "$work" rev-parse HEAD)"
+
+  cat > "$BATS_TEST_TMPDIR/hello_api.py" <<EOF
+import json, http.server
+SHA = "$HELLO_SCRIPT_SHA"
+class H(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        path = self.path.split("?", 1)[0]
+        if path == "/repos/flox/flox-hello-script/releases/latest":
+            self.send_response(404); self.end_headers(); return
+        if path == "/repos/flox/flox-hello-script":
+            body = json.dumps({"default_branch": "main"}).encode()
+        elif path.startswith("/repos/flox/flox-hello-script/commits/"):
+            body = json.dumps({"sha": SHA}).encode()
+        else:
+            self.send_response(404); self.end_headers(); return
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+    def log_message(self, *a, **k):
+        pass
+s = http.server.HTTPServer(("127.0.0.1", 0), H)
+print(s.server_address[1], flush=True)
+s.serve_forever()
+EOF
+  local py
+  if command -v python3 > /dev/null 2>&1; then
+    py=python3
+  elif command -v python > /dev/null 2>&1; then
+    py=python
+  else
+    skip "python3 not available in test environment"
+  fi
+
+  $py "$BATS_TEST_TMPDIR/hello_api.py" > "$BATS_TEST_TMPDIR/hello_port.txt" &
+  echo $! > "$BATS_TEST_TMPDIR/hello_api.pid"
+  local i
+  for i in $(seq 1 50); do
+    [ -s "$BATS_TEST_TMPDIR/hello_port.txt" ] && break
+    sleep 0.1
+  done
+  local port
+  port="$(cat "$BATS_TEST_TMPDIR/hello_port.txt")"
+  export FLOX_EXTENSIONS_GITHUB_BASE_URL="http://127.0.0.1:$port"
+
+  export GIT_CONFIG_COUNT=1
+  export GIT_CONFIG_KEY_0="url.file://$bare.insteadOf"
+  export GIT_CONFIG_VALUE_0="https://github.com/flox/flox-hello-script.git"
+}
+
+_teardown_hello_script_fixture() {
+  if [ -f "$BATS_TEST_TMPDIR/hello_api.pid" ]; then
+    kill "$(cat "$BATS_TEST_TMPDIR/hello_api.pid")" 2>/dev/null || true
+  fi
+  unset GIT_CONFIG_COUNT GIT_CONFIG_KEY_0 GIT_CONFIG_VALUE_0
+  unset FLOX_EXTENSIONS_GITHUB_BASE_URL HELLO_SCRIPT_SHA
+}
+
+# P07a-TS03: install the flox/flox-hello-script mirror end-to-end.
+@test "extension: flox/flox-hello-script mirror installs and dispatches" {
+  export FLOX_FEATURES_BETA=true
+  _setup_hello_script_fixture
+
+  run "$FLOX_BIN" extension install flox/flox-hello-script
+  assert_success
+  assert_output --partial "Installed flox-hello-script"
+
+  run "$FLOX_BIN" hello-script world
+  assert_success
+  assert_output --partial "Hello from hello-script"
+  assert_output --partial "args: world"
+
+  _teardown_hello_script_fixture
+}

--- a/docs/extensions/README.md
+++ b/docs/extensions/README.md
@@ -5,7 +5,7 @@ describe installing, authoring, and distributing Flox
 extensions.
 
 - [**User guide**](./user-guide.md) — install, list, remove,
-  upgrade; pinning; activation modes; opting out.
+  upgrade; pinning; activation modes; enabling the beta feature.
 - [**Author guide**](./author-guide.md) — repo naming,
   `flox-extension.toml` schema, release-asset naming, local dev
   loop, example extensions.

--- a/docs/extensions/README.md
+++ b/docs/extensions/README.md
@@ -1,0 +1,11 @@
+# Flox Extensions — Docs
+
+Documentation for the `flox extension` subsystem. These pages
+describe installing, authoring, and distributing Flox
+extensions.
+
+- [**User guide**](./user-guide.md) — install, list, remove,
+  upgrade; pinning; activation modes; opting out.
+- [**Author guide**](./author-guide.md) — repo naming,
+  `flox-extension.toml` schema, release-asset naming, local dev
+  loop, example extensions.

--- a/docs/extensions/author-guide.md
+++ b/docs/extensions/author-guide.md
@@ -49,9 +49,12 @@ explicitly. See [release-asset naming](#release-asset-naming).
 
 ## The `flox-extension.toml` manifest
 
-A `flox-extension.toml` at the repo root is optional for
-script-kind extensions and required for binary-kind extensions
-(to map assets to host platforms).
+A `flox-extension.toml` at the repo root is optional. A
+binary-kind extension installs without one as long as its release
+assets follow the substring naming convention (see
+[Release-asset naming](#release-asset-naming)); a manifest is only
+needed if you want to record a `sha256` for verification or an
+`[environment]` stanza.
 
 Minimal manifest:
 
@@ -88,8 +91,8 @@ inside = "error"
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `name` | string | yes | Extension name. Must match the repo `<name>` segment (repo `flox-<name>`). Lowercased, `[a-z0-9][a-z0-9_-]*`. |
-| `description` | string | no | Short human description. Shown in `flox extension list` / `search` output. |
+| `name` | string | yes | Extension name. Should match the repo `<name>` segment (repo `flox-<name>`). Lowercased, `[a-z0-9][a-z0-9_-]*`. For GitHub installs the name is derived from the repo and this field is not compared against it; only local (`--from-path`) installs check that the manifest name matches the directory. |
+| `description` | string | no | Short human description. Not currently surfaced by `flox extension list` (which has no description column); `flox extension search` shows the GitHub repository's description, not this field. |
 
 ### `[extension.binary]` table
 
@@ -98,8 +101,8 @@ Present only for binary-kind extensions.
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `source` | string | yes | Currently only `"github-release"` is supported. |
-| `asset` | string | yes | Asset-name template. Placeholders `{name}`, `{os}`, `{arch}`, `{ext}` are expanded at resolution time. `{ext}` defaults to `tar.gz` (or `zip` on Windows). |
-| `sha256` | string | no | Expected digest; reserved for future verification. |
+| `asset` | string | no | Asset-name template with `{name}`/`{os}`/`{arch}`/`{ext}` placeholders. **Not currently consulted by `install`/`upgrade`** (they select by substring match — see [Release-asset naming](#release-asset-naming)); setting it has no effect on selection today. |
+| `sha256` | string | no | Expected hex digest of the downloaded asset. **This is verified** at install time — the download's SHA-256 is compared against it and a mismatch aborts the install. |
 
 ### `[environment]` table
 
@@ -125,34 +128,12 @@ Always `"1"` for the current schema version.
 
 ## Release-asset naming
 
-For binary-kind extensions, Flox picks a release asset using this
-priority order:
+For binary-kind extensions, Flox selects a release asset by
+**substring-matching** platform tokens against the release's
+asset names, with a Rosetta fallback:
 
-1. **Manifest template match.** If `flox-extension.toml` has
-   `[extension.binary].asset`, Flox renders it for the host
-   platform and looks for an exact asset-name match. Supported
-   placeholders:
-   - `{name}` — extension name (from `[extension].name`)
-   - `{os}` — Rust's `std::env::consts::OS` for the host:
-     `"macos"`, `"linux"`, or `"windows"`. Note this is
-     **`macos`, not `darwin`** — the value is substituted
-     verbatim, so a template rendering `…-darwin-…` will not
-     match on a Mac.
-   - `{arch}` — Rust's `std::env::consts::ARCH`:
-     `"x86_64"` or `"aarch64"`
-   - `{ext}` — `"tar.gz"` (default) or `"zip"` on Windows
-
-   Only `{ext}` is computed; the rest are substituted verbatim
-   from the host's values. If the rendered name does not match a
-   release asset exactly, resolution falls through to the
-   substring match below, which accepts both `darwin` and
-   `macos` — so a `darwin`-named asset can still install, just
-   not via this step.
-
-2. **Substring match.** If the template isn't set or doesn't
-   match, Flox falls back to a substring match against a list of
-   platform tokens derived from the host. The tokens Flox looks
-   for, in order:
+1. **Substring match.** Flox looks for an asset whose name
+   contains one of the platform tokens for the host, in order:
    - On Linux x86_64: `linux-x86_64`, `linux-amd64`
    - On Linux aarch64: `linux-aarch64`, `linux-arm64`
    - On macOS x86_64: `darwin-x86_64`, `darwin-amd64`,
@@ -160,13 +141,27 @@ priority order:
    - On macOS aarch64: `darwin-aarch64`, `darwin-arm64`,
      `macos-aarch64`, `macos-arm64`
 
-3. **Rosetta fallback.** On Apple Silicon (`darwin-aarch64`), if
-   no arm64 asset matches, Flox retries with the `x86_64`
-   matchers and uses that asset under Rosetta. A
-   `tracing::info!` line is logged when this happens.
+   Both `darwin` and `macos` are accepted on macOS, so an asset
+   named either way installs.
 
-If no asset matches any of the above, `flox extension install`
-fails with a clear error naming the platform it tried to match.
+2. **Rosetta fallback.** On Apple Silicon, if no arm64 asset
+   matches, Flox retries with the `x86_64` tokens and uses that
+   asset under Rosetta. A `tracing::info!` line is logged.
+
+If no asset matches, `flox extension install` fails with an
+error naming the platform it tried to match.
+
+> **Note — the `[extension.binary].asset` template is not
+> currently used for selection.** The resolver *can* render an
+> `asset` template (`{name}`/`{os}`/`{arch}`/`{ext}` placeholders)
+> and match it exactly, but `install` and `upgrade` call the
+> resolver **without** the manifest, so only the substring match
+> above runs. Setting `asset` has no effect on which asset is
+> chosen today. (The manifest is still read afterward — its
+> `sha256`, if present, is verified against the download; see
+> [the manifest section](#the-flox-extensiontoml-manifest).)
+> Name your assets along the substring tokens above and the
+> template is unnecessary.
 
 ### Recommended naming
 
@@ -182,8 +177,11 @@ flox-deploy-darwin-x86_64.tar.gz
 flox-deploy-darwin-aarch64.tar.gz
 ```
 
-If your existing release pipeline uses a different naming
-scheme, set `[extension.binary].asset` in the manifest to map it.
+If your existing release pipeline uses a different naming scheme,
+rename the assets to include one of the platform tokens above —
+the `[extension.binary].asset` template is not consulted by the
+installer today, so it cannot be used to map a non-conforming
+scheme.
 
 ## Environment stanza
 

--- a/docs/extensions/author-guide.md
+++ b/docs/extensions/author-guide.md
@@ -1,0 +1,313 @@
+# Flox Extensions — Author Guide
+
+This guide is for people who want to ship an extension that
+other Flox users can install with `flox extension install
+<owner>/<repo>`. It covers repo layout, the
+`flox-extension.toml` manifest, release-asset naming, activation
+semantics, and the local dev loop.
+
+## Contents
+
+- [Repo naming and discovery](#repo-naming-and-discovery)
+- [Three kinds of extensions](#three-kinds-of-extensions)
+- [The `flox-extension.toml` manifest](#the-flox-extensiontoml-manifest)
+- [Release-asset naming](#release-asset-naming)
+- [Environment stanza](#environment-stanza)
+- [Local dev loop](#local-dev-loop)
+- [Example extensions](#example-extensions)
+
+## Repo naming and discovery
+
+Extensions are GitHub repositories whose name begins with
+`flox-`. A repo named `acme/flox-tidy` installs as the `tidy`
+extension and is invoked as `flox tidy`.
+
+Tag your repo with the `flox-extension` topic on GitHub so it
+shows up in search:
+
+```
+https://github.com/topics/flox-extension
+```
+
+The `flox extension search` command queries this topic to surface
+extensions.
+
+## Three kinds of extensions
+
+| Kind | What it is | When to pick |
+|------|------------|--------------|
+| **Script** | A shell, Python, or interpreted script committed to the repo. Flox `git clone`s and runs the executable directly. | Most extensions. Easy to ship, easy for users to read, no release engineering required. |
+| **Binary** | A compiled binary shipped as a GitHub release asset. Flox downloads and extracts. | Tools written in Rust, Go, C/C++ where clone-and-run isn't viable. |
+| **Local** | A directory installed via `--from-path`. Not distributed through GitHub. | Local development and iteration. See [local dev loop](#local-dev-loop). |
+
+Script is the default: if your repo has no GitHub releases with
+matching assets, Flox falls back to clone-install.
+
+Binary is selected automatically when the latest GitHub release
+has an asset Flox can match — you don't have to declare a kind
+explicitly. See [release-asset naming](#release-asset-naming).
+
+## The `flox-extension.toml` manifest
+
+A `flox-extension.toml` at the repo root is optional for
+script-kind extensions and required for binary-kind extensions
+(to map assets to host platforms).
+
+Minimal manifest:
+
+```toml
+schema = "1"
+
+[extension]
+name = "hello"
+```
+
+Full manifest with every field:
+
+```toml
+schema = "1"
+
+[extension]
+name = "deploy"
+description = "Deploys things"
+
+[extension.binary]
+source = "github-release"
+asset = "flox-deploy-{os}-{arch}.tar.gz"
+sha256 = "cafe..."
+
+[environment]
+mode = "pinned"
+inherit_name = "acme/dev"
+
+[on_active]
+inside = "error"
+```
+
+### `[extension]` table
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | yes | Extension name. Must match the repo `<name>` segment (repo `flox-<name>`). Lowercased, `[a-z0-9][a-z0-9_-]*`. |
+| `description` | string | no | Short human description. Shown in `flox extension list` / `search` output. |
+
+### `[extension.binary]` table
+
+Present only for binary-kind extensions.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `source` | string | yes | Currently only `"github-release"` is supported. |
+| `asset` | string | yes | Asset-name template. Placeholders `{name}`, `{os}`, `{arch}`, `{ext}` are expanded at resolution time. `{ext}` defaults to `tar.gz` (or `zip` on Windows). |
+| `sha256` | string | no | Expected digest; reserved for future verification. |
+
+### `[environment]` table
+
+Controls how the extension interacts with Flox activations. See
+[Environment stanza](#environment-stanza) below for the full
+semantics.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `mode` | string | yes | One of `"inherit"`, `"none"`, `"pinned"`. |
+| `inherit_name` | string | only when `mode = "pinned"` | Activation ref, e.g. `"acme/dev"`. |
+| `inherit` | enum | no | Reserved for future use (`"current"`, `"default"`, `"named"`). Not consumed by Flox today. |
+
+### `[on_active]` table
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `inside` | string | yes | One of `"override"` (default) or `"error"`. Controls behavior when the caller is already activated in a *different* environment than `inherit_name`. |
+
+### `schema` field
+
+Always `"1"` for the current schema version.
+
+## Release-asset naming
+
+For binary-kind extensions, Flox picks a release asset using this
+priority order:
+
+1. **Manifest template match.** If `flox-extension.toml` has
+   `[extension.binary].asset`, Flox renders it for the host
+   platform and looks for an exact asset-name match. Supported
+   placeholders:
+   - `{name}` — extension name (from `[extension].name`)
+   - `{os}` — Rust's `std::env::consts::OS` for the host:
+     `"macos"`, `"linux"`, or `"windows"`. Note this is
+     **`macos`, not `darwin`** — the value is substituted
+     verbatim, so a template rendering `…-darwin-…` will not
+     match on a Mac.
+   - `{arch}` — Rust's `std::env::consts::ARCH`:
+     `"x86_64"` or `"aarch64"`
+   - `{ext}` — `"tar.gz"` (default) or `"zip"` on Windows
+
+   Only `{ext}` is computed; the rest are substituted verbatim
+   from the host's values. If the rendered name does not match a
+   release asset exactly, resolution falls through to the
+   substring match below, which accepts both `darwin` and
+   `macos` — so a `darwin`-named asset can still install, just
+   not via this step.
+
+2. **Substring match.** If the template isn't set or doesn't
+   match, Flox falls back to a substring match against a list of
+   platform tokens derived from the host. The tokens Flox looks
+   for, in order:
+   - On Linux x86_64: `linux-x86_64`, `linux-amd64`
+   - On Linux aarch64: `linux-aarch64`, `linux-arm64`
+   - On macOS x86_64: `darwin-x86_64`, `darwin-amd64`,
+     `macos-x86_64`, `macos-amd64`
+   - On macOS aarch64: `darwin-aarch64`, `darwin-arm64`,
+     `macos-aarch64`, `macos-arm64`
+
+3. **Rosetta fallback.** On Apple Silicon (`darwin-aarch64`), if
+   no arm64 asset matches, Flox retries with the `x86_64`
+   matchers and uses that asset under Rosetta. A
+   `tracing::info!` line is logged when this happens.
+
+If no asset matches any of the above, `flox extension install`
+fails with a clear error naming the platform it tried to match.
+
+### Recommended naming
+
+The simplest path is to name assets along the substring
+conventions. `flox-<name>-<os>-<arch>.tar.gz` works out of the
+box on all platforms and needs no manifest template. For
+example:
+
+```
+flox-deploy-linux-x86_64.tar.gz
+flox-deploy-linux-aarch64.tar.gz
+flox-deploy-darwin-x86_64.tar.gz
+flox-deploy-darwin-aarch64.tar.gz
+```
+
+If your existing release pipeline uses a different naming
+scheme, set `[extension.binary].asset` in the manifest to map it.
+
+## Environment stanza
+
+### `inherit` (default)
+
+```toml
+[environment]
+mode = "inherit"
+```
+
+The extension runs inside the caller's current activation. All
+`FLOX_*` environment variables are preserved. If the caller is
+already inside `flox activate`, the extension sees that
+activation.
+
+### `none`
+
+```toml
+[environment]
+mode = "none"
+```
+
+Flox scrubs `FLOX_*` and `_FLOX_*` variables before exec, then
+overlays bookkeeping vars (`FLOX_EXTENSION_NAME`,
+`FLOX_EXTENSION_VERSION`, `FLOX_EXTENSION_PATH`, `FLOX_BIN`).
+Use this when the extension must not be influenced by
+caller-side Flox state.
+
+### `pinned`
+
+```toml
+[environment]
+mode = "pinned"
+inherit_name = "acme/dev"
+```
+
+The extension runs inside a specific activation. If the caller
+is already activated in the pinned environment, Flox execs the
+extension directly. Otherwise, Flox wraps the call with
+`flox activate -r <owner>/<env> -- <extension>`.
+
+Add `[on_active] inside = "error"` to make Flox refuse to run
+the extension when the caller is activated in a *different*
+environment:
+
+```toml
+[environment]
+mode = "pinned"
+inherit_name = "acme/dev"
+
+[on_active]
+inside = "error"
+```
+
+The default (`inside = "override"`) always wraps with
+`flox activate -r` when there's a mismatch.
+
+### Bookkeeping variables
+
+Regardless of mode, Flox injects four variables into the
+extension's environment:
+
+| Variable | Value |
+|----------|-------|
+| `FLOX_EXTENSION_NAME` | The extension's declared name. |
+| `FLOX_EXTENSION_VERSION` | Tag if pinned, else short SHA, else `-`. |
+| `FLOX_EXTENSION_PATH` | Absolute path to the install directory. |
+| `FLOX_BIN` | Path to the flox binary that dispatched the extension. |
+
+Extensions can read these to find their own install directory
+or to shell out to other `flox` subcommands.
+
+## Local dev loop
+
+During development, install your extension directly from a
+local directory:
+
+```console
+$ cd ~/src/flox-hello
+$ flox extension install --from-path .
+✓ Installed flox-hello
+$ flox hello
+```
+
+`--from-path` skips GitHub entirely. The installer derives the
+name from the directory basename (stripping any leading
+`flox-`), or reads it from `flox-extension.toml` if present.
+
+To iterate, edit the source and re-install with `--force`:
+
+```console
+$ flox extension install --from-path . --force
+```
+
+The `--force` overrides the already-installed check. Alternately,
+for pure script extensions, you can `flox extension remove` and
+reinstall.
+
+## Example extensions
+
+- [**flox-hello-script**](https://github.com/flox/flox-hello-script)
+  — the canonical "hello world" extension. Shell script,
+  minimal `flox-extension.toml`, demonstrates the clone-and-run
+  flow and the default `Inherit` activation mode. Install with
+  `flox extension install flox/flox-hello-script`.
+
+- [**flox-hello-local**](https://github.com/flox/flox-hello-local)
+  — canonical local-authoring reference. Clone the repo and
+  install from the working tree via `flox extension install
+  --from-path .`; demonstrates the [local dev loop](#local-dev-loop)
+  without going through GitHub at install time.
+
+- [**flox-hello-binary**](https://github.com/flox/flox-hello-binary)
+  — minimal binary-kind extension. Demonstrates the release-asset
+  pipeline and the `[extension.binary]` manifest stanza. v0.1.0
+  ships macOS assets only; Linux is tracked in the example repo's
+  `PROJECTS.md` as P02.
+
+No published example demonstrates `[environment] mode = "pinned"`
+or the `[on_active] inside = "error"` variant yet. For working
+usage of both, see the activation-mode cases in
+`cli/tests/extension.bats`.
+
+## See also
+
+- [User guide](./user-guide.md)
+- [Docs index](./README.md)

--- a/docs/extensions/user-guide.md
+++ b/docs/extensions/user-guide.md
@@ -1,0 +1,342 @@
+# Flox Extensions — User Guide
+
+> **Beta:**
+> Extensions are a beta feature and behind a feature flag, and their
+> behavior is subject to change.
+> Enable them by setting `FLOX_FEATURES_BETA=true` in your environment.
+> See [Enabling extensions](#enabling-extensions) for why the
+> `flox config` route alone is not enough for `flox <name>` dispatch.
+
+Flox extensions are out-of-tree commands that extend the `flox`
+CLI. They are installed into
+`$XDG_DATA_HOME/flox/extensions/` (typically
+`~/.local/share/flox/extensions/`) and dispatched when you run
+`flox <name>` where `<name>` is not a built-in subcommand.
+
+Extensions can be written in any language. A `flox-hello`
+extension is discovered and invoked as `flox hello`. Extensions
+integrate with Flox environments through an optional manifest
+that specifies activation behavior.
+
+## Contents
+
+- [Quick tour](#quick-tour)
+- [Installing extensions](#installing-extensions)
+- [Listing, removing, upgrading](#listing-removing-upgrading)
+- [Activation modes](#activation-modes)
+- [Reserved names](#reserved-names)
+- [GitHub Enterprise host override](#github-enterprise-host-override)
+- [Enabling extensions](#enabling-extensions)
+- [See also](#see-also)
+
+## Quick tour
+
+```console
+$ flox extension install flox/flox-hello-script
+✔ Installed flox-hello-script
+
+$ flox hello-script world
+Hello from hello-script vc8d5f41
+args: world
+
+$ flox extension list
+NAME                  REPO                              VERSION         PINNED  STATUS
+hello-script          flox/flox-hello-script            c8d5f41
+
+$ flox extension remove hello-script
+✔ Removed flox-hello-script
+```
+
+Note the name: the repo is `flox-hello-script`, so the extension
+is `hello-script` and is invoked as `flox hello-script`. The
+`flox-` prefix is stripped; nothing else is.
+
+## Installing extensions
+
+### From GitHub
+
+```console
+$ flox extension install <owner>/<repo>
+```
+
+The repo name is normalized — if you pass `acme/hello`
+or `acme/flox-hello`, both resolve to the
+`acme/flox-hello` repo and install as the `hello`
+extension. Flox auto-prefixes with `flox-` when the segment does
+not already start with it.
+
+The installer picks a source strategy based on the repo:
+
+1. If the latest GitHub release has a matching release asset
+   (see the [author guide](./author-guide.md) for asset naming),
+   Flox downloads and extracts the binary directly.
+2. Otherwise, Flox `git clone`s the repo into the install
+   directory and runs the executable from there (script-kind).
+
+### Pinning a specific commit or tag
+
+```console
+$ flox extension install --pin v1.2.3 <owner>/<repo>
+$ flox extension install --pin abc1234 <owner>/<repo>
+```
+
+A pinned extension will not upgrade past the pinned revision
+without `--force`. This is the right choice when you want a
+reproducible install, or when newer versions of the extension
+have broken behavior you depend on.
+
+### Forcing a reinstall
+
+```console
+$ flox extension install --force <owner>/<repo>
+```
+
+`--force` overwrites an existing install at the same name. Use
+this when you want to reset an extension's state or when you're
+overriding a pin.
+
+### Installing from a local path
+
+```console
+$ flox extension install --from-path ./my-extension
+```
+
+Installs directly from a local directory, skipping GitHub
+entirely. The directory must contain an executable named
+`flox-<name>`; `<name>` is derived from the directory basename
+(stripping a leading `flox-`), or read from
+`flox-extension.toml` if present. See the
+[author guide](./author-guide.md) for the manifest schema and
+local dev loop.
+
+## Listing, removing, upgrading
+
+### Listing installed extensions
+
+```console
+$ flox extension list
+NAME                  REPO                              VERSION         PINNED  STATUS
+hello-script          flox/flox-hello-script            c8d5f41
+tidy                  acme/flox-tidy                    v1.2.3          yes
+```
+
+The `VERSION` column shows the pinned tag when one exists,
+otherwise the short commit SHA, otherwise blank. `PINNED` is
+`yes` for extensions installed with `--pin`. `STATUS` is
+populated by `upgrade`; it is blank for `list`.
+
+### Removing an extension
+
+```console
+$ flox extension remove <name>
+```
+
+This deletes the install directory. Any state kept inside the
+install directory is removed with it.
+
+### Upgrading a single extension
+
+```console
+$ flox extension upgrade <name>
+```
+
+Resolves the latest commit (or release) for the extension's
+tracked ref and replaces the install in place. If there's
+nothing newer, Flox reports that the extension is already
+current and exits successfully. If the extension is pinned, the
+upgrade is a no-op and Flox tells you to pass `--force` to
+override.
+
+### Upgrading everything at once
+
+```console
+$ flox extension upgrade --all
+```
+
+Iterates every installed extension and prints a row per result:
+
+```
+NAME                  REPO                              VERSION         PINNED  STATUS
+hello-script          flox/flox-hello-script            c8d5f41                 up-to-date
+tidy                  acme/flox-tidy                    def5678                 upgraded abc1234 -> def5678
+report                acme/flox-report                  v1.2.3          yes     pinned (skip)
+```
+
+Pinned extensions are skipped unless `--force` is passed.
+
+### Dry-run
+
+```console
+$ flox extension upgrade --all --dry-run
+```
+
+Shows what would happen without mutating anything. Each row
+reports `would upgrade <old> -> <new>`, `up-to-date`, or
+`pinned (skip)`.
+
+## Activation modes
+
+An extension can declare how it interacts with Flox environments
+by setting `[environment].mode` in its
+`flox-extension.toml`. Flox honors one of three modes when
+dispatching `flox <name>`:
+
+### `inherit` (default)
+
+The extension runs inside the caller's current activation. All
+`FLOX_*` environment variables are preserved; if the caller is
+already inside `flox activate`, the extension sees that
+activation.
+
+```toml
+[environment]
+mode = "inherit"
+```
+
+This is the right default for most extensions — they behave
+like any other command you'd run at the prompt.
+
+### `none`
+
+The extension runs with a scrubbed environment. Before exec,
+Flox calls `env_clear()` and replays every non-`FLOX_*` variable,
+then overlays the extension-bookkeeping variables
+(`FLOX_EXTENSION_NAME`, `FLOX_EXTENSION_VERSION`,
+`FLOX_EXTENSION_PATH`, `FLOX_BIN`).
+
+```toml
+[environment]
+mode = "none"
+```
+
+Use `none` when the extension must not be influenced by
+caller-side Flox state. Examples: a diagnostic tool that reports
+Flox state itself, or a sandboxed auditor.
+
+### `pinned`
+
+The extension runs inside a specific activation. When the
+caller is already activated in the pinned environment, Flox
+execs the extension directly. Otherwise, Flox wraps the call
+with `flox activate -r <owner>/<env> -- <extension>`.
+
+```toml
+[environment]
+mode = "pinned"
+inherit_name = "acme/dev"
+```
+
+`inherit_name` takes the `<owner>/<environment>` reference that
+would be valid for `flox activate -r`.
+
+Optionally, an extension can refuse to run from outside its
+pinned environment when the user is already activated in a
+different one:
+
+```toml
+[environment]
+mode = "pinned"
+inherit_name = "acme/dev"
+
+[on_active]
+inside = "error"
+```
+
+`inside = "error"` causes the dispatch to fail with a
+`PinnedEnvMismatch` error rather than silently re-wrapping. The
+default (`inside = "override"`) just wraps with
+`flox activate -r` unconditionally.
+
+## Reserved names
+
+The extension installer rejects repos whose `<name>` segment
+collides with a built-in top-level `flox` subcommand. This
+prevents an extension from shadowing a built-in if bpaf's parser
+behavior ever changes.
+
+Current reserved names:
+
+- `init`, `envs`, `delete`
+- `activate`, `services`
+- `search`, `show`
+- `install`, `i`, `list`, `l`, `edit`, `include`, `upgrade`,
+  `uninstall`, `generations`
+- `build`, `publish`, `push`, `pull`, `containerize`
+- `auth`, `config`, `gc`
+- `extension`, `help`
+
+If you try to install `flox-install`, for example, the installer
+returns a clear error and exits non-zero.
+
+The authoritative list lives at
+`cli/beta/src/extensions/reserved.rs` in the
+Flox repo.
+
+## GitHub Enterprise host override
+
+Flox talks to `api.github.com` and clones from
+`github.com` by default. To point at a GitHub Enterprise host,
+export these variables before running `flox extension
+install`:
+
+```console
+$ export FLOX_EXTENSIONS_GITHUB_BASE_URL=https://ghe.example.com/api/v3
+$ export FLOX_EXTENSIONS_GITHUB_CLONE_HOST=ghe.example.com
+$ flox extension install myorg/flox-internal-tool
+```
+
+Both variables must be set when targeting GHE. The API base is
+used for metadata (releases, default branch, commits, search);
+the clone host is used when assembling the `git clone` URL for
+script-kind installs.
+
+## Enabling extensions
+
+> **Beta:**
+> Extensions are a beta feature and behind a feature flag, and their
+> behavior is subject to change.
+
+Extensions are **disabled by default**. Enable them by exporting the
+environment variable:
+
+```console
+$ export FLOX_FEATURES_BETA=true
+```
+
+While the subsystem is in beta, `extension` does not appear in
+`flox --help`.
+
+### Enabling via config is not sufficient for dispatch
+
+Beta features can also be enabled persistently:
+
+```console
+$ flox config --set features.beta true
+```
+
+This enables the `flox extension …` subcommands, but **not** the
+`flox <name>` dispatch fallback.
+
+Dispatch is resolved in `main()` before the config system has
+loaded, so it reads `FLOX_FEATURES_BETA` from the environment
+directly and never sees a config-file setting. If you enable beta
+via config and want `flox hello` to work as well as
+`flox extension install`, export the variable too:
+
+```console
+$ flox config --set features.beta true   # subcommands
+$ export FLOX_FEATURES_BETA=true         # subcommands + dispatch
+```
+
+Add the export to your shell profile to make it permanent. This
+limitation is expected to be resolved before extensions leave beta.
+
+The variable is read as opt-in: `true` and `1` enable the feature
+(case-insensitive). Any other value, or leaving it unset, keeps it
+disabled.
+
+## See also
+
+- [Author guide](./author-guide.md) — repo layout,
+  `flox-extension.toml` schema, release assets, local dev loop.
+- [Docs index](./README.md)

--- a/docs/extensions/user-guide.md
+++ b/docs/extensions/user-guide.md
@@ -25,7 +25,7 @@ that specifies activation behavior.
 - [Listing, removing, upgrading](#listing-removing-upgrading)
 - [Activation modes](#activation-modes)
 - [Reserved names](#reserved-names)
-- [GitHub Enterprise host override](#github-enterprise-host-override)
+- [GitHub Enterprise](#github-enterprise)
 - [Enabling extensions](#enabling-extensions)
 - [See also](#see-also)
 
@@ -59,11 +59,10 @@ is `hello-script` and is invoked as `flox hello-script`. The
 $ flox extension install <owner>/<repo>
 ```
 
-The repo name is normalized — if you pass `acme/hello`
-or `acme/flox-hello`, both resolve to the
-`acme/flox-hello` repo and install as the `hello`
-extension. Flox auto-prefixes with `flox-` when the segment does
-not already start with it.
+The spec must be exactly `<owner>/<repo>` (full URLs are not
+accepted), and the repo must already begin with `flox-`. So
+`acme/flox-hello` installs as the `hello` extension; `acme/hello`
+is rejected — there is no auto-prefixing.
 
 The installer picks a source strategy based on the repo:
 
@@ -257,13 +256,16 @@ behavior ever changes.
 Current reserved names:
 
 - `init`, `envs`, `delete`
-- `activate`, `services`
+- `activate`, `deactivate`, `run`, `services`
 - `search`, `show`
 - `install`, `i`, `list`, `l`, `edit`, `include`, `upgrade`,
   `uninstall`, `generations`
 - `build`, `publish`, `push`, `pull`, `containerize`
 - `auth`, `config`, `gc`
-- `extension`, `help`
+- `extension`, `help`, `beta-enabled`, `factory`
+
+The last two (`beta-enabled`, `factory`) plus `extension` and
+`help` are hidden commands that do not appear in `flox --help`.
 
 If you try to install `flox-install`, for example, the installer
 returns a clear error and exits non-zero.
@@ -272,23 +274,17 @@ The authoritative list lives at
 `cli/beta/src/extensions/reserved.rs` in the
 Flox repo.
 
-## GitHub Enterprise host override
+## GitHub Enterprise
 
-Flox talks to `api.github.com` and clones from
-`github.com` by default. To point at a GitHub Enterprise host,
-export these variables before running `flox extension
-install`:
+GitHub Enterprise is **not currently supported**. Flox talks to
+`api.github.com` for metadata and clones from `https://github.com`;
+the clone host is hardcoded and there is no configuration to point
+it elsewhere.
 
-```console
-$ export FLOX_EXTENSIONS_GITHUB_BASE_URL=https://ghe.example.com/api/v3
-$ export FLOX_EXTENSIONS_GITHUB_CLONE_HOST=ghe.example.com
-$ flox extension install myorg/flox-internal-tool
-```
-
-Both variables must be set when targeting GHE. The API base is
-used for metadata (releases, default branch, commits, search);
-the clone host is used when assembling the `git clone` URL for
-script-kind installs.
+There is one override, `FLOX_EXTENSIONS_GITHUB_BASE_URL`, but it is
+**test-only** — it redirects the API client at a mock server for
+the integration tests and does not change the `git clone` host, so
+it cannot be used to install from a GHE instance.
 
 ## Enabling extensions
 

--- a/pkgs/flox-cli-tests/default.nix
+++ b/pkgs/flox-cli-tests/default.nix
@@ -36,6 +36,7 @@
   podman,
   procps,
   pstree,
+  python3,
   unixtools,
   util-linux,
   which,
@@ -78,6 +79,7 @@ let
     openssh
     parallel
     pstree
+    python3
     unixtools.util-linux
     util-linux # for setsid
     which

--- a/research/gh_extension_flox.md
+++ b/research/gh_extension_flox.md
@@ -1,0 +1,1039 @@
+# PRD & Technical Plan — Porting `gh extension` to `flox extension`
+
+> **Status:** Draft for engineering review
+> **Target repos:** [`github.com/cli/cli`](https://github.com/cli/cli) (Go, reference implementation) → [`github.com/flox/flox`](https://github.com/flox/flox) (Rust, target)
+> **Scope:** v1 minimum viable port; roadmap through v3
+> **Date:** April 2026
+
+---
+
+## Table of contents
+
+1. Part 1 — PRD
+2. Part 2 — Technical architecture
+3. Part 3 — Side-by-side mapping (Go → Rust)
+4. Part 4 — Phased implementation plan
+
+A note on sourcing: `gh` behavior is grounded in `pkg/cmd/extension/command.go`, `pkg/cmd/extension/manager.go` (the `installBin`/`installGit`/`Dispatch` functions), and `pkg/extensions/extension.go` in `cli/cli`; the concrete on‑disk `manifest.yml` schema is corroborated by reports from running installs (`~/.local/share/gh/extensions/gh-<name>/manifest.yml` contains `owner`, `name`, `host`, `tag`, `ispinned`, `path`). Flox behavior is grounded in the public docs, release notes, and observed paths (`cli/flox/`, `cli/flox-rust-sdk/`, `cli/flox-activations/` workspace crates; `bpaf` proc‑macro style; the `$FLOX_ENV`, `$FLOX_ENV_CACHE`, `$FLOX_ENV_PROJECT`, `$FLOX_ENV_DESCRIPTION`, `$FLOX_PROMPT_ENVIRONMENTS` activation env vars; `flox activate -- <cmd>` which `exec()`s in the activated environment since v1.9). A handful of specific file/line references below are tagged `[verify]` where they are derived from third‑party mirrors or PR discussions rather than a direct read of `main` — they should be re‑verified during implementation.
+
+---
+
+# Part 1 — PRD
+
+## 1.1 Problem statement
+
+Flox users today have no first‑class way to extend the `flox` CLI with custom commands. Any "extend Flox" use case — org‑specific wrappers, domain workflows, integrations with third‑party systems that shouldn't live in `cli/cli` — must be distributed as shell aliases, standalone binaries on `PATH`, or custom Nix expressions. None of these compose with the Flox environment model, none have a discovery/update story, and none make it obvious to a user that they are invoking a Flox extension rather than a core command.
+
+`gh` solved the equivalent problem in 2021 with `gh extension` — a tiny, opinionated package manager for `gh-<name>` repos that ships scripts, precompiled binaries, or git‑cloned sources. The model has held up: the gh‑extension topic on GitHub has hundreds of published extensions and a mature authoring toolchain. **Porting that model to Flox, while honoring what makes Flox different (activated environments), is the fastest route to a credible extension story.**
+
+## 1.2 Motivation — why this is worth doing now
+
+Three forces align. **First**, Flox has reached architectural maturity: the activation subsystem was rewritten in Rust in v1.9 and now `exec()`s the child process in‑place, which means a Flox extension can be a subprocess of an activation with the exact same PID semantics as any other activated command. **Second**, FloxHub is the obvious long‑term distribution surface but isn't ready to be the *only* one; GitHub is where the Flox community already is. **Third**, the `gh` design is proven, small (roughly 2k lines of production Go in `pkg/cmd/extension/`), and maps cleanly onto Rust primitives Flox already uses (`reqwest`, `toml`, `git` via shell‑out, `bpaf` subcommands).
+
+## 1.3 Goals and non‑goals
+
+**Goals (v1):**
+
+- Install, list, remove, and upgrade third‑party extensions from GitHub.
+- Support the three `gh` flavors: script, precompiled binary from a GitHub Release, and git‑cloned source.
+- Dispatch unknown `flox <name>` invocations to `flox-<name>` executables.
+- By default, the extension inherits the currently active Flox environment, if any.
+- An extension's manifest may declare a specific Flox environment that must be activated for its invocation — this is the one piece of novelty relative to `gh`.
+- Abstract the "source" of an extension so FloxHub can be added in v2 without breaking changes.
+
+**Non‑goals (v1), stated explicitly so reviewers see them:**
+
+- **No sandboxing.** An extension runs with the user's full privileges, exactly like `gh`. Trust is by code review, not by technical enforcement.
+- **No signature verification.** Even though the release‑asset resolver records a checksum, we do not verify signatures. `gh`'s build‑provenance attestation is interesting but out of scope.
+- **No curated registry.** Discovery in v1 is "go to GitHub and search the `flox-extension` topic." A registry UX would follow FloxHub integration.
+- **No search, browse, create, or exec subcommands in v1.** These are deferred to v2/v3 (§1.6).
+- **No binary re‑publish layer.** We pull release assets straight from GitHub.
+- **No support for extensions overriding built‑in commands.** Conflicts are rejected at install time.
+
+## 1.4 Target users and workflows
+
+| User | Workflow |
+|---|---|
+| **Platform engineer at a company using Flox** | Writes `flox-deploy`, a bash script that activates the team's `prod-tools` FloxHub environment and runs a deploy. Publishes it as `acme-corp/flox-deploy`. Team runs `flox extension install acme-corp/flox-deploy`, then `flox deploy staging`. |
+| **Open‑source contributor** | Writes `flox-ai` in Rust, precompiled via GitHub Actions. Users run `flox extension install someone/flox-ai`; binary is downloaded for their OS/arch. |
+| **Solo dev** | Clones an extension repo, runs `flox extension install .` for local development, iterates, pushes a v0.1.0 tag, other users install by tag. |
+| **CI job** | Runs `flox extension install --pin v1.2.3 org/flox-report` in a pipeline to guarantee reproducibility. |
+
+## 1.5 User stories
+
+1. *As a Flox user*, I can install an extension from GitHub with a single command and immediately run it as `flox <name>`.
+2. *As a Flox user*, I can list my installed extensions with their versions and see which ones have updates.
+3. *As a Flox user*, I can pin an extension to a specific release tag or commit.
+4. *As a Flox user*, I expect `flox <extname>` inside an activated environment to see that environment's packages on `PATH`.
+5. *As an extension author*, I can declare `environment = "org/tools"` in my manifest so the extension *always* runs with that environment activated, independently of what the user has active.
+6. *As an extension author*, I can opt out of automatic activation (`environment.inherit = "none"`) for extensions that must not pick up arbitrary user state.
+
+## 1.6 Feature scope by version
+
+### v1 — minimum viable (this document's design target)
+
+- `flox extension install <repo> [--pin <ref>] [--force]`
+- `flox extension list` (alias `ls`)
+- `flox extension remove <name>`
+- `flox extension upgrade <name> | --all [--dry-run] [--force]`
+- Dispatch of `flox <name> …` to `flox-<name>`
+- Script, binary (from GitHub Release), and git extension kinds
+- Per‑extension `manifest.toml` (authored) + `state.toml` (internal)
+- Environment inheritance with manifest override
+- Source abstraction: `GitHubSource` is the only implementation
+
+### v2 — discovery, authoring, and FloxHub
+
+- `flox extension search [query] [--owner] [--limit]`
+- `flox extension create [--kind script|precompiled]`
+- `FloxHubSource` as a second `ExtensionSource` implementation; `flox extension install floxhub:org/name` URIs
+- Shell completion (`bpaf` already supports this)
+
+### v3 — richer UX and ecosystem
+
+- `flox extension browse` (TUI, mirrors `gh extension browse`)
+- `flox extension exec <name> …` for name‑conflict resolution
+- Nested extension commands (e.g., `flox env my-extension`) — the feature `gh`'s team called out as roadmap
+- Optional build‑provenance / checksum verification
+- Flox Catalog integration for package dependencies declared by extensions
+
+## 1.7 User‑facing command surface (v1)
+
+```shell
+# Install from GitHub
+flox extension install flox-examples/flox-deploy
+flox extension install https://github.com/flox-examples/flox-deploy
+flox extension install .                               # local repo
+flox extension install --pin v1.2.3 acme/flox-report
+flox extension install --force acme/flox-report        # overwrite existing
+
+# List (also shows update availability)
+flox extension list
+# NAME         REPO                              VERSION   PINNED
+# deploy       flox-examples/flox-deploy         v0.3.1
+# report       acme/flox-report                  v1.2.3    yes
+
+# Upgrade
+flox extension upgrade deploy
+flox extension upgrade --all
+flox extension upgrade --all --dry-run
+
+# Remove
+flox extension remove deploy
+
+# Dispatch (no `extension` subcommand needed)
+flox deploy staging --region us-east-1
+```
+
+### Invocation example showing environment inheritance
+
+```shell
+$ flox activate -d ./myproj          # activates myproj env
+flox [myproj] $ flox deploy staging  # deploy extension sees myproj's PATH
+flox [myproj] $ exit
+$ flox deploy staging                # no env, runs with plain user PATH
+```
+
+### Invocation example showing manifest override
+
+If `flox-deploy`'s manifest declares `environment = "acme/prod-tools"`, then:
+
+```shell
+$ flox deploy staging
+# → Flox activates acme/prod-tools in a subprocess, then execs flox-deploy
+#   with staging as argv[1], inheriting the activated env's PATH/vars.
+```
+
+## 1.8 Extension‑author surface
+
+An extension is a GitHub repository named `flox-<name>`. It must contain either:
+
+1. **An executable `flox-<name>` at the repo root** (script case), OR
+2. **A GitHub Release with assets named `flox-<name>-<os>-<arch>[.exe]`** (binary case), OR
+3. **Neither — but an executable `flox-<name>` exists at the repo root of a specific tree-ish** (git‑clone case; equivalent to (1) without a release).
+
+All three kinds may ship a top‑level `flox-extension.toml` (authored metadata; see §1.9) — optional for script/git, **required** for binary releases because the resolver uses it to know the asset file name template if non‑default.
+
+**Distinction from `gh` for authors:** a Flox extension may declare its activation behavior in the manifest; a `gh` extension cannot.
+
+### Publishing flow (mirrors `gh`)
+
+1. Name the repo `flox-<name>`.
+2. For binary: add a GitHub Actions workflow that builds per‑platform assets and attaches them to releases. (An official `flox/flox-extension-precompile` action, modeled on `cli/gh-extension-precompile`, is a v2 deliverable.)
+3. Push a `v*` tag to publish.
+4. Tag the repo with the GitHub topic `flox-extension` so it is discoverable (future search).
+
+## 1.9 Manifest / metadata file spec
+
+Two files, both TOML. TOML chosen over YAML for consistency with Flox's existing `manifest.toml`/`manifest.lock` and to keep the author‑facing surface uniform. **Alternative considered:** YAML, as `gh` uses (`manifest.yml` with `owner`, `name`, `host`, `tag`, `ispinned`, `path`). Rejected because (a) the rest of the Flox ecosystem is TOML, (b) Flox already depends on `toml`/`toml_edit`, and (c) `manifest.yml` in `gh` is an *internal* state file, not author‑facing — we split that role explicitly.
+
+### Author‑facing: `flox-extension.toml` (committed in the extension repo)
+
+```toml
+# Schema version — bump on breaking changes.
+schema = 1
+
+[extension]
+name = "deploy"                # required; must match repo suffix flox-<name>
+description = "Deploy a Flox environment to a target."
+version = "0.3.1"              # SemVer; used when no git tag is resolvable
+license = "Apache-2.0"
+homepage = "https://github.com/flox-examples/flox-deploy"
+
+# Which extension kind. If absent, inferred: release-with-assets => "binary",
+# repo with top-level executable => "script", otherwise => "git".
+kind = "binary"                # "script" | "binary" | "git"
+
+# Binary kind only: asset naming. Default template is
+#   "flox-<name>-<os>-<arch><ext>"  where <ext> is ".exe" on Windows, "" elsewhere.
+# Override if your release uses a different convention.
+[extension.binary]
+asset_template = "flox-{name}-{os}-{arch}{ext}"
+# Optional per-platform explicit mapping (overrides template).
+[extension.binary.platforms]
+"linux-x86_64"   = "deploy-linux-amd64.tar.gz"
+"darwin-aarch64" = "deploy-macos-arm64.tar.gz"
+
+# Environment behavior. All fields optional; this block as a whole is optional.
+[environment]
+# "inherit" (default): use whatever env the user has activated.
+# "none":    explicitly run outside any Flox env.
+# "pinned":  activate the env named in `ref` for every invocation.
+inherit = "inherit"
+ref     = "acme/prod-tools"    # required if inherit = "pinned"
+# When pinned, how to resolve drift if the user is ALSO in an env:
+# "override" (default) | "layer" (future) | "error"
+on_active = "override"
+```
+
+### Internal: `state.toml` (written by the manager alongside the installed extension)
+
+```toml
+# Managed by Flox. Do not edit by hand.
+schema = 1
+name     = "deploy"
+kind     = "binary"
+source   = "github"
+owner    = "flox-examples"
+repo     = "flox-deploy"
+host     = "github.com"            # supports GHE later
+tag      = "v0.3.1"                # for binary: release tag; for git/script: ref
+commit   = "a1b2c3d4..."           # for git/script: resolved commit SHA
+pinned   = false                   # true if installed with --pin
+asset_sha256 = "fe14...cafe"       # for binary; recorded but not verified in v1
+installed_at = "2026-04-17T10:11:12Z"
+path         = "/home/me/.local/share/flox/extensions/flox-deploy/flox-deploy"
+```
+
+This mirrors `gh`'s `manifest.yml` fields (`owner`, `name`, `host`, `tag`, `ispinned`, `path`) and adds `kind`, `commit`, `source`, and `asset_sha256` to cover the three kinds under a single struct and prepare for FloxHub.
+
+## 1.10 Dispatch semantics
+
+When the user types `flox foo bar baz` and `foo` is not a known top‑level subcommand:
+
+1. The `bpaf` parser either fails or the top‑level enum has an `External(Vec<OsString>)` variant (see §2.5). We catch this before emitting the "unknown subcommand" error.
+2. The manager looks for `flox-foo` first in the managed extensions directory (`$XDG_DATA_HOME/flox/extensions/flox-foo/flox-foo`), then falls back to `$PATH`. This mirrors `gh`'s behavior and allows users to `flox extension install .` a locally developed extension without polluting `$PATH`.
+3. The child process is spawned with all remaining argv (`bar baz`) forwarded untouched.
+4. Environment variables are set/inherited per §1.11.
+5. Exit code of the extension is the exit code of `flox`.
+
+If both `foo` is unknown *and* no `flox-foo` exists, we emit the standard `bpaf` "unknown command" error with a hint: `try 'flox extension install <repo>'`.
+
+**Alternative considered:** pre‑scanning `$PATH` on every `flox` invocation to build the command list. Rejected: adds latency to every CLI run; `gh` does not do this; lookup on demand is correct.
+
+## 1.11 Environment inheritance
+
+The rule: **the extension's `manifest.environment` stanza, if present and of kind `pinned`, wins; otherwise the user's currently‑active Flox environment is inherited.**
+
+Resolution algorithm on dispatch:
+
+1. Read the extension's `flox-extension.toml` (cached from install).
+2. Determine `mode`:
+   - If `environment.inherit = "pinned"` → `mode = Pinned(ref)`.
+   - Else if `$FLOX_ENV` is set (user has an active activation) → `mode = Inherit`.
+   - Else `mode = None`.
+3. Execute based on mode:
+   - **Pinned:** run the equivalent of `flox activate -r <ref> -- flox-<name> <args...>`. Reuses existing activation plumbing; guarantees the extension runs with exactly the environment the author intended.
+   - **Inherit:** spawn the child in‑process with `$FLOX_ENV`, `$FLOX_ENV_CACHE`, `$FLOX_ENV_PROJECT`, `$FLOX_ENV_DESCRIPTION`, `$FLOX_PROMPT_ENVIRONMENTS`, and the activated `$PATH` already inherited from the parent process. Nothing special to do — the child inherits the parent's env by default.
+   - **None:** spawn the child with the user's baseline env (no Flox vars). We explicitly scrub any leaked `$FLOX_*` vars for predictability.
+4. In every mode, we additionally set:
+   - `FLOX_EXTENSION_NAME=<name>`
+   - `FLOX_EXTENSION_VERSION=<version>`
+   - `FLOX_EXTENSION_PATH=<install dir>`
+   - `FLOX_BIN=<absolute path to current flox binary>` — so extensions can shell out to `flox` itself reliably without `$PATH` ambiguity. This is the analog of `gh`'s `GH_PATH`.
+
+**Why `on_active = "override"` is the default when pinned:** an author who pins an environment does so because their extension needs it. Silently falling through to the user's env would be a footgun. `"error"` is the strict alternative and is supported. `"layer"` (compose the two envs) is explicitly deferred because Flox composition semantics are still evolving.
+
+## 1.12 Compatibility and migration
+
+- **No breaking changes** to existing `flox` CLI surface. All new work lives under `flox extension …` plus an external‑subcommand fallback that only triggers on otherwise‑unknown commands.
+- **Namespace reservation:** the `extension` keyword is new. Users who have a local `flox-extension` binary on `$PATH` will no longer dispatch to it, because `extension` is now a core subcommand. This is a deliberate, documented incompatibility; searching the Flox forum shows no current usage of this name.
+- **v2 FloxHub migration:** `state.toml`'s `source = "github"` field is the discriminant. When FloxHub support lands, `source = "floxhub"` extensions will use a parallel resolver; no state migration is required for existing GitHub‑installed extensions.
+
+## 1.13 Success metrics
+
+- **Adoption:** ≥ 20 community‑published `flox-extension`‑topic repos within 6 months of v1 GA.
+- **Reliability:** < 1% install failure rate, measured by anonymous telemetry on `flox extension install` exit codes (respecting opt‑out).
+- **Performance budget:** extension dispatch overhead ≤ 50 ms on top of the extension's own startup (measured: time from `flox foo` invocation to extension's `main`).
+- **Time‑to‑first‑extension:** a new user can publish a working script extension in under 15 minutes following the docs.
+
+## 1.14 Explicit non‑goals recap
+
+| Non‑goal | Rationale |
+|---|---|
+| Sandboxing | Matches `gh`. Extensions are trusted code. |
+| Signature/attestation verification | Deferred; `asset_sha256` is recorded for a future flag. |
+| Curated registry | The GitHub topic is sufficient v1 discovery. |
+| Overriding core commands | Collision rejected at install; use `flox extension exec` (v3) to escape. |
+| Bundling the Flox env into the extension artifact | Extensions are small; environments are big and already distributed via FloxHub. |
+
+---
+
+# Part 2 — Technical architecture
+
+## 2.1 High‑level architecture
+
+```
+                 ┌────────────────────────────────────────────┐
+ user types  ──► │  flox  (cli/flox/src/main.rs)              │
+                 │    bpaf top-level parser                   │
+                 └────┬─────────────────────────────┬─────────┘
+                      │ matches known subcmd        │ unknown token
+                      ▼                             ▼
+         ┌────────────────────────┐      ┌─────────────────────────────┐
+         │ Commands::Extension(…) │      │ Commands::External(argv)    │
+         │  install/list/remove/  │      │   ExtensionManager::find()  │
+         │  upgrade               │      │   + Dispatcher::exec()      │
+         └──────────┬─────────────┘      └──────┬──────────────────────┘
+                    │                            │
+                    ▼                            │
+         ┌────────────────────────┐              │
+         │  ExtensionManager      │◄─────────────┘
+         │   (trait)              │
+         │                        │
+         │  dyn ExtensionSource ──┼──► GitHubSource  (v1)
+         │  FS layout             │    FloxHubSource (v2)
+         │  state.toml r/w        │
+         └──────────┬─────────────┘
+                    │
+         ┌──────────▼─────────────────────────────────────────┐
+         │ Filesystem: $XDG_DATA_HOME/flox/extensions/        │
+         │   flox-deploy/                                     │
+         │     flox-deploy        (executable, symlink, .git) │
+         │     state.toml                                     │
+         │     flox-extension.toml  (copied from repo)        │
+         └────────────────────────────────────────────────────┘
+```
+
+Dispatch path in detail:
+
+```
+        flox foo bar baz
+              │
+              ▼
+     bpaf parser ─── recognized? ──yes──► usual path
+              │no
+              ▼
+     External(["foo","bar","baz"])
+              │
+              ▼
+     ExtensionManager::find("foo")
+              │       │
+           Some(ext)  None → error + "try flox extension install"
+              │
+              ▼
+     activation_mode = resolve(ext.manifest, $FLOX_ENV)
+              │
+     ┌────────┴────────┬─────────────┐
+  Pinned(ref)        Inherit        None
+     │                 │              │
+     ▼                 ▼              ▼
+  spawn:          spawn directly   spawn (scrubbed env)
+  flox activate   with inherited
+  -r <ref>        $FLOX_* vars
+  -- flox-foo …
+```
+
+## 2.2 Crate / module layout
+
+Flox is a Cargo workspace with (among others) `cli/flox/` (the binary crate), `cli/flox-rust-sdk/` (the library), and `cli/flox-activations/` (the activation logic extracted in v1.9). We place new code accordingly:
+
+```
+cli/
+├── flox/
+│   └── src/
+│       ├── main.rs
+│       └── commands/
+│           ├── mod.rs                    ← register Extension variant, External fallback
+│           └── extension/                ← NEW subcommand module
+│               ├── mod.rs                ← bpaf enum + handler entrypoint
+│               ├── install.rs
+│               ├── list.rs
+│               ├── remove.rs
+│               └── upgrade.rs
+└── flox-rust-sdk/
+    └── src/
+        └── providers/
+            └── extensions/               ← NEW module tree
+                ├── mod.rs                ← public re-exports
+                ├── manager.rs            ← ExtensionManager trait + impl
+                ├── extension.rs          ← Extension struct + Kind enum
+                ├── manifest.rs           ← AuthorManifest + InstalledState
+                ├── dispatch.rs           ← find + spawn logic
+                ├── layout.rs             ← on-disk paths
+                ├── source.rs             ← ExtensionSource trait
+                ├── github.rs             ← GitHubSource impl
+                └── floxhub.rs            ← stub in v1; impl in v2
+```
+
+**Why split between `cli/flox/` and `cli/flox-rust-sdk/`:** the pattern the repo already uses. Command parsing and user‑facing error presentation live in the binary crate; the domain logic (manager, traits, FS layout) lives in the SDK so it is testable without a `bpaf` context and so FloxHub or the VS Code extension can reuse it later. This is analogous to `gh` keeping the `pkg/extensions/` interface separate from the `pkg/cmd/extension/` command surface.
+
+## 2.3 Core trait sketches
+
+All code uses `async fn` where Flox's reqwest calls already are `async`, and uses `thiserror` for a typed error enum (Flox's convention) with `anyhow` reserved for binary‑level glue. Where `impl Trait` in return position would be clearer than a boxed future, it is preferred — but the trait object needs to be dyn‑compatible, so the canonical trait uses `async_trait` for now (matching what Flox does for other provider traits).
+
+```rust
+// cli/flox-rust-sdk/src/providers/extensions/extension.rs
+
+use std::path::PathBuf;
+use serde::{Deserialize, Serialize};
+
+/// One of three flavors, mirroring gh.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExtensionKind {
+    Script,
+    Binary,
+    Git,
+}
+
+/// A fully-installed extension on disk.
+#[derive(Debug, Clone)]
+pub struct Extension {
+    pub name: String,            // "deploy" (no "flox-" prefix)
+    pub kind: ExtensionKind,
+    pub owner: String,           // "flox-examples"
+    pub repo: String,            // "flox-deploy"
+    pub host: String,            // "github.com"
+    pub tag: Option<String>,     // release tag if known
+    pub commit: Option<String>,  // git SHA for script/git kinds
+    pub pinned: bool,
+    pub install_dir: PathBuf,    // .../extensions/flox-deploy/
+    pub executable: PathBuf,     // .../flox-deploy
+    pub manifest: AuthorManifest, // parsed flox-extension.toml
+}
+```
+
+```rust
+// cli/flox-rust-sdk/src/providers/extensions/manager.rs
+
+use async_trait::async_trait;
+use std::path::PathBuf;
+
+#[async_trait]
+pub trait ExtensionManager: Send + Sync {
+    /// Enumerate installed extensions.
+    async fn list(&self) -> Result<Vec<Extension>, ExtensionError>;
+
+    /// Install from a source spec, optionally pinned.
+    async fn install(
+        &self,
+        spec: &ExtensionSpec,
+        opts: InstallOptions,
+    ) -> Result<Extension, ExtensionError>;
+
+    /// Install from a local path (used by `flox extension install .`).
+    async fn install_local(&self, path: &std::path::Path)
+        -> Result<Extension, ExtensionError>;
+
+    /// Upgrade one (name) or all (None).
+    async fn upgrade(
+        &self,
+        name: Option<&str>,
+        opts: UpgradeOptions,
+    ) -> Result<Vec<UpgradeResult>, ExtensionError>;
+
+    /// Remove by name.
+    async fn remove(&self, name: &str) -> Result<(), ExtensionError>;
+
+    /// Lookup for dispatch. Returns None if not an installed extension; callers
+    /// then fall back to $PATH.
+    async fn find(&self, name: &str) -> Result<Option<Extension>, ExtensionError>;
+}
+
+#[derive(Debug, Clone)]
+pub struct ExtensionSpec {
+    pub source: SourceKind,                 // GitHub in v1
+    pub ident:  SourceIdent,                // owner/repo or FloxHub ref
+}
+
+#[derive(Debug, Clone)]
+pub enum SourceKind { GitHub, FloxHub }     // FloxHub is a type marker in v1
+
+#[derive(Debug, Clone)]
+pub struct SourceIdent { pub owner: String, pub repo: String, pub host: String }
+
+#[derive(Debug, Clone, Default)]
+pub struct InstallOptions {
+    pub pin:   Option<String>,      // tag or commit
+    pub force: bool,                // overwrite existing
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct UpgradeOptions { pub force: bool, pub dry_run: bool }
+
+#[derive(Debug, Clone)]
+pub struct UpgradeResult {
+    pub name: String,
+    pub from: String,
+    pub to:   String,
+    pub status: UpgradeStatus,
+}
+#[derive(Debug, Clone)]
+pub enum UpgradeStatus { Upgraded, AlreadyCurrent, Pinned, Failed(String) }
+```
+
+```rust
+// cli/flox-rust-sdk/src/providers/extensions/source.rs
+
+#[async_trait]
+pub trait ExtensionSource: Send + Sync {
+    /// Identify latest tag/commit. Returns (tag, commit).
+    async fn resolve_latest(&self, id: &SourceIdent)
+        -> Result<Resolved, ExtensionError>;
+
+    /// Resolve a user-provided pin (tag or SHA prefix) to a concrete ref.
+    async fn resolve_pin(&self, id: &SourceIdent, pin: &str)
+        -> Result<Resolved, ExtensionError>;
+
+    /// Is there a release with downloadable binary assets for (tag)?
+    async fn list_release_assets(&self, id: &SourceIdent, tag: &str)
+        -> Result<Vec<ReleaseAsset>, ExtensionError>;
+
+    /// Download an asset to `dest`. Returns sha256 hex.
+    async fn download_asset(
+        &self, asset: &ReleaseAsset, dest: &std::path::Path,
+    ) -> Result<String, ExtensionError>;
+
+    /// Shallow-clone the repo at a specific ref to `dest`.
+    async fn clone_repo(
+        &self, id: &SourceIdent, reference: &str, dest: &std::path::Path,
+    ) -> Result<(), ExtensionError>;
+}
+
+#[derive(Debug, Clone)]
+pub struct Resolved { pub tag: Option<String>, pub commit: String }
+
+#[derive(Debug, Clone)]
+pub struct ReleaseAsset {
+    pub name: String,
+    pub download_url: String,
+    pub size: u64,
+    pub content_type: Option<String>,
+}
+```
+
+```rust
+// cli/flox-rust-sdk/src/providers/extensions/manifest.rs
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct AuthorManifest {
+    pub schema: u32,
+    pub extension: ExtensionMeta,
+    #[serde(default)]
+    pub environment: EnvironmentBehavior,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ExtensionMeta {
+    pub name: String,
+    pub description: Option<String>,
+    pub version: Option<String>,
+    pub license: Option<String>,
+    pub homepage: Option<String>,
+    pub kind: Option<ExtensionKind>,          // inferred if absent
+    #[serde(default)]
+    pub binary: BinaryMeta,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct BinaryMeta {
+    pub asset_template: Option<String>,        // default in code
+    pub platforms: std::collections::BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct EnvironmentBehavior {
+    #[serde(default = "default_inherit")]
+    pub inherit: InheritMode,
+    pub r#ref:   Option<String>,
+    #[serde(default)]
+    pub on_active: OnActive,
+}
+fn default_inherit() -> InheritMode { InheritMode::Inherit }
+
+#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InheritMode {
+    #[default] Inherit,
+    None,
+    Pinned,
+}
+
+#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OnActive { #[default] Override, Error }
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct InstalledState {
+    pub schema: u32,
+    pub name: String,
+    pub kind: ExtensionKind,
+    pub source: String,
+    pub owner: String,
+    pub repo: String,
+    pub host: String,
+    pub tag: Option<String>,
+    pub commit: Option<String>,
+    pub pinned: bool,
+    pub asset_sha256: Option<String>,
+    pub installed_at: String,       // RFC 3339
+    pub path: std::path::PathBuf,
+}
+```
+
+```rust
+// cli/flox-rust-sdk/src/providers/extensions/manager.rs (cont'd)
+
+#[derive(Debug, thiserror::Error)]
+pub enum ExtensionError {
+    #[error("extension '{0}' is already installed")]
+    AlreadyInstalled(String),
+    #[error("extension '{0}' not found")]
+    NotInstalled(String),
+    #[error("extension name '{0}' conflicts with a core flox command")]
+    CommandConflict(String),
+    #[error("no release asset matching platform {platform} for {owner}/{repo}")]
+    NoMatchingAsset { owner: String, repo: String, platform: String },
+    #[error("could not resolve release or ref for {0}/{1}")]
+    ResolveFailed(String, String),
+    #[error("invalid manifest: {0}")]
+    InvalidManifest(String),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    Http(#[from] reqwest::Error),
+    #[error(transparent)]
+    Toml(#[from] toml::de::Error),
+    #[error("git operation failed: {0}")]
+    Git(String),
+}
+```
+
+## 2.4 On‑disk layout
+
+We follow XDG and the paths Flox already uses (`~/.config/flox/` for config, `~/.local/share/flox/` for data, `~/.cache/flox/` for cache — consistent with the debug trace `flox/src/config/mod.rs: $FLOX_CONFIG_HOME not set, using "/root/.config/flox/"`).
+
+```
+$XDG_DATA_HOME/flox/extensions/            ← default root
+├── .lock                                  ← flock for concurrent install/upgrade
+├── index.toml                             ← optional cache: name → install_dir
+└── flox-<name>/
+    ├── flox-<name>                        ← executable (file | symlink | inside .git)
+    ├── state.toml                         ← managed InstalledState
+    ├── flox-extension.toml                ← copy of author manifest
+    ├── .git/                              ← for git/script kinds only
+    └── .checksum                          ← for binary kind: sha256 hex line
+```
+
+Per‑kind specifics:
+
+- **Script (git‑clone):** `git clone --depth=1 [--branch <pin>]` into the install dir; executable is a relative path inside the clone. A git‑clone and a "script" in `gh`'s taxonomy are the same thing on disk; the distinction only matters for upgrade (re‑clone vs. re‑download).
+- **Binary:** the release asset is downloaded directly as `flox-<name>` (or extracted, if the asset is a `.tar.gz`/`.zip`), `chmod +x`'d, and `sha256` recorded. No `.git/`.
+- **Local (`install .`):** `state.toml`'s `path` points at a symlink into the user's working copy. `gh` does the same; it enables iterative development without reinstalling.
+
+The `.lock` file uses `fs2::FileExt::try_lock_exclusive()` to serialize `install`/`upgrade`/`remove`. Read operations (`list`, `find`) are lock‑free since `state.toml` writes are atomic (temp‑file rename).
+
+## 2.5 Dispatch integration with `bpaf`
+
+Flox uses `bpaf` with the derive macro. The current top‑level command enum lives at `cli/flox/src/commands/mod.rs`. We add one enum variant for the managed subcommand plus an external fallback:
+
+```rust
+// cli/flox/src/commands/mod.rs (additions)
+
+use bpaf::Bpaf;
+
+#[derive(Debug, Clone, Bpaf)]
+#[bpaf(options, version)]
+pub enum Commands {
+    // ... existing variants: Init, Install, Activate, Search, …
+
+    /// Manage flox extensions
+    #[bpaf(command)]
+    Extension(#[bpaf(external(extension::extension))] extension::ExtensionCmd),
+
+    /// Catch-all: an unrecognized first-positional + everything after it.
+    /// Triggered only if no other variant matched.
+    #[bpaf(command(".extension-dispatch"), hide)]   // placeholder
+    External {
+        #[bpaf(any::<std::ffi::OsString, _, _>("CMD", Some))]
+        argv: Vec<std::ffi::OsString>,
+    },
+}
+```
+
+`bpaf` does not have a direct `clap`‑style `allow_external_subcommands` flag; the idiomatic approach is a fallback parser assembled after all named commands. The production pattern is to call `parse()` twice with `run_inner`: first with the full command set, and if it returns `ParseFailure::Stderr` on an unknown‑subcommand error, re‑parse with a parser that accepts the raw `argv` as `any::<OsString>(…).many()`. A thin helper in `main.rs`:
+
+```rust
+// cli/flox/src/main.rs
+
+fn main() -> ExitCode {
+    let args: Vec<std::ffi::OsString> = std::env::args_os().skip(1).collect();
+
+    // 1. Try the normal parser.
+    match commands::commands().run_inner(bpaf::Args::from(args.as_slice())) {
+        Ok(cmd) => run(cmd),
+
+        // 2. If bpaf didn't recognize the subcommand and the first arg isn't a
+        //    flag, try dispatch.
+        Err(bpaf::ParseFailure::Stderr(_)) if looks_like_extension(&args) => {
+            dispatch_extension(args)
+        }
+
+        Err(err) => {
+            err.print_mesage(80);
+            ExitCode::from(2)
+        }
+    }
+}
+
+fn looks_like_extension(args: &[std::ffi::OsString]) -> bool {
+    args.first()
+        .and_then(|a| a.to_str())
+        .map(|s| !s.starts_with('-'))
+        .unwrap_or(false)
+}
+```
+
+`dispatch_extension` calls `ExtensionManager::find(&args[0])`; if `Some(ext)`, it launches the child (see §2.7); if `None`, it prints the standard `bpaf` error, plus a `Try: flox extension install <owner>/flox-<name>` hint.
+
+**Alternative considered:** adding a new top‑level positional `Commands::Unknown(Vec<OsString>)` with `bpaf::any` as the variant‑level parser and ordering it last. Rejected because `bpaf` evaluates alternatives left‑to‑right and greedy `any` swallows legitimate unknown‑flag errors, harming UX for typos. The two‑phase parse keeps built‑in UX intact.
+
+## 2.6 Installation flow (per kind)
+
+### Script / binary / git — common preamble
+
+1. Parse the user's argument: `owner/repo`, full URL, or `.`.
+2. Normalize: ensure repo name starts with `flox-`; extract `name` (suffix).
+3. `checkValidExtension`: reject if name collides with a core `flox` subcommand (consult the `Commands` enum via a compile‑time list) or with an already‑installed extension (unless `--force`).
+4. Create `$XDG_DATA_HOME/flox/extensions/flox-<name>/` under a staging directory (`flox-<name>.staging-<uuid>`) for atomic rename on success.
+
+### Git/script kind (no release assets found)
+
+1. `git clone --depth=1 --branch <pin_or_default> https://<host>/<owner>/<repo>.git <staging>`.
+2. Verify `<staging>/flox-<name>` exists and is executable (or `chmod +x` it if not).
+3. Copy `flox-extension.toml` to staging root if present in the clone.
+4. Write `state.toml` with `kind = "script"` (or `"git"` if no entrypoint was found — we still allow a repo that uses `exec` to pick a language‑specific entrypoint).
+5. `rename(staging → final)`.
+
+### Binary kind (release asset exists)
+
+1. Call `GitHubSource::resolve_latest` — hits `GET /repos/:owner/:repo/releases/latest` (or `/releases/tags/<pin>`).
+2. Compute the current platform string: `format!("{os}-{arch}")` where `os ∈ {linux, darwin, windows}`, `arch ∈ {amd64 or x86_64, arm64 or aarch64}`. Emit both nomenclatures for matching because `gh`‑style assets use `amd64` but Rust's `std::env::consts::ARCH` returns `x86_64`.
+3. Resolve the asset:
+   - If `manifest.extension.binary.platforms[<platform>]` is set, use that exact name.
+   - Else render `asset_template` (default `flox-{name}-{os}-{arch}{ext}`).
+   - Else substring‑match release asset names for the platform string, mirroring `installBin` in `cli/cli` which simply walks the release assets and picks one whose name contains the platform; the `darwin-arm64` → `darwin-amd64` Rosetta fallback documented in `cli/cli#9592` is reproduced.
+4. Download to staging, compute sha256, record in `.checksum`.
+5. If asset is an archive (`.tar.gz`/`.zip`), extract and locate an executable named `flox-<name>`.
+6. `chmod +x` and write `state.toml`.
+
+### Local (`install .`)
+
+1. Resolve to absolute path.
+2. Symlink `final/flox-<name>` → `<abs>/flox-<name>`.
+3. Copy `flox-extension.toml` in (not symlinked, so edits don't corrupt state until reinstall).
+4. Write `state.toml` with `source = "local"`, `commit = <git rev-parse HEAD>` if the dir is a git repo, else omitted.
+
+### Name‑conflict and already‑installed behavior
+
+- If installed *with the same owner*, offer to upgrade (matches `gh`'s `alreadyInstalledError` path).
+- If installed *with a different owner* and `--force`, delete the existing install dir and proceed.
+- Otherwise emit `ExtensionError::AlreadyInstalled`.
+
+## 2.7 Upgrade flow
+
+`flox extension upgrade <name>` or `--all`:
+
+1. Load `state.toml` for each target.
+2. Skip if `pinned = true` (unless `--force`).
+3. Per kind:
+   - **Binary:** `resolve_latest`; if `tag == state.tag`, report `AlreadyCurrent`. Otherwise re‑run the install flow on a staging dir, then atomic rename.
+   - **Git/script:** `git -C <dir> fetch --depth=1 origin <default_branch>` then `git reset --hard FETCH_HEAD`. Record the new commit SHA in `state.toml`.
+   - **Local:** refuse (can't upgrade a symlink to your working tree); print a notice.
+4. With `--dry-run`, run resolution only; emit a table of what *would* happen.
+
+Version tracking is straightforward: `state.toml.tag` for binary, `state.toml.commit` for git/script. `flox extension list` displays `tag` when present, else 8‑char truncated `commit`, matching `gh`'s `displayExtensionVersion` logic.
+
+## 2.8 Environment‑activation process model
+
+The extension child process is spawned by `cli/flox-rust-sdk/src/providers/extensions/dispatch.rs`:
+
+```rust
+pub async fn spawn_extension(
+    ext: &Extension,
+    argv: &[std::ffi::OsString],
+    flox: &Flox,                       // existing shared ctx
+) -> Result<std::process::ExitCode, ExtensionError> {
+    let mode = resolve_mode(&ext.manifest.environment, std::env::vars_os().into_iter());
+
+    match mode {
+        ActivationMode::Pinned(env_ref) => {
+            // Delegate to existing activate machinery so we benefit from its
+            // caching, watchdog, trust prompts, and exec() semantics.
+            // Equivalent to: `flox activate -r <env_ref> -- flox-<name> <argv…>`
+            activate_and_exec(flox, &env_ref, &ext.executable, argv).await
+        }
+        ActivationMode::Inherit => {
+            // Just spawn with the parent's env. $FLOX_ENV et al. are already set.
+            exec_child(&ext.executable, argv, std::env::vars_os()).await
+        }
+        ActivationMode::None => {
+            let scrubbed = std::env::vars_os()
+                .filter(|(k, _)| !k.to_string_lossy().starts_with("FLOX_"));
+            exec_child(&ext.executable, argv, scrubbed).await
+        }
+    }
+}
+```
+
+`activate_and_exec` calls into `cli/flox-activations/` (the crate extracted for the v1.9 rewrite). It should *not* re‑shell through `sh -c "flox activate …"`; it should use the same in‑process path as `flox activate -- <cmd>` so the child ends up with the same PID semantics as any other activated command (per the v1.9 release notes, `flox activate -- <cmd>` now `exec()`s).
+
+In all three modes, we inject the bookkeeping vars:
+
+```rust
+cmd.env("FLOX_EXTENSION_NAME", &ext.name)
+   .env("FLOX_EXTENSION_VERSION", ext.tag.as_deref().unwrap_or(""))
+   .env("FLOX_EXTENSION_PATH", &ext.install_dir)
+   .env("FLOX_BIN", std::env::current_exe()?);
+```
+
+## 2.9 Error types and user‑facing messages
+
+`ExtensionError` is the crate‑internal type. At the CLI boundary the handler converts to the existing Flox error reporting convention (a `Display`‑oriented enum with ANSI coloring). Sample surface strings, modeled on `gh`'s:
+
+| Condition | Message |
+|---|---|
+| Install conflicts with core command | `error: name 'activate' conflicts with a built-in flox command` |
+| Install conflicts with installed ext | `error: flox-deploy is already installed (run with --force to overwrite)` |
+| No matching asset | `error: no release asset matches 'linux-x86_64' for flox-examples/flox-deploy`<br>`hint: open an issue asking the maintainer to publish a linux-x86_64 build` |
+| Extension executable missing | `error: extension 'deploy' has no executable at .../flox-deploy/flox-deploy` |
+| Pinned, env trust declined | `error: extension 'deploy' requires the 'acme/prod-tools' environment; trust it with 'flox activate -r acme/prod-tools --trust' first` |
+| Upgrade of pinned | `skipping 'deploy' (pinned to v1.2.3); pass --force to override` |
+
+## 2.10 Testing strategy
+
+Three tiers, matching Flox's existing conventions:
+
+**Unit (inline `#[cfg(test)]` in each module):**
+- `manifest.rs`: round‑trip TOML parsing and defaults.
+- `layout.rs`: path composition across `$XDG_DATA_HOME` values, including when unset.
+- `source.rs` / `github.rs`: asset‑resolution algorithm against canned release JSON fixtures (stored under `cli/flox-rust-sdk/tests/fixtures/github/releases/*.json`); use `wiremock` to stub the GitHub API. This is the analog of `manager_test.go` in `gh`.
+- `dispatch.rs`: `resolve_mode` truth table across all `InheritMode` × `$FLOX_ENV` combinations.
+
+**Integration (crate‑level `tests/`):**
+- End‑to‑end install/list/remove/upgrade of a fixture script extension served from a local `tempfile`‑backed HTTP mock and a local bare git repo (`git init --bare` + `gix` or shell‑out).
+- Dispatch integration test: install a "hello" extension whose `flox-hello` prints `$FLOX_EXTENSION_NAME`, spawn it, assert stdout.
+
+**Bats (existing Flox convention):**
+- `cli/flox/tests/extension.bats` with user‑facing scenarios: install `.`, install with `--pin`, upgrade `--all`, dispatch inside and outside an active env, and the pinned‑env override case.
+- Run under CI with `flox build && flox activate -- bats …` like the rest of the suite.
+
+Mocks: Flox uses hand‑rolled trait impls for test doubles rather than `mockall`. We follow suit — `ExtensionSource` is dyn‑compatible and a `TestSource` fixture lives in `#[cfg(test)]` modules.
+
+## 2.11 Open questions and risks
+
+1. **Windows.** `gh` supports Windows via `.exe` extension and symlink fallbacks. Flox v1 largely targets macOS/Linux with WSL. Confirm whether the extension system is Linux+macOS only in v1 or must also handle WSL properly. Reasonable default: same platform matrix as `flox` itself.
+2. **Name‑conflict list.** The list of reserved top‑level command names must be kept in sync with `Commands`. Propose a compile‑time `const` slice plus a unit test that walks the `bpaf` help output to enforce it.
+3. **Git transport.** Flox is not currently known to depend on `git2`/`gix`. Proposal: shell out to `/usr/bin/env git` (simpler, matches `gh`'s `git.Client`). Document `git` as a runtime dependency — it already effectively is.
+4. **Archive formats.** `gh` expects raw binary assets; our binary kind also supports `.tar.gz`/`.zip`. Use `flate2` + `tar` + `zip` crates. Alternative: mandate raw binaries in v1 and defer archive support. Recommendation: support archives from day one; it dramatically simplifies authoring for non‑Go languages where a single‑file artifact is unusual.
+5. **FloxHub extension fetch primitive.** FloxHub exposes `hub.flox.dev/...` endpoints for environments today; whether an "extension" object type exists there is a separate design question. We keep the `ExtensionSource` trait neutral so either a direct URL or a new FloxHub artifact type can back it.
+6. **`flox activate` reentrancy when pinned.** If a user runs `flox deploy` *while already inside* the `acme/prod-tools` activation the extension pins, re‑activating should be a no‑op rather than layering. Flox's v1.9 rewrite added "concurrent activations of the same environment in different modes (run vs. dev) are now prevented"; we need a read‑through on the current behavior to confirm the idempotent path is covered.
+7. **Telemetry.** Should `flox extension install` events be included in the existing metrics stream (the Flox debug trace references `Metrics collection disabled`)? Recommended yes, same gate as all other commands.
+
+---
+
+# Part 3 — Side‑by‑side mapping (Go → Rust)
+
+| `gh` component (Go) | File in `cli/cli` | Proposed Flox equivalent (Rust) | File in `flox/flox` |
+|---|---|---|---|
+| `NewCmdExtension` (root `gh extension` cobra cmd) | `pkg/cmd/extension/command.go` | `extension` bpaf enum + handler dispatch | `cli/flox/src/commands/extension/mod.rs` |
+| `extensions.ExtensionManager` interface | `pkg/extensions/extension.go` | `ExtensionManager` trait (async) | `cli/flox-rust-sdk/src/providers/extensions/manager.rs` |
+| Concrete `Manager` struct (`dataDir`, `client`, `gitClient`, `platform`, `io`) | `pkg/cmd/extension/manager.go` | `LocalExtensionManager` struct holding `data_dir: PathBuf`, `http: reqwest::Client`, `git: GitCli`, `platform: Platform`, `source: Arc<dyn ExtensionSource>` | `cli/flox-rust-sdk/src/providers/extensions/manager.rs` |
+| `extensions.Extension` interface (`Name`/`Owner`/`URL`/`CurrentVersion`/`IsPinned`/`IsBinary`) | `pkg/extensions/extension.go` | `Extension` struct + `ExtensionKind` enum | `cli/flox-rust-sdk/src/providers/extensions/extension.rs` |
+| `ExtTemplateType` (Git/GoBin/OtherBin) for `create` | `pkg/extensions/extension.go` | *Deferred to v2* (`CreateTemplate` enum) | `cli/flox-rust-sdk/src/providers/extensions/create.rs` (v2) |
+| `Install(repo, pin)` | `manager.go` `installGit` / `installBin` | `install()` method dispatching on `ExtensionKind` | `providers/extensions/manager.rs` |
+| `installBin` release‑asset resolver | `manager.go` (the `asset == nil` check referenced in `cli/cli#9608`) | `github::resolve_asset` function | `providers/extensions/github.rs` |
+| `Dispatch(args, in, out, err)` | `manager.go` | `dispatch::spawn_extension` free function | `providers/extensions/dispatch.rs` |
+| Unknown‑subcommand fallback | `pkg/cmd/root/root.go` | two‑phase bpaf parse in `main.rs` | `cli/flox/src/main.rs` |
+| Extensions dir `$XDG_DATA_HOME/gh/extensions/` | `manager.go` (`dataDir()`) | `$XDG_DATA_HOME/flox/extensions/` | `providers/extensions/layout.rs` |
+| `manifest.yml` (owner/name/host/tag/ispinned/path) | `manager.go` writes, `extension.go` reads | `state.toml` (`InstalledState`) | `providers/extensions/manifest.rs` |
+| `alreadyInstalledError` / `releaseNotFoundErr` / `commitNotFoundErr` / `repositoryNotFoundErr` / `ErrExtensionExecutableNotFound` | `command.go` & `manager.go` | `ExtensionError` variants | `providers/extensions/manager.rs` |
+| `checkValidExtension` | `command.go` | `validate_new_install` helper | `providers/extensions/manager.rs` |
+| `normalizeExtensionSelector` | `command.go` | `normalize_name` helper (strips `flox-`, `owner/`) | `providers/extensions/manager.rs` |
+| `gh-extension-precompile` GitHub Action | separate repo `cli/gh-extension-precompile` | `flox/flox-extension-precompile` (v2 deliverable, out of CLI scope) | n/a |
+| `browse` TUI (`pkg/cmd/extension/browse/`) | that package | v3 deliverable | `providers/extensions/browse.rs` (v3) |
+| `factory.Factory.ExtensionManager` field (DI) | `pkg/cmdutil/factory.go` | Field on the existing `Flox` shared context struct | wherever `Flox` lives in `flox-rust-sdk` |
+| `DisableFlagParsing: true` on `exec` subcmd | `command.go` | `bpaf::any::<OsString, _, _>("ARGS").many()` on the `exec` subcommand (v3) | `commands/extension/exec.rs` (v3) |
+
+The 5 architectural primitives we preserve 1:1:
+
+1. **The `ExtensionManager` as the single orchestrator** — same methods, same name.
+2. **Per‑extension directory containing the executable + managed metadata file** — same storage shape, different file name/format (`state.toml` vs. `manifest.yml`).
+3. **Three kinds (script / binary / git) detected in the same order** — try release first, fall back to clone.
+4. **Dispatch by PATH search under the managed dir with fall‑through to `$PATH`** — same behavior.
+5. **Asset‑name substring + explicit override** — the `installBin` algorithm is reproduced literally, modulo the author‑provided platform map.
+
+The one architectural addition — `environment` stanza in the author manifest plus a three‑way `ActivationMode` in dispatch — is the **only** place Flox deliberately diverges from `gh`.
+
+---
+
+# Part 4 — Phased implementation plan (v1)
+
+Milestones are ordered by dependency; sizing is engineer‑weeks (S = ≤1, M = 2–3, L = 4+). Each milestone is independently shippable behind a `FLOX_EXTENSIONS_ENABLE` feature flag until the full set ships.
+
+### M0 — Skeleton and dispatch (S, foundational)
+
+- New module tree under `cli/flox-rust-sdk/src/providers/extensions/`.
+- Add `Extension` and `Commands::Extension(Subcmd)` variants; subcommands are stubs that print `unimplemented`.
+- Wire the two‑phase `bpaf` parse in `main.rs`.
+- `find()` walks `$XDG_DATA_HOME/flox/extensions/` looking for `flox-<name>` and does not yet read `state.toml`.
+- Integration test: a pre‑placed `flox-hello` script dispatches correctly and inherits `$FLOX_ENV`.
+
+*Exit criterion:* `flox hello` runs a manually installed `flox-hello` script; `flox extension --help` lists the four subcommands.
+
+### M1 — Manifest + layout + local install (M)
+
+- `AuthorManifest` / `InstalledState` types with `serde`.
+- `layout.rs` with XDG‑aware dir resolution and the `.lock` file.
+- `flox extension install .` and `flox extension remove` end‑to‑end.
+- `flox extension list` reads `state.toml` from every subdir.
+- Bats test: init a fake extension dir, install, list, remove.
+
+*Exit criterion:* local developer loop works. Extension authors can iterate without GitHub.
+
+### M2 — GitHub source: git/script install (M)
+
+- `GitHubSource::clone_repo` via shell‑out to `git`.
+- Install flow for script/git kinds including `--pin` resolution.
+- `upgrade <name>` for git/script (`git fetch`+reset).
+- Name‑conflict validation against the compile‑time core‑command list.
+
+*Exit criterion:* `flox extension install flox-examples/flox-hello-script` works end‑to‑end.
+
+### M3 — GitHub source: binary release install (M)
+
+- `resolve_latest` / `list_release_assets` / `download_asset` against GitHub REST.
+- Asset resolution: author map → template → substring fallback → darwin‑arm64→darwin‑amd64 fallback.
+- Archive extraction (tar/zip) + `chmod +x` + sha256 record.
+- `upgrade <name>` for binary.
+
+*Exit criterion:* install a real published `flox-extension` that ships a Linux and macOS binary; confirm upgrade picks up a new tag.
+
+### M4 — Upgrade‑all and polish (S)
+
+- `flox extension upgrade --all [--dry-run] [--force]`.
+- Unified table output for `list` and `upgrade` results.
+- Good error messages per §2.9.
+- Concurrent‑install safety under the `.lock`.
+
+*Exit criterion:* `flox extension upgrade --all --dry-run` produces the expected report in a repo with multiple kinds.
+
+### M5 — Environment integration (M, the Flox‑unique piece)
+
+- `resolve_mode` implementation reading `$FLOX_ENV` and the manifest.
+- `Inherit` and `None` modes wired to `tokio::process::Command` with env scrubbing.
+- `Pinned` mode delegating to `cli/flox-activations/` for `flox activate -r <ref> -- <cmd>` semantics.
+- Bats tests covering all three modes, including the pinned‑but‑already‑in‑that‑env no‑op path.
+
+*Exit criterion:* the user stories in §1.5 (#4, #5, #6) all pass end‑to‑end.
+
+### M6 — Docs, telemetry, and GA checklist (S)
+
+- `flox.dev/docs/extensions/` pages: user guide and author guide.
+- Example `flox-examples/flox-hello-*` repos (script, binary, local) added to the `flox-examples` org.
+- Telemetry events for install/upgrade/remove/dispatch behind the existing metrics flag.
+- Remove the `FLOX_EXTENSIONS_ENABLE` feature flag.
+
+*Exit criterion:* v1 GA'd in a release; `gh`‑style parity confirmed by running the equivalent `gh` smoke tests translated to `flox`.
+
+### Rough total
+
+Approximately **10 engineer‑weeks** for a single engineer on v1, parallelizable to ~4 calendar weeks with two engineers (M0 → M1 → {M2 ∥ M3} → M4 → M5 → M6). M5 is the only milestone that requires deep familiarity with `flox-activations`; everything else is self‑contained.
+
+### Deliberately deferred (not blocking v1 GA)
+
+- `search`, `browse`, `create`, `exec` subcommands.
+- FloxHub `ExtensionSource`.
+- Checksum/attestation verification.
+- A `flox-extension-precompile` GitHub Action (parallel workstream; not needed for v1 GA since authors can hand‑build).
+- Nested extension commands (`flox env my-extension`).
+
+---
+
+### Appendix A — Verification notes for reviewers
+
+Several claims in this document are derived from third‑party mirrors (Fossies, PR comments, community blog posts) rather than direct reads of `main` on `cli/cli` and `flox/flox`. Before coding begins, the implementing engineer should verify by opening the following files and confirming the shapes referenced:
+
+- `cli/cli`: `pkg/cmd/extension/command.go`, `pkg/cmd/extension/manager.go` (in particular the `installBin` function; the `if asset == nil` diagnostic is referenced in `cli/cli#9608`), `pkg/extensions/extension.go` (the `ExtensionManager` and `Extension` interfaces).
+- `flox/flox`: `cli/flox/src/commands/mod.rs` (to confirm `bpaf` derive usage and the exact shape of the top‑level enum), `cli/flox/src/main.rs`, `cli/flox-rust-sdk/src/providers/` (to confirm the provider‑module pattern), and `cli/flox-activations/` (to understand the public API exposed for the in‑process `activate -- cmd` flow).
+
+Any discrepancy with this document should be resolved in favor of what's in the repos; the design decisions here do not depend on any particular line number, only on the presence of the named concepts (workspace crates, `bpaf` subcommands, `$FLOX_ENV` activation vars, `exec()`‑based child launch in v1.9+).
+
+### Appendix B — Example flows the design must support
+
+**B1. First‑time install and run, no active environment:**
+
+```
+$ flox extension install flox-examples/flox-hello
+✓ Downloaded flox-hello v1.0.0 (linux-x86_64, 1.2 MB, sha256=fe14…)
+✓ Installed to ~/.local/share/flox/extensions/flox-hello
+
+$ flox hello world
+Hello, world! (FLOX_ENV is unset)
+```
+
+**B2. Install inside an activation:**
+
+```
+$ flox activate
+flox [myproj] $ flox extension install flox-examples/flox-greet
+flox [myproj] $ flox greet
+Greetings from myproj! My PATH includes /nix/store/…-myproj/bin
+```
+
+**B3. Pinned‑env extension overriding the user's active env:**
+
+```
+$ flox activate -d ./dev
+flox [dev] $ flox deploy staging
+→ activating acme/prod-tools (pinned by flox-deploy manifest)
+✓ deploy complete
+flox [dev] $               # back in dev
+```
+
+**B4. Pinned install:**
+
+```
+$ flox extension install --pin v2.0.0-rc.1 flox-examples/flox-tool
+$ flox extension list
+NAME   REPO                          VERSION        PINNED
+tool   flox-examples/flox-tool       v2.0.0-rc.1    yes
+
+$ flox extension upgrade --all
+skipping 'tool' (pinned to v2.0.0-rc.1); pass --force to override
+```
+
+End of document.


### PR DESCRIPTION
## Summary

Ports a `gh extension`-style CLI plugin subsystem into flox, **entirely behind
`features.beta`** (opt-in, off by default). With beta enabled:

- `flox <name>` dispatches to an installed `flox-<name>` executable (two-phase
  bpaf parse → `execvp`), never shadowing a built-in command.
- `flox extension {install,list,remove,upgrade}` manage extensions from GitHub
  releases (binary/script/git kinds) or a local path.

## Design

- **Domain logic lives in the `beta` crate** (`cli/beta/src/extensions/`);
  the CLI surface is `cli/flox/src/commands/extension/`. **Zero
  `flox-rust-sdk` changes** — `git status --porcelain cli/flox-rust-sdk/` is
  empty.
- Gated once in the `Commands::Beta` arm and registered on `BetaCommands` with
  `hide`, so `extension` stays out of `flox --help` during the prototype
  window. Per-handler gates were removed (handlers must not re-check, per the
  `adding-beta-subcommand` convention).

## Testing

All green on this branch (rebased onto current `main`):

- `cargo build -p flox -p beta` ✅
- `cargo clippy --all-targets` ✅ (clean)
- `just unit-tests "extensions::"` ✅ 133/133
- `just integ-tests extension.bats` ✅ 27/27

## Status & tracked follow-ups

This is the prototype landing behind beta. Known limitations and deferred
hardening are tracked in Linear under parent **CLI-161**:

- **CLI-157** — nested-bundle extensions lose sibling files on install.
- **CLI-158** — `flox <name>` dispatch reads `FLOX_FEATURES_BETA` / XDG
  directly (runs before config loads), so a config-set `features.beta` /
  `flox.data_dir` is not honored by dispatch.
- **CLI-160** — decide whether to port the reserved-command drift guard.
- Deferred Tier-2 hardening (download/extract size caps, atomic `--force`
  replace, redirect/HTTPS re-validation, staging cleanup, more integration
  tests).

## Release Notes

None — the subsystem is entirely behind `features.beta` and hidden from
`flox --help`, so there is no user-facing change with the flag off.