### PR TITLE
feat(events): environment-creation and build-outcome telemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1553,6 +1553,7 @@ dependencies = [
  "anyhow",
  "apple-native-keyring-store",
  "beta",
+ "blake3",
  "bpaf",
  "chrono",
  "close_fds",

--- a/cli/flox-events/src/hub.rs
+++ b/cli/flox-events/src/hub.rs
@@ -36,21 +36,22 @@ impl EventsHub {
 
     pub fn set_client(&self, new_client: EventsClient) -> Option<EventsClient> {
         self.completed_recorded.store(false, Ordering::SeqCst);
-        self.with_client(|client| client.replace(new_client))
+        self.lock_client(|client| client.replace(new_client))
     }
 
     pub fn clear_client(&self) -> Option<EventsClient> {
         self.completed_recorded.store(false, Ordering::SeqCst);
-        self.with_client(Option::take)
+        self.lock_client(Option::take)
     }
 
-    /// Whether a client is installed.
-    pub fn has_client(&self) -> bool {
-        self.with_client(|client| client.is_some())
+    /// Run `f` only when a client is installed — for work that only feeds
+    /// event payloads and would otherwise be wasted.
+    pub fn with_client<T>(&self, f: impl FnOnce() -> T) -> Option<T> {
+        self.lock_client(|client| client.is_some()).then(f)
     }
 
     pub fn flush(&self, force: bool) -> Result<()> {
-        self.with_client(|client| {
+        self.lock_client(|client| {
             if let Some(client) = client {
                 client.flush(force)
             } else {
@@ -61,7 +62,7 @@ impl EventsHub {
     }
 
     pub fn record_event(&self, kind: EventKind) -> Result<()> {
-        self.with_client(|client| {
+        self.lock_client(|client| {
             let Some(client) = client else {
                 trace!("No v2 events client configured, skipping record");
                 return Ok(());
@@ -74,7 +75,7 @@ impl EventsHub {
     /// Record a `cli.command_run` event for `subcommand`. No-op when no
     /// client is installed.
     pub fn record_command_run(&self, subcommand: String) -> Result<()> {
-        self.with_client(|client| {
+        self.lock_client(|client| {
             let Some(client) = client else {
                 trace!("No v2 events client configured, skipping command_run record");
                 return Ok(());
@@ -96,7 +97,7 @@ impl EventsHub {
             debug!("command_completed already recorded for this client install, skipping");
             return Ok(());
         }
-        self.with_client(|client| {
+        self.lock_client(|client| {
             let Some(client) = client else {
                 trace!("No v2 events client configured, skipping command_completed record");
                 return Ok(());
@@ -120,7 +121,7 @@ impl EventsHub {
         Ok(EventsGuard::from_hub(self.clone()))
     }
 
-    fn with_client<T>(&self, f: impl FnOnce(&mut Option<EventsClient>) -> T) -> T {
+    fn lock_client<T>(&self, f: impl FnOnce(&mut Option<EventsClient>) -> T) -> T {
         let mut client = self
             .client
             .lock()

--- a/cli/flox-events/src/hub.rs
+++ b/cli/flox-events/src/hub.rs
@@ -44,8 +44,7 @@ impl EventsHub {
         self.with_client(Option::take)
     }
 
-    /// Whether a client is installed. Callers use this to skip work that
-    /// only feeds event payloads when recording would be a no-op anyway.
+    /// Whether a client is installed.
     pub fn has_client(&self) -> bool {
         self.with_client(|client| client.is_some())
     }

--- a/cli/flox-events/src/hub.rs
+++ b/cli/flox-events/src/hub.rs
@@ -44,6 +44,12 @@ impl EventsHub {
         self.with_client(Option::take)
     }
 
+    /// Whether a client is installed. Callers use this to skip work that
+    /// only feeds event payloads when recording would be a no-op anyway.
+    pub fn has_client(&self) -> bool {
+        self.with_client(|client| client.is_some())
+    }
+
     pub fn flush(&self, force: bool) -> Result<()> {
         self.with_client(|client| {
             if let Some(client) = client {

--- a/cli/flox-events/src/lib.rs
+++ b/cli/flox-events/src/lib.rs
@@ -977,9 +977,7 @@ mod tests {
         assert_eq!(value, expected);
     }
 
-    /// Remote environments carry no `environment_id` (their cached
-    /// pointer is rewritten per invocation) but do have generations and
-    /// a lockfile.
+    /// Remote environments carry no `environment_id`.
     #[test]
     fn cli_environment_remote_identity_fields_envelope_golden() {
         let detail = env_detail("remote", "alice/myenv")

--- a/cli/flox-events/src/lib.rs
+++ b/cli/flox-events/src/lib.rs
@@ -336,6 +336,20 @@ pub struct EnvDetail {
     /// for remote and managed environments, and `Environment::name(...)`
     /// for path environments. Matches the value the legacy macros emit.
     env_ref_or_name: String,
+    /// The environment's stable id from its `env.json`, when it has one.
+    /// Absent for environments created before the id existed and for
+    /// remote environments, whose cached pointer is rewritten per
+    /// invocation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    environment_id: Option<Uuid>,
+    /// Current generation the command started from. Absent for path
+    /// environments, which have no generations.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    generation_number: Option<u64>,
+    /// Number of packages locked for the invoking system (the `flox list`
+    /// count) when the command started. Absent when no lockfile exists.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    package_count: Option<u64>,
 }
 
 impl EnvDetail {
@@ -343,7 +357,25 @@ impl EnvDetail {
         Self {
             env_kind: env_kind.into(),
             env_ref_or_name: env_ref_or_name.into(),
+            environment_id: None,
+            generation_number: None,
+            package_count: None,
         }
+    }
+
+    pub fn with_environment_id(mut self, environment_id: Uuid) -> Self {
+        self.environment_id = Some(environment_id);
+        self
+    }
+
+    pub fn with_generation_number(mut self, generation_number: u64) -> Self {
+        self.generation_number = Some(generation_number);
+        self
+    }
+
+    pub fn with_package_count(mut self, package_count: u64) -> Self {
+        self.package_count = Some(package_count);
+        self
     }
 }
 
@@ -852,10 +884,7 @@ mod tests {
     }
 
     fn env_detail(kind: &str, ref_or_name: &str) -> EnvDetail {
-        EnvDetail {
-            env_kind: kind.to_string(),
-            env_ref_or_name: ref_or_name.to_string(),
-        }
+        EnvDetail::new(kind, ref_or_name)
     }
 
     fn activate_envelope_json(payload: serde_json::Value) -> serde_json::Value {
@@ -898,6 +927,90 @@ mod tests {
             "has_includes": true,
         }));
         assert_eq!(value, expected);
+    }
+
+    #[test]
+    fn cli_environment_activate_managed_identity_fields_envelope_golden() {
+        let environment_id = Uuid::from_u128(0x11111111_1111_1111_1111_111111111111);
+        let detail = env_detail("managed", "alice/myenv")
+            .with_environment_id(environment_id)
+            .with_generation_number(3)
+            .with_package_count(7);
+        let payload = CliEnvironmentActivatePayload::new(detail);
+        let value = serde_json::to_value(fixed_event(EventKind::CliEnvironmentActivate(payload)))
+            .expect("event serializes");
+        let expected = activate_envelope_json(json!({
+            "env_kind": "managed",
+            "env_ref_or_name": "alice/myenv",
+            "environment_id": "11111111-1111-1111-1111-111111111111",
+            "generation_number": 3,
+            "package_count": 7,
+        }));
+        assert_eq!(value, expected);
+    }
+
+    /// Path environments have no generations: `generation_number` stays
+    /// absent while the other identity fields ride.
+    #[test]
+    fn cli_environment_path_identity_fields_envelope_golden() {
+        let environment_id = Uuid::from_u128(0x11111111_1111_1111_1111_111111111111);
+        let detail = env_detail("path", "myenv")
+            .with_environment_id(environment_id)
+            .with_package_count(2);
+        let payload = CliEnvironmentPayload::new(detail);
+        let value = serde_json::to_value(fixed_event(EventKind::CliEnvironmentList(payload)))
+            .expect("event serializes");
+        let expected = json!({
+            "event_id": "00000000-0000-0000-0000-000000000000",
+            "event_timestamp": EPOCH_UNIX_MS,
+            "source": "cli",
+            "invocation_id": "00000000-0000-0000-0000-000000000000",
+            "device_id": "00000000-0000-0000-0000-000000000000",
+            "event_type": "cli.environment.list",
+            "payload": {
+                "env_kind": "path",
+                "env_ref_or_name": "myenv",
+                "environment_id": "11111111-1111-1111-1111-111111111111",
+                "package_count": 2,
+            },
+        });
+        assert_eq!(value, expected);
+    }
+
+    /// Remote environments carry no `environment_id` (their cached
+    /// pointer is rewritten per invocation) but do have generations and
+    /// a lockfile.
+    #[test]
+    fn cli_environment_remote_identity_fields_envelope_golden() {
+        let detail = env_detail("remote", "alice/myenv")
+            .with_generation_number(5)
+            .with_package_count(4);
+        let payload = CliEnvironmentActivatePayload::new(detail);
+        let value = serde_json::to_value(fixed_event(EventKind::CliEnvironmentActivate(payload)))
+            .expect("event serializes");
+        let expected = activate_envelope_json(json!({
+            "env_kind": "remote",
+            "env_ref_or_name": "alice/myenv",
+            "generation_number": 5,
+            "package_count": 4,
+        }));
+        assert_eq!(value, expected);
+    }
+
+    /// A buffered environment-event row recorded by a binary that predates
+    /// the identity fields must deserialize and re-serialize unchanged —
+    /// absent fields stay absent, nothing is fabricated.
+    #[test]
+    fn environment_row_without_identity_fields_round_trips() {
+        let old_row = env_envelope_json("cli.environment.delete");
+        let event: Event =
+            serde_json::from_value(old_row.clone()).expect("old-shape row deserializes");
+        let EventKind::CliEnvironmentDelete(ref payload) = event.kind else {
+            panic!("expected cli.environment.delete");
+        };
+        assert_eq!(payload, &CliEnvironmentPayload::new(managed_env_detail()));
+        let reserialized = serde_json::to_value(event).expect("event re-serializes");
+        assert_eq!(reserialized, old_row);
     }
 
     #[test]
@@ -1825,10 +1938,7 @@ mod pipeline_tests {
         let hub = EventsHub::new();
         hub.set_client(client_with_connection(&tempdir, connection));
 
-        let env_detail = EnvDetail {
-            env_kind: "path".to_string(),
-            env_ref_or_name: "myenv".to_string(),
-        };
+        let env_detail = EnvDetail::new("path", "myenv");
 
         hub.record_event(EventKind::CliEnvironmentEdit(
             CliEnvironmentEditPayload::new(env_detail.clone()),

--- a/cli/flox-events/src/lib.rs
+++ b/cli/flox-events/src/lib.rs
@@ -136,6 +136,8 @@ pub enum EventKind {
     CliPackageUninstall(CliPackagePayload),
     #[serde(rename = "cli.environment.containerize")]
     CliEnvironmentContainerize(CliEnvironmentPayload),
+    #[serde(rename = "cli.environment.create")]
+    CliEnvironmentCreate(CliEnvironmentPayload),
     #[serde(rename = "cli.environment.delete")]
     CliEnvironmentDelete(CliEnvironmentPayload),
     #[serde(rename = "cli.environment.edit")]
@@ -1019,6 +1021,30 @@ mod tests {
             "env_kind": "path",
             "env_ref_or_name": "myenv",
         }));
+        assert_eq!(value, expected);
+    }
+
+    #[test]
+    fn cli_environment_create_envelope_golden() {
+        let environment_id = Uuid::from_u128(0x11111111_1111_1111_1111_111111111111);
+        let detail = env_detail("path", "myenv").with_environment_id(environment_id);
+        let payload = CliEnvironmentPayload::new(detail);
+        let value = serde_json::to_value(fixed_event(EventKind::CliEnvironmentCreate(payload)))
+            .expect("event serializes");
+        let payload_json = json!({
+            "env_kind": "path",
+            "env_ref_or_name": "myenv",
+            "environment_id": "11111111-1111-1111-1111-111111111111",
+        });
+        let expected = json!({
+            "event_id": "00000000-0000-0000-0000-000000000000",
+            "event_timestamp": EPOCH_UNIX_MS,
+            "source": "cli",
+            "invocation_id": "00000000-0000-0000-0000-000000000000",
+            "device_id": "00000000-0000-0000-0000-000000000000",
+            "event_type": "cli.environment.create",
+            "payload": payload_json,
+        });
         assert_eq!(value, expected);
     }
 

--- a/cli/flox-events/src/lib.rs
+++ b/cli/flox-events/src/lib.rs
@@ -884,7 +884,15 @@ mod tests {
     }
 
     fn env_detail(kind: &str, ref_or_name: &str) -> EnvDetail {
-        EnvDetail::new(kind, ref_or_name)
+        // Exhaustive literal: adding an EnvDetail field must break this
+        // helper so the goldens are extended deliberately.
+        EnvDetail {
+            env_kind: kind.to_string(),
+            env_ref_or_name: ref_or_name.to_string(),
+            environment_id: None,
+            generation_number: None,
+            package_count: None,
+        }
     }
 
     fn activate_envelope_json(payload: serde_json::Value) -> serde_json::Value {
@@ -1936,7 +1944,13 @@ mod pipeline_tests {
         let hub = EventsHub::new();
         hub.set_client(client_with_connection(&tempdir, connection));
 
-        let env_detail = EnvDetail::new("path", "myenv");
+        let env_detail = EnvDetail {
+            env_kind: "path".to_string(),
+            env_ref_or_name: "myenv".to_string(),
+            environment_id: None,
+            generation_number: None,
+            package_count: None,
+        };
 
         hub.record_event(EventKind::CliEnvironmentEdit(
             CliEnvironmentEditPayload::new(env_detail.clone()),

--- a/cli/flox-events/src/lib.rs
+++ b/cli/flox-events/src/lib.rs
@@ -337,9 +337,8 @@ pub struct EnvDetail {
     /// for path environments. Matches the value the legacy macros emit.
     env_ref_or_name: String,
     /// The environment's stable id from its `env.json`, when it has one.
-    /// Absent for environments created before the id existed and for
-    /// remote environments, whose cached pointer is rewritten per
-    /// invocation.
+    /// Absent for remote environments and for environments created before
+    /// the id existed or while metrics were disabled.
     #[serde(skip_serializing_if = "Option::is_none")]
     environment_id: Option<Uuid>,
     /// Current generation the command started from. Absent for path
@@ -347,7 +346,8 @@ pub struct EnvDetail {
     #[serde(skip_serializing_if = "Option::is_none")]
     generation_number: Option<u64>,
     /// Number of packages locked for the invoking system (the `flox list`
-    /// count) when the command started. Absent when no lockfile exists.
+    /// count) when the command started. Absent when no lockfile is
+    /// available.
     #[serde(skip_serializing_if = "Option::is_none")]
     package_count: Option<u64>,
 }
@@ -884,8 +884,6 @@ mod tests {
     }
 
     fn env_detail(kind: &str, ref_or_name: &str) -> EnvDetail {
-        // Exhaustive literal: adding an EnvDetail field must break this
-        // helper so the goldens are extended deliberately.
         EnvDetail {
             env_kind: kind.to_string(),
             env_ref_or_name: ref_or_name.to_string(),
@@ -953,52 +951,6 @@ mod tests {
             "environment_id": "11111111-1111-1111-1111-111111111111",
             "generation_number": 3,
             "package_count": 7,
-        }));
-        assert_eq!(value, expected);
-    }
-
-    /// Path environments have no generations: `generation_number` stays
-    /// absent while the other identity fields ride.
-    #[test]
-    fn cli_environment_path_identity_fields_envelope_golden() {
-        let environment_id = Uuid::from_u128(0x11111111_1111_1111_1111_111111111111);
-        let detail = env_detail("path", "myenv")
-            .with_environment_id(environment_id)
-            .with_package_count(2);
-        let payload = CliEnvironmentPayload::new(detail);
-        let value = serde_json::to_value(fixed_event(EventKind::CliEnvironmentList(payload)))
-            .expect("event serializes");
-        let expected = json!({
-            "event_id": "00000000-0000-0000-0000-000000000000",
-            "event_timestamp": EPOCH_UNIX_MS,
-            "source": "cli",
-            "invocation_id": "00000000-0000-0000-0000-000000000000",
-            "device_id": "00000000-0000-0000-0000-000000000000",
-            "event_type": "cli.environment.list",
-            "payload": {
-                "env_kind": "path",
-                "env_ref_or_name": "myenv",
-                "environment_id": "11111111-1111-1111-1111-111111111111",
-                "package_count": 2,
-            },
-        });
-        assert_eq!(value, expected);
-    }
-
-    /// Remote environments carry no `environment_id`.
-    #[test]
-    fn cli_environment_remote_identity_fields_envelope_golden() {
-        let detail = env_detail("remote", "alice/myenv")
-            .with_generation_number(5)
-            .with_package_count(4);
-        let payload = CliEnvironmentActivatePayload::new(detail);
-        let value = serde_json::to_value(fixed_event(EventKind::CliEnvironmentActivate(payload)))
-            .expect("event serializes");
-        let expected = activate_envelope_json(json!({
-            "env_kind": "remote",
-            "env_ref_or_name": "alice/myenv",
-            "generation_number": 5,
-            "package_count": 4,
         }));
         assert_eq!(value, expected);
     }

--- a/cli/flox-events/src/lib.rs
+++ b/cli/flox-events/src/lib.rs
@@ -633,12 +633,33 @@ impl CliEnvironmentGenerationsListPayload {
 // environment context (build operates on the manifest's `build`
 // table; search hits the catalog without a resolved environment).
 
+/// The outcome of a `flox build` invocation's build step. Parallels
+/// [`PackageOutcome`] with the same `success`/`failure` wire values.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum BuildOutcome {
+    Success,
+    Failure,
+}
+
 /// Payload for [`EventKind::CliBuild`]. Carries `flox build`'s
-/// per-invocation build-kind detection flags.
+/// per-invocation build-kind detection flags, plus the build outcome
+/// once the build step has run.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CliBuildPayload {
     has_expression_build: bool,
     has_manifest_build: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    outcome: Option<BuildOutcome>,
+    /// Wall-clock ms for the build step only (not the whole invocation).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    duration_ms: Option<u64>,
+    /// Classified `ManifestBuilderError` slug (e.g. `build.build_failure`)
+    /// on failure — never the raw error message or build output.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error_kind: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    lockfile_hash: Option<String>,
 }
 
 impl CliBuildPayload {
@@ -646,7 +667,31 @@ impl CliBuildPayload {
         Self {
             has_expression_build,
             has_manifest_build,
+            outcome: None,
+            duration_ms: None,
+            error_kind: None,
+            lockfile_hash: None,
         }
+    }
+
+    pub fn with_outcome(mut self, value: BuildOutcome) -> Self {
+        self.outcome = Some(value);
+        self
+    }
+
+    pub fn with_duration_ms(mut self, value: u64) -> Self {
+        self.duration_ms = Some(value);
+        self
+    }
+
+    pub fn with_error_kind(mut self, value: impl Into<String>) -> Self {
+        self.error_kind = Some(value.into());
+        self
+    }
+
+    pub fn with_lockfile_hash(mut self, value: impl Into<String>) -> Self {
+        self.lockfile_hash = Some(value.into());
+        self
     }
 }
 
@@ -1362,6 +1407,62 @@ mod tests {
         let payload_json = json!({
             "has_expression_build": true,
             "has_manifest_build": false,
+        });
+        let expected = json!({
+            "event_id": "00000000-0000-0000-0000-000000000000",
+            "event_timestamp": EPOCH_UNIX_MS,
+            "source": "cli",
+            "invocation_id": "00000000-0000-0000-0000-000000000000",
+            "device_id": "00000000-0000-0000-0000-000000000000",
+            "event_type": "cli.build",
+            "payload": payload_json,
+        });
+        assert_eq!(value, expected);
+    }
+
+    #[test]
+    fn cli_build_success_envelope_golden() {
+        let payload = CliBuildPayload::new(true, true)
+            .with_duration_ms(1234)
+            .with_lockfile_hash("d5f2b8")
+            .with_outcome(BuildOutcome::Success);
+        let value = serde_json::to_value(fixed_event(EventKind::CliBuild(payload)))
+            .expect("event serializes");
+        let payload_json = json!({
+            "has_expression_build": true,
+            "has_manifest_build": true,
+            "outcome": "success",
+            "duration_ms": 1234,
+            "lockfile_hash": "d5f2b8",
+        });
+        let expected = json!({
+            "event_id": "00000000-0000-0000-0000-000000000000",
+            "event_timestamp": EPOCH_UNIX_MS,
+            "source": "cli",
+            "invocation_id": "00000000-0000-0000-0000-000000000000",
+            "device_id": "00000000-0000-0000-0000-000000000000",
+            "event_type": "cli.build",
+            "payload": payload_json,
+        });
+        assert_eq!(value, expected);
+    }
+
+    #[test]
+    fn cli_build_failure_envelope_golden() {
+        let payload = CliBuildPayload::new(false, true)
+            .with_duration_ms(50)
+            .with_lockfile_hash("d5f2b8")
+            .with_outcome(BuildOutcome::Failure)
+            .with_error_kind("build.build_failure");
+        let value = serde_json::to_value(fixed_event(EventKind::CliBuild(payload)))
+            .expect("event serializes");
+        let payload_json = json!({
+            "has_expression_build": false,
+            "has_manifest_build": true,
+            "outcome": "failure",
+            "duration_ms": 50,
+            "lockfile_hash": "d5f2b8",
+            "error_kind": "build.build_failure",
         });
         let expected = json!({
             "event_id": "00000000-0000-0000-0000-000000000000",

--- a/cli/flox-rust-sdk/src/models/env_registry.rs
+++ b/cli/flox-rust-sdk/src/models/env_registry.rs
@@ -533,6 +533,7 @@ mod test {
         let pointer = ManagedPointer::new(
             "owner".parse().unwrap(),
             "name".parse().unwrap(),
+            None,
             &flox.floxhub,
         );
         let path = flox.temp_dir.join("deleted").join(".flox");

--- a/cli/flox-rust-sdk/src/models/env_registry.rs
+++ b/cli/flox-rust-sdk/src/models/env_registry.rs
@@ -365,8 +365,8 @@ mod test {
 
     use super::*;
     use crate::flox::test_helpers::flox_instance;
-    use crate::models::environment::ManagedPointer;
     use crate::models::environment::path_environment::test_helpers::new_path_environment;
+    use crate::models::environment::{ManagedPointer, PathPointer};
 
     impl Arbitrary for RegistryEntry {
         type Parameters = ();
@@ -396,6 +396,32 @@ mod test {
                 })
                 .boxed()
         }
+    }
+
+    /// Registry entries persisted before pointer ids existed must keep
+    /// matching (and deregistering) the same environment once its pointer
+    /// carries an id.
+    #[test]
+    fn registry_matching_ignores_pointer_id() {
+        let legacy_pointer = EnvironmentPointer::Path(PathPointer::new("name".parse().unwrap()));
+        let mut entry = RegistryEntry {
+            path_hash: path_hash(Path::new("/some/path")).to_string(),
+            path: PathBuf::from("/some/path"),
+            envs: vec![RegisteredEnv {
+                created_at: 0,
+                pointer: legacy_pointer.clone(),
+            }],
+        };
+
+        let EnvironmentPointer::Path(mut with_id_pointer) = legacy_pointer else {
+            panic!("expected path pointer");
+        };
+        with_id_pointer.id = Some(uuid::Uuid::new_v4());
+        let with_id = EnvironmentPointer::Path(with_id_pointer);
+
+        assert!(entry.is_same_as_latest_env(&with_id));
+        assert!(entry.deregister_env(&with_id).is_some());
+        assert!(entry.envs.is_empty());
     }
 
     proptest! {

--- a/cli/flox-rust-sdk/src/models/env_registry.rs
+++ b/cli/flox-rust-sdk/src/models/env_registry.rs
@@ -365,8 +365,8 @@ mod test {
 
     use super::*;
     use crate::flox::test_helpers::flox_instance;
+    use crate::models::environment::ManagedPointer;
     use crate::models::environment::path_environment::test_helpers::new_path_environment;
-    use crate::models::environment::{ManagedPointer, PathPointer};
 
     impl Arbitrary for RegistryEntry {
         type Parameters = ();
@@ -396,32 +396,6 @@ mod test {
                 })
                 .boxed()
         }
-    }
-
-    /// Registry entries persisted before pointer ids existed must keep
-    /// matching (and deregistering) the same environment once its pointer
-    /// carries an id.
-    #[test]
-    fn registry_matching_ignores_pointer_id() {
-        let legacy_pointer = EnvironmentPointer::Path(PathPointer::new("name".parse().unwrap()));
-        let mut entry = RegistryEntry {
-            path_hash: path_hash(Path::new("/some/path")).to_string(),
-            path: PathBuf::from("/some/path"),
-            envs: vec![RegisteredEnv {
-                created_at: 0,
-                pointer: legacy_pointer.clone(),
-            }],
-        };
-
-        let EnvironmentPointer::Path(mut with_id_pointer) = legacy_pointer else {
-            panic!("expected path pointer");
-        };
-        with_id_pointer.id = Some(uuid::Uuid::new_v4());
-        let with_id = EnvironmentPointer::Path(with_id_pointer);
-
-        assert!(entry.is_same_as_latest_env(&with_id));
-        assert!(entry.deregister_env(&with_id).is_some());
-        assert!(entry.envs.is_empty());
     }
 
     proptest! {

--- a/cli/flox-rust-sdk/src/models/environment/fetcher.rs
+++ b/cli/flox-rust-sdk/src/models/environment/fetcher.rs
@@ -108,8 +108,12 @@ impl IncludeFetcher {
         name: &Option<String>,
         generation: Option<usize>,
     ) -> Result<(Manifest<TypedOnly>, String), EnvironmentError> {
-        let pointer =
-            ManagedPointer::new(remote.owner().clone(), remote.name().clone(), &flox.floxhub);
+        let pointer = ManagedPointer::new(
+            remote.owner().clone(),
+            remote.name().clone(),
+            None,
+            &flox.floxhub,
+        );
 
         // Don't affect existing open remotes but still uses the same floxmeta.
         let tempdir =
@@ -363,6 +367,7 @@ mod test {
             ManagedPointer::new(
                 env_ref.owner().clone(),
                 env_ref.name().clone(),
+                None,
                 &flox.floxhub,
             ),
             None,

--- a/cli/flox-rust-sdk/src/models/environment/floxmeta_branch.rs
+++ b/cli/flox-rust-sdk/src/models/environment/floxmeta_branch.rs
@@ -759,6 +759,7 @@ mod tests {
         ManagedPointer {
             owner: EnvironmentOwner::from_str("owner").unwrap(),
             name: EnvironmentName::from_str("name").unwrap(),
+            id: None,
             floxhub_base_url: Url::from_str("https://hub.flox.dev").unwrap(),
             floxhub_git_url_override: Some(
                 Url::from_directory_path(mock_floxhub_git_path).unwrap(),

--- a/cli/flox-rust-sdk/src/models/environment/generations.rs
+++ b/cli/flox-rust-sdk/src/models/environment/generations.rs
@@ -155,6 +155,15 @@ impl<S> Generations<S> {
         if !metadata.generations().contains_key(&generation.into()) {
             return Err(GenerationsError::GenerationNotFound(generation));
         }
+        self.lockfile_contents_unchecked(generation)
+    }
+
+    /// Like [Generations::lockfile_contents] but without confirming the
+    /// generation exists — for callers that already read the metadata.
+    pub(crate) fn lockfile_contents_unchecked(
+        &self,
+        generation: usize,
+    ) -> Result<String, GenerationsError> {
         let lockfile_osstr = self
             .repo
             .show(&format!(

--- a/cli/flox-rust-sdk/src/models/environment/generations.rs
+++ b/cli/flox-rust-sdk/src/models/environment/generations.rs
@@ -149,6 +149,16 @@ impl<S> Generations<S> {
         Lockfile::from_str(contents.as_str()).map_err(GenerationsError::Lockfile)
     }
 
+    /// Like [Generations::lockfile] but without confirming the generation
+    /// exists — for callers that already read the metadata.
+    pub(crate) fn lockfile_unchecked(
+        &self,
+        generation: usize,
+    ) -> Result<Lockfile, GenerationsError> {
+        let contents = self.lockfile_contents_unchecked(generation)?;
+        Lockfile::from_str(contents.as_str()).map_err(GenerationsError::Lockfile)
+    }
+
     /// Read the lockfile of a given generation and return its contents as a string.
     pub fn lockfile_contents(&self, generation: usize) -> Result<String, GenerationsError> {
         let metadata = self.metadata()?;

--- a/cli/flox-rust-sdk/src/models/environment/generations.rs
+++ b/cli/flox-rust-sdk/src/models/environment/generations.rs
@@ -149,16 +149,6 @@ impl<S> Generations<S> {
         Lockfile::from_str(contents.as_str()).map_err(GenerationsError::Lockfile)
     }
 
-    /// Like [Generations::lockfile] but without confirming the generation
-    /// exists — for callers that already read the metadata.
-    pub(crate) fn lockfile_unchecked(
-        &self,
-        generation: usize,
-    ) -> Result<Lockfile, GenerationsError> {
-        let contents = self.lockfile_contents_unchecked(generation)?;
-        Lockfile::from_str(contents.as_str()).map_err(GenerationsError::Lockfile)
-    }
-
     /// Read the lockfile of a given generation and return its contents as a string.
     pub fn lockfile_contents(&self, generation: usize) -> Result<String, GenerationsError> {
         let metadata = self.metadata()?;

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -1178,27 +1178,40 @@ impl ManagedEnvironment {
 
     /// The lockfile this environment resolves to, read without
     /// materializing the local checkout: the pinned generation's lockfile
-    /// when a generation is pinned, otherwise the local checkout's
-    /// lockfile if one exists on disk.
+    /// when a generation is pinned, the local checkout's lockfile when one
+    /// exists on disk, and the current generation's lockfile otherwise.
     pub fn existing_lockfile_without_checkout(&self) -> Result<Option<Lockfile>, EnvironmentError> {
         if let Some(generation) = self.generation {
-            let lockfile_contents = self
-                .generations()
-                .lockfile_contents(*generation)
-                .map_err(ManagedEnvironmentError::Generations)?;
-
-            return Lockfile::from_str(&lockfile_contents)
-                .map_err(EnvironmentError::Lockfile)
-                .map(Some);
+            return self.generation_lockfile(*generation);
         }
 
-        let lockfile_path = self.path.join(ENV_DIR_NAME).join(LOCKFILE_FILENAME);
-        let Ok(lockfile_path) = CanonicalPath::new(lockfile_path) else {
+        let env_dir = self.path.join(ENV_DIR_NAME);
+        if env_dir.exists() {
+            return CoreEnvironment::new(env_dir, self.include_fetcher.clone())
+                .existing_lockfile()
+                .map_err(EnvironmentError::Core);
+        }
+
+        let Some(generation) = self
+            .generations_metadata()
+            .map_err(ManagedEnvironmentError::Generations)?
+            .current_gen()
+        else {
             return Ok(None);
         };
-        Lockfile::read_from_file(&lockfile_path)
-            .map(Some)
+        self.generation_lockfile(*generation)
+    }
+
+    /// Read `generation`'s lockfile from the floxmeta branch.
+    fn generation_lockfile(&self, generation: usize) -> Result<Option<Lockfile>, EnvironmentError> {
+        let lockfile_contents = self
+            .generations()
+            .lockfile_contents(generation)
+            .map_err(ManagedEnvironmentError::Generations)?;
+
+        Lockfile::from_str(&lockfile_contents)
             .map_err(EnvironmentError::Lockfile)
+            .map(Some)
     }
 
     pub(crate) fn generations(&self) -> Generations {
@@ -1670,6 +1683,7 @@ pub mod test_helpers {
 
     use flox_core::floxhub::{DEFAULT_FLOXHUB_URL, Floxhub};
     use tempfile::tempdir_in;
+    use uuid::Uuid;
 
     use super::*;
     use crate::models::environment::fetcher::test_helpers::mock_include_fetcher;
@@ -1700,6 +1714,21 @@ pub mod test_helpers {
             include_fetcher: mock_include_fetcher(),
             generation: None,
         }
+    }
+
+    /// Set the pointer id on a mock environment, as a pull would have.
+    pub fn with_pointer_id(mut env: ManagedEnvironment, id: Uuid) -> ManagedEnvironment {
+        env.pointer.id = Some(id);
+        env
+    }
+
+    /// Pin `env` to a generation, as `flox activate --generation` would.
+    pub fn with_pinned_generation(
+        mut env: ManagedEnvironment,
+        generation: GenerationId,
+    ) -> ManagedEnvironment {
+        env.generation = Some(generation);
+        env
     }
 
     /// Get a [ManagedEnvironment] that has been pushed to (a mock) FloxHub and
@@ -1845,21 +1874,33 @@ mod test {
         assert_eq!(push(&flox, "optedout", None), None);
     }
 
-    /// The checkout-free lockfile read reports absence rather than
-    /// materializing a local checkout, and the generation accessor
-    /// reports the pin.
+    /// The checkout-free lockfile read resolves generation lockfiles from
+    /// floxmeta rather than materializing a local checkout, and the
+    /// generation accessor reports the pin.
     #[test]
     fn existing_lockfile_without_checkout_never_materializes() {
         let owner = EnvironmentOwner::from_str("owner").unwrap();
         let (flox, _temp_dir_handle) = flox_instance_with_optional_floxhub(Some(&owner));
 
         let manifest = toml_edit::ser::to_string_pretty(&Manifest::default()).unwrap();
-        let mut managed_env = mock_managed_environment_unlocked(&flox, &manifest, owner);
+        let lockfile = serde_json::to_string(&Lockfile::default()).unwrap();
+        let dot_flox_path =
+            CanonicalPath::new(tempfile::tempdir_in(&flox.temp_dir).unwrap().keep()).unwrap();
+        let mut managed_env = ManagedEnvironment::push_new_without_building(
+            &flox,
+            ManagedPointer::new(owner, "name".parse().unwrap(), &flox.floxhub),
+            false,
+            false,
+            dot_flox_path,
+            new_core_environment_with_lockfile(&flox, &manifest, &lockfile),
+        )
+        .unwrap();
         assert_eq!(managed_env.generation(), None);
 
         assert_eq!(
             managed_env.existing_lockfile_without_checkout().unwrap(),
-            None
+            Some(Lockfile::default()),
+            "the current generation's lockfile is read from floxmeta"
         );
         assert!(
             !managed_env.path.join(ENV_DIR_NAME).exists(),
@@ -1868,6 +1909,11 @@ mod test {
 
         managed_env.generation = Some(GenerationId::from(1_usize));
         assert_eq!(managed_env.generation(), Some(GenerationId::from(1_usize)));
+        assert_eq!(
+            managed_env.existing_lockfile_without_checkout().unwrap(),
+            Some(Lockfile::default()),
+            "the pinned generation's lockfile is read from floxmeta"
+        );
     }
 
     /// Converting a managed environment back to a path environment

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -1176,18 +1176,14 @@ impl ManagedEnvironment {
         self.generation
     }
 
-    /// The lockfile this environment resolves to, read without
-    /// materializing the local checkout: the pinned generation's lockfile
-    /// when a generation is pinned, the local checkout's lockfile when one
-    /// exists on disk, and `current_generation`'s lockfile otherwise.
-    /// Callers that already read the generations metadata pass the current
-    /// generation so this read doesn't repeat it.
+    /// The lockfile this environment resolves to, read without materializing
+    /// the local checkout. Callers that already read the generations metadata
+    /// pass `current_generation` to avoid a second read.
     pub fn existing_lockfile_without_checkout(
         &self,
         current_generation: Option<GenerationId>,
     ) -> Result<Option<Lockfile>, EnvironmentError> {
         if let Some(generation) = self.generation {
-            // Validated: a user-supplied pin may not exist.
             return self
                 .generations()
                 .lockfile(*generation)
@@ -1206,7 +1202,6 @@ impl ManagedEnvironment {
         let Some(generation) = current_generation else {
             return Ok(None);
         };
-        // Unchecked: the caller took the generation from the metadata.
         self.generations()
             .lockfile_unchecked(*generation)
             .map_err(ManagedEnvironmentError::Generations)
@@ -1327,8 +1322,6 @@ impl ManagedEnvironment {
         check_for_local_includes(&lockfile)?;
 
         let mut pointer = ManagedPointer::new(owner, name, &flox.floxhub);
-        // Carry the path environment's id through the conversion, minting
-        // one if it never had one (the file is rewritten anyway).
         pointer.id = pointer_id.or_else(|| EnvironmentPointer::new_id(flox));
 
         Self::push_new_without_building(
@@ -1657,7 +1650,7 @@ impl ManagedEnvironment {
             &EnvironmentPointer::Managed(self.pointer.clone()),
         )?;
 
-        // create the metadata for a path environment, keeping the id
+        // create the metadata for a path environment
         let mut path_pointer = PathPointer::new(self.pointer.name);
         path_pointer.id = self.pointer.id;
         fs::write(

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -220,7 +220,7 @@ impl Environment for ManagedEnvironment {
     /// Returns the lockfile if it already exists.
     fn existing_lockfile(&self, flox: &Flox) -> Result<Option<Lockfile>, EnvironmentError> {
         if self.generation.is_some() {
-            return self.existing_lockfile_without_checkout();
+            return self.existing_lockfile_without_checkout(None);
         }
 
         self.local_env_or_copy_current_generation(flox)?
@@ -1179,10 +1179,22 @@ impl ManagedEnvironment {
     /// The lockfile this environment resolves to, read without
     /// materializing the local checkout: the pinned generation's lockfile
     /// when a generation is pinned, the local checkout's lockfile when one
-    /// exists on disk, and the current generation's lockfile otherwise.
-    pub fn existing_lockfile_without_checkout(&self) -> Result<Option<Lockfile>, EnvironmentError> {
+    /// exists on disk, and `current_generation`'s lockfile otherwise.
+    /// Callers that already read the generations metadata pass the current
+    /// generation so this read doesn't repeat it.
+    pub fn existing_lockfile_without_checkout(
+        &self,
+        current_generation: Option<GenerationId>,
+    ) -> Result<Option<Lockfile>, EnvironmentError> {
         if let Some(generation) = self.generation {
-            return self.generation_lockfile(*generation);
+            // Validated: a user-supplied pin may not exist.
+            let lockfile_contents = self
+                .generations()
+                .lockfile_contents(*generation)
+                .map_err(ManagedEnvironmentError::Generations)?;
+            return Lockfile::from_str(&lockfile_contents)
+                .map_err(EnvironmentError::Lockfile)
+                .map(Some);
         }
 
         let env_dir = self.path.join(ENV_DIR_NAME);
@@ -1192,23 +1204,14 @@ impl ManagedEnvironment {
                 .map_err(EnvironmentError::Core);
         }
 
-        let Some(generation) = self
-            .generations_metadata()
-            .map_err(ManagedEnvironmentError::Generations)?
-            .current_gen()
-        else {
+        let Some(generation) = current_generation else {
             return Ok(None);
         };
-        self.generation_lockfile(*generation)
-    }
-
-    /// Read `generation`'s lockfile from the floxmeta branch.
-    fn generation_lockfile(&self, generation: usize) -> Result<Option<Lockfile>, EnvironmentError> {
+        // Unchecked: the caller took the generation from the metadata.
         let lockfile_contents = self
             .generations()
-            .lockfile_contents(generation)
+            .lockfile_contents_unchecked(*generation)
             .map_err(ManagedEnvironmentError::Generations)?;
-
         Lockfile::from_str(&lockfile_contents)
             .map_err(EnvironmentError::Lockfile)
             .map(Some)
@@ -1806,6 +1809,7 @@ mod test {
 
     use flox_core::Version;
     use flox_manifest::interfaces::{AsLatestSchema, AsTypedOnlyManifest};
+    use flox_manifest::lockfile::LockedPackage;
     use flox_manifest::lockfile::test_helpers::fake_catalog_package_lock;
     use flox_manifest::parsed::Inner;
     use flox_manifest::parsed::latest::{self, ManifestLatest};
@@ -1883,7 +1887,12 @@ mod test {
         let (flox, _temp_dir_handle) = flox_instance_with_optional_floxhub(Some(&owner));
 
         let manifest = toml_edit::ser::to_string_pretty(&Manifest::default()).unwrap();
-        let lockfile = serde_json::to_string(&Lockfile::default()).unwrap();
+        let (_install_id, _descriptor, locked_package) = fake_catalog_package_lock("hello", None);
+        let generation_lockfile = Lockfile {
+            packages: vec![LockedPackage::Catalog(locked_package)],
+            ..Lockfile::default()
+        };
+        let lockfile_contents = serde_json::to_string(&generation_lockfile).unwrap();
         let dot_flox_path =
             CanonicalPath::new(tempfile::tempdir_in(&flox.temp_dir).unwrap().keep()).unwrap();
         let mut managed_env = ManagedEnvironment::push_new_without_building(
@@ -1892,15 +1901,21 @@ mod test {
             false,
             false,
             dot_flox_path,
-            new_core_environment_with_lockfile(&flox, &manifest, &lockfile),
+            new_core_environment_with_lockfile(&flox, &manifest, &lockfile_contents),
         )
         .unwrap();
         assert_eq!(managed_env.generation(), None);
 
+        // Unpinned with no local checkout: the caller supplies the current
+        // generation it read from the metadata.
+        let current_gen = managed_env.generations_metadata().unwrap().current_gen();
+        assert_eq!(current_gen, Some(GenerationId::from(1_usize)));
         assert_eq!(
-            managed_env.existing_lockfile_without_checkout().unwrap(),
-            Some(Lockfile::default()),
-            "the current generation's lockfile is read from floxmeta"
+            managed_env
+                .existing_lockfile_without_checkout(current_gen)
+                .unwrap(),
+            Some(generation_lockfile.clone()),
+            "the current generation's non-empty lockfile is read from floxmeta"
         );
         assert!(
             !managed_env.path.join(ENV_DIR_NAME).exists(),
@@ -1910,8 +1925,10 @@ mod test {
         managed_env.generation = Some(GenerationId::from(1_usize));
         assert_eq!(managed_env.generation(), Some(GenerationId::from(1_usize)));
         assert_eq!(
-            managed_env.existing_lockfile_without_checkout().unwrap(),
-            Some(Lockfile::default()),
+            managed_env
+                .existing_lockfile_without_checkout(None)
+                .unwrap(),
+            Some(generation_lockfile),
             "the pinned generation's lockfile is read from floxmeta"
         );
     }

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -1188,12 +1188,11 @@ impl ManagedEnvironment {
     ) -> Result<Option<Lockfile>, EnvironmentError> {
         if let Some(generation) = self.generation {
             // Validated: a user-supplied pin may not exist.
-            let lockfile_contents = self
+            return self
                 .generations()
-                .lockfile_contents(*generation)
-                .map_err(ManagedEnvironmentError::Generations)?;
-            return Lockfile::from_str(&lockfile_contents)
-                .map_err(EnvironmentError::Lockfile)
+                .lockfile(*generation)
+                .map_err(ManagedEnvironmentError::Generations)
+                .map_err(EnvironmentError::from)
                 .map(Some);
         }
 
@@ -1208,12 +1207,10 @@ impl ManagedEnvironment {
             return Ok(None);
         };
         // Unchecked: the caller took the generation from the metadata.
-        let lockfile_contents = self
-            .generations()
-            .lockfile_contents_unchecked(*generation)
-            .map_err(ManagedEnvironmentError::Generations)?;
-        Lockfile::from_str(&lockfile_contents)
-            .map_err(EnvironmentError::Lockfile)
+        self.generations()
+            .lockfile_unchecked(*generation)
+            .map_err(ManagedEnvironmentError::Generations)
+            .map_err(EnvironmentError::from)
             .map(Some)
     }
 

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -220,7 +220,7 @@ impl Environment for ManagedEnvironment {
     /// Returns the lockfile if it already exists.
     fn existing_lockfile(&self, flox: &Flox) -> Result<Option<Lockfile>, EnvironmentError> {
         if self.generation.is_some() {
-            return self.existing_lockfile_without_checkout(None);
+            return self.existing_lockfile_without_checkout();
         }
 
         self.local_env_or_copy_current_generation(flox)?
@@ -1170,19 +1170,22 @@ impl ManagedEnvironment {
         &self.pointer
     }
 
-    /// The generation this environment was opened at when pinned
-    /// (e.g. `flox activate --generation`), otherwise `None`.
-    pub fn generation(&self) -> Option<GenerationId> {
-        self.generation
+    /// The generation this environment operates on: the pinned generation
+    /// when opened at one (e.g. `flox activate --generation`), otherwise
+    /// the current generation.
+    pub fn generation(&self) -> Result<Option<GenerationId>, EnvironmentError> {
+        if let Some(generation) = self.generation {
+            return Ok(Some(generation));
+        }
+        Ok(self
+            .generations_metadata()
+            .map_err(ManagedEnvironmentError::Generations)?
+            .current_gen())
     }
 
     /// The lockfile this environment resolves to, read without materializing
-    /// the local checkout. Callers that already read the generations metadata
-    /// pass `current_generation` to avoid a second read.
-    pub fn existing_lockfile_without_checkout(
-        &self,
-        current_generation: Option<GenerationId>,
-    ) -> Result<Option<Lockfile>, EnvironmentError> {
+    /// the local checkout.
+    pub fn existing_lockfile_without_checkout(&self) -> Result<Option<Lockfile>, EnvironmentError> {
         if let Some(generation) = self.generation {
             return self
                 .generations()
@@ -1193,20 +1196,12 @@ impl ManagedEnvironment {
         }
 
         let env_dir = self.path.join(ENV_DIR_NAME);
-        if env_dir.exists() {
-            return CoreEnvironment::new(env_dir, self.include_fetcher.clone())
-                .existing_lockfile()
-                .map_err(EnvironmentError::Core);
-        }
-
-        let Some(generation) = current_generation else {
+        if !env_dir.exists() {
             return Ok(None);
-        };
-        self.generations()
-            .lockfile_unchecked(*generation)
-            .map_err(ManagedEnvironmentError::Generations)
-            .map_err(EnvironmentError::from)
-            .map(Some)
+        }
+        CoreEnvironment::new(env_dir, self.include_fetcher.clone())
+            .existing_lockfile()
+            .map_err(EnvironmentError::Core)
     }
 
     pub(crate) fn generations(&self) -> Generations {
@@ -1321,8 +1316,7 @@ impl ManagedEnvironment {
         // Ensure that the environment does not include other local environments
         check_for_local_includes(&lockfile)?;
 
-        let mut pointer = ManagedPointer::new(owner, name, &flox.floxhub);
-        pointer.id = pointer_id.or_else(|| EnvironmentPointer::new_id(flox));
+        let pointer = ManagedPointer::new(owner, name, pointer_id, &flox.floxhub);
 
         Self::push_new_without_building(
             flox,
@@ -1651,8 +1645,7 @@ impl ManagedEnvironment {
         )?;
 
         // create the metadata for a path environment
-        let mut path_pointer = PathPointer::new(self.pointer.name);
-        path_pointer.id = self.pointer.id;
+        let path_pointer = PathPointer::new(self.pointer.name, self.pointer.id);
         fs::write(
             self.path.join(ENVIRONMENT_POINTER_FILENAME),
             serde_json::to_string(&path_pointer)
@@ -1676,7 +1669,6 @@ pub mod test_helpers {
 
     use flox_core::floxhub::{DEFAULT_FLOXHUB_URL, Floxhub};
     use tempfile::tempdir_in;
-    use uuid::Uuid;
 
     use super::*;
     use crate::models::environment::fetcher::test_helpers::mock_include_fetcher;
@@ -1701,18 +1693,13 @@ pub mod test_helpers {
             pointer: ManagedPointer::new(
                 "owner".parse().unwrap(),
                 "test".parse().unwrap(),
+                None,
                 &floxhub,
             ),
             floxmeta_branch,
             include_fetcher: mock_include_fetcher(),
             generation: None,
         }
-    }
-
-    /// Set the pointer id on a mock environment, as a pull would have.
-    pub fn with_pointer_id(mut env: ManagedEnvironment, id: Uuid) -> ManagedEnvironment {
-        env.pointer.id = Some(id);
-        env
     }
 
     /// Pin `env` to a generation, as `flox activate --generation` would.
@@ -1743,7 +1730,7 @@ pub mod test_helpers {
     ) -> ManagedEnvironment {
         ManagedEnvironment::push_new_without_building(
             flox,
-            ManagedPointer::new(owner, "name".parse().unwrap(), &flox.floxhub),
+            ManagedPointer::new(owner, "name".parse().unwrap(), None, &flox.floxhub),
             false,
             false,
             CanonicalPath::new(tempdir_in(&flox.temp_dir).unwrap().keep()).unwrap(),
@@ -1833,13 +1820,11 @@ mod test {
     use crate::providers::git::tests::{commit_file, test_git_options};
 
     /// Pushing a path environment carries its pointer id into the managed
-    /// pointer, mints one when it never had one (metrics enabled), and
-    /// leaves it unset when metrics are disabled.
+    /// pointer; an environment without one stays without one.
     #[test]
-    fn push_new_carries_or_mints_pointer_id() {
+    fn push_new_carries_pointer_id() {
         let owner = EnvironmentOwner::from_str("owner").unwrap();
-        let (mut flox, _temp_dir_handle) = flox_instance_with_optional_floxhub(Some(&owner));
-        flox.metrics_device_uuid = Some(Uuid::new_v4());
+        let (flox, _temp_dir_handle) = flox_instance_with_optional_floxhub(Some(&owner));
 
         let manifest = toml_edit::ser::to_string_pretty(&Manifest::default()).unwrap();
         let push = |flox: &Flox, name: &str, pointer_id: Option<Uuid>| {
@@ -1862,15 +1847,12 @@ mod test {
 
         let carried = Uuid::new_v4();
         assert_eq!(push(&flox, "carried", Some(carried)), Some(carried));
-        assert!(push(&flox, "minted", None).is_some());
-
-        flox.metrics_device_uuid = None;
-        assert_eq!(push(&flox, "optedout", None), None);
+        assert_eq!(push(&flox, "unset", None), None);
     }
 
-    /// The checkout-free lockfile read resolves generation lockfiles from
-    /// floxmeta rather than materializing a local checkout, and the
-    /// generation accessor reports the pin.
+    /// The checkout-free lockfile read reads the pinned generation's
+    /// lockfile from floxmeta and otherwise only the local checkout —
+    /// never materializing one.
     #[test]
     fn existing_lockfile_without_checkout_never_materializes() {
         let owner = EnvironmentOwner::from_str("owner").unwrap();
@@ -1887,25 +1869,23 @@ mod test {
             CanonicalPath::new(tempfile::tempdir_in(&flox.temp_dir).unwrap().keep()).unwrap();
         let mut managed_env = ManagedEnvironment::push_new_without_building(
             &flox,
-            ManagedPointer::new(owner, "name".parse().unwrap(), &flox.floxhub),
+            ManagedPointer::new(owner, "name".parse().unwrap(), None, &flox.floxhub),
             false,
             false,
             dot_flox_path,
             new_core_environment_with_lockfile(&flox, &manifest, &lockfile_contents),
         )
         .unwrap();
-        assert_eq!(managed_env.generation(), None);
 
-        // Unpinned with no local checkout: the caller supplies the current
-        // generation it read from the metadata.
-        let current_gen = managed_env.generations_metadata().unwrap().current_gen();
-        assert_eq!(current_gen, Some(GenerationId::from(1_usize)));
         assert_eq!(
-            managed_env
-                .existing_lockfile_without_checkout(current_gen)
-                .unwrap(),
-            Some(generation_lockfile.clone()),
-            "the current generation's non-empty lockfile is read from floxmeta"
+            managed_env.generation().unwrap(),
+            Some(GenerationId::from(1_usize)),
+            "unpinned resolves to the current generation"
+        );
+        assert_eq!(
+            managed_env.existing_lockfile_without_checkout().unwrap(),
+            None,
+            "no local checkout, nothing to read"
         );
         assert!(
             !managed_env.path.join(ENV_DIR_NAME).exists(),
@@ -1913,11 +1893,12 @@ mod test {
         );
 
         managed_env.generation = Some(GenerationId::from(1_usize));
-        assert_eq!(managed_env.generation(), Some(GenerationId::from(1_usize)));
         assert_eq!(
-            managed_env
-                .existing_lockfile_without_checkout(None)
-                .unwrap(),
+            managed_env.generation().unwrap(),
+            Some(GenerationId::from(1_usize))
+        );
+        assert_eq!(
+            managed_env.existing_lockfile_without_checkout().unwrap(),
             Some(generation_lockfile),
             "the pinned generation's lockfile is read from floxmeta"
         );

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -1270,6 +1270,7 @@ impl ManagedEnvironment {
         // path of the original .flox directory
         let dot_flox_path = path_environment.path.clone();
         let name = path_environment.name();
+        let pointer_id = path_environment.pointer.id;
 
         let mut core_environment = path_environment.into_core_environment()?;
 
@@ -1288,10 +1289,14 @@ impl ManagedEnvironment {
         // Ensure that the environment does not include other local environments
         check_for_local_includes(&lockfile)?;
 
+        let mut pointer = ManagedPointer::new(owner, name, &flox.floxhub);
+        // Carry the path environment's id through the conversion, minting
+        // one if it never had one (the file is rewritten anyway).
+        pointer.id = pointer_id.or_else(|| EnvironmentPointer::new_id(flox));
+
         Self::push_new_without_building(
             flox,
-            owner,
-            name,
+            pointer,
             force,
             initializing,
             dot_flox_path,
@@ -1310,15 +1315,12 @@ impl ManagedEnvironment {
     /// [HistoryKind::Initialize] for environments that are (virtually) created on FloxHub.
     fn push_new_without_building(
         flox: &Flox,
-        owner: EnvironmentOwner,
-        name: EnvironmentName,
+        pointer: ManagedPointer,
         force: bool,
         initializing: bool,
         dot_flox_path: CanonicalPath,
         mut core_environment: CoreEnvironment,
     ) -> Result<Self, EnvironmentError> {
-        let pointer = ManagedPointer::new(owner.clone(), name.clone(), &flox.floxhub);
-
         let checkedout_floxmeta_path = tempfile::tempdir_in(&flox.temp_dir).unwrap().keep();
         let temp_floxmeta_path = tempfile::tempdir_in(&flox.temp_dir).unwrap().keep();
 
@@ -1339,7 +1341,7 @@ impl ManagedEnvironment {
             checkedout_floxmeta_path,
             temp_floxmeta_path,
             remote_branch_name(&pointer),
-            &name,
+            &pointer.name,
         )
         .map_err(ManagedEnvironmentError::InitializeFloxmeta)?;
 
@@ -1385,7 +1387,10 @@ impl ManagedEnvironment {
             // we also need to catch this success.
             Err(GitRemoteCommandError::Diverged) | Ok(PushFlag::UptoDate) => {
                 Err(ManagedEnvironmentError::UpstreamAlreadyExists {
-                    env_ref: RemoteEnvironmentRef::new_from_parts(owner, name),
+                    env_ref: RemoteEnvironmentRef::new_from_parts(
+                        pointer.owner.clone(),
+                        pointer.name.clone(),
+                    ),
                     upstream: flox.floxhub.base_url().to_string(),
                 })?
             },
@@ -1615,8 +1620,9 @@ impl ManagedEnvironment {
             &EnvironmentPointer::Managed(self.pointer.clone()),
         )?;
 
-        // create the metadata for a path environment
-        let path_pointer = PathPointer::new(self.pointer.name);
+        // create the metadata for a path environment, keeping the id
+        let mut path_pointer = PathPointer::new(self.pointer.name);
+        path_pointer.id = self.pointer.id;
         fs::write(
             self.path.join(ENVIRONMENT_POINTER_FILENAME),
             serde_json::to_string(&path_pointer)
@@ -1691,8 +1697,7 @@ pub mod test_helpers {
     ) -> ManagedEnvironment {
         ManagedEnvironment::push_new_without_building(
             flox,
-            owner,
-            "name".parse().unwrap(),
+            ManagedPointer::new(owner, "name".parse().unwrap(), &flox.floxhub),
             false,
             false,
             CanonicalPath::new(tempdir_in(&flox.temp_dir).unwrap().keep()).unwrap(),
@@ -1759,6 +1764,7 @@ mod test {
         mock_managed_environment_unlocked,
     };
     use url::Url;
+    use uuid::Uuid;
 
     use super::test_helpers::mock_managed_environment_in;
     use super::*;
@@ -1775,8 +1781,70 @@ mod test {
     };
     use crate::models::floxmeta::floxmeta_dir;
     use crate::providers::catalog::test_helpers::catalog_replay_client;
+    use crate::models::environment::path_environment::test_helpers::new_named_path_environment_in;
     use crate::providers::git::GitCommandProvider;
     use crate::providers::git::tests::{commit_file, test_git_options};
+
+    /// Pushing a path environment carries its pointer id into the managed
+    /// pointer, mints one when it never had one (metrics enabled), and
+    /// leaves it unset when metrics are disabled.
+    #[test]
+    fn push_new_carries_or_mints_pointer_id() {
+        let owner = EnvironmentOwner::from_str("owner").unwrap();
+        let (mut flox, _temp_dir_handle) = flox_instance_with_optional_floxhub(Some(&owner));
+        flox.metrics_device_uuid = Some(Uuid::new_v4());
+
+        let manifest = toml_edit::ser::to_string_pretty(&Manifest::default()).unwrap();
+        let push = |flox: &Flox, name: &str, pointer_id: Option<Uuid>| {
+            let dir = tempfile::tempdir_in(&flox.temp_dir).unwrap().keep();
+            let mut path_env = new_named_path_environment_in(flox, &manifest, &dir, name);
+            path_env.pointer.id = pointer_id;
+            let dot_flox_path = path_env.path.clone();
+            let env =
+                ManagedEnvironment::push_new(flox, path_env, owner.clone(), false, false).unwrap();
+            let written: EnvironmentPointer = serde_json::from_str(
+                &fs::read_to_string(dot_flox_path.join(ENVIRONMENT_POINTER_FILENAME)).unwrap(),
+            )
+            .unwrap();
+            let EnvironmentPointer::Managed(written) = written else {
+                panic!("expected managed pointer");
+            };
+            assert_eq!(written.id, env.pointer.id, "in-memory and on-disk id agree");
+            written.id
+        };
+
+        let carried = Uuid::new_v4();
+        assert_eq!(push(&flox, "carried", Some(carried)), Some(carried));
+        assert!(push(&flox, "minted", None).is_some());
+
+        flox.metrics_device_uuid = None;
+        assert_eq!(push(&flox, "optedout", None), None);
+    }
+
+    /// Converting a managed environment back to a path environment
+    /// (`flox pull --copy`) keeps the pointer id.
+    #[test]
+    fn into_path_environment_preserves_pointer_id() {
+        let owner = EnvironmentOwner::from_str("owner").unwrap();
+        let (flox, _temp_dir_handle) = flox_instance_with_optional_floxhub(Some(&owner));
+
+        let id = Uuid::new_v4();
+        let manifest = toml_edit::ser::to_string_pretty(&Manifest::default()).unwrap();
+        let mut managed_env = mock_managed_environment_unlocked(&flox, &manifest, owner);
+        managed_env.pointer.id = Some(id);
+
+        let path_env = managed_env.into_path_environment(&flox).unwrap();
+        assert_eq!(path_env.pointer.id, Some(id));
+
+        let written: EnvironmentPointer = serde_json::from_str(
+            &fs::read_to_string(path_env.path.join(ENVIRONMENT_POINTER_FILENAME)).unwrap(),
+        )
+        .unwrap();
+        let EnvironmentPointer::Path(written) = written else {
+            panic!("expected path pointer");
+        };
+        assert_eq!(written.id, Some(id));
+    }
 
     /// Create a [ManagedPointer] for testing with mock owner and name data
     /// as well as an override for the floxhub git url to fetch from local
@@ -1785,6 +1853,7 @@ mod test {
         ManagedPointer {
             owner: EnvironmentOwner::from_str("owner").unwrap(),
             name: EnvironmentName::from_str("name").unwrap(),
+            id: None,
             floxhub_base_url: Url::from_str("https://hub.flox.dev").unwrap(),
             floxhub_git_url_override: Some(
                 Url::from_directory_path(mock_floxhub_git_path).unwrap(),

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -219,15 +219,8 @@ impl Environment for ManagedEnvironment {
 
     /// Returns the lockfile if it already exists.
     fn existing_lockfile(&self, flox: &Flox) -> Result<Option<Lockfile>, EnvironmentError> {
-        if let Some(generation) = self.generation {
-            let lockfile_contents = self
-                .generations()
-                .lockfile_contents(*generation)
-                .map_err(ManagedEnvironmentError::Generations)?;
-
-            return Lockfile::from_str(&lockfile_contents)
-                .map_err(EnvironmentError::Lockfile)
-                .map(Some);
+        if self.generation.is_some() {
+            return self.existing_lockfile_without_checkout();
         }
 
         self.local_env_or_copy_current_generation(flox)?
@@ -1177,6 +1170,37 @@ impl ManagedEnvironment {
         &self.pointer
     }
 
+    /// The generation this environment was opened at when pinned
+    /// (e.g. `flox activate --generation`), otherwise `None`.
+    pub fn generation(&self) -> Option<GenerationId> {
+        self.generation
+    }
+
+    /// The lockfile this environment resolves to, read without
+    /// materializing the local checkout: the pinned generation's lockfile
+    /// when a generation is pinned, otherwise the local checkout's
+    /// lockfile if one exists on disk.
+    pub fn existing_lockfile_without_checkout(&self) -> Result<Option<Lockfile>, EnvironmentError> {
+        if let Some(generation) = self.generation {
+            let lockfile_contents = self
+                .generations()
+                .lockfile_contents(*generation)
+                .map_err(ManagedEnvironmentError::Generations)?;
+
+            return Lockfile::from_str(&lockfile_contents)
+                .map_err(EnvironmentError::Lockfile)
+                .map(Some);
+        }
+
+        let lockfile_path = self.path.join(ENV_DIR_NAME).join(LOCKFILE_FILENAME);
+        let Ok(lockfile_path) = CanonicalPath::new(lockfile_path) else {
+            return Ok(None);
+        };
+        Lockfile::read_from_file(&lockfile_path)
+            .map(Some)
+            .map_err(EnvironmentError::Lockfile)
+    }
+
     pub(crate) fn generations(&self) -> Generations {
         self.floxmeta_branch.generations()
     }
@@ -1775,13 +1799,13 @@ mod test {
         read_environment_registry,
     };
     use crate::models::environment::DOT_FLOX;
+    use crate::models::environment::path_environment::test_helpers::new_named_path_environment_in;
     use crate::models::environment::test_helpers::{
         new_core_environment,
         new_core_environment_with_lockfile,
     };
     use crate::models::floxmeta::floxmeta_dir;
     use crate::providers::catalog::test_helpers::catalog_replay_client;
-    use crate::models::environment::path_environment::test_helpers::new_named_path_environment_in;
     use crate::providers::git::GitCommandProvider;
     use crate::providers::git::tests::{commit_file, test_git_options};
 
@@ -1819,6 +1843,31 @@ mod test {
 
         flox.metrics_device_uuid = None;
         assert_eq!(push(&flox, "optedout", None), None);
+    }
+
+    /// The checkout-free lockfile read reports absence rather than
+    /// materializing a local checkout, and the generation accessor
+    /// reports the pin.
+    #[test]
+    fn existing_lockfile_without_checkout_never_materializes() {
+        let owner = EnvironmentOwner::from_str("owner").unwrap();
+        let (flox, _temp_dir_handle) = flox_instance_with_optional_floxhub(Some(&owner));
+
+        let manifest = toml_edit::ser::to_string_pretty(&Manifest::default()).unwrap();
+        let mut managed_env = mock_managed_environment_unlocked(&flox, &manifest, owner);
+        assert_eq!(managed_env.generation(), None);
+
+        assert_eq!(
+            managed_env.existing_lockfile_without_checkout().unwrap(),
+            None
+        );
+        assert!(
+            !managed_env.path.join(ENV_DIR_NAME).exists(),
+            "reading the lockfile must not materialize the checkout"
+        );
+
+        managed_env.generation = Some(GenerationId::from(1_usize));
+        assert_eq!(managed_env.generation(), Some(GenerationId::from(1_usize)));
     }
 
     /// Converting a managed environment back to a path environment

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -1,3 +1,4 @@
+use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::{fs, io};
@@ -27,6 +28,7 @@ use thiserror::Error;
 use tracing::debug;
 use uninstall::UninstallSpec;
 use url::{ParseError, Url};
+use uuid::Uuid;
 use walkdir::WalkDir;
 
 use self::managed_environment::ManagedEnvironmentError;
@@ -447,10 +449,16 @@ pub enum EnvironmentPointer {
 /// The identifier for a project environment.
 ///
 /// This is serialized to `env.json` inside the `.flox` directory
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Serialize, Deserialize, Eq)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 pub struct PathPointer {
     pub name: EnvironmentName,
+    /// Stable identifier minted when the environment is created and
+    /// carried through renames and conversions. `None` for environments
+    /// created before the field existed or with metrics disabled.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(test, proptest(value = "None"))]
+    pub id: Option<Uuid>,
     version: Version<1>,
 }
 
@@ -459,8 +467,30 @@ impl PathPointer {
     pub fn new(name: EnvironmentName) -> Self {
         Self {
             name,
+            id: None,
             version: Version::<1>,
         }
+    }
+}
+
+/// Compares everything except `id`: the id identifies an environment in
+/// metrics but is not part of pointer identity, so records written before
+/// it existed (registry entries, active-environment values) keep matching.
+impl PartialEq for PathPointer {
+    fn eq(&self, other: &Self) -> bool {
+        (&self.name, &self.version) == (&other.name, &other.version)
+    }
+}
+
+impl PartialOrd for PathPointer {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for PathPointer {
+    fn cmp(&self, other: &Self) -> Ordering {
+        (&self.name, &self.version).cmp(&(&other.name, &other.version))
     }
 }
 
@@ -468,11 +498,17 @@ impl PathPointer {
 /// points to an environment owner and the name of the environment.
 ///
 /// This is serialized to an `env.json` inside the `.flox` directory.
-#[derive(Debug, Serialize, Clone, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Serialize, Clone, Deserialize, Eq)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 pub struct ManagedPointer {
     pub owner: EnvironmentOwner,
     pub name: EnvironmentName,
+    /// Stable identifier carried over from the path environment this was
+    /// pushed from (or minted at pull). `None` for environments created
+    /// before the field existed or with metrics disabled.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(test, proptest(value = "None"))]
+    pub id: Option<Uuid>,
     #[serde(rename = "floxhub_url")]
     #[cfg_attr(
         test,
@@ -491,6 +527,7 @@ impl ManagedPointer {
         Self {
             name,
             owner,
+            id: None,
             floxhub_base_url: floxhub.base_url().clone(),
             floxhub_git_url_override: floxhub.git_url_override().cloned(),
             version: Version::<1>,
@@ -504,6 +541,38 @@ impl ManagedPointer {
     }
 }
 
+/// Compares everything except `id` — see the [PathPointer] impl.
+impl PartialEq for ManagedPointer {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
+}
+
+impl PartialOrd for ManagedPointer {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for ManagedPointer {
+    fn cmp(&self, other: &Self) -> Ordering {
+        (
+            &self.owner,
+            &self.name,
+            &self.floxhub_base_url,
+            &self.floxhub_git_url_override,
+            &self.version,
+        )
+            .cmp(&(
+                &other.owner,
+                &other.name,
+                &other.floxhub_base_url,
+                &other.floxhub_git_url_override,
+                &other.version,
+            ))
+    }
+}
+
 impl From<ManagedPointer> for RemoteEnvironmentRef {
     fn from(pointer: ManagedPointer) -> Self {
         RemoteEnvironmentRef::from_parts(pointer.owner, pointer.name)
@@ -511,6 +580,13 @@ impl From<ManagedPointer> for RemoteEnvironmentRef {
 }
 
 impl EnvironmentPointer {
+    /// A fresh pointer `id` for an environment being created, or `None`
+    /// when metrics are disabled — the id identifies environments in
+    /// metrics, so none is minted or persisted for opted-out users.
+    pub fn new_id(flox: &Flox) -> Option<Uuid> {
+        flox.metrics_device_uuid.is_some().then(Uuid::new_v4)
+    }
+
     /// Attempt to read an environment pointer file ([ENVIRONMENT_POINTER_FILENAME])
     /// in the specified `.flox` directory.
     ///
@@ -1164,6 +1240,7 @@ mod test {
         EnvironmentPointer::Managed(ManagedPointer {
             name: EnvironmentName::from_str("name").unwrap(),
             owner: EnvironmentOwner::from_str("owner").unwrap(),
+            id: None,
             floxhub_base_url: DEFAULT_FLOXHUB_URL.clone(),
             floxhub_git_url_override: None,
             version: Version::<1> {},
@@ -1175,6 +1252,7 @@ mod test {
         let managed_pointer = EnvironmentPointer::Managed(ManagedPointer {
             name: EnvironmentName::from_str("name").unwrap(),
             owner: EnvironmentOwner::from_str("owner").unwrap(),
+            id: None,
             floxhub_base_url: DEFAULT_FLOXHUB_URL.clone(),
             floxhub_git_url_override: None,
             version: Version::<1> {},
@@ -1197,6 +1275,7 @@ mod test {
     fn serializes_path_environment_pointer() {
         let path_pointer = EnvironmentPointer::Path(PathPointer {
             name: EnvironmentName::from_str("name").unwrap(),
+            id: None,
             version: Version::<1> {},
         });
 
@@ -1214,6 +1293,7 @@ mod test {
             path_pointer,
             EnvironmentPointer::Path(PathPointer {
                 name: EnvironmentName::from_str("name").unwrap(),
+                id: None,
                 version: Version::<1> {},
             })
         );
@@ -1224,6 +1304,7 @@ mod test {
         let mut managed_pointer = ManagedPointer {
             name: EnvironmentName::from_str("name").unwrap(),
             owner: EnvironmentOwner::from_str("owner").unwrap(),
+            id: None,
             floxhub_base_url: Url::from_str("https://example.com/").unwrap(),
             floxhub_git_url_override: None,
             version: Version::<1> {},
@@ -1240,6 +1321,80 @@ mod test {
             "https://example.com/base/owner/name",
             "should respect additional paths in the base URL",
         );
+    }
+
+    #[test]
+    fn pointer_id_round_trips_for_both_variants() {
+        let id = Uuid::from_u128(0x11111111_1111_1111_1111_111111111111);
+
+        let mut path_pointer = PathPointer::new(EnvironmentName::from_str("name").unwrap());
+        path_pointer.id = Some(id);
+        let json = serde_json::to_value(EnvironmentPointer::Path(path_pointer.clone())).unwrap();
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "name": "name",
+                "id": "11111111-1111-1111-1111-111111111111",
+                "version": 1,
+            })
+        );
+        let reparsed: EnvironmentPointer = serde_json::from_value(json).unwrap();
+        let EnvironmentPointer::Path(reparsed) = reparsed else {
+            panic!("expected path pointer");
+        };
+        assert_eq!(reparsed.id, Some(id));
+
+        let mut managed_pointer = ManagedPointer {
+            name: EnvironmentName::from_str("name").unwrap(),
+            owner: EnvironmentOwner::from_str("owner").unwrap(),
+            id: Some(id),
+            floxhub_base_url: DEFAULT_FLOXHUB_URL.clone(),
+            floxhub_git_url_override: None,
+            version: Version::<1> {},
+        };
+        let json =
+            serde_json::to_value(EnvironmentPointer::Managed(managed_pointer.clone())).unwrap();
+        assert_eq!(
+            json.get("id").and_then(|v| v.as_str()),
+            Some("11111111-1111-1111-1111-111111111111")
+        );
+        let reparsed: EnvironmentPointer = serde_json::from_value(json).unwrap();
+        let EnvironmentPointer::Managed(reparsed) = reparsed else {
+            panic!("expected managed pointer");
+        };
+        assert_eq!(reparsed.id, Some(id));
+        managed_pointer.id = None;
+        assert_eq!(reparsed, managed_pointer, "id is not part of equality");
+    }
+
+    /// Pointers written before the `id` field existed (registry entries,
+    /// serialized active environments) must compare equal to the same
+    /// pointer carrying an id, in both equality and ordering.
+    #[test]
+    fn pointer_comparisons_ignore_id() {
+        let mut with_id = PathPointer::new(EnvironmentName::from_str("name").unwrap());
+        with_id.id = Some(Uuid::new_v4());
+        let without_id = PathPointer::new(EnvironmentName::from_str("name").unwrap());
+        assert_eq!(with_id, without_id);
+        assert_eq!(with_id.cmp(&without_id), std::cmp::Ordering::Equal);
+
+        let EnvironmentPointer::Managed(managed) = MANAGED_ENV_POINTER.clone() else {
+            panic!("expected managed pointer");
+        };
+        let mut managed_with_id = managed.clone();
+        managed_with_id.id = Some(Uuid::new_v4());
+        assert_eq!(managed_with_id, managed);
+        assert_eq!(managed_with_id.cmp(&managed), std::cmp::Ordering::Equal);
+    }
+
+    #[test]
+    fn pointer_id_minted_only_when_metrics_enabled() {
+        let (mut flox, _temp_dir_handle) = flox_instance();
+        flox.metrics_device_uuid = None;
+        assert_eq!(EnvironmentPointer::new_id(&flox), None);
+
+        flox.metrics_device_uuid = Some(Uuid::new_v4());
+        assert!(EnvironmentPointer::new_id(&flox).is_some());
     }
 
     #[test]

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -23,7 +23,7 @@ use indoc::formatdoc;
 use managed_environment::ManagedEnvironment;
 use path_environment::PathEnvironment;
 use remote_environment::RemoteEnvironment;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use thiserror::Error;
 use tracing::debug;
 use uninstall::UninstallSpec;
@@ -446,6 +446,20 @@ pub enum EnvironmentPointer {
     Path(PathPointer),
 }
 
+/// Deserialize a pointer `id`, treating a malformed value as absent.
+/// The id only feeds metrics, so it must never make an `env.json` (which a
+/// user may hand-edit) fail to parse.
+fn pointer_id_or_none<'de, D>(deserializer: D) -> Result<Option<Uuid>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw = Option::<serde_json::Value>::deserialize(deserializer)?;
+    Ok(raw
+        .as_ref()
+        .and_then(serde_json::Value::as_str)
+        .and_then(|id| Uuid::parse_str(id).ok()))
+}
+
 /// The identifier for a project environment.
 ///
 /// This is serialized to `env.json` inside the `.flox` directory
@@ -456,7 +470,11 @@ pub struct PathPointer {
     /// Stable identifier minted when the environment is created and
     /// carried through renames and conversions. `None` for environments
     /// created before the field existed or with metrics disabled.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "pointer_id_or_none"
+    )]
     #[cfg_attr(test, proptest(value = "None"))]
     pub id: Option<Uuid>,
     version: Version<1>,
@@ -490,7 +508,18 @@ impl PartialOrd for PathPointer {
 
 impl Ord for PathPointer {
     fn cmp(&self, other: &Self) -> Ordering {
-        (&self.name, &self.version).cmp(&(&other.name, &other.version))
+        // Destructured exhaustively so a future field can't be forgotten.
+        let Self {
+            name,
+            id: _,
+            version,
+        } = self;
+        let Self {
+            name: other_name,
+            id: _,
+            version: other_version,
+        } = other;
+        (name, version).cmp(&(other_name, other_version))
     }
 }
 
@@ -506,7 +535,11 @@ pub struct ManagedPointer {
     /// Stable identifier carried over from the path environment this was
     /// pushed from (or minted at pull). `None` for environments created
     /// before the field existed or with metrics disabled.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "pointer_id_or_none"
+    )]
     #[cfg_attr(test, proptest(value = "None"))]
     pub id: Option<Uuid>,
     #[serde(rename = "floxhub_url")]
@@ -556,19 +589,36 @@ impl PartialOrd for ManagedPointer {
 
 impl Ord for ManagedPointer {
     fn cmp(&self, other: &Self) -> Ordering {
+        // Destructured exhaustively so a future field can't be forgotten.
+        let Self {
+            owner,
+            name,
+            id: _,
+            floxhub_base_url,
+            floxhub_git_url_override,
+            version,
+        } = self;
+        let Self {
+            owner: other_owner,
+            name: other_name,
+            id: _,
+            floxhub_base_url: other_floxhub_base_url,
+            floxhub_git_url_override: other_floxhub_git_url_override,
+            version: other_version,
+        } = other;
         (
-            &self.owner,
-            &self.name,
-            &self.floxhub_base_url,
-            &self.floxhub_git_url_override,
-            &self.version,
+            owner,
+            name,
+            floxhub_base_url,
+            floxhub_git_url_override,
+            version,
         )
             .cmp(&(
-                &other.owner,
-                &other.name,
-                &other.floxhub_base_url,
-                &other.floxhub_git_url_override,
-                &other.version,
+                other_owner,
+                other_name,
+                other_floxhub_base_url,
+                other_floxhub_git_url_override,
+                other_version,
             ))
     }
 }
@@ -1355,8 +1405,14 @@ mod test {
         let json =
             serde_json::to_value(EnvironmentPointer::Managed(managed_pointer.clone())).unwrap();
         assert_eq!(
-            json.get("id").and_then(|v| v.as_str()),
-            Some("11111111-1111-1111-1111-111111111111")
+            json,
+            serde_json::json!({
+                "name": "name",
+                "owner": "owner",
+                "id": "11111111-1111-1111-1111-111111111111",
+                "floxhub_url": DEFAULT_FLOXHUB_URL.as_str(),
+                "version": 1,
+            })
         );
         let reparsed: EnvironmentPointer = serde_json::from_value(json).unwrap();
         let EnvironmentPointer::Managed(reparsed) = reparsed else {
@@ -1365,6 +1421,33 @@ mod test {
         assert_eq!(reparsed.id, Some(id));
         managed_pointer.id = None;
         assert_eq!(reparsed, managed_pointer, "id is not part of equality");
+    }
+
+    /// A malformed `id` in `env.json` must not fail opening the
+    /// environment — the id feeds metrics only, so it parses as absent.
+    #[test]
+    fn malformed_pointer_id_parses_as_absent() {
+        let path_pointer: EnvironmentPointer =
+            serde_json::from_str(r#"{"name": "name", "id": "not-a-uuid", "version": 1}"#).unwrap();
+        let EnvironmentPointer::Path(path_pointer) = path_pointer else {
+            panic!("expected path pointer");
+        };
+        assert_eq!(path_pointer.id, None);
+
+        let managed_pointer: EnvironmentPointer = serde_json::from_str(
+            r#"{
+                "name": "name",
+                "owner": "owner",
+                "id": 42,
+                "floxhub_url": "https://hub.flox.dev/",
+                "version": 1
+            }"#,
+        )
+        .unwrap();
+        let EnvironmentPointer::Managed(managed_pointer) = managed_pointer else {
+            panic!("expected managed pointer");
+        };
+        assert_eq!(managed_pointer.id, None);
     }
 
     /// Pointers written before the `id` field existed (registry entries,

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -468,11 +468,11 @@ pub struct PathPointer {
 }
 
 impl PathPointer {
-    /// Create a new [PathPointer] with the given name.
-    pub fn new(name: EnvironmentName) -> Self {
+    /// Create a new [PathPointer] with the given name and id.
+    pub fn new(name: EnvironmentName, id: Option<Uuid>) -> Self {
         Self {
             name,
-            id: None,
+            id,
             version: Version::<1>,
         }
     }
@@ -540,12 +540,17 @@ pub struct ManagedPointer {
 }
 
 impl ManagedPointer {
-    /// Create a new [ManagedPointer] with the given owner and name.
-    pub fn new(owner: EnvironmentOwner, name: EnvironmentName, floxhub: &Floxhub) -> Self {
+    /// Create a new [ManagedPointer] with the given owner, name, and id.
+    pub fn new(
+        owner: EnvironmentOwner,
+        name: EnvironmentName,
+        id: Option<Uuid>,
+        floxhub: &Floxhub,
+    ) -> Self {
         Self {
             name,
             owner,
-            id: None,
+            id,
             floxhub_base_url: floxhub.base_url().clone(),
             floxhub_git_url_override: floxhub.git_url_override().cloned(),
             version: Version::<1>,
@@ -614,12 +619,6 @@ impl From<ManagedPointer> for RemoteEnvironmentRef {
 }
 
 impl EnvironmentPointer {
-    /// A fresh pointer id, or `None` when metrics are disabled — no id
-    /// is minted or persisted for opted-out users.
-    pub fn new_id(flox: &Flox) -> Option<Uuid> {
-        flox.metrics_device_uuid.is_some().then(Uuid::new_v4)
-    }
-
     /// Attempt to read an environment pointer file ([ENVIRONMENT_POINTER_FILENAME])
     /// in the specified `.flox` directory.
     ///
@@ -1360,7 +1359,7 @@ mod test {
     fn pointer_id_round_trips_for_both_variants() {
         let id = Uuid::from_u128(0x11111111_1111_1111_1111_111111111111);
 
-        let mut path_pointer = PathPointer::new(EnvironmentName::from_str("name").unwrap());
+        let mut path_pointer = PathPointer::new(EnvironmentName::from_str("name").unwrap(), None);
         path_pointer.id = Some(id);
         let json = serde_json::to_value(EnvironmentPointer::Path(path_pointer.clone())).unwrap();
         assert_eq!(
@@ -1436,9 +1435,9 @@ mod test {
     /// pointer carrying an id, in both equality and ordering.
     #[test]
     fn pointer_comparisons_ignore_id() {
-        let mut with_id = PathPointer::new(EnvironmentName::from_str("name").unwrap());
+        let mut with_id = PathPointer::new(EnvironmentName::from_str("name").unwrap(), None);
         with_id.id = Some(Uuid::new_v4());
-        let without_id = PathPointer::new(EnvironmentName::from_str("name").unwrap());
+        let without_id = PathPointer::new(EnvironmentName::from_str("name").unwrap(), None);
         assert_eq!(with_id, without_id);
         assert_eq!(with_id.cmp(&without_id), std::cmp::Ordering::Equal);
 
@@ -1453,16 +1452,6 @@ mod test {
             EnvironmentPointer::Managed(managed_with_id),
             EnvironmentPointer::Managed(managed)
         );
-    }
-
-    #[test]
-    fn pointer_id_minted_only_when_metrics_enabled() {
-        let (mut flox, _temp_dir_handle) = flox_instance();
-        flox.metrics_device_uuid = None;
-        assert_eq!(EnvironmentPointer::new_id(&flox), None);
-
-        flox.metrics_device_uuid = Some(Uuid::new_v4());
-        assert!(EnvironmentPointer::new_id(&flox).is_some());
     }
 
     #[test]

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -23,7 +23,8 @@ use indoc::formatdoc;
 use managed_environment::ManagedEnvironment;
 use path_environment::PathEnvironment;
 use remote_environment::RemoteEnvironment;
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
+use serde_with::{DefaultOnError, serde_as};
 use thiserror::Error;
 use tracing::debug;
 use uninstall::UninstallSpec;
@@ -446,23 +447,10 @@ pub enum EnvironmentPointer {
     Path(PathPointer),
 }
 
-/// Deserialize a pointer `id`, treating a malformed value as absent.
-/// The id only feeds metrics, so it must never make an `env.json` (which a
-/// user may hand-edit) fail to parse.
-fn pointer_id_or_none<'de, D>(deserializer: D) -> Result<Option<Uuid>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let raw = Option::<serde_json::Value>::deserialize(deserializer)?;
-    Ok(raw
-        .as_ref()
-        .and_then(serde_json::Value::as_str)
-        .and_then(|id| Uuid::parse_str(id).ok()))
-}
-
 /// The identifier for a project environment.
 ///
 /// This is serialized to `env.json` inside the `.flox` directory
+#[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize, Eq)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 pub struct PathPointer {
@@ -470,11 +458,10 @@ pub struct PathPointer {
     /// Stable identifier minted when the environment is created and
     /// carried through renames and conversions. `None` for environments
     /// created before the field existed or with metrics disabled.
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        deserialize_with = "pointer_id_or_none"
-    )]
+    /// `DefaultOnError`: a malformed id must never make an `env.json`
+    /// (which a user may hand-edit) fail to parse.
+    #[serde_as(deserialize_as = "DefaultOnError")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg_attr(test, proptest(value = "None"))]
     pub id: Option<Uuid>,
     version: Version<1>,
@@ -527,6 +514,7 @@ impl Ord for PathPointer {
 /// points to an environment owner and the name of the environment.
 ///
 /// This is serialized to an `env.json` inside the `.flox` directory.
+#[serde_as]
 #[derive(Debug, Serialize, Clone, Deserialize, Eq)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 pub struct ManagedPointer {
@@ -535,11 +523,9 @@ pub struct ManagedPointer {
     /// Stable identifier carried over from the path environment this was
     /// pushed from (or minted at pull). `None` for environments created
     /// before the field existed or with metrics disabled.
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        deserialize_with = "pointer_id_or_none"
-    )]
+    /// `DefaultOnError`: see [PathPointer::id].
+    #[serde_as(deserialize_as = "DefaultOnError")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg_attr(test, proptest(value = "None"))]
     pub id: Option<Uuid>,
     #[serde(rename = "floxhub_url")]

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -478,7 +478,7 @@ impl PathPointer {
 /// it existed (registry entries, active-environment values) keep matching.
 impl PartialEq for PathPointer {
     fn eq(&self, other: &Self) -> bool {
-        (&self.name, &self.version) == (&other.name, &other.version)
+        self.cmp(other) == Ordering::Equal
     }
 }
 

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -495,7 +495,6 @@ impl PartialOrd for PathPointer {
 
 impl Ord for PathPointer {
     fn cmp(&self, other: &Self) -> Ordering {
-        // Destructured exhaustively so a future field can't be forgotten.
         let Self {
             name,
             id: _,
@@ -575,7 +574,6 @@ impl PartialOrd for ManagedPointer {
 
 impl Ord for ManagedPointer {
     fn cmp(&self, other: &Self) -> Ordering {
-        // Destructured exhaustively so a future field can't be forgotten.
         let Self {
             owner,
             name,
@@ -616,9 +614,8 @@ impl From<ManagedPointer> for RemoteEnvironmentRef {
 }
 
 impl EnvironmentPointer {
-    /// A fresh pointer `id` for an environment being created, or `None`
-    /// when metrics are disabled — the id identifies environments in
-    /// metrics, so none is minted or persisted for opted-out users.
+    /// A fresh pointer id, or `None` when metrics are disabled — no id
+    /// is minted or persisted for opted-out users.
     pub fn new_id(flox: &Flox) -> Option<Uuid> {
         flox.metrics_device_uuid.is_some().then(Uuid::new_v4)
     }
@@ -1380,7 +1377,7 @@ mod test {
         };
         assert_eq!(reparsed.id, Some(id));
 
-        let mut managed_pointer = ManagedPointer {
+        let managed_pointer = ManagedPointer {
             name: EnvironmentName::from_str("name").unwrap(),
             owner: EnvironmentOwner::from_str("owner").unwrap(),
             id: Some(id),
@@ -1405,8 +1402,6 @@ mod test {
             panic!("expected managed pointer");
         };
         assert_eq!(reparsed.id, Some(id));
-        managed_pointer.id = None;
-        assert_eq!(reparsed, managed_pointer, "id is not part of equality");
     }
 
     /// A malformed `id` in `env.json` must not fail opening the
@@ -1454,6 +1449,10 @@ mod test {
         managed_with_id.id = Some(Uuid::new_v4());
         assert_eq!(managed_with_id, managed);
         assert_eq!(managed_with_id.cmp(&managed), std::cmp::Ordering::Equal);
+        assert_eq!(
+            EnvironmentPointer::Managed(managed_with_id),
+            EnvironmentPointer::Managed(managed)
+        );
     }
 
     #[test]

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -805,6 +805,40 @@ pub mod tests {
         })
     }
 
+    /// Renaming rewrites `env.json` and must keep the pointer id, and
+    /// merely opening an id-less environment must not modify `env.json`.
+    #[test]
+    fn rename_preserves_pointer_id_and_open_does_not_backfill() {
+        let (flox, temp_dir) = flox_instance();
+        let environment_temp_dir = tempfile::tempdir_in(&temp_dir).unwrap();
+        let id = uuid::Uuid::new_v4();
+        let mut pointer = PathPointer::new("test".parse().unwrap());
+        pointer.id = Some(id);
+
+        let mut env = PathEnvironment::init(
+            pointer,
+            environment_temp_dir.path(),
+            &InitCustomization::default(),
+            &flox,
+        )
+        .unwrap();
+        let pointer_path = env.path.join(ENVIRONMENT_POINTER_FILENAME);
+
+        env.rename("renamed".parse().unwrap()).unwrap();
+        let written: PathPointer =
+            serde_json::from_str(&fs::read_to_string(&pointer_path).unwrap()).unwrap();
+        assert_eq!(written.id, Some(id));
+        assert_eq!(written.name.to_string(), "renamed");
+
+        // An environment written without an id (an older binary's output)
+        // stays untouched by read paths.
+        fs::write(&pointer_path, r#"{"name": "renamed", "version": 1}"#).unwrap();
+        let before = fs::read_to_string(&pointer_path).unwrap();
+        let opened = DotFlox::open_in(environment_temp_dir.path()).unwrap();
+        assert_eq!(opened.pointer.name().to_string(), "renamed");
+        assert_eq!(fs::read_to_string(&pointer_path).unwrap(), before);
+    }
+
     #[test]
     fn create_env() {
         let (flox, temp_dir) = flox_instance();

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -649,6 +649,7 @@ pub mod test_helpers {
                 .unwrap()
                 .parse()
                 .unwrap(),
+            None,
         );
         let manifest = Manifest::parse_toml_typed(contents).unwrap();
         PathEnvironment::write_new_unchecked(flox, pointer, path, &manifest.as_writable()).unwrap()
@@ -660,7 +661,7 @@ pub mod test_helpers {
         path: impl AsRef<Path>,
         name: &str,
     ) -> PathEnvironment {
-        let pointer = PathPointer::new(name.parse().unwrap());
+        let pointer = PathPointer::new(name.parse().unwrap(), None);
         let manifest = Manifest::parse_toml_typed(contents).unwrap();
         PathEnvironment::write_new_unchecked(flox, pointer, path, &manifest.as_writable()).unwrap()
     }
@@ -720,6 +721,7 @@ pub mod test_helpers {
             })
             .parse()
             .unwrap(),
+            None,
         );
         PathEnvironment::write_new_unchecked(
             flox,
@@ -812,7 +814,7 @@ pub mod tests {
         let (flox, temp_dir) = flox_instance();
         let environment_temp_dir = tempfile::tempdir_in(&temp_dir).unwrap();
         let id = uuid::Uuid::new_v4();
-        let mut pointer = PathPointer::new("test".parse().unwrap());
+        let mut pointer = PathPointer::new("test".parse().unwrap(), None);
         pointer.id = Some(id);
 
         let mut env = PathEnvironment::init(
@@ -843,7 +845,7 @@ pub mod tests {
     fn create_env() {
         let (flox, temp_dir) = flox_instance();
         let environment_temp_dir = tempfile::tempdir_in(&temp_dir).unwrap();
-        let pointer = PathPointer::new("test".parse().unwrap());
+        let pointer = PathPointer::new("test".parse().unwrap(), None);
 
         let actual = PathEnvironment::init(
             pointer,
@@ -854,7 +856,7 @@ pub mod tests {
         .unwrap();
 
         let expected = PathEnvironment::new(
-            PathPointer::new("test".parse().unwrap()),
+            PathPointer::new("test".parse().unwrap(), None),
             CanonicalPath::new(environment_temp_dir.path().join(DOT_FLOX)).unwrap(),
             &flox.system,
         )
@@ -879,7 +881,7 @@ pub mod tests {
         let (flox, temp_dir) = flox_instance();
 
         let environment_temp_dir = tempfile::tempdir_in(&temp_dir).unwrap();
-        let pointer = PathPointer::new("test".parse().unwrap());
+        let pointer = PathPointer::new("test".parse().unwrap(), None);
 
         let env = PathEnvironment::init(
             pointer,
@@ -913,7 +915,7 @@ pub mod tests {
     fn registers_on_init() {
         let (flox, tmp_dir) = flox_instance();
         let environment_temp_dir = tempfile::tempdir_in(&tmp_dir).unwrap();
-        let ptr = PathPointer::new("test".parse().unwrap());
+        let ptr = PathPointer::new("test".parse().unwrap(), None);
         let _env = PathEnvironment::init(
             ptr,
             environment_temp_dir.path(),
@@ -935,7 +937,7 @@ pub mod tests {
         let (flox, tmp_dir) = flox_instance();
         let environment_temp_dir = tempfile::tempdir_in(&tmp_dir).unwrap();
         // Create an environment so that the .flox directory is populated and we can open it later
-        let ptr = PathPointer::new("test".parse().unwrap());
+        let ptr = PathPointer::new("test".parse().unwrap(), None);
         let env = PathEnvironment::init(
             ptr.clone(),
             environment_temp_dir.path(),
@@ -960,7 +962,7 @@ pub mod tests {
         let (flox, tmp_dir) = flox_instance();
         let environment_temp_dir = tempfile::tempdir_in(&tmp_dir).unwrap();
         // Create an environment so that the .flox directory is populated and we can open it later
-        let ptr = PathPointer::new("test".parse().unwrap());
+        let ptr = PathPointer::new("test".parse().unwrap(), None);
         let env = PathEnvironment::init(
             ptr.clone(),
             environment_temp_dir.path(),

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -289,6 +289,16 @@ impl RemoteEnvironment {
         self.inner.pointer()
     }
 
+    /// See [ManagedEnvironment::generation].
+    pub fn generation(&self) -> Option<GenerationId> {
+        self.inner.generation()
+    }
+
+    /// See [ManagedEnvironment::existing_lockfile_without_checkout].
+    pub fn existing_lockfile_without_checkout(&self) -> Result<Option<Lockfile>, EnvironmentError> {
+        self.inner.existing_lockfile_without_checkout()
+    }
+
     /// Push local changes to FloxHub for this remote environment
     ///
     /// This pushes any local changes made to the cached remote environment back to FloxHub.

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -295,8 +295,12 @@ impl RemoteEnvironment {
     }
 
     /// See [ManagedEnvironment::existing_lockfile_without_checkout].
-    pub fn existing_lockfile_without_checkout(&self) -> Result<Option<Lockfile>, EnvironmentError> {
-        self.inner.existing_lockfile_without_checkout()
+    pub fn existing_lockfile_without_checkout(
+        &self,
+        current_generation: Option<GenerationId>,
+    ) -> Result<Option<Lockfile>, EnvironmentError> {
+        self.inner
+            .existing_lockfile_without_checkout(current_generation)
     }
 
     /// Push local changes to FloxHub for this remote environment

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -290,17 +290,13 @@ impl RemoteEnvironment {
     }
 
     /// See [ManagedEnvironment::generation].
-    pub fn generation(&self) -> Option<GenerationId> {
-        self.generation
+    pub fn generation(&self) -> Result<Option<GenerationId>, EnvironmentError> {
+        self.inner.generation()
     }
 
     /// See [ManagedEnvironment::existing_lockfile_without_checkout].
-    pub fn existing_lockfile_without_checkout(
-        &self,
-        current_generation: Option<GenerationId>,
-    ) -> Result<Option<Lockfile>, EnvironmentError> {
-        self.inner
-            .existing_lockfile_without_checkout(current_generation)
+    pub fn existing_lockfile_without_checkout(&self) -> Result<Option<Lockfile>, EnvironmentError> {
+        self.inner.existing_lockfile_without_checkout()
     }
 
     /// Push local changes to FloxHub for this remote environment
@@ -341,7 +337,7 @@ impl RemoteEnvironment {
         let temp_env_dir = tempfile::TempDir::new_in(&flox.temp_dir)
             .map_err(RemoteEnvironmentError::CreateTempDotFlox)?;
 
-        let path_pointer = PathPointer::new(env_ref.name().clone());
+        let path_pointer = PathPointer::new(env_ref.name().clone(), None);
 
         let path_environment = if bare {
             PathEnvironment::init_bare(path_pointer, temp_env_dir.path(), flox)?
@@ -716,9 +712,12 @@ mod tests {
         let (flox, _tempdir_handle) = flox_instance_with_optional_floxhub(Some(&owner));
         RemoteEnvironment::init_floxhub_environment(&flox, env_ref.clone(), true).unwrap();
 
-        let env =
-            RemoteEnvironment::new(&flox, ManagedPointer::new(owner, name, &flox.floxhub), None)
-                .expect("find initialized remote environment");
+        let env = RemoteEnvironment::new(
+            &flox,
+            ManagedPointer::new(owner, name, None, &flox.floxhub),
+            None,
+        )
+        .expect("find initialized remote environment");
 
         // TODO: should be changed to version 2 once released!
         assert_eq!(
@@ -765,9 +764,12 @@ mod tests {
         let (flox, _tempdir_handle) = flox_instance_with_optional_floxhub(Some(&owner));
         RemoteEnvironment::init_floxhub_environment(&flox, env_ref.clone(), true).unwrap();
 
-        let env =
-            RemoteEnvironment::new(&flox, ManagedPointer::new(owner, name, &flox.floxhub), None)
-                .expect("find initialized remote environment");
+        let env = RemoteEnvironment::new(
+            &flox,
+            ManagedPointer::new(owner, name, None, &flox.floxhub),
+            None,
+        )
+        .expect("find initialized remote environment");
 
         let generation_metadata = env.generations_metadata().unwrap();
         let history = generation_metadata.history();

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -291,7 +291,7 @@ impl RemoteEnvironment {
 
     /// See [ManagedEnvironment::generation].
     pub fn generation(&self) -> Option<GenerationId> {
-        self.inner.generation()
+        self.generation
     }
 
     /// See [ManagedEnvironment::existing_lockfile_without_checkout].

--- a/cli/flox-rust-sdk/src/models/floxmeta.rs
+++ b/cli/flox-rust-sdk/src/models/floxmeta.rs
@@ -396,6 +396,7 @@ mod tests {
         let pointer = ManagedPointer::new(
             "floxtest".parse().unwrap(),
             "test".parse().unwrap(),
+            None,
             &floxhub,
         );
 

--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -82,7 +82,8 @@ pub trait ManifestBuilder {
     fn clean(self, package: &[PackageTargetName]) -> Result<(), ManifestBuilderError>;
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, strum::IntoStaticStr)]
+#[strum(serialize_all = "snake_case", prefix = "build.")]
 pub enum ManifestBuilderError {
     #[error("failed to call package builder: {0}")]
     CallBuilderError(#[source] std::io::Error),
@@ -1230,6 +1231,7 @@ mod license_tests {
 mod tests {
     use std::fs::{self, File};
     use std::os::unix::fs::PermissionsExt;
+    use std::os::unix::process::ExitStatusExt;
 
     use anyhow::Context;
     use flox_manifest::interfaces::{AsWritableManifest, WriteManifest};
@@ -1246,6 +1248,54 @@ mod tests {
     use crate::models::environment::{Environment, copy_dir_recursive};
     use crate::providers::catalog::test_helpers::catalog_replay_client;
     use crate::providers::git::{GitCommandProvider, GitProvider};
+
+    #[test]
+    fn manifest_builder_error_slugs_are_namespaced() {
+        // These slugs are telemetry wire values (flox-events `error_kind`);
+        // a variant rename is a wire change. Every variant is reachable at
+        // the emit site, so pin them all.
+        let io = || std::io::Error::other("");
+        let cases: [(ManifestBuilderError, &str); 9] = [
+            (
+                ManifestBuilderError::CallBuilderError(io()),
+                "build.call_builder_error",
+            ),
+            (
+                ManifestBuilderError::CreateBuildResultFile(io()),
+                "build.create_build_result_file",
+            ),
+            (
+                ManifestBuilderError::ReadBuildResultFile(io()),
+                "build.read_build_result_file",
+            ),
+            (
+                ManifestBuilderError::ParseBuildResultFile(
+                    serde_json::from_str::<i32>("x").unwrap_err(),
+                ),
+                "build.parse_build_result_file",
+            ),
+            (ManifestBuilderError::CallNef(io()), "build.call_nef"),
+            (
+                ManifestBuilderError::ListNixExpressions(String::new()),
+                "build.list_nix_expressions",
+            ),
+            (
+                ManifestBuilderError::ParseLicenseMetaData(String::new()),
+                "build.parse_license_meta_data",
+            ),
+            (
+                ManifestBuilderError::RunClean {
+                    status: ExitStatus::from_raw(0),
+                },
+                "build.run_clean",
+            ),
+            (ManifestBuilderError::BuildFailure, "build.build_failure"),
+        ];
+        for (err, expected) in &cases {
+            let slug: &'static str = err.into();
+            assert_eq!(slug, *expected);
+        }
+    }
 
     #[test]
     fn build_returns_failure_when_package_not_defined() {

--- a/cli/flox/Cargo.toml
+++ b/cli/flox/Cargo.toml
@@ -10,6 +10,7 @@ ignored = ["sapling-renderdag"]
 anstream.workspace = true
 anyhow.workspace = true
 beta.workspace = true
+blake3.workspace = true
 bpaf.workspace = true
 chrono.workspace = true
 close_fds.workspace = true

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -234,7 +234,7 @@ impl Activate {
         // *outcome* is carried on `cli.command_completed` (exit_code), not by
         // the presence of this dispatch-time event, so emitting before a
         // possible trust decline is intentional, not a logged false success.
-        let v2_env_detail = env_detail_from_concrete(&concrete_environment);
+        let v2_env_detail = env_detail_from_concrete(&flox, &concrete_environment);
         let v2_mode = options
             .mode
             .clone()
@@ -416,8 +416,11 @@ impl ActivateOptions {
         subcommand_metric!("activate", "has_includes" = has_includes);
 
         if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentActivate(
-            CliEnvironmentActivatePayload::new(env_detail_from_concrete(&concrete_environment))
-                .with_has_includes(has_includes),
+            CliEnvironmentActivatePayload::new(env_detail_from_concrete(
+                &flox,
+                &concrete_environment,
+            ))
+            .with_has_includes(has_includes),
         )) {
             debug!(error = %err, "Failed to record v2 event");
         }
@@ -452,9 +455,12 @@ impl ActivateOptions {
         // subcommand and rides `lockfile_version` on a real
         // `cli.environment.activate` event instead.
         if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentActivate(
-            CliEnvironmentActivatePayload::new(env_detail_from_concrete(&concrete_environment))
-                .with_lockfile_version(lockfile_version.to_string())
-                .with_manifest_version(lockfile.manifest_schema_version().to_string()),
+            CliEnvironmentActivatePayload::new(env_detail_from_concrete(
+                &flox,
+                &concrete_environment,
+            ))
+            .with_lockfile_version(lockfile_version.to_string())
+            .with_manifest_version(lockfile.manifest_schema_version().to_string()),
         )) {
             debug!(error = %err, "Failed to record v2 event");
         }
@@ -575,8 +581,11 @@ impl ActivateOptions {
         // synchronously by the pre-exec emit + flush block below
         // (spec AC #5).
         if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentActivate(
-            CliEnvironmentActivatePayload::new(env_detail_from_concrete(&concrete_environment))
-                .with_shell(shell.to_string()),
+            CliEnvironmentActivatePayload::new(env_detail_from_concrete(
+                &flox,
+                &concrete_environment,
+            ))
+            .with_shell(shell.to_string()),
         )) {
             debug!(error = %err, "Failed to record v2 event");
         }

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -241,7 +241,7 @@ impl Activate {
             .unwrap_or(ActivateMode::Dev)
             .to_string();
         if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentActivate(
-            CliEnvironmentActivatePayload::new(v2_env_detail)
+            CliEnvironmentActivatePayload::new(v2_env_detail.clone())
                 .with_start_services(options.start_services)
                 .with_mode(v2_mode),
         )) {
@@ -384,6 +384,7 @@ impl ActivateOptions {
         services_for_ephemeral_activation: Vec<String>,
     ) -> Result<()> {
         let now_active = UninitializedEnvironment::from_concrete_environment(&concrete_environment);
+        let v2_env_detail = env_detail_from_concrete(&flox, &concrete_environment);
 
         let lockfile = match concrete_environment.lockfile(&flox)? {
             LockResult::Changed(lockfile) => {
@@ -416,11 +417,8 @@ impl ActivateOptions {
         subcommand_metric!("activate", "has_includes" = has_includes);
 
         if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentActivate(
-            CliEnvironmentActivatePayload::new(env_detail_from_concrete(
-                &flox,
-                &concrete_environment,
-            ))
-            .with_has_includes(has_includes),
+            CliEnvironmentActivatePayload::new(v2_env_detail.clone())
+                .with_has_includes(has_includes),
         )) {
             debug!(error = %err, "Failed to record v2 event");
         }
@@ -455,12 +453,9 @@ impl ActivateOptions {
         // subcommand and rides `lockfile_version` on a real
         // `cli.environment.activate` event instead.
         if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentActivate(
-            CliEnvironmentActivatePayload::new(env_detail_from_concrete(
-                &flox,
-                &concrete_environment,
-            ))
-            .with_lockfile_version(lockfile_version.to_string())
-            .with_manifest_version(lockfile.manifest_schema_version().to_string()),
+            CliEnvironmentActivatePayload::new(v2_env_detail.clone())
+                .with_lockfile_version(lockfile_version.to_string())
+                .with_manifest_version(lockfile.manifest_schema_version().to_string()),
         )) {
             debug!(error = %err, "Failed to record v2 event");
         }
@@ -581,11 +576,7 @@ impl ActivateOptions {
         // synchronously by the pre-exec emit + flush block below
         // (spec AC #5).
         if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentActivate(
-            CliEnvironmentActivatePayload::new(env_detail_from_concrete(
-                &flox,
-                &concrete_environment,
-            ))
-            .with_shell(shell.to_string()),
+            CliEnvironmentActivatePayload::new(v2_env_detail.clone()).with_shell(shell.to_string()),
         )) {
             debug!(error = %err, "Failed to record v2 event");
         }
@@ -1048,14 +1039,14 @@ mod tests {
     static DEFAULT_ENV: LazyLock<UninitializedEnvironment> = LazyLock::new(|| {
         UninitializedEnvironment::DotFlox(DotFlox {
             path: PathBuf::from(""),
-            pointer: EnvironmentPointer::Path(PathPointer::new("default".parse().unwrap())),
+            pointer: EnvironmentPointer::Path(PathPointer::new("default".parse().unwrap(), None)),
         })
     });
 
     static NON_DEFAULT_ENV: LazyLock<UninitializedEnvironment> = LazyLock::new(|| {
         UninitializedEnvironment::DotFlox(DotFlox {
             path: PathBuf::from(""),
-            pointer: EnvironmentPointer::Path(PathPointer::new("wichtig".parse().unwrap())),
+            pointer: EnvironmentPointer::Path(PathPointer::new("wichtig".parse().unwrap(), None)),
         })
     });
 

--- a/cli/flox/src/commands/build.rs
+++ b/cli/flox/src/commands/build.rs
@@ -1,11 +1,12 @@
 use std::env;
 use std::path::Path;
 use std::process::Stdio;
+use std::time::Instant;
 
 use anyhow::{Context, Result, bail};
 use bpaf::Bpaf;
 use flox_core::data::CanonicalPath;
-use flox_events::{CliBuildPayload, EventKind, EventsHub};
+use flox_events::{BuildOutcome, CliBuildPayload, EventKind, EventsHub};
 use flox_manifest::lockfile::Lockfile;
 use flox_manifest::{Manifest, MigratedTypedOnly};
 use flox_rust_sdk::flox::Flox;
@@ -33,6 +34,7 @@ use tracing::{debug, instrument, trace};
 use url::Url;
 
 use super::{DirEnvironmentSelect, dir_environment_select};
+use crate::utils::events::duration_to_ms;
 use crate::utils::message;
 use crate::{environment_subcommand_metric, subcommand_metric};
 
@@ -312,13 +314,15 @@ impl Build {
             "has_expression_build" = has_expression_build,
             "has_manifest_build" = has_manifest_build
         );
-        if let Err(err) = EventsHub::global().record_event(EventKind::CliBuild(
-            CliBuildPayload::new(has_expression_build, has_manifest_build),
-        )) {
-            debug!(error = %err, "Failed to record v2 event");
-        }
+
+        // Fingerprint of the locked state being built, stable within a CLI
+        // version (the lockfile serializes through ordered maps).
+        let lockfile_hash = serde_json::to_vec(&lockfile)
+            .ok()
+            .map(|bytes| blake3::hash(&bytes).to_hex().to_string());
 
         let builder = FloxBuildMk::new(&flox, &base_dir, &expression_ref, &built_environments);
+        let build_start = Instant::now();
         let results = builder.build(
             &base_nixpkgs_url,
             &FLOX_INTERPRETER,
@@ -326,7 +330,28 @@ impl Build {
             nef_stability,
             None,
             system_override,
-        )?;
+        );
+        let build_duration_ms = duration_to_ms(build_start.elapsed());
+
+        let mut payload = CliBuildPayload::new(has_expression_build, has_manifest_build)
+            .with_duration_ms(build_duration_ms);
+        if let Some(lockfile_hash) = lockfile_hash {
+            payload = payload.with_lockfile_hash(lockfile_hash);
+        }
+        payload = match &results {
+            Ok(_) => payload.with_outcome(BuildOutcome::Success),
+            Err(err) => {
+                let error_kind: &'static str = err.into();
+                payload
+                    .with_outcome(BuildOutcome::Failure)
+                    .with_error_kind(error_kind)
+            },
+        };
+        if let Err(err) = EventsHub::global().record_event(EventKind::CliBuild(payload)) {
+            debug!(error = %err, "Failed to record v2 event");
+        }
+
+        let results = results?;
 
         let current_dir = env::current_dir()
             .context("could not get current directory")?

--- a/cli/flox/src/commands/containerize/mod.rs
+++ b/cli/flox/src/commands/containerize/mod.rs
@@ -71,7 +71,7 @@ impl Containerize {
             .await?;
         environment_subcommand_metric!("containerize", env);
         if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentContainerize(
-            CliEnvironmentPayload::new(env_detail_from_concrete(&env)),
+            CliEnvironmentPayload::new(env_detail_from_concrete(&flox, &env)),
         )) {
             debug!(error = %err, "Failed to record v2 event");
         }

--- a/cli/flox/src/commands/delete.rs
+++ b/cli/flox/src/commands/delete.rs
@@ -34,7 +34,7 @@ impl Delete {
 
         environment_subcommand_metric!("delete", environment);
         if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentDelete(
-            CliEnvironmentPayload::new(env_detail_from_concrete(&environment)),
+            CliEnvironmentPayload::new(env_detail_from_concrete(&flox, &environment)),
         )) {
             debug!(error = %err, "Failed to record v2 event");
         }

--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -270,7 +270,7 @@ impl Edit {
                 let edited_includes = old_includes != new_includes;
                 subcommand_metric!("edit", "edited_includes" = edited_includes);
                 if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentEdit(
-                    CliEnvironmentEditPayload::new(env_detail_from_concrete(&flox, environment))
+                    CliEnvironmentEditPayload::new(env_detail_from_concrete(flox, environment))
                         .with_edited_includes(edited_includes)
                         .with_manifest_version(new_lockfile.manifest_schema_version().to_string()),
                 )) {

--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -102,7 +102,7 @@ impl Edit {
         };
         environment_subcommand_metric!("edit", detected_environment);
         if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentEdit(
-            CliEnvironmentEditPayload::new(env_detail_from_concrete(&detected_environment)),
+            CliEnvironmentEditPayload::new(env_detail_from_concrete(&flox, &detected_environment)),
         )) {
             debug!(error = %err, "Failed to record v2 event");
         }
@@ -270,7 +270,7 @@ impl Edit {
                 let edited_includes = old_includes != new_includes;
                 subcommand_metric!("edit", "edited_includes" = edited_includes);
                 if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentEdit(
-                    CliEnvironmentEditPayload::new(env_detail_from_concrete(environment))
+                    CliEnvironmentEditPayload::new(env_detail_from_concrete(&flox, environment))
                         .with_edited_includes(edited_includes)
                         .with_manifest_version(new_lockfile.manifest_schema_version().to_string()),
                 )) {

--- a/cli/flox/src/commands/envs.rs
+++ b/cli/flox/src/commands/envs.rs
@@ -261,6 +261,7 @@ mod tests {
             path: PathBuf::from("/envs/path/.flox"),
             pointer: EnvironmentPointer::Path(PathPointer::new(
                 EnvironmentName::from_str("name_path").unwrap(),
+                None,
             )),
         });
 
@@ -269,6 +270,7 @@ mod tests {
             pointer: EnvironmentPointer::Managed(ManagedPointer::new(
                 owner.clone(),
                 EnvironmentName::from_str("name_managed").unwrap(),
+                None,
                 &floxhub,
             )),
         });
@@ -276,6 +278,7 @@ mod tests {
         let remote_env = UninitializedEnvironment::Remote(ManagedPointer::new(
             owner.clone(),
             EnvironmentName::from_str("name_remote").unwrap(),
+            None,
             &floxhub,
         ));
 

--- a/cli/flox/src/commands/generations/history.rs
+++ b/cli/flox/src/commands/generations/history.rs
@@ -56,7 +56,7 @@ impl History {
         environment_subcommand_metric!("generations::history", env);
         if let Err(err) =
             EventsHub::global().record_event(EventKind::CliEnvironmentGenerationsHistory(
-                CliEnvironmentPayload::new(env_detail_from_concrete(&env)),
+                CliEnvironmentPayload::new(env_detail_from_concrete(&flox, &env)),
             ))
         {
             debug!(error = %err, "Failed to record v2 event");

--- a/cli/flox/src/commands/generations/list.rs
+++ b/cli/flox/src/commands/generations/list.rs
@@ -62,7 +62,7 @@ impl List {
         environment_subcommand_metric!("generations::list", env, request_tree = request_tree);
         if let Err(err) =
             EventsHub::global().record_event(EventKind::CliEnvironmentGenerationsList(
-                CliEnvironmentGenerationsListPayload::new(env_detail_from_concrete(&env))
+                CliEnvironmentGenerationsListPayload::new(env_detail_from_concrete(&flox, &env))
                     .with_request_tree(request_tree),
             ))
         {

--- a/cli/flox/src/commands/generations/rollback.rs
+++ b/cli/flox/src/commands/generations/rollback.rs
@@ -39,7 +39,7 @@ impl Rollback {
         environment_subcommand_metric!("generations::rollback", env);
         if let Err(err) =
             EventsHub::global().record_event(EventKind::CliEnvironmentGenerationsRollback(
-                CliEnvironmentPayload::new(env_detail_from_concrete(&env)),
+                CliEnvironmentPayload::new(env_detail_from_concrete(&flox, &env)),
             ))
         {
             debug!(error = %err, "Failed to record v2 event");

--- a/cli/flox/src/commands/generations/switch.rs
+++ b/cli/flox/src/commands/generations/switch.rs
@@ -35,7 +35,7 @@ impl Switch {
         environment_subcommand_metric!("generations::switch", env);
         if let Err(err) =
             EventsHub::global().record_event(EventKind::CliEnvironmentGenerationsSwitch(
-                CliEnvironmentPayload::new(env_detail_from_concrete(&env)),
+                CliEnvironmentPayload::new(env_detail_from_concrete(&flox, &env)),
             ))
         {
             debug!(error = %err, "Failed to record v2 event");

--- a/cli/flox/src/commands/include.rs
+++ b/cli/flox/src/commands/include.rs
@@ -77,7 +77,7 @@ impl Upgrade {
 
         environment_subcommand_metric!("include::upgrade", environment);
         if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentIncludeUpgrade(
-            CliEnvironmentPayload::new(env_detail_from_concrete(&environment)),
+            CliEnvironmentPayload::new(env_detail_from_concrete(&flox, &environment)),
         )) {
             debug!(error = %err, "Failed to record v2 event");
         }

--- a/cli/flox/src/commands/init/mod.rs
+++ b/cli/flox/src/commands/init/mod.rs
@@ -11,7 +11,12 @@ use flox_rust_sdk::data::AttrPath;
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::path_environment::{InitCustomization, PathEnvironment};
 use flox_rust_sdk::models::environment::remote_environment::RemoteEnvironment;
-use flox_rust_sdk::models::environment::{ConcreteEnvironment, Environment, PathPointer};
+use flox_rust_sdk::models::environment::{
+    ConcreteEnvironment,
+    Environment,
+    EnvironmentPointer,
+    PathPointer,
+};
 use flox_rust_sdk::providers::catalog::ALL_SYSTEMS;
 use flox_rust_sdk::providers::git::{GitCommandProvider, GitProvider};
 use flox_rust_sdk::providers::manifest_init::ManifestInitializer;
@@ -226,7 +231,8 @@ async fn init_local_environment(
         customization.activate_mode = Some(ActivateMode::Run);
     }
 
-    let path_pointer = PathPointer::new(name.clone());
+    let mut path_pointer = PathPointer::new(name.clone());
+    path_pointer.id = EnvironmentPointer::new_id(flox);
     let env = if customization.packages.is_some() {
         info_span!(
             "init_with_suggested_packages",

--- a/cli/flox/src/commands/init/mod.rs
+++ b/cli/flox/src/commands/init/mod.rs
@@ -11,12 +11,7 @@ use flox_rust_sdk::data::AttrPath;
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::path_environment::{InitCustomization, PathEnvironment};
 use flox_rust_sdk::models::environment::remote_environment::RemoteEnvironment;
-use flox_rust_sdk::models::environment::{
-    ConcreteEnvironment,
-    Environment,
-    EnvironmentPointer,
-    PathPointer,
-};
+use flox_rust_sdk::models::environment::{ConcreteEnvironment, Environment, PathPointer};
 use flox_rust_sdk::providers::catalog::ALL_SYSTEMS;
 use flox_rust_sdk::providers::git::{GitCommandProvider, GitProvider};
 use flox_rust_sdk::providers::manifest_init::ManifestInitializer;
@@ -28,6 +23,7 @@ use tracing::{debug, info_span, instrument};
 use crate::commands::{SHELL_COMPLETION_DIR, ensure_auth, environment_description};
 use crate::subcommand_metric;
 use crate::utils::dialog::Dialog;
+use crate::utils::events::new_environment_pointer_id;
 use crate::utils::message;
 
 mod go;
@@ -231,8 +227,7 @@ async fn init_local_environment(
         customization.activate_mode = Some(ActivateMode::Run);
     }
 
-    let mut path_pointer = PathPointer::new(name.clone());
-    path_pointer.id = EnvironmentPointer::new_id(flox);
+    let path_pointer = PathPointer::new(name.clone(), new_environment_pointer_id(flox));
     let env = if customization.packages.is_some() {
         info_span!(
             "init_with_suggested_packages",
@@ -983,7 +978,11 @@ mod tests {
                 .contains("Add environment variables and shell hooks")
         );
 
-        RemoteEnvironment::new(&flox, ManagedPointer::new(owner, name, &flox.floxhub), None)
-            .expect("find initialized remote environment");
+        RemoteEnvironment::new(
+            &flox,
+            ManagedPointer::new(owner, name, None, &flox.floxhub),
+            None,
+        )
+        .expect("find initialized remote environment");
     }
 }

--- a/cli/flox/src/commands/init/mod.rs
+++ b/cli/flox/src/commands/init/mod.rs
@@ -6,6 +6,7 @@ use anyhow::{Context, Result, anyhow, bail};
 use bpaf::Bpaf;
 use flox_core::activate::mode::ActivateMode;
 use flox_core::data::environment_ref::{DEFAULT_NAME, EnvironmentName, RemoteEnvironmentRef};
+use flox_events::{CliEnvironmentPayload, EventKind, EventsHub};
 use flox_manifest::raw::{CatalogPackage, PackageToInstall};
 use flox_rust_sdk::data::AttrPath;
 use flox_rust_sdk::flox::Flox;
@@ -23,7 +24,7 @@ use tracing::{debug, info_span, instrument};
 use crate::commands::{SHELL_COMPLETION_DIR, ensure_auth, environment_description};
 use crate::subcommand_metric;
 use crate::utils::dialog::Dialog;
-use crate::utils::events::new_environment_pointer_id;
+use crate::utils::events::{env_detail_from_concrete, new_environment_pointer_id};
 use crate::utils::message;
 
 mod go;
@@ -242,6 +243,13 @@ async fn init_local_environment(
         PathEnvironment::init(path_pointer, dir, &customization, flox)?
     };
 
+    let env = ConcreteEnvironment::Path(env);
+    if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentCreate(
+        CliEnvironmentPayload::new(env_detail_from_concrete(flox, &env)),
+    )) {
+        debug!(error = %err, "Failed to record v2 event");
+    }
+
     let env_in_git_repo = GitCommandProvider::discover(dir).is_ok();
 
     message::created(format!(
@@ -250,7 +258,7 @@ async fn init_local_environment(
         system = flox.system
     ));
     if let Some(packages) = customization.packages {
-        let description = environment_description(&ConcreteEnvironment::Path(env))?;
+        let description = environment_description(&env)?;
         for package in packages {
             message::package_installed(&PackageToInstall::Catalog(package), &description);
         }
@@ -288,7 +296,16 @@ fn init_floxhub_environment_decorated(
     env_ref: RemoteEnvironmentRef,
     bare: bool,
 ) -> Result<()> {
-    RemoteEnvironment::init_floxhub_environment(flox, env_ref.clone(), bare)?;
+    let env = ConcreteEnvironment::Remote(RemoteEnvironment::init_floxhub_environment(
+        flox,
+        env_ref.clone(),
+        bare,
+    )?);
+    if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentCreate(
+        CliEnvironmentPayload::new(env_detail_from_concrete(flox, &env)),
+    )) {
+        debug!(error = %err, "Failed to record v2 event");
+    }
     message::created(format!("Created environment '{env_ref}'"));
     message::plain(formatdoc! {"
 
@@ -704,6 +721,7 @@ mod tests {
     use flox_rust_sdk::utils::logging::test_helpers::test_subscriber_message_only;
     use indoc::indoc;
     use pretty_assertions::assert_eq;
+    use serial_test::serial;
 
     use super::*;
 
@@ -953,6 +971,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(global_events_client)]
     fn init_floxhub_environment_initializes_and_prints_message() {
         let owner = EnvironmentOwner::from_str("test").unwrap();
         let name = EnvironmentName::from_str("foo").unwrap();

--- a/cli/flox/src/commands/install.rs
+++ b/cli/flox/src/commands/install.rs
@@ -655,7 +655,7 @@ async fn try_create_default_environment_interactive(
 
     // Creates a default environment for the user, skipping checks for init
     // customizations and skipping the normal `init` output.
-    let env = {
+    let (env, newly_created) = {
         // ensure user is logged in
         let handle = ensure_auth(flox).await?;
         let owner = handle
@@ -670,15 +670,28 @@ async fn try_create_default_environment_interactive(
         match RemoteEnvironment::new(flox, pointer, None) {
             Ok(existing_env) => {
                 debug!("environment already exists -- will not init again");
-                existing_env
+                (existing_env, false)
             },
             Err(RemoteEnvironmentError::OpenManagedEnvironment(
                 ManagedEnvironmentError::UpstreamNotFound { env_ref, .. },
-            )) => RemoteEnvironment::init_floxhub_environment(flox, env_ref.clone(), false)
-                .with_context(|| format!("Failed to initialize FloxHub environment '{env_ref}'"))?,
+            )) => (
+                RemoteEnvironment::init_floxhub_environment(flox, env_ref.clone(), false)
+                    .with_context(|| {
+                        format!("Failed to initialize FloxHub environment '{env_ref}'")
+                    })?,
+                true,
+            ),
             Err(e) => Err(e)?,
         }
     };
+    let env = ConcreteEnvironment::Remote(env);
+    if newly_created
+        && let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentCreate(
+            CliEnvironmentPayload::new(env_detail_from_concrete(flox, &env)),
+        ))
+    {
+        debug!(error = %err, "Failed to record v2 event");
+    }
 
     // record that we created default env
     // Note: we record this _after_ attempting to create the default env,
@@ -689,7 +702,7 @@ async fn try_create_default_environment_interactive(
 
     prompt_to_modify_rc_file()?;
 
-    Ok(ConcreteEnvironment::Remote(env))
+    Ok(env)
 }
 /// Returns a formatted string representing a possibly truncated list of
 /// packages to install.

--- a/cli/flox/src/commands/install.rs
+++ b/cli/flox/src/commands/install.rs
@@ -185,7 +185,7 @@ impl Install {
         };
         environment_subcommand_metric!("install", concrete_environment);
         if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentInstall(
-            CliEnvironmentPayload::new(env_detail_from_concrete(&concrete_environment)),
+            CliEnvironmentPayload::new(env_detail_from_concrete(&flox, &concrete_environment)),
         )) {
             debug!(error = %err, "Failed to record v2 event");
         }

--- a/cli/flox/src/commands/install.rs
+++ b/cli/flox/src/commands/install.rs
@@ -665,7 +665,7 @@ async fn try_create_default_environment_interactive(
             .parse()
             .expect("'default' is a known accepted name");
 
-        let pointer = ManagedPointer::new(owner, name, &flox.floxhub);
+        let pointer = ManagedPointer::new(owner, name, None, &flox.floxhub);
 
         match RemoteEnvironment::new(flox, pointer, None) {
             Ok(existing_env) => {

--- a/cli/flox/src/commands/list.rs
+++ b/cli/flox/src/commands/list.rs
@@ -69,7 +69,7 @@ impl List {
             .await?;
         environment_subcommand_metric!("list", env);
         if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentList(
-            CliEnvironmentPayload::new(env_detail_from_concrete(&env)),
+            CliEnvironmentPayload::new(env_detail_from_concrete(&flox, &env)),
         )) {
             debug!(error = %err, "Failed to record v2 event");
         }

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -1335,6 +1335,7 @@ impl EnvironmentSelect {
                 let pointer = ManagedPointer::new(
                     env_ref.owner().clone(),
                     env_ref.name().clone(),
+                    None,
                     &flox.floxhub,
                 );
 
@@ -1356,6 +1357,7 @@ impl EnvironmentSelect {
                 let pointer = ManagedPointer::new(
                     env_ref.owner().clone(),
                     env_ref.name().clone(),
+                    None,
                     &flox.floxhub,
                 );
 
@@ -1393,6 +1395,7 @@ impl EnvironmentSelect {
                 let pointer = ManagedPointer::new(
                     env_ref.owner().clone(),
                     env_ref.name().clone(),
+                    None,
                     &flox.floxhub,
                 );
 
@@ -1419,6 +1422,7 @@ impl EnvironmentSelect {
                 let pointer = ManagedPointer::new(
                     env_ref.owner().clone(),
                     env_ref.name().clone(),
+                    None,
                     &flox.floxhub,
                 );
 

--- a/cli/flox/src/commands/publish.rs
+++ b/cli/flox/src/commands/publish.rs
@@ -139,7 +139,7 @@ impl Publish {
             .detect_concrete_environment(&mut flox, "Publish")?;
         environment_subcommand_metric!("publish", env);
         if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentPublish(
-            CliEnvironmentPublishPayload::new(env_detail_from_concrete(&env)),
+            CliEnvironmentPublishPayload::new(env_detail_from_concrete(&flox, &env)),
         )) {
             debug!(error = %err, "Failed to record v2 event");
         }
@@ -185,7 +185,7 @@ impl Publish {
         let handle = ensure_auth(&mut flox).await?;
         let catalog_name = publish_config.cache_args.org.clone().unwrap_or(handle);
 
-        let env_detail = env_detail_from_concrete(&env);
+        let env_detail = env_detail_from_concrete(&flox, &env);
         let path_env = match env {
             ConcreteEnvironment::Path(path_env) => path_env,
             ConcreteEnvironment::Managed(_) => {

--- a/cli/flox/src/commands/pull.rs
+++ b/cli/flox/src/commands/pull.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, anyhow, bail};
 use bpaf::Bpaf;
@@ -32,6 +32,7 @@ use flox_rust_sdk::providers::buildenv::BuildEnvError;
 use floxhub_client::AuthContext;
 use indoc::{formatdoc, indoc};
 use tracing::{debug, info_span, instrument};
+use uuid::Uuid;
 
 use super::services::warn_manifest_changes_for_services;
 use super::{ConcreteEnvironment, open_path};
@@ -90,6 +91,20 @@ pub struct Pull {
 struct QueryFunctions {
     query_add_system: fn(&str) -> Result<bool>,
     query_ignore_build_errors: fn() -> Result<bool>,
+}
+
+/// The pointer id to carry through a force re-pull: kept only when the
+/// existing checkout is the same environment being pulled.
+fn existing_pointer_id(env_path: &Path, env_ref: &RemoteEnvironmentRef) -> Option<Uuid> {
+    let dot_flox = DotFlox::open_in(env_path).ok()?;
+    match dot_flox.pointer {
+        EnvironmentPointer::Managed(pointer)
+            if pointer.owner == *env_ref.owner() && pointer.name == *env_ref.name() =>
+        {
+            pointer.id
+        },
+        _ => None,
+    }
 }
 
 impl Pull {
@@ -310,17 +325,12 @@ impl Pull {
         generation: Option<GenerationId>,
     ) -> Result<()> {
         let dot_flox_path = env_path.join(DOT_FLOX);
-        // A force re-pull replaces the checkout but is still the same
-        // environment: keep its pointer id if it has one.
+        // A force re-pull of the same environment replaces the checkout but
+        // keeps its pointer id; replacing a different environment does not.
         let mut existing_id = None;
         if dot_flox_path.exists() {
             if force {
-                existing_id = DotFlox::open_in(&env_path)
-                    .ok()
-                    .and_then(|dot_flox| match dot_flox.pointer {
-                        EnvironmentPointer::Managed(pointer) => pointer.id,
-                        EnvironmentPointer::Path(pointer) => pointer.id,
-                    });
+                existing_id = existing_pointer_id(&env_path, &env_ref);
                 match open_path(flox, &dot_flox_path, None) {
                     Ok(concrete_env) => match concrete_env {
                         ConcreteEnvironment::Path(env) => {
@@ -736,7 +746,9 @@ enum PullResultResolutionContext {
 
 #[cfg(test)]
 mod tests {
+    use flox_core::floxhub::{DEFAULT_FLOXHUB_URL, Floxhub};
     use flox_rust_sdk::flox::test_helpers::{flox_instance, flox_instance_with_optional_floxhub};
+    use flox_rust_sdk::models::environment::PathPointer;
     use flox_rust_sdk::models::environment::managed_environment::test_helpers::{
         mock_managed_environment_unlocked,
         unusable_mock_managed_environment,
@@ -746,6 +758,54 @@ mod tests {
     use tempfile::tempdir_in;
 
     use super::*;
+
+    /// A force re-pull keeps the existing pointer id only when the checkout
+    /// holds the same environment being pulled.
+    #[test]
+    fn existing_pointer_id_carries_only_for_the_same_environment() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let env_path = tempdir.path();
+        fs::create_dir_all(env_path.join(DOT_FLOX)).unwrap();
+        let id = Uuid::new_v4();
+        let env_ref: RemoteEnvironmentRef = "owner/name".parse().unwrap();
+
+        let write_pointer = |pointer: &EnvironmentPointer| {
+            fs::write(
+                env_path.join(DOT_FLOX).join(ENVIRONMENT_POINTER_FILENAME),
+                serde_json::to_string(pointer).unwrap(),
+            )
+            .unwrap();
+        };
+
+        let floxhub = Floxhub::new(DEFAULT_FLOXHUB_URL.clone(), None, None).unwrap();
+        let mut same_env =
+            ManagedPointer::new(env_ref.owner().clone(), env_ref.name().clone(), &floxhub);
+        same_env.id = Some(id);
+        write_pointer(&EnvironmentPointer::Managed(same_env));
+        assert_eq!(existing_pointer_id(env_path, &env_ref), Some(id));
+
+        let mut other_env = ManagedPointer::new(
+            "otherowner".parse().unwrap(),
+            env_ref.name().clone(),
+            &floxhub,
+        );
+        other_env.id = Some(id);
+        write_pointer(&EnvironmentPointer::Managed(other_env));
+        assert_eq!(
+            existing_pointer_id(env_path, &env_ref),
+            None,
+            "a different environment's id must not carry over"
+        );
+
+        let mut path_env = PathPointer::new("name".parse().unwrap());
+        path_env.id = Some(id);
+        write_pointer(&EnvironmentPointer::Path(path_env));
+        assert_eq!(
+            existing_pointer_id(env_path, &env_ref),
+            None,
+            "a path environment's id must not carry onto a pulled environment"
+        );
+    }
 
     fn incompatible_system_result() -> Result<(), EnvironmentError> {
         Err(EnvironmentError::Core(CoreEnvironmentError::BuildEnv(

--- a/cli/flox/src/commands/pull.rs
+++ b/cli/flox/src/commands/pull.rs
@@ -23,6 +23,7 @@ use flox_rust_sdk::models::environment::{
     ENVIRONMENT_POINTER_FILENAME,
     Environment,
     EnvironmentError,
+    EnvironmentPointer,
     ManagedPointer,
     create_dot_flox_gitignore,
 };
@@ -157,7 +158,7 @@ impl Pull {
                 // contract). Outcome rides on `cli.command_completed`
                 // (exit_code), so emitting before the bail is intentional.
                 if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentPull(
-                    CliEnvironmentPayload::new(env_detail_from_concrete(&environment)),
+                    CliEnvironmentPayload::new(env_detail_from_concrete(&flox, &environment)),
                 )) {
                     debug!(error = %err, "Failed to record v2 event");
                 }
@@ -337,11 +338,12 @@ impl Pull {
         }
 
         // region: write pointer
-        let pointer = ManagedPointer::new(
+        let mut pointer = ManagedPointer::new(
             env_ref.owner().clone(),
             env_ref.name().clone(),
             &flox.floxhub,
         );
+        pointer.id = EnvironmentPointer::new_id(flox);
         let mut pointer_content =
             serde_json::to_string_pretty(&pointer).context("Could not serialize pointer")?;
         pointer_content.push('\n');

--- a/cli/flox/src/commands/pull.rs
+++ b/cli/flox/src/commands/pull.rs
@@ -325,8 +325,6 @@ impl Pull {
         generation: Option<GenerationId>,
     ) -> Result<()> {
         let dot_flox_path = env_path.join(DOT_FLOX);
-        // A force re-pull of the same environment replaces the checkout but
-        // keeps its pointer id; replacing a different environment does not.
         let mut existing_id = None;
         if dot_flox_path.exists() {
             if force {

--- a/cli/flox/src/commands/pull.rs
+++ b/cli/flox/src/commands/pull.rs
@@ -39,7 +39,7 @@ use super::{ConcreteEnvironment, open_path};
 use crate::commands::{EnvironmentSelect, environment_description, environment_select};
 use crate::utils::dialog::{Dialog, Select};
 use crate::utils::errors::{display_chain, format_core_error};
-use crate::utils::events::env_detail_from_concrete;
+use crate::utils::events::{env_detail_from_concrete, new_environment_pointer_id};
 use crate::utils::message;
 use crate::{environment_subcommand_metric, subcommand_metric};
 
@@ -356,12 +356,12 @@ impl Pull {
         }
 
         // region: write pointer
-        let mut pointer = ManagedPointer::new(
+        let pointer = ManagedPointer::new(
             env_ref.owner().clone(),
             env_ref.name().clone(),
+            existing_id.or_else(|| new_environment_pointer_id(flox)),
             &flox.floxhub,
         );
-        pointer.id = existing_id.or_else(|| EnvironmentPointer::new_id(flox));
         let mut pointer_content =
             serde_json::to_string_pretty(&pointer).context("Could not serialize pointer")?;
         pointer_content.push('\n');
@@ -776,8 +776,12 @@ mod tests {
         };
 
         let floxhub = Floxhub::new(DEFAULT_FLOXHUB_URL.clone(), None, None).unwrap();
-        let mut same_env =
-            ManagedPointer::new(env_ref.owner().clone(), env_ref.name().clone(), &floxhub);
+        let mut same_env = ManagedPointer::new(
+            env_ref.owner().clone(),
+            env_ref.name().clone(),
+            None,
+            &floxhub,
+        );
         same_env.id = Some(id);
         write_pointer(&EnvironmentPointer::Managed(same_env));
         assert_eq!(existing_pointer_id(env_path, &env_ref), Some(id));
@@ -785,6 +789,7 @@ mod tests {
         let mut other_env = ManagedPointer::new(
             "otherowner".parse().unwrap(),
             env_ref.name().clone(),
+            None,
             &floxhub,
         );
         other_env.id = Some(id);
@@ -795,7 +800,7 @@ mod tests {
             "a different environment's id must not carry over"
         );
 
-        let mut path_env = PathPointer::new("name".parse().unwrap());
+        let mut path_env = PathPointer::new("name".parse().unwrap(), None);
         path_env.id = Some(id);
         write_pointer(&EnvironmentPointer::Path(path_env));
         assert_eq!(

--- a/cli/flox/src/commands/pull.rs
+++ b/cli/flox/src/commands/pull.rs
@@ -20,6 +20,7 @@ use flox_rust_sdk::models::environment::remote_environment::RemoteEnvironment;
 use flox_rust_sdk::models::environment::{
     CoreEnvironmentError,
     DOT_FLOX,
+    DotFlox,
     ENVIRONMENT_POINTER_FILENAME,
     Environment,
     EnvironmentError,
@@ -309,8 +310,17 @@ impl Pull {
         generation: Option<GenerationId>,
     ) -> Result<()> {
         let dot_flox_path = env_path.join(DOT_FLOX);
+        // A force re-pull replaces the checkout but is still the same
+        // environment: keep its pointer id if it has one.
+        let mut existing_id = None;
         if dot_flox_path.exists() {
             if force {
+                existing_id = DotFlox::open_in(&env_path)
+                    .ok()
+                    .and_then(|dot_flox| match dot_flox.pointer {
+                        EnvironmentPointer::Managed(pointer) => pointer.id,
+                        EnvironmentPointer::Path(pointer) => pointer.id,
+                    });
                 match open_path(flox, &dot_flox_path, None) {
                     Ok(concrete_env) => match concrete_env {
                         ConcreteEnvironment::Path(env) => {
@@ -343,7 +353,7 @@ impl Pull {
             env_ref.name().clone(),
             &flox.floxhub,
         );
-        pointer.id = EnvironmentPointer::new_id(flox);
+        pointer.id = existing_id.or_else(|| EnvironmentPointer::new_id(flox));
         let mut pointer_content =
             serde_json::to_string_pretty(&pointer).context("Could not serialize pointer")?;
         pointer_content.push('\n');

--- a/cli/flox/src/commands/push.rs
+++ b/cli/flox/src/commands/push.rs
@@ -64,6 +64,7 @@ impl Push {
             let pointer = ManagedPointer::new(
                 env_ref.owner().clone(),
                 env_ref.name().clone(),
+                None,
                 &flox.floxhub,
             );
 
@@ -125,7 +126,7 @@ fn handle_path_environment_push(
         EnvironmentOwner::from_str(flox.auth_context.handle().context("Need to be logged in")?)?
     };
 
-    let pointer = ManagedPointer::new(owner.clone(), path_environment.name(), &flox.floxhub);
+    let pointer = ManagedPointer::new(owner.clone(), path_environment.name(), None, &flox.floxhub);
 
     let managed_environment =
         ManagedEnvironment::push_new(flox, path_environment, owner, force, false)
@@ -444,7 +445,8 @@ mod tests {
         env.push(&flox, false).unwrap();
 
         // Now open it as a remote environment (this will cache it)
-        let pointer = ManagedPointer::new(owner.clone(), name.parse().unwrap(), &flox.floxhub);
+        let pointer =
+            ManagedPointer::new(owner.clone(), name.parse().unwrap(), None, &flox.floxhub);
         let mut remote_env = RemoteEnvironment::new(&flox, pointer, None).unwrap();
 
         // Make changes to the cached remote environment
@@ -499,7 +501,8 @@ mod tests {
         env.push(&flox, false).unwrap();
 
         // Now open it as a remote environment (this will cache it)
-        let pointer = ManagedPointer::new(owner.clone(), name.parse().unwrap(), &flox.floxhub);
+        let pointer =
+            ManagedPointer::new(owner.clone(), name.parse().unwrap(), None, &flox.floxhub);
         let remote_env = RemoteEnvironment::new(&flox, pointer, None).unwrap();
 
         // Push the remote environment without making changes using -r

--- a/cli/flox/src/commands/push.rs
+++ b/cli/flox/src/commands/push.rs
@@ -86,7 +86,7 @@ impl Push {
         environment_subcommand_metric!("push", env);
 
         if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentPush(
-            CliEnvironmentPayload::new(env_detail_from_concrete(&env)),
+            CliEnvironmentPayload::new(env_detail_from_concrete(&flox, &env)),
         )) {
             debug!(error = %err, "Failed to record v2 event");
         }

--- a/cli/flox/src/commands/services/logs.rs
+++ b/cli/flox/src/commands/services/logs.rs
@@ -42,7 +42,7 @@ impl Logs {
             ServicesEnvironment::from_environment_selection(&mut flox, &self.environment).await?;
         environment_subcommand_metric!("services::logs", env.environment);
         if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentServicesLogs(
-            CliEnvironmentPayload::new(env_detail_from_concrete(&env.environment)),
+            CliEnvironmentPayload::new(env_detail_from_concrete(&flox, &env.environment)),
         )) {
             debug!(error = %err, "Failed to record v2 event");
         }

--- a/cli/flox/src/commands/services/persist.rs
+++ b/cli/flox/src/commands/services/persist.rs
@@ -39,7 +39,7 @@ impl Persist {
         environment_subcommand_metric!("services::persist", env.environment);
         if let Err(err) =
             EventsHub::global().record_event(EventKind::CliEnvironmentServicesPersist(
-                CliEnvironmentPayload::new(env_detail_from_concrete(&env.environment)),
+                CliEnvironmentPayload::new(env_detail_from_concrete(&flox, &env.environment)),
             ))
         {
             debug!(error = %err, "Failed to record v2 event");

--- a/cli/flox/src/commands/services/restart.rs
+++ b/cli/flox/src/commands/services/restart.rs
@@ -47,7 +47,7 @@ impl Restart {
         environment_subcommand_metric!("services::restart", env.environment);
         if let Err(err) =
             EventsHub::global().record_event(EventKind::CliEnvironmentServicesRestart(
-                CliEnvironmentPayload::new(env_detail_from_concrete(&env.environment)),
+                CliEnvironmentPayload::new(env_detail_from_concrete(&flox, &env.environment)),
             ))
         {
             debug!(error = %err, "Failed to record v2 event");

--- a/cli/flox/src/commands/services/start.rs
+++ b/cli/flox/src/commands/services/start.rs
@@ -42,7 +42,7 @@ impl Start {
             ServicesEnvironment::from_environment_selection(&mut flox, &self.environment).await?;
         environment_subcommand_metric!("services::start", env.environment);
         if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentServicesStart(
-            CliEnvironmentPayload::new(env_detail_from_concrete(&env.environment)),
+            CliEnvironmentPayload::new(env_detail_from_concrete(&flox, &env.environment)),
         )) {
             debug!(error = %err, "Failed to record v2 event");
         }

--- a/cli/flox/src/commands/services/status.rs
+++ b/cli/flox/src/commands/services/status.rs
@@ -43,7 +43,7 @@ impl Status {
             ServicesEnvironment::from_environment_selection(&mut flox, &self.environment).await?;
         environment_subcommand_metric!("services::status", env.environment);
         if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentServicesStatus(
-            CliEnvironmentPayload::new(env_detail_from_concrete(&env.environment)),
+            CliEnvironmentPayload::new(env_detail_from_concrete(&flox, &env.environment)),
         )) {
             debug!(error = %err, "Failed to record v2 event");
         }

--- a/cli/flox/src/commands/services/stop.rs
+++ b/cli/flox/src/commands/services/stop.rs
@@ -29,7 +29,7 @@ impl Stop {
             ServicesEnvironment::from_environment_selection(&mut flox, &self.environment).await?;
         environment_subcommand_metric!("services::stop", env.environment);
         if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentServicesStop(
-            CliEnvironmentPayload::new(env_detail_from_concrete(&env.environment)),
+            CliEnvironmentPayload::new(env_detail_from_concrete(&flox, &env.environment)),
         )) {
             debug!(error = %err, "Failed to record v2 event");
         }

--- a/cli/flox/src/commands/uninstall.rs
+++ b/cli/flox/src/commands/uninstall.rs
@@ -72,7 +72,7 @@ impl Uninstall {
         };
         environment_subcommand_metric!("uninstall", concrete_environment);
         if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentUninstall(
-            CliEnvironmentPayload::new(env_detail_from_concrete(&concrete_environment)),
+            CliEnvironmentPayload::new(env_detail_from_concrete(&flox, &concrete_environment)),
         )) {
             debug!(error = %err, "Failed to record v2 event");
         }

--- a/cli/flox/src/commands/upgrade.rs
+++ b/cli/flox/src/commands/upgrade.rs
@@ -53,7 +53,7 @@ impl Upgrade {
             .await?;
         environment_subcommand_metric!("upgrade", concrete_environment);
         if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentUpgrade(
-            CliEnvironmentPayload::new(env_detail_from_concrete(&concrete_environment)),
+            CliEnvironmentPayload::new(env_detail_from_concrete(&flox, &concrete_environment)),
         )) {
             debug!(error = %err, "Failed to record v2 event");
         }

--- a/cli/flox/src/main.rs
+++ b/cli/flox/src/main.rs
@@ -35,6 +35,7 @@ use crate::utils::errors::{
     format_managed_error,
     format_remote_error,
 };
+use crate::utils::events::duration_to_ms;
 use crate::utils::init::init_telemetry_uuid;
 use crate::utils::metrics::{Hub, read_metrics_uuid};
 
@@ -260,12 +261,6 @@ where
     for<'a> &'a T: Into<&'static str>,
 {
     e.into()
-}
-
-/// Saturate a duration into whole ms (u64::MAX ms is ~584M years — a
-/// ceiling only).
-fn duration_to_ms(elapsed: std::time::Duration) -> u64 {
-    u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX)
 }
 
 /// Fixed bash completion script that replaces bpaf's generated version.

--- a/cli/flox/src/utils/active_environments.rs
+++ b/cli/flox/src/utils/active_environments.rs
@@ -204,6 +204,7 @@ mod tests {
             path: PathBuf::new(),
             pointer: EnvironmentPointer::Path(PathPointer::new(
                 EnvironmentName::from_str(name).unwrap(),
+                None,
             )),
         })
     }

--- a/cli/flox/src/utils/active_environments.rs
+++ b/cli/flox/src/utils/active_environments.rs
@@ -235,6 +235,29 @@ mod tests {
         assert_eq!(active.is_active_with_generation(&env2), None);
     }
 
+    /// An activation recorded by a binary that predates pointer ids (or vice
+    /// versa) must still be detected: the pointer id is not part of identity.
+    #[test]
+    fn activation_detection_ignores_pointer_id() {
+        let recorded = new_uninitialized_environment("env1");
+        let mut with_id = recorded.clone();
+        let UninitializedEnvironment::DotFlox(DotFlox {
+            pointer: EnvironmentPointer::Path(pointer),
+            ..
+        }) = &mut with_id
+        else {
+            panic!("expected path pointer");
+        };
+        pointer.id = Some(uuid::Uuid::new_v4());
+
+        let generation = Some(GenerationId::from_str("42").unwrap());
+        let mut active = ActiveEnvironments::default();
+        active.set_last_active(recorded, generation, ActivateMode::Dev);
+
+        assert!(active.is_active(&with_id));
+        assert_eq!(active.is_active_with_generation(&with_id), generation);
+    }
+
     /// Simulate setting an active environment in one flox invocation and then
     /// checking if it's active in a second.
     #[test]

--- a/cli/flox/src/utils/events.rs
+++ b/cli/flox/src/utils/events.rs
@@ -13,13 +13,14 @@
 
 use std::env;
 use std::str::FromStr;
-use std::sync::{LazyLock, OnceLock};
+use std::sync::{LazyLock, Mutex, OnceLock};
 
 use flox_config::Config;
 use flox_events::{EnvDetail, EventsClient, EventsHub, SharedMetadataTemplate};
+use flox_manifest::lockfile::Lockfile;
 use flox_rust_sdk::flox::{FLOX_VERSION, Flox};
-use flox_rust_sdk::models::environment::generations::GenerationsExt;
-use flox_rust_sdk::models::environment::{ConcreteEnvironment, Environment};
+use flox_rust_sdk::models::environment::generations::{GenerationId, GenerationsExt};
+use flox_rust_sdk::models::environment::{ConcreteEnvironment, Environment, EnvironmentError};
 use flox_rust_sdk::utils::INVOCATION_SOURCES;
 use tracing::debug;
 use uuid::Uuid;
@@ -151,12 +152,18 @@ struct EnvIdentityFields {
     package_count: Option<u64>,
 }
 
-/// Process-global; never resets within a test binary, so tests that install
-/// a client must use distinct environments.
-static ENV_IDENTITY_FIELDS: OnceLock<(String, EnvIdentityFields)> = OnceLock::new();
+/// Process-global; resets only via [`reset_env_identity_fields`] in tests.
+static ENV_IDENTITY_FIELDS: Mutex<Option<(String, EnvIdentityFields)>> = Mutex::new(None);
+
+/// Clear the per-invocation cache so tests are isolated from each other.
+#[cfg(test)]
+fn reset_env_identity_fields() {
+    *ENV_IDENTITY_FIELDS.lock().unwrap() = None;
+}
 
 /// Read the identity fields for `env`. Every read is best-effort: a failure
-/// leaves the field absent, never fails the command.
+/// leaves the field absent, never fails the command. At most one
+/// generations-metadata read and one lockfile read happen here.
 fn read_env_identity_fields(flox: &Flox, env: &ConcreteEnvironment) -> EnvIdentityFields {
     let environment_id = match env {
         ConcreteEnvironment::Path(environment) => environment.pointer.id,
@@ -166,83 +173,86 @@ fn read_env_identity_fields(flox: &Flox, env: &ConcreteEnvironment) -> EnvIdenti
         ConcreteEnvironment::Remote(_) => None,
     };
     // A command opened at a pinned generation acts on that generation;
-    // only unpinned managed/remote environments read the branch tip.
-    let generation_number = match env {
-        ConcreteEnvironment::Managed(environment) => environment
-            .generation()
-            .map(|generation| *generation as u64)
-            .or_else(|| current_generation_number(environment)),
-        ConcreteEnvironment::Remote(environment) => environment
-            .generation()
-            .map(|generation| *generation as u64)
-            .or_else(|| current_generation_number(environment)),
-        // Path environments have no generations.
-        ConcreteEnvironment::Path(_) => None,
+    // only unpinned managed/remote environments read the branch tip. The
+    // resolved generation feeds the lockfile read so the metadata isn't
+    // read twice.
+    let (generation_number, package_count) = match env {
+        ConcreteEnvironment::Path(environment) => (
+            None,
+            count_packages(flox, environment.existing_lockfile(flox)),
+        ),
+        ConcreteEnvironment::Managed(environment) => {
+            let generation = environment
+                .generation()
+                .or_else(|| current_generation(environment));
+            (
+                generation.map(|generation| *generation as u64),
+                count_packages(
+                    flox,
+                    environment.existing_lockfile_without_checkout(generation),
+                ),
+            )
+        },
+        ConcreteEnvironment::Remote(environment) => {
+            let generation = environment
+                .generation()
+                .or_else(|| current_generation(environment));
+            (
+                generation.map(|generation| *generation as u64),
+                count_packages(
+                    flox,
+                    environment.existing_lockfile_without_checkout(generation),
+                ),
+            )
+        },
     };
 
     EnvIdentityFields {
         environment_id,
         generation_number,
-        package_count: package_count(flox, env),
+        package_count,
     }
 }
 
-fn current_generation_number(env: &impl GenerationsExt) -> Option<u64> {
+fn current_generation(env: &impl GenerationsExt) -> Option<GenerationId> {
     env.generations_metadata()
         .map_err(|err| debug!(error = %err, "could not read generations metadata for event"))
         .ok()
         .and_then(|metadata| metadata.current_gen())
-        .map(|generation| *generation as u64)
 }
 
-/// Packages locked for the invoking system (the `flox list` count), read
-/// without locking, building, materializing a checkout, or touching the
-/// network.
-fn package_count(flox: &Flox, env: &ConcreteEnvironment) -> Option<u64> {
-    let lockfile = match env {
-        ConcreteEnvironment::Path(environment) => environment.existing_lockfile(flox),
-        // `Environment::existing_lockfile` may materialize the local
-        // checkout for managed/remote environments; these reads must not.
-        ConcreteEnvironment::Managed(environment) => {
-            environment.existing_lockfile_without_checkout()
-        },
-        ConcreteEnvironment::Remote(environment) => {
-            environment.existing_lockfile_without_checkout()
-        },
-    };
+/// Packages locked for the invoking system (the `flox list` count), counted
+/// without cloning the package list.
+fn count_packages(
+    flox: &Flox,
+    lockfile: Result<Option<Lockfile>, EnvironmentError>,
+) -> Option<u64> {
     lockfile
         .map_err(|err| debug!(error = %err, "could not read lockfile for event"))
         .ok()
         .flatten()
-        .and_then(|lockfile| {
+        .map(|lockfile| {
             lockfile
-                .list_packages(&flox.system)
-                .map_err(|err| debug!(error = %err, "could not list packages for event"))
-                .ok()
+                .packages
+                .iter()
+                .filter(|package| package.system() == &flox.system)
+                .count() as u64
         })
-        .map(|packages| packages.len() as u64)
 }
 
 /// Identity fields for `env`, computed once per invocation (keyed by the
-/// environment's kind and `.flox` path) and skipped entirely when no events
-/// client is installed.
-fn env_identity_fields(
-    flox: &Flox,
-    env: &ConcreteEnvironment,
-    key: &str,
-) -> Option<EnvIdentityFields> {
-    if !EventsHub::global().has_client() {
-        return None;
-    }
-    match ENV_IDENTITY_FIELDS.get() {
-        Some((cached_key, fields)) if cached_key == key => Some(*fields),
+/// environment's kind and `.flox` path).
+fn env_identity_fields(flox: &Flox, env: &ConcreteEnvironment, key: &str) -> EnvIdentityFields {
+    let mut cached = ENV_IDENTITY_FIELDS.lock().unwrap();
+    match cached.as_ref() {
+        Some((cached_key, fields)) if cached_key == key => *fields,
         // A second environment in the same process is computed fresh but
         // not cached; commands operate on one environment.
-        Some(_) => Some(read_env_identity_fields(flox, env)),
+        Some(_) => read_env_identity_fields(flox, env),
         None => {
             let fields = read_env_identity_fields(flox, env);
-            let _ = ENV_IDENTITY_FIELDS.set((key.to_string(), fields));
-            Some(fields)
+            *cached = Some((key.to_string(), fields));
+            fields
         },
     }
 }
@@ -250,7 +260,8 @@ fn env_identity_fields(
 /// Build an [`EnvDetail`] for the supplied [`ConcreteEnvironment`], using the
 /// same env-kind / env-ref mapping as the legacy
 /// `environment_subcommand_metric!` macro. Shared across call sites so the
-/// per-kind match is not duplicated.
+/// per-kind match is not duplicated. The identity fields are skipped
+/// entirely when no events client is installed.
 pub fn env_detail_from_concrete(flox: &Flox, env: &ConcreteEnvironment) -> EnvDetail {
     let (env_kind, env_ref_or_name) = match env {
         ConcreteEnvironment::Remote(environment) => ("remote", environment.env_ref().to_string()),
@@ -259,9 +270,10 @@ pub fn env_detail_from_concrete(flox: &Flox, env: &ConcreteEnvironment) -> EnvDe
             ("path", Environment::name(environment).to_string())
         },
     };
-    let cache_key = format!("{env_kind}:{}", env.dot_flox_path().display());
     let mut detail = EnvDetail::new(env_kind, env_ref_or_name);
-    if let Some(fields) = env_identity_fields(flox, env, &cache_key) {
+    if EventsHub::global().has_client() {
+        let cache_key = format!("{env_kind}:{}", env.dot_flox_path().display());
+        let fields = env_identity_fields(flox, env, &cache_key);
         if let Some(environment_id) = fields.environment_id {
             detail = detail.with_environment_id(environment_id);
         }
@@ -284,7 +296,6 @@ mod tests {
     use flox_events::test_helpers::MockEventsConnection;
     use flox_events::{EVENTS_BUFFER_FILE_NAME, EventsHub, LifecycleFields};
     use flox_rust_sdk::flox::test_helpers::{flox_instance, flox_instance_with_optional_floxhub};
-    use flox_rust_sdk::models::environment::generations::GenerationId;
     use flox_rust_sdk::models::environment::managed_environment::test_helpers::{
         mock_managed_environment_in,
         mock_managed_environment_unlocked,
@@ -446,6 +457,7 @@ mod tests {
     #[test]
     #[serial(global_events_client)]
     fn env_detail_carries_identity_fields_for_path_env() {
+        reset_env_identity_fields();
         let (flox, _temp_dir_handle) = flox_instance();
         let mut env = new_path_environment(&flox, "version = 1\n");
         let environment_id = Uuid::new_v4();
@@ -489,6 +501,7 @@ mod tests {
     #[test]
     #[serial(global_events_client)]
     fn env_detail_carries_identity_fields_for_managed_env() {
+        reset_env_identity_fields();
         let owner: EnvironmentOwner = "owner".parse().unwrap();
         let (flox, _temp_dir_handle) = flox_instance_with_optional_floxhub(Some(&owner));
         let environment_id = Uuid::new_v4();

--- a/cli/flox/src/utils/events.rs
+++ b/cli/flox/src/utils/events.rs
@@ -151,6 +151,8 @@ struct EnvIdentityFields {
     package_count: Option<u64>,
 }
 
+/// Process-global; never resets within a test binary, so tests that install
+/// a client must use distinct environments.
 static ENV_IDENTITY_FIELDS: OnceLock<(String, EnvIdentityFields)> = OnceLock::new();
 
 /// Read the identity fields for `env`. Every read is best-effort: a failure
@@ -163,22 +165,20 @@ fn read_env_identity_fields(flox: &Flox, env: &ConcreteEnvironment) -> EnvIdenti
         // invocation, so it carries no stable id.
         ConcreteEnvironment::Remote(_) => None,
     };
-    let generations_metadata = match env {
-        ConcreteEnvironment::Managed(environment) => Some(environment.generations_metadata()),
-        ConcreteEnvironment::Remote(environment) => Some(environment.generations_metadata()),
+    // A command opened at a pinned generation acts on that generation;
+    // only unpinned managed/remote environments read the branch tip.
+    let generation_number = match env {
+        ConcreteEnvironment::Managed(environment) => environment
+            .generation()
+            .map(|generation| *generation as u64)
+            .or_else(|| current_generation_number(environment)),
+        ConcreteEnvironment::Remote(environment) => environment
+            .generation()
+            .map(|generation| *generation as u64)
+            .or_else(|| current_generation_number(environment)),
         // Path environments have no generations.
         ConcreteEnvironment::Path(_) => None,
     };
-    let generation_number = generations_metadata
-        .and_then(|metadata| {
-            metadata
-                .map_err(
-                    |err| debug!(error = %err, "could not read generations metadata for event"),
-                )
-                .ok()
-        })
-        .and_then(|metadata| metadata.current_gen())
-        .map(|generation| *generation as u64);
 
     EnvIdentityFields {
         environment_id,
@@ -187,10 +187,30 @@ fn read_env_identity_fields(flox: &Flox, env: &ConcreteEnvironment) -> EnvIdenti
     }
 }
 
-/// Packages locked for the invoking system (the `flox list` count), from the
-/// existing lockfile only — never locks, builds, or touches the network.
+fn current_generation_number(env: &impl GenerationsExt) -> Option<u64> {
+    env.generations_metadata()
+        .map_err(|err| debug!(error = %err, "could not read generations metadata for event"))
+        .ok()
+        .and_then(|metadata| metadata.current_gen())
+        .map(|generation| *generation as u64)
+}
+
+/// Packages locked for the invoking system (the `flox list` count), read
+/// without locking, building, materializing a checkout, or touching the
+/// network.
 fn package_count(flox: &Flox, env: &ConcreteEnvironment) -> Option<u64> {
-    env.existing_lockfile(flox)
+    let lockfile = match env {
+        ConcreteEnvironment::Path(environment) => environment.existing_lockfile(flox),
+        // `Environment::existing_lockfile` may materialize the local
+        // checkout for managed/remote environments; these reads must not.
+        ConcreteEnvironment::Managed(environment) => {
+            environment.existing_lockfile_without_checkout()
+        },
+        ConcreteEnvironment::Remote(environment) => {
+            environment.existing_lockfile_without_checkout()
+        },
+    };
+    lockfile
         .map_err(|err| debug!(error = %err, "could not read lockfile for event"))
         .ok()
         .flatten()
@@ -204,8 +224,8 @@ fn package_count(flox: &Flox, env: &ConcreteEnvironment) -> Option<u64> {
 }
 
 /// Identity fields for `env`, computed once per invocation (keyed by the
-/// environment's ref/name) and skipped entirely when no events client is
-/// installed.
+/// environment's kind and `.flox` path) and skipped entirely when no events
+/// client is installed.
 fn env_identity_fields(
     flox: &Flox,
     env: &ConcreteEnvironment,
@@ -239,8 +259,9 @@ pub fn env_detail_from_concrete(flox: &Flox, env: &ConcreteEnvironment) -> EnvDe
             ("path", Environment::name(environment).to_string())
         },
     };
-    let mut detail = EnvDetail::new(env_kind, env_ref_or_name.clone());
-    if let Some(fields) = env_identity_fields(flox, env, &env_ref_or_name) {
+    let cache_key = format!("{env_kind}:{}", env.dot_flox_path().display());
+    let mut detail = EnvDetail::new(env_kind, env_ref_or_name);
+    if let Some(fields) = env_identity_fields(flox, env, &cache_key) {
         if let Some(environment_id) = fields.environment_id {
             detail = detail.with_environment_id(environment_id);
         }

--- a/cli/flox/src/utils/events.rs
+++ b/cli/flox/src/utils/events.rs
@@ -16,8 +16,9 @@ use std::str::FromStr;
 use std::sync::{LazyLock, OnceLock};
 
 use flox_config::Config;
-use flox_events::{EnvDetail, EventsClient, SharedMetadataTemplate};
-use flox_rust_sdk::flox::FLOX_VERSION;
+use flox_events::{EnvDetail, EventsClient, EventsHub, SharedMetadataTemplate};
+use flox_rust_sdk::flox::{FLOX_VERSION, Flox};
+use flox_rust_sdk::models::environment::generations::GenerationsExt;
 use flox_rust_sdk::models::environment::{ConcreteEnvironment, Environment};
 use flox_rust_sdk::utils::INVOCATION_SOURCES;
 use tracing::debug;
@@ -139,22 +140,118 @@ pub fn build_events_client(
     ))
 }
 
+/// The identity fields for the environment the current invocation operates
+/// on, read once at the first environment event and reused by later emits of
+/// the same command so the generation and lockfile reads don't repeat on
+/// multi-emit paths like `activate`.
+#[derive(Debug, Clone, Copy)]
+struct EnvIdentityFields {
+    environment_id: Option<Uuid>,
+    generation_number: Option<u64>,
+    package_count: Option<u64>,
+}
+
+static ENV_IDENTITY_FIELDS: OnceLock<(String, EnvIdentityFields)> = OnceLock::new();
+
+/// Read the identity fields for `env`. Every read is best-effort: a failure
+/// leaves the field absent, never fails the command.
+fn read_env_identity_fields(flox: &Flox, env: &ConcreteEnvironment) -> EnvIdentityFields {
+    let environment_id = match env {
+        ConcreteEnvironment::Path(environment) => environment.pointer.id,
+        ConcreteEnvironment::Managed(environment) => environment.pointer().id,
+        // The cached pointer of a remote environment is rewritten on every
+        // invocation, so it carries no stable id.
+        ConcreteEnvironment::Remote(_) => None,
+    };
+    let generations_metadata = match env {
+        ConcreteEnvironment::Managed(environment) => Some(environment.generations_metadata()),
+        ConcreteEnvironment::Remote(environment) => Some(environment.generations_metadata()),
+        // Path environments have no generations.
+        ConcreteEnvironment::Path(_) => None,
+    };
+    let generation_number = generations_metadata
+        .and_then(|metadata| {
+            metadata
+                .map_err(
+                    |err| debug!(error = %err, "could not read generations metadata for event"),
+                )
+                .ok()
+        })
+        .and_then(|metadata| metadata.current_gen())
+        .map(|generation| *generation as u64);
+
+    EnvIdentityFields {
+        environment_id,
+        generation_number,
+        package_count: package_count(flox, env),
+    }
+}
+
+/// Packages locked for the invoking system (the `flox list` count), from the
+/// existing lockfile only — never locks, builds, or touches the network.
+fn package_count(flox: &Flox, env: &ConcreteEnvironment) -> Option<u64> {
+    env.existing_lockfile(flox)
+        .map_err(|err| debug!(error = %err, "could not read lockfile for event"))
+        .ok()
+        .flatten()
+        .and_then(|lockfile| {
+            lockfile
+                .list_packages(&flox.system)
+                .map_err(|err| debug!(error = %err, "could not list packages for event"))
+                .ok()
+        })
+        .map(|packages| packages.len() as u64)
+}
+
+/// Identity fields for `env`, computed once per invocation (keyed by the
+/// environment's ref/name) and skipped entirely when no events client is
+/// installed.
+fn env_identity_fields(
+    flox: &Flox,
+    env: &ConcreteEnvironment,
+    key: &str,
+) -> Option<EnvIdentityFields> {
+    if !EventsHub::global().has_client() {
+        return None;
+    }
+    match ENV_IDENTITY_FIELDS.get() {
+        Some((cached_key, fields)) if cached_key == key => Some(*fields),
+        // A second environment in the same process is computed fresh but
+        // not cached; commands operate on one environment.
+        Some(_) => Some(read_env_identity_fields(flox, env)),
+        None => {
+            let fields = read_env_identity_fields(flox, env);
+            let _ = ENV_IDENTITY_FIELDS.set((key.to_string(), fields));
+            Some(fields)
+        },
+    }
+}
+
 /// Build an [`EnvDetail`] for the supplied [`ConcreteEnvironment`], using the
 /// same env-kind / env-ref mapping as the legacy
 /// `environment_subcommand_metric!` macro. Shared across call sites so the
 /// per-kind match is not duplicated.
-pub fn env_detail_from_concrete(env: &ConcreteEnvironment) -> EnvDetail {
-    match env {
-        ConcreteEnvironment::Remote(environment) => {
-            EnvDetail::new("remote", environment.env_ref().to_string())
-        },
-        ConcreteEnvironment::Managed(environment) => {
-            EnvDetail::new("managed", environment.env_ref().to_string())
-        },
+pub fn env_detail_from_concrete(flox: &Flox, env: &ConcreteEnvironment) -> EnvDetail {
+    let (env_kind, env_ref_or_name) = match env {
+        ConcreteEnvironment::Remote(environment) => ("remote", environment.env_ref().to_string()),
+        ConcreteEnvironment::Managed(environment) => ("managed", environment.env_ref().to_string()),
         ConcreteEnvironment::Path(environment) => {
-            EnvDetail::new("path", Environment::name(environment).to_string())
+            ("path", Environment::name(environment).to_string())
         },
+    };
+    let mut detail = EnvDetail::new(env_kind, env_ref_or_name.clone());
+    if let Some(fields) = env_identity_fields(flox, env, &env_ref_or_name) {
+        if let Some(environment_id) = fields.environment_id {
+            detail = detail.with_environment_id(environment_id);
+        }
+        if let Some(generation_number) = fields.generation_number {
+            detail = detail.with_generation_number(generation_number);
+        }
+        if let Some(package_count) = fields.package_count {
+            detail = detail.with_package_count(package_count);
+        }
     }
+    detail
 }
 
 #[cfg(test)]
@@ -164,6 +261,8 @@ mod tests {
     use flox_config::FloxConfig;
     use flox_events::test_helpers::MockEventsConnection;
     use flox_events::{EVENTS_BUFFER_FILE_NAME, EventsHub, LifecycleFields};
+    use flox_rust_sdk::flox::test_helpers::flox_instance;
+    use flox_rust_sdk::models::environment::path_environment::test_helpers::new_path_environment;
     use serial_test::serial;
     use temp_env::with_var;
     use tempfile::TempDir;
@@ -280,6 +379,61 @@ mod tests {
 
         let client = build_events_client(&config, Uuid::new_v4(), None).expect("client installs");
         assert_eq!(client.auth_subject, None, "anonymous use stays anonymous");
+    }
+
+    /// The env-detail identity fields ride for a path environment with a
+    /// pointer id — and the sourcing is skipped entirely when no events
+    /// client is installed.
+    #[test]
+    #[serial(global_events_client)]
+    fn env_detail_carries_identity_fields_for_path_env() {
+        let (flox, _temp_dir_handle) = flox_instance();
+        let mut env = new_path_environment(&flox, "version = 1\n");
+        let environment_id = Uuid::new_v4();
+        env.pointer.id = Some(environment_id);
+        env.lockfile(&flox).unwrap();
+        let concrete = ConcreteEnvironment::Path(env);
+
+        // No client installed: recording is a no-op, so nothing is sourced.
+        let previous = EventsHub::global().clear_client();
+        let detail = serde_json::to_value(env_detail_from_concrete(&flox, &concrete))
+            .expect("detail serializes");
+        assert_eq!(detail.get("environment_id"), None);
+        assert_eq!(detail.get("package_count"), None);
+
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let template = SharedMetadataTemplate {
+            flox_version: "0.0.0-test".to_string(),
+            os_family: None,
+            os_family_release: None,
+            os: None,
+            os_version: None,
+            empty_flags: vec![],
+            invocation_sources: vec![],
+        };
+        let client = EventsClient::new_with_connection(
+            Uuid::new_v4(),
+            tempdir.path(),
+            Uuid::new_v4(),
+            None,
+            template,
+            MockEventsConnection::default(),
+        );
+        EventsHub::global().set_client(client);
+
+        let detail = serde_json::to_value(env_detail_from_concrete(&flox, &concrete))
+            .expect("detail serializes");
+        assert_eq!(
+            detail.get("environment_id"),
+            Some(&serde_json::json!(environment_id.to_string()))
+        );
+        assert_eq!(detail.get("generation_number"), None, "path envs have none");
+        assert_eq!(detail.get("package_count"), Some(&serde_json::json!(0)));
+
+        EventsHub::global().clear_client();
+        if let Some(previous) = previous {
+            EventsHub::global().set_client(previous);
+        }
     }
 
     /// End-to-end: install a hub-owned client backed by a

--- a/cli/flox/src/utils/events.rs
+++ b/cli/flox/src/utils/events.rs
@@ -13,14 +13,12 @@
 
 use std::env;
 use std::str::FromStr;
-use std::sync::{LazyLock, Mutex, OnceLock};
+use std::sync::{LazyLock, OnceLock};
 
 use flox_config::Config;
 use flox_events::{EnvDetail, EventsClient, EventsHub, SharedMetadataTemplate};
-use flox_manifest::lockfile::Lockfile;
 use flox_rust_sdk::flox::{FLOX_VERSION, Flox};
-use flox_rust_sdk::models::environment::generations::{GenerationId, GenerationsExt};
-use flox_rust_sdk::models::environment::{ConcreteEnvironment, Environment, EnvironmentError};
+use flox_rust_sdk::models::environment::{ConcreteEnvironment, Environment};
 use flox_rust_sdk::utils::INVOCATION_SOURCES;
 use tracing::debug;
 use uuid::Uuid;
@@ -141,21 +139,18 @@ pub fn build_events_client(
     ))
 }
 
+/// A fresh environment pointer id, or `None` when metrics are disabled —
+/// no id is minted or persisted for opted-out users.
+pub fn new_environment_pointer_id(flox: &Flox) -> Option<Uuid> {
+    flox.metrics_device_uuid.is_some().then(Uuid::new_v4)
+}
+
 /// Identity fields for the environment the current invocation operates on.
 #[derive(Debug, Clone, Copy)]
 struct EnvIdentityFields {
     environment_id: Option<Uuid>,
     generation_number: Option<u64>,
     package_count: Option<u64>,
-}
-
-/// Process-global; resets only via [`reset_env_identity_fields`] in tests.
-static ENV_IDENTITY_FIELDS: Mutex<Option<(String, EnvIdentityFields)>> = Mutex::new(None);
-
-/// Clear the per-invocation cache so tests are isolated from each other.
-#[cfg(test)]
-fn reset_env_identity_fields() {
-    *ENV_IDENTITY_FIELDS.lock().unwrap() = None;
 }
 
 /// Read the identity fields for `env`. Every read is best-effort: a failure
@@ -166,36 +161,34 @@ fn read_env_identity_fields(flox: &Flox, env: &ConcreteEnvironment) -> EnvIdenti
         ConcreteEnvironment::Managed(environment) => environment.pointer().id,
         ConcreteEnvironment::Remote(_) => None,
     };
-    let (generation_number, package_count) = match env {
-        ConcreteEnvironment::Path(environment) => (
-            None,
-            count_packages(flox, environment.existing_lockfile(flox)),
-        ),
+    let generation_number = match env {
+        ConcreteEnvironment::Managed(environment) => environment.generation(),
+        ConcreteEnvironment::Remote(environment) => environment.generation(),
+        ConcreteEnvironment::Path(_) => Ok(None),
+    }
+    .map_err(|err| debug!(error = %err, "v2 events: could not read generation"))
+    .ok()
+    .flatten()
+    .map(|generation| *generation as u64);
+    let package_count = match env {
+        ConcreteEnvironment::Path(environment) => environment.existing_lockfile(flox),
         ConcreteEnvironment::Managed(environment) => {
-            let generation = environment
-                .generation()
-                .or_else(|| current_generation(environment));
-            (
-                generation.map(|generation| *generation as u64),
-                count_packages(
-                    flox,
-                    environment.existing_lockfile_without_checkout(generation),
-                ),
-            )
+            environment.existing_lockfile_without_checkout()
         },
         ConcreteEnvironment::Remote(environment) => {
-            let generation = environment
-                .generation()
-                .or_else(|| current_generation(environment));
-            (
-                generation.map(|generation| *generation as u64),
-                count_packages(
-                    flox,
-                    environment.existing_lockfile_without_checkout(generation),
-                ),
-            )
+            environment.existing_lockfile_without_checkout()
         },
-    };
+    }
+    .map_err(|err| debug!(error = %err, "v2 events: could not read lockfile"))
+    .ok()
+    .flatten()
+    .map(|lockfile| {
+        lockfile
+            .packages
+            .iter()
+            .filter(|package| package.system() == &flox.system)
+            .count() as u64
+    });
 
     EnvIdentityFields {
         environment_id,
@@ -204,53 +197,11 @@ fn read_env_identity_fields(flox: &Flox, env: &ConcreteEnvironment) -> EnvIdenti
     }
 }
 
-fn current_generation(env: &impl GenerationsExt) -> Option<GenerationId> {
-    env.generations_metadata()
-        .map_err(|err| debug!(error = %err, "v2 events: could not read generations metadata"))
-        .ok()
-        .and_then(|metadata| metadata.current_gen())
-}
-
-/// Packages locked for the invoking system — the `flox list` count.
-fn count_packages(
-    flox: &Flox,
-    lockfile: Result<Option<Lockfile>, EnvironmentError>,
-) -> Option<u64> {
-    lockfile
-        .map_err(|err| debug!(error = %err, "v2 events: could not read lockfile"))
-        .ok()
-        .flatten()
-        .map(|lockfile| {
-            lockfile
-                .packages
-                .iter()
-                .filter(|package| package.system() == &flox.system)
-                .count() as u64
-        })
-}
-
-/// Identity fields for `env`, computed once per invocation (keyed by the
-/// environment's kind and `.flox` path).
-fn env_identity_fields(flox: &Flox, env: &ConcreteEnvironment, key: &str) -> EnvIdentityFields {
-    let mut cached = ENV_IDENTITY_FIELDS.lock().unwrap();
-    match cached.as_ref() {
-        Some((cached_key, fields)) if cached_key == key => *fields,
-        // A second environment in the same process is computed fresh but
-        // not cached; commands operate on one environment.
-        Some(_) => read_env_identity_fields(flox, env),
-        None => {
-            let fields = read_env_identity_fields(flox, env);
-            *cached = Some((key.to_string(), fields));
-            fields
-        },
-    }
-}
-
 /// Build an [`EnvDetail`] for the supplied [`ConcreteEnvironment`], using the
 /// same env-kind / env-ref mapping as the legacy
 /// `environment_subcommand_metric!` macro. Shared across call sites so the
-/// per-kind match is not duplicated. The identity fields are skipped
-/// entirely when no events client is installed.
+/// per-kind match is not duplicated. The identity fields are only read when
+/// an events client is installed.
 pub fn env_detail_from_concrete(flox: &Flox, env: &ConcreteEnvironment) -> EnvDetail {
     let (env_kind, env_ref_or_name) = match env {
         ConcreteEnvironment::Remote(environment) => ("remote", environment.env_ref().to_string()),
@@ -260,9 +211,7 @@ pub fn env_detail_from_concrete(flox: &Flox, env: &ConcreteEnvironment) -> EnvDe
         },
     };
     let mut detail = EnvDetail::new(env_kind, env_ref_or_name);
-    if EventsHub::global().has_client() {
-        let cache_key = format!("{env_kind}:{}", env.dot_flox_path().display());
-        let fields = env_identity_fields(flox, env, &cache_key);
+    if let Some(fields) = EventsHub::global().with_client(|| read_env_identity_fields(flox, env)) {
         if let Some(environment_id) = fields.environment_id {
             detail = detail.with_environment_id(environment_id);
         }
@@ -285,11 +234,11 @@ mod tests {
     use flox_events::test_helpers::MockEventsConnection;
     use flox_events::{EVENTS_BUFFER_FILE_NAME, EventsHub, LifecycleFields};
     use flox_rust_sdk::flox::test_helpers::{flox_instance, flox_instance_with_optional_floxhub};
+    use flox_rust_sdk::models::environment::generations::GenerationId;
     use flox_rust_sdk::models::environment::managed_environment::test_helpers::{
         mock_managed_environment_in,
         mock_managed_environment_unlocked,
         with_pinned_generation,
-        with_pointer_id,
     };
     use flox_rust_sdk::models::environment::path_environment::test_helpers::new_path_environment;
     use serial_test::serial;
@@ -446,7 +395,6 @@ mod tests {
     #[test]
     #[serial(global_events_client)]
     fn env_detail_carries_identity_fields_for_path_env() {
-        reset_env_identity_fields();
         let (flox, _temp_dir_handle) = flox_instance();
         let mut env = new_path_environment(&flox, "version = 1\n");
         let environment_id = Uuid::new_v4();
@@ -485,19 +433,14 @@ mod tests {
         restore_client(previous);
     }
 
-    /// The managed arm sources the current generation when unpinned and
-    /// prefers the pin when set — without materializing the checkout.
+    /// The managed arm sources the effective generation (current when
+    /// unpinned, the pin when pinned) without materializing the checkout.
     #[test]
     #[serial(global_events_client)]
     fn env_detail_carries_identity_fields_for_managed_env() {
-        reset_env_identity_fields();
         let owner: EnvironmentOwner = "owner".parse().unwrap();
         let (flox, _temp_dir_handle) = flox_instance_with_optional_floxhub(Some(&owner));
-        let environment_id = Uuid::new_v4();
-        let env = with_pointer_id(
-            mock_managed_environment_unlocked(&flox, "version = 1\n", owner.clone()),
-            environment_id,
-        );
+        let env = mock_managed_environment_unlocked(&flox, "version = 1\n", owner.clone());
         let dot_flox_path = env.dot_flox_path().to_path_buf();
 
         let tempdir = tempfile::tempdir().expect("tempdir");
@@ -507,14 +450,13 @@ mod tests {
         let concrete = ConcreteEnvironment::Managed(env);
         let detail = serde_json::to_value(env_detail_from_concrete(&flox, &concrete))
             .expect("detail serializes");
-        // The mock generation carries no lockfile, so package_count is
-        // absent; the current generation is 1.
+        // The mock has no pointer id, no local checkout, and no lockfile in
+        // its generation: only the generation number rides.
         assert_eq!(
             detail,
             serde_json::json!({
                 "env_kind": "managed",
                 "env_ref_or_name": "owner/name",
-                "environment_id": environment_id.to_string(),
                 "generation_number": 1,
             })
         );
@@ -523,8 +465,6 @@ mod tests {
             "sourcing must not materialize the checkout"
         );
 
-        // A fresh environment (fresh dot-flox path, so a fresh cache key):
-        // the pin must win over the current generation.
         let pinned_env_dir = tempfile::tempdir().expect("tempdir");
         let pinned_env = with_pinned_generation(
             mock_managed_environment_in(
@@ -546,6 +486,17 @@ mod tests {
         );
 
         restore_client(previous);
+    }
+
+    /// Pointer ids are only minted while metrics are enabled.
+    #[test]
+    fn pointer_id_minted_only_when_metrics_enabled() {
+        let (mut flox, _temp_dir_handle) = flox_instance();
+        flox.metrics_device_uuid = None;
+        assert_eq!(new_environment_pointer_id(&flox), None);
+
+        flox.metrics_device_uuid = Some(Uuid::new_v4());
+        assert!(new_environment_pointer_id(&flox).is_some());
     }
 
     /// End-to-end: install a hub-owned client backed by a

--- a/cli/flox/src/utils/events.rs
+++ b/cli/flox/src/utils/events.rs
@@ -221,8 +221,9 @@ fn current_generation(env: &impl GenerationsExt) -> Option<GenerationId> {
         .and_then(|metadata| metadata.current_gen())
 }
 
-/// Packages locked for the invoking system (the `flox list` count), counted
-/// without cloning the package list.
+/// Packages locked for the invoking system — the same system filter as
+/// [`Lockfile::list_packages`] (the `flox list` view), counted directly so
+/// nothing is cloned and a manifest-join failure can't lose the count.
 fn count_packages(
     flox: &Flox,
     lockfile: Result<Option<Lockfile>, EnvironmentError>,

--- a/cli/flox/src/utils/events.rs
+++ b/cli/flox/src/utils/events.rs
@@ -77,6 +77,12 @@ pub fn current_invocation_id() -> Option<Uuid> {
     RESOLVED_INVOCATION_ID.get().copied()
 }
 
+/// Saturate a duration into whole ms (u64::MAX ms is ~584M years — a
+/// ceiling only).
+pub(crate) fn duration_to_ms(elapsed: std::time::Duration) -> u64 {
+    u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX)
+}
+
 /// Build the [`SharedMetadataTemplate`] stamped onto every v2 event emitted
 /// by this process. The fields mirror the legacy
 /// [`crate::utils::metrics::MetricEntry`] so downstream consumers can

--- a/cli/flox/src/utils/events.rs
+++ b/cli/flox/src/utils/events.rs
@@ -280,9 +280,17 @@ mod tests {
     use std::path::PathBuf;
 
     use flox_config::FloxConfig;
+    use flox_core::data::environment_ref::EnvironmentOwner;
     use flox_events::test_helpers::MockEventsConnection;
     use flox_events::{EVENTS_BUFFER_FILE_NAME, EventsHub, LifecycleFields};
-    use flox_rust_sdk::flox::test_helpers::flox_instance;
+    use flox_rust_sdk::flox::test_helpers::{flox_instance, flox_instance_with_optional_floxhub};
+    use flox_rust_sdk::models::environment::generations::GenerationId;
+    use flox_rust_sdk::models::environment::managed_environment::test_helpers::{
+        mock_managed_environment_in,
+        mock_managed_environment_unlocked,
+        with_pinned_generation,
+        with_pointer_id,
+    };
     use flox_rust_sdk::models::environment::path_environment::test_helpers::new_path_environment;
     use serial_test::serial;
     use temp_env::with_var;
@@ -402,27 +410,9 @@ mod tests {
         assert_eq!(client.auth_subject, None, "anonymous use stays anonymous");
     }
 
-    /// The env-detail identity fields ride for a path environment with a
-    /// pointer id — and the sourcing is skipped entirely when no events
-    /// client is installed.
-    #[test]
-    #[serial(global_events_client)]
-    fn env_detail_carries_identity_fields_for_path_env() {
-        let (flox, _temp_dir_handle) = flox_instance();
-        let mut env = new_path_environment(&flox, "version = 1\n");
-        let environment_id = Uuid::new_v4();
-        env.pointer.id = Some(environment_id);
-        env.lockfile(&flox).unwrap();
-        let concrete = ConcreteEnvironment::Path(env);
-
-        // No client installed: recording is a no-op, so nothing is sourced.
-        let previous = EventsHub::global().clear_client();
-        let detail = serde_json::to_value(env_detail_from_concrete(&flox, &concrete))
-            .expect("detail serializes");
-        assert_eq!(detail.get("environment_id"), None);
-        assert_eq!(detail.get("package_count"), None);
-
-        let tempdir = tempfile::tempdir().expect("tempdir");
+    /// Install a mock client on the global hub; returns whatever client
+    /// was installed before so callers can restore it.
+    fn install_mock_client(tempdir: &TempDir) -> Option<EventsClient> {
         let template = SharedMetadataTemplate {
             flox_version: "0.0.0-test".to_string(),
             os_family: None,
@@ -440,21 +430,120 @@ mod tests {
             template,
             MockEventsConnection::default(),
         );
-        EventsHub::global().set_client(client);
+        EventsHub::global().set_client(client)
+    }
 
-        let detail = serde_json::to_value(env_detail_from_concrete(&flox, &concrete))
-            .expect("detail serializes");
-        assert_eq!(
-            detail.get("environment_id"),
-            Some(&serde_json::json!(environment_id.to_string()))
-        );
-        assert_eq!(detail.get("generation_number"), None, "path envs have none");
-        assert_eq!(detail.get("package_count"), Some(&serde_json::json!(0)));
-
+    fn restore_client(previous: Option<EventsClient>) {
         EventsHub::global().clear_client();
         if let Some(previous) = previous {
             EventsHub::global().set_client(previous);
         }
+    }
+
+    /// The env-detail identity fields ride for a path environment with a
+    /// pointer id — and the sourcing is skipped entirely when no events
+    /// client is installed.
+    #[test]
+    #[serial(global_events_client)]
+    fn env_detail_carries_identity_fields_for_path_env() {
+        let (flox, _temp_dir_handle) = flox_instance();
+        let mut env = new_path_environment(&flox, "version = 1\n");
+        let environment_id = Uuid::new_v4();
+        env.pointer.id = Some(environment_id);
+        env.lockfile(&flox).unwrap();
+        let name = Environment::name(&env).to_string();
+        let concrete = ConcreteEnvironment::Path(env);
+
+        // No client installed: recording is a no-op, so nothing is sourced.
+        let previous = EventsHub::global().clear_client();
+        let detail = serde_json::to_value(env_detail_from_concrete(&flox, &concrete))
+            .expect("detail serializes");
+        assert_eq!(
+            detail,
+            serde_json::json!({
+                "env_kind": "path",
+                "env_ref_or_name": name,
+            })
+        );
+
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        install_mock_client(&tempdir);
+
+        let detail = serde_json::to_value(env_detail_from_concrete(&flox, &concrete))
+            .expect("detail serializes");
+        assert_eq!(
+            detail,
+            serde_json::json!({
+                "env_kind": "path",
+                "env_ref_or_name": name,
+                "environment_id": environment_id.to_string(),
+                "package_count": 0,
+            })
+        );
+
+        restore_client(previous);
+    }
+
+    /// The managed arm sources the current generation when unpinned and
+    /// prefers the pin when set — without materializing the checkout.
+    #[test]
+    #[serial(global_events_client)]
+    fn env_detail_carries_identity_fields_for_managed_env() {
+        let owner: EnvironmentOwner = "owner".parse().unwrap();
+        let (flox, _temp_dir_handle) = flox_instance_with_optional_floxhub(Some(&owner));
+        let environment_id = Uuid::new_v4();
+        let env = with_pointer_id(
+            mock_managed_environment_unlocked(&flox, "version = 1\n", owner.clone()),
+            environment_id,
+        );
+        let dot_flox_path = env.dot_flox_path().to_path_buf();
+
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let previous = EventsHub::global().clear_client();
+        install_mock_client(&tempdir);
+
+        let concrete = ConcreteEnvironment::Managed(env);
+        let detail = serde_json::to_value(env_detail_from_concrete(&flox, &concrete))
+            .expect("detail serializes");
+        // The mock generation carries no lockfile, so package_count is
+        // absent; the current generation is 1.
+        assert_eq!(
+            detail,
+            serde_json::json!({
+                "env_kind": "managed",
+                "env_ref_or_name": "owner/name",
+                "environment_id": environment_id.to_string(),
+                "generation_number": 1,
+            })
+        );
+        assert!(
+            !dot_flox_path.join("env").exists(),
+            "sourcing must not materialize the checkout"
+        );
+
+        // A fresh environment (fresh dot-flox path, so a fresh cache key):
+        // the pin must win over the current generation.
+        let pinned_env_dir = tempfile::tempdir().expect("tempdir");
+        let pinned_env = with_pinned_generation(
+            mock_managed_environment_in(
+                &flox,
+                "version = 1\n",
+                owner,
+                pinned_env_dir.path(),
+                Some("name2"),
+            ),
+            GenerationId::from(5_usize),
+        );
+        let concrete = ConcreteEnvironment::Managed(pinned_env);
+        let detail = serde_json::to_value(env_detail_from_concrete(&flox, &concrete))
+            .expect("detail serializes");
+        assert_eq!(
+            detail.get("generation_number"),
+            Some(&serde_json::json!(5)),
+            "the pin wins over the current generation"
+        );
+
+        restore_client(previous);
     }
 
     /// End-to-end: install a hub-owned client backed by a

--- a/cli/flox/src/utils/events.rs
+++ b/cli/flox/src/utils/events.rs
@@ -141,10 +141,7 @@ pub fn build_events_client(
     ))
 }
 
-/// The identity fields for the environment the current invocation operates
-/// on, read once at the first environment event and reused by later emits of
-/// the same command so the generation and lockfile reads don't repeat on
-/// multi-emit paths like `activate`.
+/// Identity fields for the environment the current invocation operates on.
 #[derive(Debug, Clone, Copy)]
 struct EnvIdentityFields {
     environment_id: Option<Uuid>,
@@ -162,20 +159,13 @@ fn reset_env_identity_fields() {
 }
 
 /// Read the identity fields for `env`. Every read is best-effort: a failure
-/// leaves the field absent, never fails the command. At most one
-/// generations-metadata read and one lockfile read happen here.
+/// leaves the field absent, never fails the command.
 fn read_env_identity_fields(flox: &Flox, env: &ConcreteEnvironment) -> EnvIdentityFields {
     let environment_id = match env {
         ConcreteEnvironment::Path(environment) => environment.pointer.id,
         ConcreteEnvironment::Managed(environment) => environment.pointer().id,
-        // The cached pointer of a remote environment is rewritten on every
-        // invocation, so it carries no stable id.
         ConcreteEnvironment::Remote(_) => None,
     };
-    // A command opened at a pinned generation acts on that generation;
-    // only unpinned managed/remote environments read the branch tip. The
-    // resolved generation feeds the lockfile read so the metadata isn't
-    // read twice.
     let (generation_number, package_count) = match env {
         ConcreteEnvironment::Path(environment) => (
             None,
@@ -216,20 +206,18 @@ fn read_env_identity_fields(flox: &Flox, env: &ConcreteEnvironment) -> EnvIdenti
 
 fn current_generation(env: &impl GenerationsExt) -> Option<GenerationId> {
     env.generations_metadata()
-        .map_err(|err| debug!(error = %err, "could not read generations metadata for event"))
+        .map_err(|err| debug!(error = %err, "v2 events: could not read generations metadata"))
         .ok()
         .and_then(|metadata| metadata.current_gen())
 }
 
-/// Packages locked for the invoking system — the same system filter as
-/// [`Lockfile::list_packages`] (the `flox list` view), counted directly so
-/// nothing is cloned and a manifest-join failure can't lose the count.
+/// Packages locked for the invoking system — the `flox list` count.
 fn count_packages(
     flox: &Flox,
     lockfile: Result<Option<Lockfile>, EnvironmentError>,
 ) -> Option<u64> {
     lockfile
-        .map_err(|err| debug!(error = %err, "could not read lockfile for event"))
+        .map_err(|err| debug!(error = %err, "v2 events: could not read lockfile"))
         .ok()
         .flatten()
         .map(|lockfile| {


### PR DESCRIPTION
# feat(events): environment-creation and build-outcome telemetry

> Stacked on #4541 (environment identity); retarget to `main` when it
> merges.

Two related, additive telemetry changes that close the remaining P0
"Environment Events" gaps: a new `cli.environment.create` event at
environment creation, and build-outcome fields on the existing
`cli.build` event. Both are purely additive — the existing metrics
emission (including the legacy stream) is unchanged. Two commits, one
per change; review top-to-bottom.

## Commit 1 — `cli.environment.create` at environment creation

The `cli.environment.*` event family covers every mutating verb —
install, edit, push, pull, delete — except the one that starts an
environment's life. This adds `cli.environment.create`, emitted
once when an environment is successfully created.

- **feat(events): emit cli.environment.create at environment creation**

  There are three places the CLI creates an environment, and all three
  now emit the event at their success point:

  1. `flox init` (path arm, `init_local_environment`) — the event
     carries `env_kind: "path"` and, because init mints the
     environment id introduced in #4541, `environment_id` — so a
     fresh environment's id is observable from its first event
     onward. The created `PathEnvironment` is wrapped in
     `ConcreteEnvironment::Path` once and the binding reused for the
     existing `environment_description` call; no behavior change.
  2. `flox init -r owner/name` (FloxHub arm,
     `init_floxhub_environment_decorated`) — binds the validated
     `RemoteEnvironment` the SDK call already returns (previously
     discarded) and emits with `env_kind: "remote"`. Remote
     environments carry no `environment_id`, consistent with every
     other remote event (see #4541's pointer-id semantics).
  3. The `flox install` first-run flow
     (`try_create_default_environment_interactive`) — this path
     creates a default FloxHub environment for users who accept the
     prompt, via the same `init_floxhub_environment` SDK call as arm
     2. Only the `UpstreamNotFound` match arm creates; the
     `Ok(existing_env)` arm opens an environment that already exists
     upstream and deliberately does not emit. That asymmetry also
     covers the retry path: if creation succeeds but the user-state
     write afterwards fails, the next attempt finds the environment
     upstream and takes the no-emit arm, so no duplicate create
     event is recorded. The match arms now return a created flag and
     the `ConcreteEnvironment::Remote` wrap moves before the
     user-state write so the emit sits directly at the success point.

  The payload is the existing `CliEnvironmentPayload` (no new struct;
  the enum variant is the discriminant, per the enum's convention),
  and emission follows the established best-effort discipline: a
  failed record logs at debug and never fails the command. Failure
  paths (init errors, auth failures, declined prompt) emit nothing —
  only a successful creation emits. Known limitation: on the FloxHub
  arms, if the SDK pushes the environment upstream but then fails its
  post-push validation, the command errors before the emit and a
  later retry takes the already-exists arm — so that rare
  partial-failure window undercounts creations. Emitting from inside
  the SDK to close it would break this PR's CLI-only emission
  boundary; left as a follow-up.

  The FloxHub-arm test `init_floxhub_environment_initializes_and_prints_message`
  now records against the process-global events hub, so it carries the
  `#[serial(global_events_client)]` marker the other hub-touching
  tests use — without it, its create event could land in a concurrent
  mock-client test and flake CI.

  Wire shape locked by a new golden,
  `cli_environment_create_envelope_golden` (path kind with
  `environment_id` present — the one payload shape no sibling golden
  pins). Verified by `cargo clippy --workspace --tests --no-deps --
  -D warnings` (clean), `cargo fmt --check` (clean), and `flox` +
  `flox-events` 491/491. (The `flox-rust-sdk` git-backed tests
  `floxmeta_branch` / `providers::git` flake under parallel nextest —
  they fail identically on `main` without this change and pass in
  isolation and under `--test-threads 1`.)

  Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

## Commit 2 — build outcome on `cli.build`

- **feat(events): add build outcome fields to cli.build**

  Today `cli.build` fires *before* the build runs, carrying only the
  two build-kind flags — it can't say whether the build succeeded or
  how long it took. This relocates the emit to after the build step
  and adds four optional fields to `CliBuildPayload`. Field names
  follow the existing telemetry vocabulary — `outcome` (as on
  `cli.package.*`), `duration_ms` and `error_kind` (as on
  `cli.command_completed`) — discriminated by `event_type`, not by a
  domain prefix:

  - `outcome` — `success` / `failure` (`BuildOutcome`, paralleling
    `PackageOutcome`'s wire values). Note: an *interrupted* build
    (Ctrl-C) or a panic mid-build emits no `cli.build` at all — this
    is an outcome event, and an interrupted build has no outcome; the
    v1 stream still counts the attempt.
  - `duration_ms` — times only the `builder.build()` call, reusing the
    `duration_to_ms` helper (moved from `main.rs` to `utils::events`
    now that it has a second consumer).
  - `error_kind` — on failure, the classified `ManifestBuilderError`
    variant slug via a namespaced strum derive
    (`#[strum(serialize_all = "snake_case", prefix = "build.")]`, e.g.
    `build.build_failure`). It is the variant *name* only —
    structurally never the error message or build output, which can
    contain paths or secrets. Same namespaced-slug scheme as
    `cli.command_completed`'s `error_kind` (`environment.*`,
    `service.*`). This is also the *only* place the specific
    build-failure class surfaces: `ManifestBuilderError` isn't in
    `main.rs`'s `error_kind` ladder, so the invocation's
    `cli.command_completed.error_kind` is `uncategorized` for a build
    failure — the two are complementary, not redundant.
  - `lockfile_hash` — a blake3 fingerprint of the locked state
    actually built. It hashes the in-memory `Lockfile` used for this
    build (which `env.lockfile()` may re-lock to differ from disk), so
    it is the right identity for "what was built" — but note it is a
    fingerprint of the CLI's canonical serialization, **stable within a
    CLI version**, not a hash of the on-disk `lockfile.json` bytes and
    not a durable cross-version identity. Deterministic within a
    version because the lockfile serializes through ordered maps.

  The build error is re-propagated unchanged after emission (exit code
  and message identical), and the v1 `subcommand_metric!` stays where
  it is. Fields are optional/skip-if-none, so old buffered rows stay
  valid.

  Wire shape locked by two new goldens — `cli_build_success_envelope_golden`
  (status/duration/hash, no error) and `cli_build_failure_envelope_golden`
  (a representative failure row: status/duration/hash/error slug) —
  plus the retained bare golden for the skip-if-none / old-row shape,
  plus an SDK test
  (`manifest_builder_error_slugs_are_namespaced`) pinning the slug
  taxonomy against a variant rename. Verified: `cargo clippy
  --workspace --tests --no-deps -- -D warnings` clean, `cargo fmt
  --check` clean, `flox` + `flox-events` 491/491, `flox-rust-sdk`
  build module green.

  Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
