### PR TITLE
feat(events): restore remaining legacy telemetry parity fields

### DIFF
--- a/cli/flox-events/src/lib.rs
+++ b/cli/flox-events/src/lib.rs
@@ -197,6 +197,13 @@ pub struct CommandPayload {
     os_family: Option<String>,
     /// OS family release version.
     os_family_release: Option<String>,
+    /// Kernel version string from `sys_info::os_release()`; `None` when
+    /// `sys_info` failed. Deliberately the same value as
+    /// `os_family_release` at the producer — consumers derive two
+    /// distinct legacy fields from this one field and treat the
+    /// OS-family release as a separate concept.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    kernel_version: Option<String>,
     /// Linux distribution id (e.g. `ubuntu`); `None` outside Linux.
     os: Option<String>,
     /// Linux distribution version (e.g. `22.04`); `None` outside Linux.
@@ -207,6 +214,34 @@ pub struct CommandPayload {
     /// Tokens describing how this CLI invocation was launched (shell, prompt,
     /// service runner, etc.). Mirrors the legacy `INVOCATION_SOURCES`.
     invocation_sources: Vec<String>,
+    /// Whether `invocation_sources` carries the `"ci"` token or a
+    /// hierarchical sub-token of it (e.g. `"ci.github-actions"`).
+    /// Derived in [`SharedMetadataTemplate::into_payload`], so `Some`
+    /// on every emitted row; `None` only when reading back rows
+    /// buffered by binaries that predate the field, and omitted on
+    /// re-serialization so unknown stays unknown.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    in_ci: Option<bool>,
+    /// Whether `invocation_sources` carries the `"containerd"` token
+    /// (the `FLOX_CONTAINERD` marker exported by flox-built container
+    /// images — not generic container detection) or a sub-token of
+    /// it. Same `None` semantics as `in_ci`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    containerd: Option<bool>,
+}
+
+/// `true` when `sources` carries `root` itself or a hierarchical
+/// sub-token of it (`"ci.github-actions"` counts for `"ci"`;
+/// `"citrus"` does not). ASCII-case-insensitive, because explicit
+/// `FLOX_INVOCATION_SOURCE` tokens arrive verbatim.
+fn has_source_token(sources: &[String], root: &str) -> bool {
+    sources.iter().any(|source| {
+        let Some(prefix) = source.get(..root.len()) else {
+            return false;
+        };
+        prefix.eq_ignore_ascii_case(root)
+            && (source.len() == root.len() || source.as_bytes()[root.len()] == b'.')
+    })
 }
 
 /// Static slice of [`CommandPayload`] that is constant for the duration of
@@ -230,15 +265,22 @@ pub struct SharedMetadataTemplate {
 impl SharedMetadataTemplate {
     /// Merge the stored static fields with the supplied subcommand to produce
     /// a complete [`CommandPayload`] ready for serialization.
+    ///
+    /// `kernel_version` and the `in_ci` / `containerd` bools are derived
+    /// here from the template's own fields, so they cannot disagree with
+    /// the values they mirror.
     pub fn into_payload(&self, subcommand: String) -> CommandPayload {
         CommandPayload {
             subcommand,
             flox_version: self.flox_version.clone(),
             os_family: self.os_family.clone(),
             os_family_release: self.os_family_release.clone(),
+            kernel_version: self.os_family_release.clone(),
             os: self.os.clone(),
             os_version: self.os_version.clone(),
             empty_flags: self.empty_flags.clone(),
+            in_ci: Some(has_source_token(&self.invocation_sources, "ci")),
+            containerd: Some(has_source_token(&self.invocation_sources, "containerd")),
             invocation_sources: self.invocation_sources.clone(),
         }
     }
@@ -375,6 +417,11 @@ pub struct CliEnvironmentActivatePayload {
     has_includes: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     lockfile_version: Option<String>,
+    /// The locked manifest's declared schema version (`"1"`, `"1.10.0"`,
+    /// …) — distinct from `lockfile_version`, the lockfile's own schema
+    /// version. Absent on emits that precede the manifest load.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    manifest_version: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     shell: Option<String>,
 }
@@ -389,6 +436,7 @@ impl CliEnvironmentActivatePayload {
             mode: None,
             has_includes: None,
             lockfile_version: None,
+            manifest_version: None,
             shell: None,
         }
     }
@@ -410,6 +458,11 @@ impl CliEnvironmentActivatePayload {
 
     pub fn with_lockfile_version(mut self, value: impl Into<String>) -> Self {
         self.lockfile_version = Some(value.into());
+        self
+    }
+
+    pub fn with_manifest_version(mut self, value: impl Into<String>) -> Self {
+        self.manifest_version = Some(value.into());
         self
     }
 
@@ -477,6 +530,11 @@ pub struct CliEnvironmentEditPayload {
     /// env-detail emit; `Some(bool)` on the result-known emit.
     #[serde(skip_serializing_if = "Option::is_none")]
     edited_includes: Option<bool>,
+    /// The edited manifest's declared schema version (`"1"`, `"1.10.0"`,
+    /// …), from the post-edit lockfile. `None` on the eager emit — the
+    /// manifest has not been loaded yet at that site.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    manifest_version: Option<String>,
 }
 
 impl CliEnvironmentEditPayload {
@@ -484,11 +542,17 @@ impl CliEnvironmentEditPayload {
         Self {
             env_detail,
             edited_includes: None,
+            manifest_version: None,
         }
     }
 
     pub fn with_edited_includes(mut self, value: bool) -> Self {
         self.edited_includes = Some(value);
+        self
+    }
+
+    pub fn with_manifest_version(mut self, value: impl Into<String>) -> Self {
+        self.manifest_version = Some(value.into());
         self
     }
 }
@@ -507,6 +571,11 @@ pub struct CliEnvironmentPublishPayload {
     /// published package; `None` on the eager env-detail emit.
     #[serde(skip_serializing_if = "Option::is_none")]
     has_manifest_build: Option<bool>,
+    /// The published manifest's declared schema version (`"1"`,
+    /// `"1.10.0"`, …), from the locked environment. `None` on the eager
+    /// env-detail emit.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    manifest_version: Option<String>,
 }
 
 impl CliEnvironmentPublishPayload {
@@ -515,6 +584,7 @@ impl CliEnvironmentPublishPayload {
             env_detail,
             has_expression_build: None,
             has_manifest_build: None,
+            manifest_version: None,
         }
     }
 
@@ -525,6 +595,11 @@ impl CliEnvironmentPublishPayload {
     ) -> Self {
         self.has_expression_build = Some(has_expression_build);
         self.has_manifest_build = Some(has_manifest_build);
+        self
+    }
+
+    pub fn with_manifest_version(mut self, value: impl Into<String>) -> Self {
+        self.manifest_version = Some(value.into());
         self
     }
 }
@@ -620,10 +695,13 @@ mod tests {
             flox_version: "0.0.0-test".to_string(),
             os_family: Some("Linux".to_string()),
             os_family_release: Some("6.10.0".to_string()),
+            kernel_version: Some("6.10.0".to_string()),
             os: Some("ubuntu".to_string()),
             os_version: Some("24.04".to_string()),
             empty_flags: vec![],
             invocation_sources: vec!["shell".to_string()],
+            in_ci: Some(false),
+            containerd: Some(false),
         }
     }
 
@@ -633,10 +711,25 @@ mod tests {
             "flox_version": "0.0.0-test",
             "os_family": "Linux",
             "os_family_release": "6.10.0",
+            "kernel_version": "6.10.0",
             "os": "ubuntu",
             "os_version": "24.04",
             "empty_flags": [],
             "invocation_sources": ["shell"],
+            "in_ci": false,
+            "containerd": false,
+        })
+    }
+
+    fn command_run_envelope_json(payload: serde_json::Value) -> serde_json::Value {
+        json!({
+            "event_id": "00000000-0000-0000-0000-000000000000",
+            "event_timestamp": EPOCH_UNIX_MS,
+            "source": "cli",
+            "invocation_id": "00000000-0000-0000-0000-000000000000",
+            "device_id": "00000000-0000-0000-0000-000000000000",
+            "event_type": "cli.command_run",
+            "payload": payload,
         })
     }
 
