### PR TITLE
docs(contributing): require conventional commits format for PR titles

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,5 @@
+<!-- The PR title becomes the squash-merge commit message, so it must follow the conventional commits format (e.g. "feat(parser): add support for parsing arrays"). See CONTRIBUTING.md. -->
+
 ## Proposed Changes
 
 <!-- Describe the changes proposed in this pull request. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,3 @@
-<!-- The PR title becomes the squash-merge commit message, so it must follow the conventional commits format (e.g. "feat(parser): add support for parsing arrays"). See CONTRIBUTING.md. -->
 
 ## Proposed Changes
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,4 @@
+<!-- The PR title becomes the merge commit message, so it must follow the conventional commits format (e.g. "feat(parser): add ability to parse arrays"). See CONTRIBUTING.md. -->
 
 ## Proposed Changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,6 +115,21 @@ $ cz commit
 
 to make conforming commits interactively.
 
+-----
+
+**The pull request title must also follow the conventional commits format.**
+
+Pull requests are squash-merged (see [Merges](#merges)), and GitHub uses the
+pull request title as the message of the resulting squashed commit on `main`.
+That commit message is validated the same way individual commits are, so a PR
+whose commits are all correctly formatted can still fail at merge time if the
+title itself does not conform.
+
+```
+❌ Add support for parsing arrays
+✅ feat(parser): add support for parsing arrays
+```
+
 ## Development
 
 ```console
@@ -558,3 +573,7 @@ Merges to `main` should be squashed and *ff-only* back to `main` using GitHub
 PRs.  Or, if they represent multiple bigger changes, squashed into multiple
 distinct change sets.  Also be sure to run all tests before creating a mergeable
 PR (See [above](#testing)).
+
+Because the squashed commit takes its message from the pull request title, that
+title must follow the [conventional commits](#commits) format just like an
+individual commit — otherwise the merge fails validation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -574,6 +574,6 @@ PRs.  Or, if they represent multiple bigger changes, squashed into multiple
 distinct change sets.  Also be sure to run all tests before creating a mergeable
 PR (See [above](#testing)).
 
-Because the squashed commit takes its message from the pull request title, that
+Because the merge commit takes its message from the pull request title, that
 title must follow the [conventional commits](#commits) format just like an
 individual commit — otherwise the merge fails validation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,8 +126,8 @@ whose commits are all correctly formatted can still fail at merge time if the
 title itself does not conform.
 
 ```
-❌ Add support for parsing arrays
-✅ feat(parser): add support for parsing arrays
+❌ Add ability to parse arrays
+✅ feat(parser): add ability to parse arrays
 ```
 
 ## Development

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -570,10 +570,10 @@ changes.
 
 Development is done on branches and merged back to `main`.  Keep your branch
 updated by rebasing and resolving conflicts regularly to avoid messy merges.
-Merges to `main` should be squashed and *ff-only* back to `main` using GitHub
-PRs.  Or, if they represent multiple bigger changes, squashed into multiple
-distinct change sets.  Also be sure to run all tests before creating a mergeable
-PR (See [above](#testing)).
+Merges to `main` go through a GitHub merge queue, which creates a merge commit
+on `main` whose message is the pull request title.  Keep each branch focused;
+if a change is large, split it into multiple distinct change sets.  Also be
+sure to run all tests before creating a mergeable PR (See [above](#testing)).
 
 Because the merge commit takes its message from the pull request title, that
 title must follow the [conventional commits](#commits) format just like an

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,8 +119,9 @@ to make conforming commits interactively.
 
 **The pull request title must also follow the conventional commits format.**
 
-Pull requests are squash-merged (see [Merges](#merges)), and GitHub uses the
-pull request title as the message of the resulting squashed commit on `main`.
+Pull requests are merged via a merge queue (see [Merges](#merges)), and GitHub
+uses the pull request title as the message of the resulting merge commit on
+`main`.
 That commit message is validated the same way individual commits are, so a PR
 whose commits are all correctly formatted can still fail at merge time if the
 title itself does not conform.


### PR DESCRIPTION
## Proposed Changes

Flox merges pull requests via merge commits, and GitHub uses the **PR title** as the
message of the resulting commit on `main`. That commit message is
validated by commitizen the same way individual commits are — but
`CONTRIBUTING.md` only documented the format requirement for individual
commits, never for the PR title itself.

The result is a footgun: a contributor can write perfectly conventional
commits throughout a PR and still hit a validation failure at merge time
because the PR title doesn't conform. This happened on #4481 (fixed manually
that time), and it has bitten us more than once.

This is a docs-only change that closes the gap:

- **`CONTRIBUTING.md` → "Commits" section:** adds a note that the PR title
  must also follow the conventional commits format, explaining *why* (squash
  merge uses it as the commit message), with a bad-vs-good example.
- **`CONTRIBUTING.md` → "Merges" section:** adds a one-line cross-reference so
  a reader who lands there sees the same requirement.
- **`.github/PULL_REQUEST_TEMPLATE.md`:** adds a one-line HTML-comment reminder
  (invisible in the rendered PR) so authors see it while writing the title.

No code, workflow, or CI config is touched.

## Release Notes

N/A
