### PR TITLE
refactor(deactivate): derive teardown data from the active-stack entry

### DIFF
--- a/cli/flox-core/src/activations.rs
+++ b/cli/flox-core/src/activations.rs
@@ -358,11 +358,9 @@ enum Ready {
 
 /// Information about the activated environment.
 ///
-/// `dot_flox_path` is only intended for humans to debug the serialized state
-/// and should be promoted to the top-level if it is later needed
-/// programmatically. `flox_env` is read programmatically via
-/// [ActivationState::flox_env] to tear down an activation whose environment
-/// directory no longer exists.
+/// This is only intended for humans to debug the serialized state.
+/// Fields should be promoted to the top-level if they are later needed
+/// programmatically.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 struct EnvironmentInfo {
     /// Path to the activated environment's .flox directory (None for containers)
@@ -446,16 +444,6 @@ impl ActivationState {
     /// Returns the current activation mode
     pub fn mode(&self) -> &ActivateMode {
         &self.mode
-    }
-
-    /// Returns the rendered environment path (`$FLOX_ENV`) recorded when the
-    /// activation started.
-    ///
-    /// This is what lets an activation be torn down after its environment
-    /// directory has been deleted, when the path can no longer be derived by
-    /// opening the environment.
-    pub fn flox_env(&self) -> &Path {
-        &self.info.flox_env
     }
 
     /// Check if the activation state has running processes.

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -97,34 +97,34 @@ pub struct RemoteEnvironment {
 }
 
 impl RemoteEnvironment {
-    /// Check if a remote environment is already cached locally.
-    /// I.e. whether there is a backing managed environment in the cache.
-    pub fn is_cached(flox: &Flox, pointer: &ManagedPointer) -> bool {
-        let path = flox
-            .cache_dir
+    /// The directory in `flox.cache_dir` that `pointer`'s environment is
+    /// checked out into (its `.flox` lives directly inside).
+    ///
+    /// A pure path computation — the checkout may not exist yet, which is
+    /// what lets deactivation locate it without opening the environment.
+    pub fn checkout_path(flox: &Flox, pointer: &ManagedPointer) -> PathBuf {
+        flox.cache_dir
             .join(REMOTE_ENVIRONMENT_BASE_DIR)
             .join(pointer.owner.as_ref())
             .join(pointer.name.as_ref())
-            .join(DOT_FLOX);
-        path.exists()
+    }
+
+    /// Check if a remote environment is already cached locally.
+    /// I.e. whether there is a backing managed environment in the cache.
+    pub fn is_cached(flox: &Flox, pointer: &ManagedPointer) -> bool {
+        Self::checkout_path(flox, pointer).join(DOT_FLOX).exists()
     }
 
     /// Pull a remote environment into a flox-provided managed environment
-    /// in `<FLOX_CACHE_DIR>/remote/<owner>/<name>`
+    /// at [RemoteEnvironment::checkout_path].
     ///
-    /// This function provides the sensible default directory to [RemoteEnvironment::new_in].
     /// The directory will be created by [RemoteEnvironment::new_in].
     pub fn new(
         flox: &Flox,
         pointer: ManagedPointer,
         generation: Option<GenerationId>,
     ) -> Result<Self, RemoteEnvironmentError> {
-        let path = flox
-            .cache_dir
-            .join(REMOTE_ENVIRONMENT_BASE_DIR)
-            .join(pointer.owner.as_ref())
-            .join(pointer.name.as_ref());
-
+        let path = Self::checkout_path(flox, &pointer);
         Self::new_in(flox, path, pointer, generation)
     }
 

--- a/cli/flox/src/commands/deactivate.rs
+++ b/cli/flox/src/commands/deactivate.rs
@@ -6,9 +6,8 @@ use anyhow::{Context, Result, anyhow, bail};
 use bpaf::Bpaf;
 use flox_config::Config;
 use flox_core::activate::context::{InvocationKind, InvocationTypes};
-use flox_core::activate::mode::ActivateMode;
 use flox_core::activate::vars::{FLOX_ACTIVATIONS_BIN, FLOX_INVOCATION_TYPES_WIRE_VAR};
-use flox_core::activations::{activation_state_dir_path, read_activations_json, state_json_path};
+use flox_core::activations::activation_state_dir_path;
 use flox_core::canonical_path::CanonicalPath;
 use flox_core::hook_actions::{
     HookAction,
@@ -17,9 +16,10 @@ use flox_core::hook_actions::{
     write_hook_actions,
 };
 use flox_rust_sdk::flox::Flox;
+use flox_rust_sdk::models::environment::remote_environment::RemoteEnvironment;
 use flox_rust_sdk::models::environment::{
-    Environment,
-    EnvironmentError,
+    DOT_FLOX,
+    DotFlox,
     GCROOTS_DIR_NAME,
     RenderedEnvironmentLinks,
     UninitializedEnvironment,
@@ -105,7 +105,7 @@ impl Deactivate {
         // than printing a success message for a deactivation that never happens.
         ensure_prompt_hook_available(&config)?;
 
-        let target = open_deactivation_target(&flox, active)?;
+        let target = deactivation_target(&flox, &active);
 
         debug!(
             flox_env = ?target.flox_env,
@@ -156,7 +156,7 @@ impl Deactivate {
             .is_some()
             .then_some(remaining_invocation_types);
 
-        let target = open_deactivation_target(&flox, active)?;
+        let target = deactivation_target(&flox, &active);
 
         let mut writer = BufWriter::new(stdout());
         emit_deactivate_script(
@@ -220,98 +220,87 @@ pub(crate) struct DeactivationTarget {
 
 /// Resolve an active-stack entry into the data needed to deactivate it.
 ///
-/// Opens the concrete environment so managed and remote environments are also
-/// supported (not just local path environments). The rendered env link is
-/// resolved via the entry's activation `mode` rather than read from `$FLOX_ENV`
-/// at runtime, which is what lets an env that isn't the most recently activated
-/// one be torn down. This is also where a future `flox deactivate <ENV>`
-/// argument would resolve a specific environment rather than the last-active
-/// one.
+/// Everything derives from the entry itself, recorded in the shell's
+/// environment when the layer was activated; the environment is deliberately
+/// never opened. Opening re-derives data the stack already records, and can
+/// rebuild the environment, contact FloxHub, or fail outright (deleted
+/// directory, broken manifest, expired auth) — none of which should be able
+/// to stop or slow down a teardown. Deriving the rendered env link from the
+/// entry rather than reading `$FLOX_ENV` at runtime is what lets an env that
+/// isn't the most recently activated one be torn down. This is also where a
+/// future `flox deactivate <ENV>` argument would resolve a specific
+/// environment rather than the last-active one.
 ///
-/// An environment whose directory was deleted while active (e.g. a removed git
-/// worktree) can no longer be opened; its deactivation data is recovered from
-/// the state recorded at activation time instead, so leaving a deleted
-/// directory still tears the activation down.
-pub(crate) fn open_deactivation_target(
-    flox: &Flox,
-    active: ActiveEnvironment,
-) -> Result<DeactivationTarget> {
-    let mode = active.mode;
-    let mut concrete_env = match active
-        .environment
-        .clone()
-        .into_concrete_environment(flox, None)
-    {
-        Ok(concrete_env) => concrete_env,
-        Err(EnvironmentError::DotFloxNotFound(_)) => {
-            return deactivation_target_from_recorded_state(flox, &active.environment, &mode);
-        },
-        Err(err) => {
-            return Err(err).context("failed to open active environment for deactivation");
-        },
-    };
-    let dot_flox_path = concrete_env.dot_flox_path().to_path_buf();
-    let flox_env = concrete_env
-        .rendered_env_links(flox)
-        .context("failed to read rendered env links for active environment")?
-        .for_mode(&mode)
-        .to_path_buf();
+/// Both fields reproduce the activation's exact bytes:
+/// - The activation state dir is keyed by a hash of the `.flox` path the
+///   activation used. The stack entry records that canonicalized path, so it
+///   is used verbatim rather than re-canonicalized (symlink resolution may
+///   have changed since, and fails once the directory is deleted).
+/// - `flox_env` is built with the same link constructors activation used,
+///   from the same recorded inputs, so it byte-matches the `$FLOX_ENV` the
+///   activation exported — the deactivation script matches it against the
+///   shell's script-tracking state by string equality. The per-shell entry
+///   is the only trustworthy source for this: `state.json` is shared by
+///   every activation of the same `.flox` path and keeps the values of
+///   whichever activation created it, which can describe a different
+///   generation than the layer being torn down. If the link no longer exists
+///   on disk (deleted environment or link), env-var restoration and detach
+///   are unaffected; only the env's own `profile.deactivate` scripts are
+///   skipped, where opening would have rebuilt the link first.
+pub(crate) fn deactivation_target(flox: &Flox, active: &ActiveEnvironment) -> DeactivationTarget {
+    let dot_flox_path = recorded_dot_flox_path(flox, &active.environment);
     let activation_state_dir = activation_state_dir_path(&flox.runtime_dir, &dot_flox_path);
 
-    Ok(DeactivationTarget {
+    // Previously canonicalized path that may no longer exist.
+    let run_dir = CanonicalPath::new_unchecked(dot_flox_path.join(GCROOTS_DIR_NAME));
+    let name = active.environment.name();
+    let links = match active.generation {
+        Some(generation) => {
+            RenderedEnvironmentLinks::new_in_base_dir_with_name_system_and_generation(
+                &run_dir,
+                name.as_ref(),
+                &flox.system,
+                generation,
+            )
+        },
+        None => RenderedEnvironmentLinks::new_in_base_dir_with_name_and_system(
+            &run_dir,
+            name.as_ref(),
+            &flox.system,
+        ),
+    };
+    let flox_env = links.for_mode(&active.mode).to_path_buf();
+
+    DeactivationTarget {
         activation_state_dir,
         flox_env,
-    })
+    }
 }
 
-/// Construct a [DeactivationTarget] for an environment whose `.flox` directory
-/// no longer exists, from state recorded when it was activated.
+/// The `.flox` path this entry's activation used, without opening the
+/// environment.
 ///
-/// The activation state dir derives from the recorded `.flox` path alone, a
-/// pure computation that supports deleted environments by design. The rendered
-/// env path comes from `state.json`, which recorded the exact `$FLOX_ENV` the
-/// activation exported; if that state is gone too (e.g. the runtime dir was
-/// cleaned), the path is reconstructed from the recorded environment name and
-/// mode, mirroring how opening the environment would derive it. The generated
-/// deactivation script restores env vars from the activation diff and only
-/// uses this path for string matching and existence-guarded sourcing, so a
-/// dangling path is harmless.
-fn deactivation_target_from_recorded_state(
-    flox: &Flox,
-    environment: &UninitializedEnvironment,
-    mode: &ActivateMode,
-) -> Result<DeactivationTarget> {
-    let Some(dot_flox_path) = environment.path() else {
-        // Unreachable: remote environments live under the cache dir, which is
-        // recreated when they are opened, so they never fail to open with
-        // `DotFloxNotFound`.
-        bail!("cannot recover deactivation data for a remote environment");
-    };
-    let activation_state_dir = activation_state_dir_path(&flox.runtime_dir, dot_flox_path);
-    let recorded_flox_env = match read_activations_json(state_json_path(&activation_state_dir)) {
-        Ok((Some(state), _lock)) => Some(state.flox_env().to_path_buf()),
-        Ok((None, _lock)) => None,
-        Err(err) => {
-            debug!(%err, "failed to read activation state of deleted environment");
-            None
+/// Local environments record their canonicalized `.flox` path in the active
+/// stack. Remote environments record only a pointer; their checkout lives at
+/// a deterministic location in the cache dir, canonicalized here the same way
+/// activation did. If the checkout was deleted mid-session, the
+/// uncanonicalized derivation stands in: the state dir selected from it may
+/// then miss, in which case the emitted detach is a no-op, but the teardown
+/// still proceeds.
+fn recorded_dot_flox_path(flox: &Flox, environment: &UninitializedEnvironment) -> PathBuf {
+    match environment {
+        UninitializedEnvironment::DotFlox(DotFlox { path, .. }) => path.clone(),
+        UninitializedEnvironment::Remote(pointer) => {
+            let dot_flox_path = RemoteEnvironment::checkout_path(flox, pointer).join(DOT_FLOX);
+            match CanonicalPath::new(&dot_flox_path) {
+                Ok(path) => path.into_inner(),
+                Err(err) => {
+                    debug!(%err, "could not canonicalize remote checkout path");
+                    dot_flox_path
+                },
+            }
         },
-    };
-    let flox_env = recorded_flox_env.unwrap_or_else(|| {
-        // Previously canonicalized path that we know no longer exists.
-        let run_dir = CanonicalPath::new_unchecked(dot_flox_path.join(GCROOTS_DIR_NAME));
-        RenderedEnvironmentLinks::new_in_base_dir_with_name_and_system(
-            &run_dir,
-            environment.name().as_ref(),
-            &flox.system,
-        )
-        .for_mode(mode)
-        .to_path_buf()
-    });
-
-    Ok(DeactivationTarget {
-        activation_state_dir,
-        flox_env,
-    })
+    }
 }
 
 /// The subsystem verbosity to thread into a generated deactivation script, read
@@ -419,13 +408,16 @@ mod tests {
     use std::collections::{HashMap, HashSet};
 
     use flox_activations::attach_diff::diff_serializer::DiffSerializer;
+    use flox_core::activate::mode::ActivateMode;
     use flox_core::activations::{
         ActivationState,
         acquire_activations_json_lock,
+        state_json_path,
         write_activations_json,
     };
     use flox_rust_sdk::flox::test_helpers::flox_instance;
-    use flox_rust_sdk::models::environment::{DotFlox, EnvironmentPointer, PathPointer};
+    use flox_rust_sdk::models::environment::generations::GenerationId;
+    use flox_rust_sdk::models::environment::{EnvironmentPointer, ManagedPointer, PathPointer};
 
     use super::*;
 
@@ -550,44 +542,128 @@ mod tests {
         }
     }
 
+    /// Write a state.json recording `flox_env` for an activation of
+    /// `dot_flox_path` in `mode`, returning the activation state dir.
+    fn write_activation_state(
+        runtime_dir: &Path,
+        dot_flox_path: &Path,
+        mode: &ActivateMode,
+        flox_env: &Path,
+    ) -> PathBuf {
+        let activation_state_dir = activation_state_dir_path(runtime_dir, dot_flox_path);
+        std::fs::create_dir_all(&activation_state_dir).unwrap();
+        let state_json = state_json_path(&activation_state_dir);
+        let mut state = ActivationState::new(mode, Some(dot_flox_path), flox_env);
+        state.set_executive_pid(1);
+        let lock = acquire_activations_json_lock(&state_json).unwrap();
+        write_activations_json(&state, &state_json, lock).unwrap();
+        activation_state_dir
+    }
+
     #[test]
-    fn deactivation_target_recovered_from_state_json_when_directory_deleted() {
+    fn deactivation_target_for_deleted_directory() {
         let (flox, tempdir) = flox_instance();
         // Never created: stands in for a project directory deleted while its
         // environment was active.
         let dot_flox_path = tempdir.path().join("proj/.flox");
-        let recorded_flox_env = dot_flox_path.join(format!("run/{}.proj-dev", flox.system));
 
-        let activation_state_dir = activation_state_dir_path(&flox.runtime_dir, &dot_flox_path);
-        std::fs::create_dir_all(&activation_state_dir).unwrap();
-        let state_json = state_json_path(&activation_state_dir);
-        let mut state =
-            ActivationState::new(&ActivateMode::Dev, Some(&dot_flox_path), &recorded_flox_env);
-        state.set_executive_pid(1);
-        let lock = acquire_activations_json_lock(&state_json).unwrap();
-        write_activations_json(&state, &state_json, lock).unwrap();
-
-        let target = open_deactivation_target(
+        let target = deactivation_target(
             &flox,
-            active_path_environment(&dot_flox_path, ActivateMode::Dev),
-        )
-        .unwrap();
+            &active_path_environment(&dot_flox_path, ActivateMode::Run),
+        );
         assert_eq!(target, DeactivationTarget {
-            activation_state_dir,
-            flox_env: recorded_flox_env,
+            activation_state_dir: activation_state_dir_path(&flox.runtime_dir, &dot_flox_path),
+            flox_env: dot_flox_path.join(format!("run/{}.proj-run", flox.system)),
         });
     }
 
     #[test]
-    fn deactivation_target_reconstructed_when_state_json_also_missing() {
+    fn deactivation_target_ignores_recorded_activation_state() {
+        // state.json keeps the values of whichever activation created the
+        // shared state dir — here a generation-pinned one. The unpinned layer
+        // being deactivated must get its own link back, not the creator's.
+        let (flox, tempdir) = flox_instance();
+        let dot_flox_path = tempdir.path().join("proj/.flox");
+        let activation_state_dir = write_activation_state(
+            &flox.runtime_dir,
+            &dot_flox_path,
+            &ActivateMode::Dev,
+            &dot_flox_path.join(format!("run/{}.proj.gen4-dev", flox.system)),
+        );
+
+        let target = deactivation_target(
+            &flox,
+            &active_path_environment(&dot_flox_path, ActivateMode::Dev),
+        );
+        assert_eq!(target, DeactivationTarget {
+            activation_state_dir,
+            flox_env: dot_flox_path.join(format!("run/{}.proj-dev", flox.system)),
+        });
+    }
+
+    #[test]
+    fn deactivation_target_includes_generation() {
         let (flox, tempdir) = flox_instance();
         let dot_flox_path = tempdir.path().join("proj/.flox");
 
-        let target = open_deactivation_target(
-            &flox,
-            active_path_environment(&dot_flox_path, ActivateMode::Run),
-        )
-        .unwrap();
+        let target = deactivation_target(&flox, &ActiveEnvironment {
+            environment: UninitializedEnvironment::DotFlox(DotFlox {
+                path: dot_flox_path.clone(),
+                pointer: EnvironmentPointer::Path(PathPointer::new("proj".parse().unwrap())),
+            }),
+            generation: Some(GenerationId::from(4usize)),
+            mode: ActivateMode::Run,
+        });
+        assert_eq!(target, DeactivationTarget {
+            activation_state_dir: activation_state_dir_path(&flox.runtime_dir, &dot_flox_path),
+            flox_env: dot_flox_path.join(format!("run/{}.proj.gen4-run", flox.system)),
+        });
+    }
+
+    #[test]
+    fn deactivation_target_for_remote_environment_uses_canonicalized_checkout() {
+        let (flox, _tempdir) = flox_instance();
+        let pointer = ManagedPointer::new(
+            "owner".parse().unwrap(),
+            "proj".parse().unwrap(),
+            &flox.floxhub,
+        );
+        // Mirror activation: the checkout is created and canonicalized before
+        // its path is hashed into the activation state dir.
+        let dot_flox_path = RemoteEnvironment::checkout_path(&flox, &pointer).join(DOT_FLOX);
+        std::fs::create_dir_all(&dot_flox_path).unwrap();
+        let dot_flox_path = std::fs::canonicalize(&dot_flox_path).unwrap();
+
+        let target = deactivation_target(&flox, &ActiveEnvironment {
+            environment: UninitializedEnvironment::Remote(pointer),
+            generation: None,
+            mode: ActivateMode::Dev,
+        });
+        assert_eq!(target, DeactivationTarget {
+            activation_state_dir: activation_state_dir_path(&flox.runtime_dir, &dot_flox_path),
+            flox_env: dot_flox_path.join(format!("run/{}.proj-dev", flox.system)),
+        });
+    }
+
+    #[test]
+    fn deactivation_target_for_remote_environment_with_missing_checkout() {
+        // The checkout was deleted mid-session: canonicalization is
+        // impossible, so the uncanonicalized derivation stands in and the
+        // teardown still resolves.
+        let (flox, _tempdir) = flox_instance();
+        let pointer = ManagedPointer::new(
+            "owner".parse().unwrap(),
+            "proj".parse().unwrap(),
+            &flox.floxhub,
+        );
+
+        let target = deactivation_target(&flox, &ActiveEnvironment {
+            environment: UninitializedEnvironment::Remote(pointer.clone()),
+            generation: None,
+            mode: ActivateMode::Run,
+        });
+
+        let dot_flox_path = RemoteEnvironment::checkout_path(&flox, &pointer).join(DOT_FLOX);
         assert_eq!(target, DeactivationTarget {
             activation_state_dir: activation_state_dir_path(&flox.runtime_dir, &dot_flox_path),
             flox_env: dot_flox_path.join(format!("run/{}.proj-run", flox.system)),

--- a/cli/flox/src/commands/hook_env.rs
+++ b/cli/flox/src/commands/hook_env.rs
@@ -22,11 +22,7 @@ use tracing::debug;
 
 use super::activate::write_auto_activation_preference;
 use super::activated_environments;
-use super::deactivate::{
-    emit_deactivate_script,
-    flox_activate_tracelevel,
-    open_deactivation_target,
-};
+use super::deactivate::{deactivation_target, emit_deactivate_script, flox_activate_tracelevel};
 use crate::subcommand_metric;
 use crate::utils::active_environments::ActiveEnvironment;
 use crate::utils::dialog::{Confirm, Dialog};
@@ -206,7 +202,7 @@ impl HookEnv {
                     popped_all = false;
                     break;
                 };
-                let target = open_deactivation_target(&flox, layer.clone())?;
+                let target = deactivation_target(&flox, layer);
                 // Auto-activations are always in-place, so the matching
                 // deactivation restores in place either way; this layer's
                 // map entry only decides whether to detach. A non-in-place


### PR DESCRIPTION
Explores the unification discussed in https://github.com/flox/flox/pull/4504#discussion_r3634075443. Stacked on #4504, so the diff shows only the unification.

## What

`deactivation_target` (formerly `open_deactivation_target`) now derives both fields of `DeactivationTarget` purely from the per-shell active-stack entry, for **all** environment types, and is infallible:

- **Activation state dir** — hash of the recorded canonicalized `.flox` path, used verbatim (re-canonicalizing could resolve differently, and fails for deleted directories). Remote environments record no path, so the checkout location is derived from the pointer via the new `RemoteEnvironment::checkout_path` (now also shared by `new` and `is_cached`) and canonicalized the way activation did.
- **`$FLOX_ENV` link** — rebuilt from the entry's name, generation, and mode with the same `RenderedEnvironmentLinks` constructors activation used, so it byte-matches what the activation exported.

The environment is never opened. The deleted-directory `state.json` fallback from #4504 is subsumed, and `ActivationState::flox_env` is removed with it.

## Why

Opening the environment during deactivation could:

- rebuild it (lockfile drift → `needs_rebuild` → a full build while *leaving* the environment),
- contact FloxHub for managed/remote environments (fails offline or with expired auth),
- write `env.lock`/`env.json`/registry entries,
- fail outright on a corrupt manifest or a deleted directory (the original #4504 bug).

It also had a latent bug: `active.generation` was discarded (`into_concrete_environment(flox, None)`), so `flox activate --generation N` layers were torn down with the unpinned link — the wrong `$FLOX_ENV` for `_FLOX_SOURCED_PROFILE_SCRIPTS` bookkeeping and `profile.deactivate` sourcing.

Why not read `state.json` (the #4504 fallback approach)? It is shared by every activation of the same `.flox` path and keeps the values of whichever activation created it — e.g. a generation-pinned activation's link — so trusting it can hand a layer a *different activation's* `$FLOX_ENV`. The per-shell stack entry is the only source that always describes the layer being torn down.

## Behavior changes

- `flox deactivate` no longer rebuilds, locks, fetches, or writes anything; it works offline and on broken or unopenable environments.
- Generation-pinned activations tear down with the correct `.genN` link.
- Edge case: if the rendered `run/` link was deleted mid-session, the env's `profile.deactivate` scripts are skipped (existence-guarded sourcing) where opening would have rebuilt the link first. Env-var restoration and detach are unaffected — they come from the activation diff and the state dir.
- Remote edge case: if the cache checkout was wiped mid-session, canonicalization is impossible, so the derived state dir may miss the activation's; the emitted detach becomes a no-op, but teardown still proceeds.

## Testing

- Unit tests for each derivation case: deleted directory, generation pin, remote with/without checkout, and `state.json` contents being ignored.
- `deactivate.bats` (44), the hook.bats deactivate tests (16, incl. both deleted-dir regression tests), and `deactivate_profile_e2e.bats` all pass.

## Release Notes

- `flox deactivate` no longer rebuilds the environment or contacts FloxHub, and succeeds even when the environment is broken or its directory was deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