@@ -646,15 +739,7 @@ mod tests {
             CliCommandRunPayload::new(command_payload("install")),
         )))
         .expect("event serializes");
-        let expected = json!({
-            "event_id": "00000000-0000-0000-0000-000000000000",
-            "event_timestamp": EPOCH_UNIX_MS,
-            "source": "cli",
-            "invocation_id": "00000000-0000-0000-0000-000000000000",
-            "device_id": "00000000-0000-0000-0000-000000000000",
-            "event_type": "cli.command_run",
-            "payload": expected_payload_json("install"),
-        });
+        let expected = command_run_envelope_json(expected_payload_json("install"));
         assert_eq!(value, expected);
     }
 
@@ -789,7 +874,16 @@ mod tests {
 
     #[test]
     fn shared_metadata_template_merges_subcommand_into_payload() {
-        let template = SharedMetadataTemplate {
+        let template = shared_metadata_for_payload_tests();
+        let payload = template.into_payload("activate".to_string());
+        assert_eq!(payload, command_payload("activate"));
+    }
+
+    /// Template fixture matching [`command_payload`]'s derived fields:
+    /// `kernel_version` mirrors `os_family_release`, and `["shell"]`
+    /// carries neither detection token.
+    fn shared_metadata_for_payload_tests() -> SharedMetadataTemplate {
+        SharedMetadataTemplate {
             flox_version: "0.0.0-test".to_string(),
             os_family: Some("Linux".to_string()),
             os_family_release: Some("6.10.0".to_string()),
@@ -797,9 +891,119 @@ mod tests {
             os_version: Some("24.04".to_string()),
             empty_flags: vec![],
             invocation_sources: vec!["shell".to_string()],
+        }
+    }
+
+    /// True-case sibling of the `false`/`false` shape in
+    /// [`command_run_serializes_to_v2_envelope`].
+    #[test]
+    fn command_run_typed_detection_bools_envelope_golden() {
+        let mut payload = command_payload("install");
+        payload.in_ci = Some(true);
+        payload.containerd = Some(true);
+        payload.invocation_sources = vec!["ci".to_string(), "containerd".to_string()];
+        let value = serde_json::to_value(fixed_event(EventKind::CliCommandRun(
+            CliCommandRunPayload::new(payload),
+        )))
+        .expect("event serializes");
+        let mut expected_payload = expected_payload_json("install");
+        let obj = expected_payload.as_object_mut().expect("payload object");
+        obj.insert("in_ci".to_string(), json!(true));
+        obj.insert("containerd".to_string(), json!(true));
+        obj.insert(
+            "invocation_sources".to_string(),
+            json!(["ci", "containerd"]),
+        );
+        let expected = command_run_envelope_json(expected_payload);
+        assert_eq!(value, expected);
+    }
+
+    /// A `cli.command_run` row buffered by a binary that predates the
+    /// parity fields must still deserialize (the buffer file outlives
+    /// binary upgrades, and one unreadable row poisons the whole
+    /// read-back) — and must re-serialize with the unknown fields
+    /// still absent, not fabricated.
+    #[test]
+    fn command_run_row_without_parity_fields_round_trips() {
+        let old_row = json!({
+            "event_id": "00000000-0000-0000-0000-000000000000",
+            "event_timestamp": EPOCH_UNIX_MS,
+            "source": "cli",
+            "invocation_id": "00000000-0000-0000-0000-000000000000",
+            "device_id": "00000000-0000-0000-0000-000000000000",
+            "event_type": "cli.command_run",
+            "payload": {
+                "subcommand": "install",
+                "flox_version": "0.0.0-test",
+                "os_family": "Linux",
+                "os_family_release": "6.10.0",
+                "os": "ubuntu",
+                "os_version": "24.04",
+                "empty_flags": [],
+                "invocation_sources": ["shell"],
+            },
+        });
+        let event: Event =
+            serde_json::from_value(old_row.clone()).expect("old-shape row deserializes");
+        let EventKind::CliCommandRun(ref payload) = event.kind else {
+            panic!("expected cli.command_run");
         };
-        let payload = template.into_payload("activate".to_string());
-        assert_eq!(payload, command_payload("activate"));
+        let mut expected = command_payload("install");
+        expected.kernel_version = None;
+        expected.in_ci = None;
+        expected.containerd = None;
+        assert_eq!(payload, &CliCommandRunPayload::new(expected));
+        // Round trip: the flush path re-serializes buffered rows, and a
+        // value the old binary never recorded must stay absent.
+        let reserialized = serde_json::to_value(event).expect("event re-serializes");
+        assert_eq!(reserialized, old_row);
+    }
+
+    /// The typed bools are derived from the token list when the payload
+    /// is built, counting hierarchical sub-tokens — an explicit
+    /// `"ci.github-actions"` override sets `in_ci` even when the bare
+    /// `"ci"` token is absent, while a lookalike token does not.
+    #[test]
+    fn into_payload_counts_hierarchical_source_tokens() {
+        let mut template = shared_metadata_for_payload_tests();
+        template.invocation_sources = vec!["ci.github-actions".to_string()];
+        let mut expected = command_payload("activate");
+        expected.invocation_sources = vec!["ci.github-actions".to_string()];
+        expected.in_ci = Some(true);
+        assert_eq!(template.into_payload("activate".to_string()), expected);
+
+        template.invocation_sources = vec!["citrus".to_string()];
+        let mut expected = command_payload("activate");
+        expected.invocation_sources = vec!["citrus".to_string()];
+        expected.in_ci = Some(false);
+        assert_eq!(template.into_payload("activate".to_string()), expected);
+
+        // Explicit overrides arrive verbatim; matching is
+        // case-insensitive.
+        template.invocation_sources = vec!["CI.jenkins".to_string()];
+        let mut expected = command_payload("activate");
+        expected.invocation_sources = vec!["CI.jenkins".to_string()];
+        expected.in_ci = Some(true);
+        assert_eq!(template.into_payload("activate".to_string()), expected);
+    }
+
+    /// `kernel_version` is omitted from the wire (not serialized as
+    /// `null`) when `sys_info` failed at the producer.
+    #[test]
+    fn command_run_omits_kernel_version_when_unavailable() {
+        let mut payload = command_payload("install");
+        payload.kernel_version = None;
+        let value = serde_json::to_value(fixed_event(EventKind::CliCommandRun(
+            CliCommandRunPayload::new(payload),
+        )))
+        .expect("event serializes");
+        let mut expected_payload = expected_payload_json("install");
+        expected_payload
+            .as_object_mut()
+            .expect("payload object")
+            .remove("kernel_version");
+        let expected = command_run_envelope_json(expected_payload);
+        assert_eq!(value, expected);
     }
 
     fn env_detail(kind: &str, ref_or_name: &str) -> EnvDetail {
@@ -853,6 +1057,27 @@ mod tests {
 
     #[test]
     fn cli_environment_activate_path_envelope_golden() {
+        let payload = CliEnvironmentActivatePayload::new(env_detail("path", "myenv"))
+            .with_lockfile_version("1")
+            .with_manifest_version("1")
+            .with_shell("bash");
+        let value = serde_json::to_value(fixed_event(EventKind::CliEnvironmentActivate(payload)))
+            .expect("event serializes");
+        let expected = activate_envelope_json(json!({
+            "env_kind": "path",
+            "env_ref_or_name": "myenv",
+            "lockfile_version": "1",
+            "manifest_version": "1",
+            "shell": "bash",
+        }));
+        assert_eq!(value, expected);
+    }
+
+    /// The result-emit shape binaries predating `manifest_version`
+    /// buffered (extras present, no `manifest_version`) must keep
+    /// re-serializing without the new key.
+    #[test]
+    fn cli_environment_activate_without_manifest_version_envelope_golden() {
         let payload = CliEnvironmentActivatePayload::new(env_detail("path", "myenv"))
             .with_lockfile_version("1")
             .with_shell("bash");
@@ -1083,6 +1308,26 @@ mod tests {
     /// consumer side recovers the full row.
     #[test]
     fn cli_environment_edit_result_envelope_golden() {
+        let payload = CliEnvironmentEditPayload::new(managed_env_detail())
+            .with_edited_includes(true)
+            .with_manifest_version("1");
+        let value = serde_json::to_value(fixed_event(EventKind::CliEnvironmentEdit(payload)))
+            .expect("event serializes");
+        let mut expected = env_envelope_json("cli.environment.edit");
+        let obj = expected
+            .get_mut("payload")
+            .and_then(|p| p.as_object_mut())
+            .expect("payload object");
+        obj.insert("edited_includes".to_string(), json!(true));
+        obj.insert("manifest_version".to_string(), json!("1"));
+        assert_eq!(value, expected);
+    }
+
+    /// The result-emit shape binaries predating `manifest_version`
+    /// buffered (extras present, no `manifest_version`) must keep
+    /// re-serializing without the new key.
+    #[test]
+    fn cli_environment_edit_result_without_manifest_version_envelope_golden() {
         let payload =
             CliEnvironmentEditPayload::new(managed_env_detail()).with_edited_includes(true);
         let value = serde_json::to_value(fixed_event(EventKind::CliEnvironmentEdit(payload)))
@@ -1096,12 +1341,22 @@ mod tests {
         assert_eq!(value, expected);
     }
 
-    /// `cli.environment.publish` result-known emit carries both
-    /// build-kind flags. The eager emit shape (extras omitted) is
-    /// covered by [`cli_environment_edit_eager_envelope_golden`]'s
-    /// pattern — they share the same `skip_serializing_if` behavior.
+    /// `cli.environment.publish` on the eager call site: every
+    /// Optional extra is omitted from the wire.
     #[test]
-    fn cli_environment_publish_with_build_kinds_envelope_golden() {
+    fn cli_environment_publish_eager_envelope_golden() {
+        let payload = CliEnvironmentPublishPayload::new(managed_env_detail());
+        let value = serde_json::to_value(fixed_event(EventKind::CliEnvironmentPublish(payload)))
+            .expect("event serializes");
+        let expected = env_envelope_json("cli.environment.publish");
+        assert_eq!(value, expected);
+    }
+
+    /// The result-emit shape binaries predating `manifest_version`
+    /// buffered (build kinds present, no `manifest_version`) must keep
+    /// re-serializing without the new key.
+    #[test]
+    fn cli_environment_publish_without_manifest_version_envelope_golden() {
         let payload =
             CliEnvironmentPublishPayload::new(managed_env_detail()).with_build_kinds(true, false);
         let value = serde_json::to_value(fixed_event(EventKind::CliEnvironmentPublish(payload)))
@@ -1113,6 +1368,26 @@ mod tests {
             .expect("payload object");
         obj.insert("has_expression_build".to_string(), json!(true));
         obj.insert("has_manifest_build".to_string(), json!(false));
+        assert_eq!(value, expected);
+    }
+
+    /// `cli.environment.publish` result-known emit carries both
+    /// build-kind flags.
+    #[test]
+    fn cli_environment_publish_with_build_kinds_envelope_golden() {
+        let payload = CliEnvironmentPublishPayload::new(managed_env_detail())
+            .with_build_kinds(true, false)
+            .with_manifest_version("1.10.0");
+        let value = serde_json::to_value(fixed_event(EventKind::CliEnvironmentPublish(payload)))
+            .expect("event serializes");
+        let mut expected = env_envelope_json("cli.environment.publish");
+        let obj = expected
+            .get_mut("payload")
+            .and_then(|p| p.as_object_mut())
+            .expect("payload object");
+        obj.insert("has_expression_build".to_string(), json!(true));
+        obj.insert("has_manifest_build".to_string(), json!(false));
+        obj.insert("manifest_version".to_string(), json!("1.10.0"));
         assert_eq!(value, expected);
     }
 

--- a/cli/flox-events/src/lib.rs
+++ b/cli/flox-events/src/lib.rs
@@ -216,35 +216,11 @@ pub struct CommandPayload {
     empty_flags: Vec<String>,
     /// Tokens describing how this CLI invocation was launched (shell, prompt,
     /// service runner, etc.). Mirrors the legacy `INVOCATION_SOURCES`.
+    /// CI / container membership is derived from these tokens by the
+    /// consumer (a token equal to `"ci"` / `"containerd"` or a
+    /// hierarchical sub-token like `"ci.github-actions"`, matched
+    /// case-insensitively).
     invocation_sources: Vec<String>,
-    /// Whether `invocation_sources` carries the `"ci"` token or a
-    /// hierarchical sub-token of it (e.g. `"ci.github-actions"`).
-    /// Derived in [`SharedMetadataTemplate::into_payload`], so `Some`
-    /// on every emitted row; `None` only when reading back rows
-    /// buffered by binaries that predate the field, and omitted on
-    /// re-serialization so unknown stays unknown.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    in_ci: Option<bool>,
-    /// Whether `invocation_sources` carries the `"containerd"` token
-    /// (the `FLOX_CONTAINERD` marker exported by flox-built container
-    /// images — not generic container detection) or a sub-token of
-    /// it. Same `None` semantics as `in_ci`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    containerd: Option<bool>,
-}
-
-/// `true` when `sources` carries `root` itself or a hierarchical
-/// sub-token of it (`"ci.github-actions"` counts for `"ci"`;
-/// `"citrus"` does not). ASCII-case-insensitive, because explicit
-/// `FLOX_INVOCATION_SOURCE` tokens arrive verbatim.
-fn has_source_token(sources: &[String], root: &str) -> bool {
-    sources.iter().any(|source| {
-        let Some(prefix) = source.get(..root.len()) else {
-            return false;
-        };
-        prefix.eq_ignore_ascii_case(root)
-            && (source.len() == root.len() || source.as_bytes()[root.len()] == b'.')
-    })
 }
 
 /// Static slice of [`CommandPayload`] that is constant for the duration of
@@ -269,12 +245,11 @@ impl SharedMetadataTemplate {
     /// Merge the stored static fields with the supplied subcommand to produce
     /// a complete [`CommandPayload`] ready for serialization.
     ///
-    /// `kernel_version` and the `in_ci` / `containerd` bools are derived
-    /// here from the template's own fields. This is the only production
-    /// constructor of [`CommandPayload`] (its fields are private), so
-    /// every *emitted* payload agrees with the values it mirrors.
-    /// Deserialization is exempt on purpose: rows buffered by older
-    /// binaries reload with the derived fields absent.
+    /// `kernel_version` is derived here from the template's own fields.
+    /// This is the only production constructor of [`CommandPayload`]
+    /// (its fields are private), so every *emitted* payload agrees with
+    /// the value it mirrors. Deserialization is exempt on purpose: rows
+    /// buffered by older binaries reload with the derived field absent.
     pub fn into_payload(&self, subcommand: String) -> CommandPayload {
         CommandPayload {
             subcommand,
@@ -285,8 +260,6 @@ impl SharedMetadataTemplate {
             os: self.os.clone(),
             os_version: self.os_version.clone(),
             empty_flags: self.empty_flags.clone(),
-            in_ci: Some(has_source_token(&self.invocation_sources, "ci")),
-            containerd: Some(has_source_token(&self.invocation_sources, "containerd")),
             invocation_sources: self.invocation_sources.clone(),
         }
     }
@@ -707,8 +680,6 @@ mod tests {
             os_version: Some("24.04".to_string()),
             empty_flags: vec![],
             invocation_sources: vec!["shell".to_string()],
-            in_ci: Some(false),
-            containerd: Some(false),
         }
     }
 
@@ -723,8 +694,6 @@ mod tests {
             "os_version": "24.04",
             "empty_flags": [],
             "invocation_sources": ["shell"],
-            "in_ci": false,
-            "containerd": false,
         })
     }
 
@@ -886,9 +855,8 @@ mod tests {
         assert_eq!(payload, command_payload("activate"));
     }
 
-    /// Template fixture matching [`command_payload`]'s derived fields:
-    /// `kernel_version` mirrors `os_family_release`, and `["shell"]`
-    /// carries neither detection token.
+    /// Template fixture matching [`command_payload`]'s derived field:
+    /// `kernel_version` mirrors `os_family_release`.
     fn shared_metadata_for_payload_tests() -> SharedMetadataTemplate {
         SharedMetadataTemplate {
             flox_version: "0.0.0-test".to_string(),
@@ -899,30 +867,6 @@ mod tests {
             empty_flags: vec![],
             invocation_sources: vec!["shell".to_string()],
         }
-    }
-
-    /// True-case sibling of the `false`/`false` shape in
-    /// [`command_run_serializes_to_v2_envelope`].
-    #[test]
-    fn command_run_typed_detection_bools_envelope_golden() {
-        let mut payload = command_payload("install");
-        payload.in_ci = Some(true);
-        payload.containerd = Some(true);
-        payload.invocation_sources = vec!["ci".to_string(), "containerd".to_string()];
-        let value = serde_json::to_value(fixed_event(EventKind::CliCommandRun(
-            CliCommandRunPayload::new(payload),
-        )))
-        .expect("event serializes");
-        let mut expected_payload = expected_payload_json("install");
-        let obj = expected_payload.as_object_mut().expect("payload object");
-        obj.insert("in_ci".to_string(), json!(true));
-        obj.insert("containerd".to_string(), json!(true));
-        obj.insert(
-            "invocation_sources".to_string(),
-            json!(["ci", "containerd"]),
-        );
-        let expected = command_run_envelope_json(expected_payload);
-        assert_eq!(value, expected);
     }
 
     /// A `cli.command_run` row buffered by a binary that predates the
@@ -957,55 +901,11 @@ mod tests {
         };
         let mut expected = command_payload("install");
         expected.kernel_version = None;
-        expected.in_ci = None;
-        expected.containerd = None;
         assert_eq!(payload, &CliCommandRunPayload::new(expected));
         // Round trip: the flush path re-serializes buffered rows, and a
         // value the old binary never recorded must stay absent.
         let reserialized = serde_json::to_value(event).expect("event re-serializes");
         assert_eq!(reserialized, old_row);
-    }
-
-    /// The typed bools are derived from the token list when the payload
-    /// is built, counting hierarchical sub-tokens — an explicit
-    /// `"ci.github-actions"` override sets `in_ci` even when the bare
-    /// `"ci"` token is absent, while a lookalike token does not.
-    #[test]
-    fn into_payload_counts_hierarchical_source_tokens() {
-        let mut template = shared_metadata_for_payload_tests();
-        template.invocation_sources = vec!["ci.github-actions".to_string()];
-        let mut expected = command_payload("activate");
-        expected.invocation_sources = vec!["ci.github-actions".to_string()];
-        expected.in_ci = Some(true);
-        assert_eq!(template.into_payload("activate".to_string()), expected);
-
-        template.invocation_sources = vec!["citrus".to_string()];
-        let mut expected = command_payload("activate");
-        expected.invocation_sources = vec!["citrus".to_string()];
-        expected.in_ci = Some(false);
-        assert_eq!(template.into_payload("activate".to_string()), expected);
-
-        // Explicit overrides arrive verbatim; matching is
-        // case-insensitive.
-        template.invocation_sources = vec!["CI.jenkins".to_string()];
-        let mut expected = command_payload("activate");
-        expected.invocation_sources = vec!["CI.jenkins".to_string()];
-        expected.in_ci = Some(true);
-        assert_eq!(template.into_payload("activate".to_string()), expected);
-
-        // Bare exact-match root token.
-        template.invocation_sources = vec!["ci".to_string()];
-        let mut expected = command_payload("activate");
-        expected.invocation_sources = vec!["ci".to_string()];
-        expected.in_ci = Some(true);
-        assert_eq!(template.into_payload("activate".to_string()), expected);
-
-        // The containerd root follows the same hierarchy rule.
-        template.invocation_sources = vec!["containerd.foo".to_string()];
-        let mut expected = command_payload("activate");
-        expected.invocation_sources = vec!["containerd.foo".to_string()];
-        expected.containerd = Some(true);
-        assert_eq!(template.into_payload("activate".to_string()), expected);
     }
 
     /// `kernel_version` is omitted from the wire (not serialized as

--- a/cli/flox-events/src/lib.rs
+++ b/cli/flox-events/src/lib.rs
@@ -201,7 +201,10 @@ pub struct CommandPayload {
     /// `sys_info` failed. Deliberately the same value as
     /// `os_family_release` at the producer — consumers derive two
     /// distinct legacy fields from this one field and treat the
-    /// OS-family release as a separate concept.
+    /// OS-family release as a separate concept. Unlike
+    /// `os_family_release` (serialized as `null` when absent), this
+    /// field is omitted from the wire so rows buffered by binaries that
+    /// predate it round-trip unchanged.
     #[serde(skip_serializing_if = "Option::is_none")]
     kernel_version: Option<String>,
     /// Linux distribution id (e.g. `ubuntu`); `None` outside Linux.
@@ -267,8 +270,11 @@ impl SharedMetadataTemplate {
     /// a complete [`CommandPayload`] ready for serialization.
     ///
     /// `kernel_version` and the `in_ci` / `containerd` bools are derived
-    /// here from the template's own fields, so they cannot disagree with
-    /// the values they mirror.
+    /// here from the template's own fields. This is the only production
+    /// constructor of [`CommandPayload`] (its fields are private), so
+    /// every *emitted* payload agrees with the values it mirrors.
+    /// Deserialization is exempt on purpose: rows buffered by older
+    /// binaries reload with the derived fields absent.
     pub fn into_payload(&self, subcommand: String) -> CommandPayload {
         CommandPayload {
             subcommand,
@@ -419,7 +425,8 @@ pub struct CliEnvironmentActivatePayload {
     lockfile_version: Option<String>,
     /// The locked manifest's declared schema version (`"1"`, `"1.10.0"`,
     /// …) — distinct from `lockfile_version`, the lockfile's own schema
-    /// version. Absent on emits that precede the manifest load.
+    /// version. Absent on the eager emits; populated only on the
+    /// result-known emit.
     #[serde(skip_serializing_if = "Option::is_none")]
     manifest_version: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -984,6 +991,20 @@ mod tests {
         let mut expected = command_payload("activate");
         expected.invocation_sources = vec!["CI.jenkins".to_string()];
         expected.in_ci = Some(true);
+        assert_eq!(template.into_payload("activate".to_string()), expected);
+
+        // Bare exact-match root token.
+        template.invocation_sources = vec!["ci".to_string()];
+        let mut expected = command_payload("activate");
+        expected.invocation_sources = vec!["ci".to_string()];
+        expected.in_ci = Some(true);
+        assert_eq!(template.into_payload("activate".to_string()), expected);
+
+        // The containerd root follows the same hierarchy rule.
+        template.invocation_sources = vec!["containerd.foo".to_string()];
+        let mut expected = command_payload("activate");
+        expected.invocation_sources = vec!["containerd.foo".to_string()];
+        expected.containerd = Some(true);
         assert_eq!(template.into_payload("activate".to_string()), expected);
     }
 

--- a/cli/flox-events/src/lib.rs
+++ b/cli/flox-events/src/lib.rs
@@ -195,18 +195,10 @@ pub struct CommandPayload {
     flox_version: String,
     /// Coarse operating system family (e.g. `Mac OS`, `Linux`).
     os_family: Option<String>,
-    /// OS family release version.
+    /// OS family release version (the kernel version from
+    /// `sys_info::os_release()`) — consumers derive every
+    /// kernel-version-shaped legacy field from this one value.
     os_family_release: Option<String>,
-    /// Kernel version string from `sys_info::os_release()`; `None` when
-    /// `sys_info` failed. Deliberately the same value as
-    /// `os_family_release` at the producer — consumers derive two
-    /// distinct legacy fields from this one field and treat the
-    /// OS-family release as a separate concept. Unlike
-    /// `os_family_release` (serialized as `null` when absent), this
-    /// field is omitted from the wire so rows buffered by binaries that
-    /// predate it round-trip unchanged.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    kernel_version: Option<String>,
     /// Linux distribution id (e.g. `ubuntu`); `None` outside Linux.
     os: Option<String>,
     /// Linux distribution version (e.g. `22.04`); `None` outside Linux.
@@ -244,19 +236,12 @@ pub struct SharedMetadataTemplate {
 impl SharedMetadataTemplate {
     /// Merge the stored static fields with the supplied subcommand to produce
     /// a complete [`CommandPayload`] ready for serialization.
-    ///
-    /// `kernel_version` is derived here from the template's own fields.
-    /// This is the only production constructor of [`CommandPayload`]
-    /// (its fields are private), so every *emitted* payload agrees with
-    /// the value it mirrors. Deserialization is exempt on purpose: rows
-    /// buffered by older binaries reload with the derived field absent.
     pub fn into_payload(&self, subcommand: String) -> CommandPayload {
         CommandPayload {
             subcommand,
             flox_version: self.flox_version.clone(),
             os_family: self.os_family.clone(),
             os_family_release: self.os_family_release.clone(),
-            kernel_version: self.os_family_release.clone(),
             os: self.os.clone(),
             os_version: self.os_version.clone(),
             empty_flags: self.empty_flags.clone(),
@@ -675,7 +660,6 @@ mod tests {
             flox_version: "0.0.0-test".to_string(),
             os_family: Some("Linux".to_string()),
             os_family_release: Some("6.10.0".to_string()),
-            kernel_version: Some("6.10.0".to_string()),
             os: Some("ubuntu".to_string()),
             os_version: Some("24.04".to_string()),
             empty_flags: vec![],
@@ -689,7 +673,6 @@ mod tests {
             "flox_version": "0.0.0-test",
             "os_family": "Linux",
             "os_family_release": "6.10.0",
-            "kernel_version": "6.10.0",
             "os": "ubuntu",
             "os_version": "24.04",
             "empty_flags": [],
@@ -855,8 +838,7 @@ mod tests {
         assert_eq!(payload, command_payload("activate"));
     }
 
-    /// Template fixture matching [`command_payload`]'s derived field:
-    /// `kernel_version` mirrors `os_family_release`.
+    /// Template fixture matching [`command_payload`].
     fn shared_metadata_for_payload_tests() -> SharedMetadataTemplate {
         SharedMetadataTemplate {
             flox_version: "0.0.0-test".to_string(),
@@ -867,64 +849,6 @@ mod tests {
             empty_flags: vec![],
             invocation_sources: vec!["shell".to_string()],
         }
-    }
-
-    /// A `cli.command_run` row buffered by a binary that predates the
-    /// parity fields must still deserialize (the buffer file outlives
-    /// binary upgrades, and one unreadable row poisons the whole
-    /// read-back) — and must re-serialize with the unknown fields
-    /// still absent, not fabricated.
-    #[test]
-    fn command_run_row_without_parity_fields_round_trips() {
-        let old_row = json!({
-            "event_id": "00000000-0000-0000-0000-000000000000",
-            "event_timestamp": EPOCH_UNIX_MS,
-            "source": "cli",
-            "invocation_id": "00000000-0000-0000-0000-000000000000",
-            "device_id": "00000000-0000-0000-0000-000000000000",
-            "event_type": "cli.command_run",
-            "payload": {
-                "subcommand": "install",
-                "flox_version": "0.0.0-test",
-                "os_family": "Linux",
-                "os_family_release": "6.10.0",
-                "os": "ubuntu",
-                "os_version": "24.04",
-                "empty_flags": [],
-                "invocation_sources": ["shell"],
-            },
-        });
-        let event: Event =
-            serde_json::from_value(old_row.clone()).expect("old-shape row deserializes");
-        let EventKind::CliCommandRun(ref payload) = event.kind else {
-            panic!("expected cli.command_run");
-        };
-        let mut expected = command_payload("install");
-        expected.kernel_version = None;
-        assert_eq!(payload, &CliCommandRunPayload::new(expected));
-        // Round trip: the flush path re-serializes buffered rows, and a
-        // value the old binary never recorded must stay absent.
-        let reserialized = serde_json::to_value(event).expect("event re-serializes");
-        assert_eq!(reserialized, old_row);
-    }
-
-    /// `kernel_version` is omitted from the wire (not serialized as
-    /// `null`) when `sys_info` failed at the producer.
-    #[test]
-    fn command_run_omits_kernel_version_when_unavailable() {
-        let mut payload = command_payload("install");
-        payload.kernel_version = None;
-        let value = serde_json::to_value(fixed_event(EventKind::CliCommandRun(
-            CliCommandRunPayload::new(payload),
-        )))
-        .expect("event serializes");
-        let mut expected_payload = expected_payload_json("install");
-        expected_payload
-            .as_object_mut()
-            .expect("payload object")
-            .remove("kernel_version");
-        let expected = command_run_envelope_json(expected_payload);
-        assert_eq!(value, expected);
     }
 
     fn env_detail(kind: &str, ref_or_name: &str) -> EnvDetail {

--- a/cli/flox-rust-sdk/src/utils/invocation_sources.rs
+++ b/cli/flox-rust-sdk/src/utils/invocation_sources.rs
@@ -6,7 +6,10 @@ use std::sync::LazyLock;
 /// Each entry: (env_var_name, expected_value_or_none, invocation_source_tag)
 /// Use None for expected_value to check env var presence only
 const INFERENCE_HEURISTICS: &[(&str, Option<&str>, &str)] = &[
-    // CI and containerd contexts
+    // CI and containerd contexts. The "ci" / "containerd" tags are also
+    // matched by literal in `flox-events` to derive the typed payload
+    // booleans — renaming them silently breaks that derivation (guarded
+    // by `detection_tokens_drive_typed_payload_bools` in the flox crate).
     ("CI", None, "ci"),
     ("FLOX_CONTAINERD", None, "containerd"),
     // Terminal programs

--- a/cli/flox-rust-sdk/src/utils/invocation_sources.rs
+++ b/cli/flox-rust-sdk/src/utils/invocation_sources.rs
@@ -6,10 +6,8 @@ use std::sync::LazyLock;
 /// Each entry: (env_var_name, expected_value_or_none, invocation_source_tag)
 /// Use None for expected_value to check env var presence only
 const INFERENCE_HEURISTICS: &[(&str, Option<&str>, &str)] = &[
-    // CI and containerd contexts. The "ci" / "containerd" tags are also
-    // matched by literal in `flox-events` to derive the typed payload
-    // booleans — renaming them silently breaks that derivation (guarded
-    // by `detection_tokens_drive_typed_payload_bools` in the flox crate).
+    // CI and containerd contexts. Consumers derive CI / container
+    // membership from these tags — renaming them changes what they see.
     ("CI", None, "ci"),
     ("FLOX_CONTAINERD", None, "containerd"),
     // Terminal programs

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -449,11 +449,12 @@ impl ActivateOptions {
         subcommand_metric!("activate#version", lockfile_version = lockfile_version);
 
         // The new pipeline drops the legacy `activate#version` pseudo-
-        // subcommand (per spec AC #4) and rides `lockfile_version` on a
-        // real `cli.environment.activate` event instead.
+        // subcommand and rides `lockfile_version` on a real
+        // `cli.environment.activate` event instead.
         if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentActivate(
             CliEnvironmentActivatePayload::new(env_detail_from_concrete(&concrete_environment))
-                .with_lockfile_version(lockfile_version.to_string()),
+                .with_lockfile_version(lockfile_version.to_string())
+                .with_manifest_version(lockfile.manifest_schema_version().to_string()),
         )) {
             debug!(error = %err, "Failed to record v2 event");
         }

--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -271,7 +271,8 @@ impl Edit {
                 subcommand_metric!("edit", "edited_includes" = edited_includes);
                 if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentEdit(
                     CliEnvironmentEditPayload::new(env_detail_from_concrete(environment))
-                        .with_edited_includes(edited_includes),
+                        .with_edited_includes(edited_includes)
+                        .with_manifest_version(new_lockfile.manifest_schema_version().to_string()),
                 )) {
                     debug!(error = %err, "Failed to record v2 event");
                 }

--- a/cli/flox/src/commands/publish.rs
+++ b/cli/flox/src/commands/publish.rs
@@ -280,7 +280,14 @@ impl Publish {
         );
         if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentPublish(
             CliEnvironmentPublishPayload::new(env_detail)
-                .with_build_kinds(has_expression_build, has_manifest_build),
+                .with_build_kinds(has_expression_build, has_manifest_build)
+                .with_manifest_version(
+                    publish_provider
+                        .env_metadata
+                        .lockfile
+                        .manifest_schema_version()
+                        .to_string(),
+                ),
         )) {
             debug!(error = %err, "Failed to record v2 event");
         }

--- a/cli/flox/src/utils/events.rs
+++ b/cli/flox/src/utils/events.rs
@@ -221,6 +221,10 @@ mod tests {
                     .expect("payload serializes");
                 assert_eq!(payload.get("in_ci"), Some(&serde_json::json!(true)));
                 assert_eq!(payload.get("containerd"), Some(&serde_json::json!(true)));
+                // The template above has `os_family_release: None`, so
+                // the derived `kernel_version` must be absent — not
+                // fabricated.
+                assert_eq!(payload.get("kernel_version"), None);
             },
         );
     }

--- a/cli/flox/src/utils/events.rs
+++ b/cli/flox/src/utils/events.rs
@@ -196,6 +196,35 @@ mod tests {
         }
     }
 
+    /// Ties the SDK's detection-token vocabulary to the payload's typed
+    /// bools across the crate boundary: `flox-events` matches the
+    /// `"ci"` / `"containerd"` tokens by literal and does not depend on
+    /// `flox-rust-sdk`, so this is the only place a respelling on
+    /// either side can fail a test.
+    #[test]
+    #[serial(v2_events_wrapper_env)]
+    fn detection_tokens_drive_typed_payload_bools() {
+        temp_env::with_vars(
+            [("CI", Some("true")), ("FLOX_CONTAINERD", Some("1"))],
+            || {
+                let template = SharedMetadataTemplate {
+                    flox_version: "0.0.0-test".to_string(),
+                    os_family: None,
+                    os_family_release: None,
+                    os: None,
+                    os_version: None,
+                    empty_flags: vec![],
+                    invocation_sources:
+                        flox_rust_sdk::utils::invocation_sources::detect_invocation_sources(),
+                };
+                let payload = serde_json::to_value(template.into_payload("envs".to_string()))
+                    .expect("payload serializes");
+                assert_eq!(payload.get("in_ci"), Some(&serde_json::json!(true)));
+                assert_eq!(payload.get("containerd"), Some(&serde_json::json!(true)));
+            },
+        );
+    }
+
     #[test]
     #[serial(v2_events_wrapper_env)]
     fn resolve_invocation_id_returns_parent_id_when_env_set() {

--- a/cli/flox/src/utils/events.rs
+++ b/cli/flox/src/utils/events.rs
@@ -196,39 +196,6 @@ mod tests {
         }
     }
 
-    /// Ties the SDK's detection-token vocabulary to the payload's typed
-    /// bools across the crate boundary: `flox-events` matches the
-    /// `"ci"` / `"containerd"` tokens by literal and does not depend on
-    /// `flox-rust-sdk`, so this is the only place a respelling on
-    /// either side can fail a test.
-    #[test]
-    #[serial(v2_events_wrapper_env)]
-    fn detection_tokens_drive_typed_payload_bools() {
-        temp_env::with_vars(
-            [("CI", Some("true")), ("FLOX_CONTAINERD", Some("1"))],
-            || {
-                let template = SharedMetadataTemplate {
-                    flox_version: "0.0.0-test".to_string(),
-                    os_family: None,
-                    os_family_release: None,
-                    os: None,
-                    os_version: None,
-                    empty_flags: vec![],
-                    invocation_sources:
-                        flox_rust_sdk::utils::invocation_sources::detect_invocation_sources(),
-                };
-                let payload = serde_json::to_value(template.into_payload("envs".to_string()))
-                    .expect("payload serializes");
-                assert_eq!(payload.get("in_ci"), Some(&serde_json::json!(true)));
-                assert_eq!(payload.get("containerd"), Some(&serde_json::json!(true)));
-                // The template above has `os_family_release: None`, so
-                // the derived `kernel_version` must be absent — not
-                // fabricated.
-                assert_eq!(payload.get("kernel_version"), None);
-            },
-        );
-    }
-
     #[test]
     #[serial(v2_events_wrapper_env)]
     fn resolve_invocation_id_returns_parent_id_when_env_set() {


### PR DESCRIPTION
# PR 9 — Remaining parity fields

> Based on `main` (includes #4534). Two feature commits plus review
> follow-ups.

**feat(events): add manifest_version to the env events that load a manifest**

Following review feedback, this PR is now much smaller than first
published. It originally restored four legacy-parity fields; three of
them turned out to repeat information already on the wire and were
dropped rather than grandfathered in:

- `in_ci` / `containerd` were pure derivations of the
  `invocation_sources` token list serialized on the same row (the CI
  and container signals flow into the tokens at detection time).
  Consumers derive membership from the tokens instead — a token equal
  to `ci` / `containerd` or a dot-separated sub-token like
  `ci.github-actions`, matched case-insensitively.
- `kernel_version` was an exact copy of `os_family_release` on the
  same row; consumers derive every kernel-version-shaped legacy field
  from `os_family_release` directly.

What remains is the one field carrying genuinely new information:
the edit / publish / activate payloads gain `manifest_version` + a
`with_manifest_version(...)` builder, populated on the result-known
emit from the locked manifest's declared schema version (`"1"`,
`"1.10.0"`, …). On `activate` it is distinct from the existing
`lockfile_version` (manifest schema vs lockfile schema).
`generations.list` is deliberately excluded — its handler never loads
a manifest, so no unwired builder surface ships.

The legacy emission path is untouched — both streams keep emitting
exactly as before this change.

Verified by full-value envelope goldens (populated and absent
`manifest_version` shapes on all three payloads, including a new eager
publish golden). Full unit suite green, `cargo fmt` and clippy clean.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
