### PR TITLE
feat(cli): support deleting the local copy of a remote environment

### DIFF
--- a/.github/CONTRIBUTORS.csv
+++ b/.github/CONTRIBUTORS.csv
@@ -30,3 +30,4 @@ yes,noor-latif,Noor Latif,<noor@latif.se>
 yes,martijnarts,Martijn Arts,<martijn@martijnarts.com>
 yes,electricalen,David Sawyer,<electricalen@gmail.com>
 yes,jsoref,Josh Soref,<jsoref@gmail.com>
+yes,imkarrer,Isaac Karrer,<isaac.karrer@gmail.com>

--- a/.github/CONTRIBUTORS.csv
+++ b/.github/CONTRIBUTORS.csv
@@ -31,3 +31,4 @@ yes,martijnarts,Martijn Arts,<martijn@martijnarts.com>
 yes,electricalen,David Sawyer,<electricalen@gmail.com>
 yes,jsoref,Josh Soref,<jsoref@gmail.com>
 yes,esteve,Esteve Fernández,<github@nara.ac>
+yes,imkarrer,Isaac Karrer,<isaac.karrer@gmail.com>

--- a/cli/flox-core/src/data/environment_ref.rs
+++ b/cli/flox-core/src/data/environment_ref.rs
@@ -11,6 +11,18 @@ use thiserror::Error;
 pub static DEFAULT_NAME: &str = "default";
 pub static DEFAULT_OWNER: &str = "local";
 
+/// Whether `s` is usable as a single owner or name component.
+///
+/// Owners and names are interpolated directly into filesystem paths — most
+/// visibly the local checkout at `<cache>/remote/<owner>/<name>` — so the
+/// components that carry meaning to the filesystem are rejected here, at the
+/// parse boundary, rather than left for each consumer to re-check. `..` is the
+/// one that matters: `PathBuf::join` does not normalize it, so it would
+/// otherwise resolve outside the directory the reference names.
+fn is_valid_component(s: &str) -> bool {
+    !s.is_empty() && !s.contains([' ', '/']) && s != "." && s != ".."
+}
+
 #[derive(
     Debug,
     Clone,
@@ -32,7 +44,7 @@ impl FromStr for EnvironmentOwner {
     type Err = RemoteEnvironmentRefError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if [' ', '/'].iter().any(|c| s.contains(*c)) {
+        if !is_valid_component(s) {
             Err(RemoteEnvironmentRefError::InvalidOwner(s.to_string()))?
         }
 
@@ -48,7 +60,10 @@ impl proptest::arbitrary::Arbitrary for EnvironmentName {
     fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
         use proptest::prelude::Strategy;
 
-        "[^ /]".prop_map(|s| EnvironmentName(s.to_string())).boxed()
+        // Leading character excludes '.' so the strategy can never produce
+        // the `.` / `..` that `is_valid_component` rejects, while still
+        // covering dots elsewhere in the component.
+        "[^ /.][^ /]{0,7}".prop_map(EnvironmentName).boxed()
     }
 }
 
@@ -72,7 +87,7 @@ impl FromStr for EnvironmentName {
     type Err = RemoteEnvironmentRefError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if [' ', '/'].iter().any(|c| s.contains(*c)) {
+        if !is_valid_component(s) {
             Err(RemoteEnvironmentRefError::InvalidName(s.to_string()))?
         }
 
@@ -88,9 +103,8 @@ impl proptest::arbitrary::Arbitrary for EnvironmentOwner {
     fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
         use proptest::prelude::Strategy;
 
-        "[^ /]"
-            .prop_map(|s| EnvironmentOwner(s.to_string()))
-            .boxed()
+        // See the note on `EnvironmentName`'s strategy.
+        "[^ /.][^ /]{0,7}".prop_map(EnvironmentOwner).boxed()
     }
 }
 
@@ -143,12 +157,12 @@ impl JsonSchema for RemoteEnvironmentRef {
 #[derive(Error, Debug)]
 pub enum RemoteEnvironmentRefError {
     #[error(
-        "Name '{0}' is invalid.\nEnvironment names may only contain alphanumeric characters, '.', '_', and '-'."
+        "Name '{0}' is invalid.\nEnvironment names cannot be empty, '.' or '..', and cannot contain spaces or '/'."
     )]
     InvalidName(String),
 
     #[error(
-        "Owner '{0}' is invalid.\nEnvironment owners may only contain alphanumeric characters, '.', '_', and '-'."
+        "Owner '{0}' is invalid.\nEnvironment owners cannot be empty, '.' or '..', and cannot contain spaces or '/'."
     )]
     InvalidOwner(String),
 }
@@ -199,5 +213,36 @@ impl ActivateEnvironmentRef {
                 format!("-r {}", escape(remote.to_string().into()))
             },
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A reference is interpolated into a filesystem path, so a component that
+    /// traverses out of that path must not parse in the first place.
+    #[test]
+    fn rejects_path_traversing_references() {
+        for reference in ["../scratch", "owner/..", "./x", "x/.", "/name", "owner/"] {
+            assert!(
+                RemoteEnvironmentRef::from_str(reference).is_err(),
+                "'{reference}' should not parse as an environment reference"
+            );
+        }
+    }
+
+    #[test]
+    fn accepts_ordinary_references() {
+        assert_eq!(
+            RemoteEnvironmentRef::from_str("owner/name").unwrap(),
+            RemoteEnvironmentRef::new("owner", "name").unwrap()
+        );
+        // A leading dot is only a problem when the component is exactly `.`
+        // or `..`, so hidden-looking names stay valid.
+        assert_eq!(
+            RemoteEnvironmentRef::from_str(".owner/..name").unwrap(),
+            RemoteEnvironmentRef::new(".owner", "..name").unwrap()
+        );
     }
 }

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -28,6 +28,7 @@ use super::{
     EditResult,
     Environment,
     EnvironmentError,
+    EnvironmentPointer,
     GCROOTS_DIR_NAME,
     InstallationAttempt,
     ManagedPointer,
@@ -35,17 +36,20 @@ use super::{
     UninstallationAttempt,
 };
 use crate::flox::Flox;
+use crate::models::env_registry::{EnvRegistryError, deregister};
 use crate::models::environment::PathPointer;
 use crate::models::environment::floxmeta_branch::{
     BranchOrd,
     FloxmetaBranch,
     FloxmetaBranchError,
     GenerationLock,
+    prune_branches_from_floxmeta_by_pointer,
     write_generation_lock,
 };
 use crate::models::environment::generations::SyncToGenerationResult;
 use crate::models::environment::managed_environment::GENERATION_LOCK_FILENAME;
 use crate::models::environment::path_environment::{InitCustomization, PathEnvironment};
+use crate::models::floxmeta::{FloxMeta, FloxMetaError};
 use crate::providers::lock_manifest::LockResult;
 
 const REMOTE_ENVIRONMENT_BASE_DIR: &str = "remote";
@@ -86,6 +90,15 @@ pub enum RemoteEnvironmentError {
 
     #[error("generations error")]
     Generations(#[source] GenerationsError),
+
+    #[error("could not deregister local copy of environment")]
+    DeregisterLocalCheckout(#[source] EnvRegistryError),
+
+    #[error("could not delete local copy of environment")]
+    DeleteLocalCheckout(#[source] std::io::Error),
+
+    #[error("could not prune local metadata for environment")]
+    PruneFloxmetaBranch(#[source] FloxMetaError),
 }
 
 #[derive(Debug)]
@@ -113,6 +126,54 @@ impl RemoteEnvironment {
     /// I.e. whether there is a backing managed environment in the cache.
     pub fn is_cached(flox: &Flox, pointer: &ManagedPointer) -> bool {
         Self::checkout_path(flox, pointer).join(DOT_FLOX).exists()
+    }
+
+    /// Delete the local copy of a remote environment cached at
+    /// [RemoteEnvironment::checkout_path].
+    ///
+    /// This removes the checkout created by `flox activate --reference` /
+    /// `flox pull --reference`, prunes the per-checkout branch from the local
+    /// floxmeta repository, and deregisters it from the environment registry,
+    /// **without** deleting the upstream environment on FloxHub.
+    ///
+    /// This is a purely local filesystem operation: it neither requires
+    /// network access nor that the checkout still be openable, so it can clean
+    /// up a cached copy even when it can no longer be activated. Metadata
+    /// cleanup is best-effort — if no local floxmeta exists (e.g. a broken
+    /// copy), there is simply nothing to prune.
+    pub fn delete_local_checkout(
+        flox: &Flox,
+        pointer: &ManagedPointer,
+    ) -> Result<(), RemoteEnvironmentError> {
+        let checkout_path = Self::checkout_path(flox, pointer);
+        let dot_flox_path = checkout_path.join(DOT_FLOX);
+
+        // Prune the per-checkout floxmeta branch and deregister the checkout
+        // while its `.flox` still exists, since both key off the hash of the
+        // canonicalized path. Branch pruning stays local: `FloxMeta::open_local`
+        // never contacts FloxHub, and a missing floxmeta (e.g. a broken cached
+        // copy) simply leaves nothing to prune.
+        if let Ok(canonical_dot_flox) = CanonicalPath::new(&dot_flox_path) {
+            if let Ok(mut floxmeta) = FloxMeta::open_local(flox, pointer) {
+                prune_branches_from_floxmeta_by_pointer(
+                    &mut floxmeta,
+                    pointer,
+                    &canonical_dot_flox,
+                )
+                .map_err(RemoteEnvironmentError::PruneFloxmetaBranch)?;
+            }
+
+            deregister(
+                flox,
+                &canonical_dot_flox,
+                &EnvironmentPointer::Managed(pointer.clone()),
+            )
+            .map_err(RemoteEnvironmentError::DeregisterLocalCheckout)?;
+        }
+
+        fs::remove_dir_all(&checkout_path).map_err(RemoteEnvironmentError::DeleteLocalCheckout)?;
+
+        Ok(())
     }
 
     /// Pull a remote environment into a flox-provided managed environment
@@ -713,6 +774,48 @@ mod tests {
                 .as_writable()
                 .to_string(),
             with_latest_schema("")
+        );
+    }
+
+    /// Deleting the local checkout removes the cached copy and prunes the
+    /// per-checkout floxmeta branch, without requiring the upstream environment
+    /// (which is untouched here).
+    #[test]
+    fn delete_local_checkout_removes_cached_copy() {
+        use crate::models::environment::floxmeta_branch::branch_name;
+
+        let owner = EnvironmentOwner::from_str("test").unwrap();
+        let name = EnvironmentName::from_str("foo").unwrap();
+        let env_ref = RemoteEnvironmentRef::new_from_parts(owner.clone(), name.clone());
+
+        let (flox, _tempdir_handle) = flox_instance_with_optional_floxhub(Some(&owner));
+        RemoteEnvironment::init_floxhub_environment(&flox, env_ref, true).unwrap();
+
+        let pointer = ManagedPointer::new(owner, name, &flox.floxhub);
+
+        // Materialize the local checkout at `checkout_path`.
+        RemoteEnvironment::new(&flox, pointer.clone(), None).expect("cache remote environment");
+        assert!(RemoteEnvironment::is_cached(&flox, &pointer));
+
+        // The cached copy has a per-checkout branch in the local floxmeta repo.
+        let dot_flox =
+            CanonicalPath::new(RemoteEnvironment::checkout_path(&flox, &pointer).join(DOT_FLOX))
+                .expect("cached checkout has a .flox directory");
+        let branch = branch_name(&pointer, &dot_flox);
+        let floxmeta = FloxMeta::open_local(&flox, &pointer).expect("local floxmeta exists");
+        assert!(
+            floxmeta.git.has_branch(&branch).unwrap(),
+            "per-checkout branch should exist before deletion"
+        );
+
+        RemoteEnvironment::delete_local_checkout(&flox, &pointer).expect("delete local checkout");
+        assert!(!RemoteEnvironment::is_cached(&flox, &pointer));
+
+        // The per-checkout branch was pruned; the floxmeta repo itself remains.
+        let floxmeta = FloxMeta::open_local(&flox, &pointer).expect("local floxmeta still exists");
+        assert!(
+            !floxmeta.git.has_branch(&branch).unwrap(),
+            "per-checkout branch should be pruned after deletion"
         );
     }
 

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -7,7 +7,7 @@ use flox_manifest::lockfile::Lockfile;
 use flox_manifest::raw::PackageToInstall;
 use flox_manifest::{Manifest, Migrated, Validated};
 use thiserror::Error;
-use tracing::debug;
+use tracing::{debug, warn};
 
 use super::core_environment::UpgradeResult;
 use super::fetcher::IncludeFetcher;
@@ -24,10 +24,12 @@ use super::{
     CanonicalPath,
     CanonicalizeError,
     DOT_FLOX,
+    DotFlox,
     ENVIRONMENT_POINTER_FILENAME,
     EditResult,
     Environment,
     EnvironmentError,
+    EnvironmentPointer,
     GCROOTS_DIR_NAME,
     InstallationAttempt,
     ManagedPointer,
@@ -35,17 +37,20 @@ use super::{
     UninstallationAttempt,
 };
 use crate::flox::Flox;
+use crate::models::env_registry::{EnvRegistryError, deregister};
 use crate::models::environment::PathPointer;
 use crate::models::environment::floxmeta_branch::{
     BranchOrd,
     FloxmetaBranch,
     FloxmetaBranchError,
     GenerationLock,
+    prune_branches_from_floxmeta_by_pointer,
     write_generation_lock,
 };
 use crate::models::environment::generations::SyncToGenerationResult;
 use crate::models::environment::managed_environment::GENERATION_LOCK_FILENAME;
 use crate::models::environment::path_environment::{InitCustomization, PathEnvironment};
+use crate::models::floxmeta::{FloxMeta, FloxMetaError};
 use crate::providers::lock_manifest::LockResult;
 
 const REMOTE_ENVIRONMENT_BASE_DIR: &str = "remote";
@@ -86,6 +91,9 @@ pub enum RemoteEnvironmentError {
 
     #[error("generations error")]
     Generations(#[source] GenerationsError),
+
+    #[error("could not delete local copy of environment")]
+    DeleteLocalCheckout(#[source] std::io::Error),
 }
 
 #[derive(Debug)]
@@ -113,6 +121,110 @@ impl RemoteEnvironment {
     /// I.e. whether there is a backing managed environment in the cache.
     pub fn is_cached(flox: &Flox, pointer: &ManagedPointer) -> bool {
         Self::checkout_path(flox, pointer).join(DOT_FLOX).exists()
+    }
+
+    /// Check whether anything is present at [RemoteEnvironment::checkout_path].
+    ///
+    /// Weaker than [RemoteEnvironment::is_cached], which additionally requires
+    /// a `.flox` inside the checkout. Deletion gates on this so that a
+    /// directory left behind by a half-finished checkout — the case a user is
+    /// most likely to be cleaning up after — is still removable.
+    pub fn local_checkout_exists(flox: &Flox, pointer: &ManagedPointer) -> bool {
+        Self::checkout_path(flox, pointer).exists()
+    }
+
+    /// Delete the local copy of a remote environment cached at
+    /// [RemoteEnvironment::checkout_path].
+    ///
+    /// This removes the checkout created by `flox activate --reference` /
+    /// `flox pull --reference`, prunes the per-checkout branch from the local
+    /// floxmeta repository, and deregisters it from the environment registry,
+    /// **without** deleting the upstream environment on FloxHub.
+    ///
+    /// This is a purely local filesystem operation: it neither requires
+    /// network access nor that the checkout still be openable, so it can clean
+    /// up a cached copy even when it can no longer be activated.
+    ///
+    /// Removing the checkout is the operation that must succeed; the metadata
+    /// cleanup that follows is best-effort and only warns. Ordering matters
+    /// both ways round. Doing the removal first means a missing or damaged
+    /// registry entry cannot strand a directory the user asked to delete, and
+    /// leaving the registry entry behind on a later failure is recoverable —
+    /// [`EnvRegistry::prune_nonexistent`] sweeps entries whose path is gone,
+    /// so a stale entry is collected on the next `flox envs`. The reverse
+    /// order has no such safety net: an entry deregistered before a failed
+    /// removal leaves a directory nothing will ever reclaim.
+    ///
+    /// [`EnvRegistry::prune_nonexistent`]: crate::models::env_registry::EnvRegistry
+    pub fn delete_local_checkout(
+        flox: &Flox,
+        pointer: &ManagedPointer,
+    ) -> Result<(), RemoteEnvironmentError> {
+        let checkout_path = Self::checkout_path(flox, pointer);
+
+        // Canonicalize `.flox` up front: the floxmeta branch name and the
+        // registry key both derive from the hash of the canonicalized path,
+        // which can no longer be resolved once the directory is gone.
+        let canonical_dot_flox = CanonicalPath::new(checkout_path.join(DOT_FLOX)).ok();
+
+        // Deregistration matches on the whole pointer, including the FloxHub
+        // URL, so prefer the one recorded in the checkout over the caller's,
+        // which is built from current configuration and stops matching if that
+        // configuration changed since the checkout was created. Reading it is
+        // local and optional: an unreadable `.flox` falls back to the caller's
+        // pointer, and the deregistration below tolerates a miss either way.
+        let registered_pointer = DotFlox::open_in(&checkout_path)
+            .ok()
+            .and_then(|dot_flox| match dot_flox.pointer {
+                EnvironmentPointer::Managed(pointer) => Some(pointer),
+                EnvironmentPointer::Path(_) => None,
+            })
+            .unwrap_or_else(|| pointer.clone());
+
+        fs::remove_dir_all(&checkout_path).map_err(RemoteEnvironmentError::DeleteLocalCheckout)?;
+
+        // Nothing keyed off the checkout to clean up: a directory without a
+        // `.flox` was never registered and never had a branch.
+        let Some(canonical_dot_flox) = canonical_dot_flox else {
+            return Ok(());
+        };
+
+        // Branch pruning stays local — `FloxMeta::open_local` never contacts
+        // FloxHub. Distinguish a missing floxmeta, which is simply nothing to
+        // prune, from a damaged one, which the user should hear about.
+        let pruned = FloxMeta::open_local(flox, pointer).and_then(|mut floxmeta| {
+            prune_branches_from_floxmeta_by_pointer(&mut floxmeta, pointer, &canonical_dot_flox)
+        });
+        match pruned {
+            Ok(()) => {},
+            Err(FloxMetaError::NotFound(_)) => {},
+            Err(err) => warn!(
+                %err,
+                owner = %pointer.owner,
+                name = %pointer.name,
+                "failed to prune floxmeta branches for deleted local checkout"
+            ),
+        }
+
+        match deregister(
+            flox,
+            &canonical_dot_flox,
+            &EnvironmentPointer::Managed(registered_pointer),
+        ) {
+            Ok(()) => {},
+            // The checkout was never registered, or was registered under a
+            // different pointer (e.g. a different FloxHub host). Either way
+            // there is no entry of ours left to remove.
+            Err(EnvRegistryError::UnknownKey(_) | EnvRegistryError::EnvNotRegistered) => {},
+            Err(err) => warn!(
+                %err,
+                owner = %pointer.owner,
+                name = %pointer.name,
+                "failed to deregister deleted local checkout"
+            ),
+        }
+
+        Ok(())
     }
 
     /// Pull a remote environment into a flox-provided managed environment
@@ -621,12 +733,16 @@ mod tests {
     use flox_manifest::test_helpers::with_latest_schema;
     use flox_test_utils::GENERATED_DATA;
     use indoc::indoc;
+    use tempfile::TempDir;
 
     use super::test_helpers::mock_remote_environment;
     use super::*;
     use crate::flox::test_helpers::flox_instance_with_optional_floxhub;
+    use crate::models::env_registry::{EnvRegistry, env_registry_path, read_environment_registry};
+    use crate::models::environment::floxmeta_branch::branch_name;
     use crate::models::environment::generations::HistoryKind;
     use crate::models::environment::managed_environment::test_helpers::mock_managed_environment_from_env_files;
+    use crate::models::environment::path_hash;
     use crate::providers::lock_manifest::RecoverableMergeError;
 
     #[test]
@@ -724,6 +840,127 @@ mod tests {
                 .to_string(),
             with_latest_schema("")
         );
+    }
+
+    /// State a deletion test asserts against, for a materialized local checkout
+    /// of the remote environment `test/foo`.
+    struct CachedCheckout {
+        flox: Flox,
+        _tempdir_handle: TempDir,
+        pointer: ManagedPointer,
+        /// The per-checkout floxmeta branch that deletion should prune.
+        branch: String,
+        /// Registry key for the checkout. The upstream fixture registers
+        /// itself under a separate key, so deregistration is asserted against
+        /// this entry rather than against an empty registry.
+        dot_flox_hash: String,
+    }
+
+    fn cached_remote_checkout() -> CachedCheckout {
+        let owner = EnvironmentOwner::from_str("test").unwrap();
+        let name = EnvironmentName::from_str("foo").unwrap();
+        let env_ref = RemoteEnvironmentRef::new_from_parts(owner.clone(), name.clone());
+
+        let (flox, tempdir_handle) = flox_instance_with_optional_floxhub(Some(&owner));
+        RemoteEnvironment::init_floxhub_environment(&flox, env_ref, true).unwrap();
+
+        let pointer = ManagedPointer::new(owner, name, &flox.floxhub);
+        RemoteEnvironment::new(&flox, pointer.clone(), None).expect("cache remote environment");
+        assert!(RemoteEnvironment::is_cached(&flox, &pointer));
+
+        let dot_flox =
+            CanonicalPath::new(RemoteEnvironment::checkout_path(&flox, &pointer).join(DOT_FLOX))
+                .expect("cached checkout has a .flox directory");
+        let branch = branch_name(&pointer, &dot_flox);
+        let dot_flox_hash = path_hash(&dot_flox);
+
+        CachedCheckout {
+            flox,
+            _tempdir_handle: tempdir_handle,
+            pointer,
+            branch,
+            dot_flox_hash,
+        }
+    }
+
+    fn registry(flox: &Flox) -> EnvRegistry {
+        read_environment_registry(env_registry_path(flox))
+            .expect("registry is readable")
+            .unwrap_or_default()
+    }
+
+    /// Deleting the local checkout removes the cached copy, prunes the
+    /// per-checkout floxmeta branch, and deregisters the checkout, without
+    /// requiring the upstream environment (which is untouched here).
+    #[test]
+    fn delete_local_checkout_removes_cached_copy() {
+        let checkout = cached_remote_checkout();
+        let CachedCheckout {
+            ref flox,
+            ref pointer,
+            ref branch,
+            ref dot_flox_hash,
+            ..
+        } = checkout;
+
+        let floxmeta = FloxMeta::open_local(flox, pointer).expect("local floxmeta exists");
+        assert!(
+            floxmeta.git.has_branch(branch).unwrap(),
+            "per-checkout branch should exist before deletion"
+        );
+        assert!(
+            registry(flox).entry_for_hash(dot_flox_hash).is_some(),
+            "the checkout should be registered before deletion"
+        );
+
+        RemoteEnvironment::delete_local_checkout(flox, pointer).expect("delete local checkout");
+
+        assert!(!RemoteEnvironment::local_checkout_exists(flox, pointer));
+        assert_eq!(
+            registry(flox).entry_for_hash(dot_flox_hash),
+            None,
+            "the checkout's registry entry should be gone after deletion"
+        );
+
+        // The per-checkout branch was pruned; the floxmeta repo itself remains.
+        let floxmeta = FloxMeta::open_local(flox, pointer).expect("local floxmeta still exists");
+        assert!(
+            !floxmeta.git.has_branch(branch).unwrap(),
+            "per-checkout branch should be pruned after deletion"
+        );
+    }
+
+    /// A checkout the registry has no record of is still removable. This is the
+    /// case a user is most likely to be cleaning up after — `RemoteEnvironment`
+    /// creates `.flox` before the fallible work that would register it, so an
+    /// interrupted first `--reference` command leaves exactly this state.
+    #[test]
+    fn delete_local_checkout_removes_unregistered_checkout() {
+        let checkout = cached_remote_checkout();
+        let (flox, pointer) = (&checkout.flox, &checkout.pointer);
+
+        fs::remove_file(env_registry_path(flox)).expect("remove registry");
+
+        RemoteEnvironment::delete_local_checkout(flox, pointer)
+            .expect("delete local checkout without a registry entry");
+        assert!(!RemoteEnvironment::local_checkout_exists(flox, pointer));
+    }
+
+    /// A checkout whose `.flox` is gone has no branch and no registry entry to
+    /// key off, but the directory it left behind is still the user's to remove.
+    #[test]
+    fn delete_local_checkout_removes_checkout_without_dot_flox() {
+        let checkout = cached_remote_checkout();
+        let (flox, pointer) = (&checkout.flox, &checkout.pointer);
+
+        let checkout_path = RemoteEnvironment::checkout_path(flox, pointer);
+        fs::remove_dir_all(checkout_path.join(DOT_FLOX)).expect("remove .flox");
+        assert!(!RemoteEnvironment::is_cached(flox, pointer));
+        assert!(RemoteEnvironment::local_checkout_exists(flox, pointer));
+
+        RemoteEnvironment::delete_local_checkout(flox, pointer)
+            .expect("delete local checkout without a .flox");
+        assert!(!RemoteEnvironment::local_checkout_exists(flox, pointer));
     }
 
     #[test]

--- a/cli/flox/doc/flox-delete.md
+++ b/cli/flox/doc/flox-delete.md
@@ -32,7 +32,11 @@ The `--reference` flag instead deletes the local copy of a FloxHub environment
 that was cached on this machine by
 [`flox-activate(1)`](./flox-activate.md) or [`flox-pull(1)`](./flox-pull.md)
 with `--reference`.
-The environment on FloxHub is *not* deleted.
+Only the local copy is removed:
+the environment on FloxHub is *not* deleted,
+and will be downloaded again the next time you activate or pull the reference.
+Deleting the upstream environment on FloxHub is not currently supported from
+the command line.
 This is a local operation and does not require network access, so it can also
 clean up a cached copy that can no longer be activated.
 
@@ -49,10 +53,11 @@ use.
 :   Delete the environment without confirmation.
 
 `-r <owner>/<name>`, `--reference <owner>/<name>`
-:   Delete the local copy of the FloxHub environment `<owner>/<name>`
+:   Delete only the local copy of the FloxHub environment `<owner>/<name>`
     cached in `~/.cache`.
 
-    The environment on FloxHub is not deleted.
+    The environment on FloxHub is not deleted and will be downloaded again
+    the next time you activate or pull the reference.
 
     Cannot be used with `--dir`.
 

--- a/cli/flox/doc/flox-delete.md
+++ b/cli/flox/doc/flox-delete.md
@@ -12,9 +12,14 @@ flox-delete - delete an environment
 # SYNOPSIS
 
 ```text
+# Delete an environment in a directory
 flox [<general options>] delete
      [-f]
      [-d=<path>]
+
+# Delete the local copy of a FloxHub environment
+flox [<general options>] delete -r <owner>/<name>
+     [-f]
 ```
 
 # DESCRIPTION
@@ -22,6 +27,14 @@ flox [<general options>] delete
 Deletes all data pertaining to an environment.
 By default, only the environment in the current directory is deleted,
 but environments in other directories may be deleted via the `-d` flag.
+
+The `--reference` flag instead deletes the local copy of a FloxHub environment
+that was cached on this machine by
+[`flox-activate(1)`](./flox-activate.md) or [`flox-pull(1)`](./flox-pull.md)
+with `--reference`.
+The environment on FloxHub is *not* deleted.
+This is a local operation and does not require network access, so it can also
+clean up a cached copy that can no longer be activated.
 
 By default, you will be prompted for a confirmation before deleting the
 environment.
@@ -35,10 +48,14 @@ use.
 `-f`, `--force`
 :   Delete the environment without confirmation.
 
-<!-- Copied from ./include/environment-options.md
-     `flox delete` does not currently handle remote environments
-     Replace with an include once support is added.
- -->
+`-r <owner>/<name>`, `--reference <owner>/<name>`
+:   Delete the local copy of the FloxHub environment `<owner>/<name>`
+    cached in `~/.cache`.
+
+    The environment on FloxHub is not deleted.
+
+    Cannot be used with `--dir`.
+
 ## Environment Options
 
 If no environment is specified for an environment command,

--- a/cli/flox/doc/flox-delete.md
+++ b/cli/flox/doc/flox-delete.md
@@ -12,9 +12,15 @@ flox-delete - delete an environment
 # SYNOPSIS
 
 ```text
+# Delete an environment in a directory
 flox [<general options>] delete
      [-f]
      [-d=<path>]
+
+# Delete the local copy of a FloxHub environment
+flox [<general options>] delete
+     [-f]
+     [-r=<owner/name> | -D]
 ```
 
 # DESCRIPTION
@@ -23,10 +29,23 @@ Deletes all data pertaining to an environment.
 By default, only the environment in the current directory is deleted,
 but environments in other directories may be deleted via the `-d` flag.
 
+The `--reference` and `--default` flags instead delete the local copy of a
+FloxHub environment that was cached on this machine by a command run with
+`--reference`, such as [`flox-activate(1)`](./flox-activate.md) or
+[`flox-pull(1)`](./flox-pull.md).
+Only the local copy is removed:
+the environment on FloxHub is *not* deleted,
+and will be downloaded again the next time you activate or pull the reference.
+Deleting the upstream environment on FloxHub is not currently supported from
+the command line.
+This is a local operation and does not require network access, so it can also
+clean up a cached copy that can no longer be activated.
+
 By default, you will be prompted for a confirmation before deleting the
 environment.
-The `-f` flag skips the confirmation dialog and is required for non-interactive
-use.
+The `-f` flag skips the confirmation dialog,
+and is required to delete the local copy of a FloxHub environment in a
+non-interactive context.
 
 # OPTIONS
 
@@ -35,20 +54,8 @@ use.
 `-f`, `--force`
 :   Delete the environment without confirmation.
 
-<!-- Copied from ./include/environment-options.md
-     `flox delete` does not currently handle remote environments
-     Replace with an include once support is added.
- -->
-## Environment Options
-
-If no environment is specified for an environment command,
-the environment in the current directory
-or the active environment that was last activated is used.
-
-`-d`, `--dir`
-:   Path containing a .flox/ directory.
-
 ```{.include}
+./include/environment-options.md
 ./include/general-options.md
 ```
 

--- a/cli/flox/src/commands/delete.rs
+++ b/cli/flox/src/commands/delete.rs
@@ -1,16 +1,18 @@
 use anyhow::{Result, bail};
 use bpaf::Bpaf;
+use flox_core::data::environment_ref::RemoteEnvironmentRef;
 use flox_events::{CliEnvironmentPayload, EventKind, EventsHub};
 use flox_rust_sdk::flox::Flox;
-use flox_rust_sdk::models::environment::{ConcreteEnvironment, Environment};
+use flox_rust_sdk::models::environment::remote_environment::RemoteEnvironment;
+use flox_rust_sdk::models::environment::{ConcreteEnvironment, Environment, ManagedPointer};
 use indoc::formatdoc;
 use tracing::{debug, instrument};
 
 use crate::commands::{DirEnvironmentSelect, dir_environment_select, environment_description};
-use crate::environment_subcommand_metric;
 use crate::utils::dialog::{Confirm, Dialog};
 use crate::utils::events::env_detail_from_concrete;
 use crate::utils::message;
+use crate::{environment_subcommand_metric, subcommand_metric};
 
 // Delete an environment
 #[derive(Bpaf, Clone)]
@@ -18,6 +20,13 @@ pub struct Delete {
     /// Delete an environment without confirmation.
     #[bpaf(short, long)]
     force: bool,
+
+    /// Delete the local copy of a FloxHub environment.
+    ///
+    /// Removes the copy cached on this machine by `flox activate --reference`
+    /// or `flox pull --reference`. The environment on FloxHub is not deleted.
+    #[bpaf(long("reference"), long("ref"), short('r'), argument("owner>/<name"))]
+    remote: Option<RemoteEnvironmentRef>,
 
     // TODO: switch back to `EnvironmentSelect` once we implement
     // <https://github.com/flox/flox/issues/3391>
@@ -28,6 +37,15 @@ pub struct Delete {
 impl Delete {
     #[instrument(name = "delete", skip_all)]
     pub async fn handle(self, mut flox: Flox) -> Result<()> {
+        // `-r`/`--reference` deletes only the local cached copy of a FloxHub
+        // environment; the upstream environment is never touched.
+        if let Some(env_ref) = self.remote.clone() {
+            if matches!(self.environment, DirEnvironmentSelect::Dir(_)) {
+                bail!("`--reference` cannot be combined with `-d`.");
+            }
+            return delete_local_remote_copy(&flox, env_ref, self.force).await;
+        }
+
         let environment = self
             .environment
             .detect_concrete_environment(&mut flox, "Delete")?;
@@ -93,4 +111,55 @@ impl Delete {
 
         Ok(())
     }
+}
+
+/// Delete the local cached copy of a remote (FloxHub) environment.
+///
+/// The copy is the one created on this machine by `flox activate --reference`
+/// or `flox pull --reference`. This does not delete the environment on FloxHub,
+/// and is a local operation that doesn't require network access.
+async fn delete_local_remote_copy(
+    flox: &Flox,
+    env_ref: RemoteEnvironmentRef,
+    force: bool,
+) -> Result<()> {
+    subcommand_metric!("delete", remote_environment = env_ref.to_string());
+
+    let pointer = ManagedPointer::new(
+        env_ref.owner().clone(),
+        env_ref.name().clone(),
+        &flox.floxhub,
+    );
+
+    if !RemoteEnvironment::is_cached(flox, &pointer) {
+        bail!(formatdoc! {"
+            No local copy of remote environment {env_ref} was found.
+
+            A local copy is created by 'flox activate --reference {env_ref}' or 'flox pull --reference {env_ref}'.
+        "});
+    }
+
+    let confirm = Dialog {
+        message: &format!(
+            "You are about to delete the local copy of {env_ref}. \
+             The environment on FloxHub will not be deleted. Are you sure?"
+        ),
+        help_message: Some("Use `-f` to force deletion"),
+        typed: Confirm {
+            default: Some(false),
+        },
+    };
+
+    if !force && Dialog::can_prompt() && !confirm.prompt().await? {
+        bail!("Environment deletion cancelled");
+    }
+
+    RemoteEnvironment::delete_local_checkout(flox, &pointer)?;
+
+    message::deleted(format!(
+        "Local copy of environment {env_ref} deleted. \
+         The environment on FloxHub was not deleted."
+    ));
+
+    Ok(())
 }

--- a/cli/flox/src/commands/delete.rs
+++ b/cli/flox/src/commands/delete.rs
@@ -23,8 +23,10 @@ pub struct Delete {
 
     /// Delete the local copy of a FloxHub environment.
     ///
-    /// Removes the copy cached on this machine by `flox activate --reference`
-    /// or `flox pull --reference`. The environment on FloxHub is not deleted.
+    /// Removes only the copy cached on this machine by `flox activate
+    /// --reference` or `flox pull --reference`. The environment on FloxHub is
+    /// not deleted and will be downloaded again the next time you activate or
+    /// pull the reference.
     #[bpaf(long("reference"), long("ref"), short('r'), argument("owner>/<name"))]
     remote: Option<RemoteEnvironmentRef>,
 
@@ -142,7 +144,9 @@ async fn delete_local_remote_copy(
     let confirm = Dialog {
         message: &format!(
             "You are about to delete the local copy of {env_ref}. \
-             The environment on FloxHub will not be deleted. Are you sure?"
+             The environment on FloxHub will not be deleted and will be \
+             downloaded again the next time you activate or pull it. \
+             Are you sure?"
         ),
         help_message: Some("Use `-f` to force deletion"),
         typed: Confirm {
@@ -158,7 +162,8 @@ async fn delete_local_remote_copy(
 
     message::deleted(format!(
         "Local copy of environment {env_ref} deleted. \
-         The environment on FloxHub was not deleted."
+         The environment on FloxHub was not deleted; it will be downloaded \
+         again the next time you activate or pull {env_ref}."
     ));
 
     Ok(())

--- a/cli/flox/src/commands/delete.rs
+++ b/cli/flox/src/commands/delete.rs
@@ -1,12 +1,21 @@
 use anyhow::{Result, bail};
 use bpaf::Bpaf;
-use flox_events::{CliEnvironmentPayload, EventKind, EventsHub};
+use flox_core::data::environment_ref::{DEFAULT_NAME, RemoteEnvironmentRef};
+use flox_events::{CliEnvironmentPayload, EnvDetail, EventKind, EventsHub};
 use flox_rust_sdk::flox::Flox;
-use flox_rust_sdk::models::environment::{ConcreteEnvironment, Environment};
+use flox_rust_sdk::models::environment::remote_environment::RemoteEnvironment;
+use flox_rust_sdk::models::environment::{ConcreteEnvironment, Environment, ManagedPointer};
 use indoc::formatdoc;
 use tracing::{debug, instrument};
 
-use crate::commands::{DirEnvironmentSelect, dir_environment_select, environment_description};
+use crate::commands::{
+    DirEnvironmentSelect,
+    EnvironmentSelect,
+    EnvironmentSelectError,
+    ensure_auth,
+    environment_description,
+    environment_select,
+};
 use crate::environment_subcommand_metric;
 use crate::utils::dialog::{Confirm, Dialog};
 use crate::utils::events::env_detail_from_concrete;
@@ -19,18 +28,45 @@ pub struct Delete {
     #[bpaf(short, long)]
     force: bool,
 
-    // TODO: switch back to `EnvironmentSelect` once we implement
-    // <https://github.com/flox/flox/issues/3391>
-    #[bpaf(external(dir_environment_select), fallback(Default::default()))]
-    environment: DirEnvironmentSelect,
+    #[bpaf(external(environment_select), fallback(Default::default()))]
+    environment: EnvironmentSelect,
 }
 
 impl Delete {
     #[instrument(name = "delete", skip_all)]
     pub async fn handle(self, mut flox: Flox) -> Result<()> {
-        let environment = self
-            .environment
-            .detect_concrete_environment(&mut flox, "Delete")?;
+        // `-r`/`--reference` and `-D`/`--default` name a FloxHub environment,
+        // for which the only supported deletion is of the copy cached on this
+        // machine. Resolve the reference without opening the checkout so that
+        // a copy which can no longer be activated is still removable.
+        if let Some(env_ref) = self.remote_reference(&mut flox).await? {
+            return delete_local_remote_copy(&flox, env_ref, self.force).await;
+        }
+
+        // Deliberately narrowed to the directory variants. `EnvironmentSelect`
+        // would materialize an active remote environment over the network just
+        // to reject it below, where `DirEnvironmentSelect` reports it as
+        // `RemoteNotSupported` without a round trip.
+        let dir_select = match self.environment {
+            EnvironmentSelect::Dir(ref path) => DirEnvironmentSelect::Dir(path.clone()),
+            EnvironmentSelect::Unspecified => DirEnvironmentSelect::Unspecified,
+            EnvironmentSelect::Remote(_) | EnvironmentSelect::Default => {
+                unreachable!("handled by remote_reference above")
+            },
+        };
+
+        let environment = match dir_select.detect_concrete_environment(&mut flox, "Delete") {
+            // The user is standing in an activation of a FloxHub environment.
+            // Deleting it upstream is not supported, but deleting the local
+            // copy is, so name that rather than stopping at the refusal.
+            Err(EnvironmentSelectError::RemoteNotSupported) => bail!(formatdoc! {"
+                Cannot delete an active FloxHub environment.
+
+                The environment on FloxHub cannot be deleted from the command line.
+                To remove only the copy cached on this machine, run 'flox delete --reference <OWNER>/<NAME>'.
+            "}),
+            other => other?,
+        };
 
         environment_subcommand_metric!("delete", environment);
         if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentDelete(
@@ -40,15 +76,6 @@ impl Delete {
         }
 
         let description = environment_description(&environment)?;
-
-        if matches!(environment, ConcreteEnvironment::Remote(_)) {
-            let message = formatdoc! {"
-                Environment {description} was not deleted.
-
-                Remote environments on FloxHub cannot yet be deleted.
-            "};
-            bail!("{message}")
-        }
 
         // TODO: Inform about `--upstream` option once we implement
         // <https://github.com/flox/flox/issues/3391>
@@ -65,7 +92,7 @@ impl Delete {
             message::warning(message);
         }
 
-        let message = if let DirEnvironmentSelect::Unspecified = self.environment {
+        let message = if let DirEnvironmentSelect::Unspecified = dir_select {
             format!("You are about to delete your environment {description}. Are you sure?")
         } else {
             "Are you sure?".to_string()
@@ -93,4 +120,92 @@ impl Delete {
 
         Ok(())
     }
+
+    /// The FloxHub environment named by `-r`/`--reference` or `-D`/`--default`,
+    /// or [None] when the selection names a directory instead.
+    ///
+    /// Resolves `--default` the same way [EnvironmentSelect] does, but stops at
+    /// the reference rather than going on to open the environment.
+    async fn remote_reference(&self, flox: &mut Flox) -> Result<Option<RemoteEnvironmentRef>> {
+        match self.environment {
+            EnvironmentSelect::Remote(ref env_ref) => Ok(Some(env_ref.clone())),
+            EnvironmentSelect::Default => {
+                let user_handle = ensure_auth(flox).await?;
+                debug!(
+                    user = %user_handle,
+                    "getting default environment for logged-in user"
+                );
+                Ok(Some(RemoteEnvironmentRef::new(user_handle, DEFAULT_NAME)?))
+            },
+            EnvironmentSelect::Dir(_) | EnvironmentSelect::Unspecified => Ok(None),
+        }
+    }
+}
+
+/// Delete the local cached copy of a remote (FloxHub) environment.
+///
+/// The copy is the one created on this machine by any command run with
+/// `--reference`, e.g. `flox activate --reference` or `flox pull --reference`.
+/// This does not delete the environment on FloxHub, and is a local operation
+/// that doesn't require network access.
+async fn delete_local_remote_copy(
+    flox: &Flox,
+    env_ref: RemoteEnvironmentRef,
+    force: bool,
+) -> Result<()> {
+    let pointer = ManagedPointer::new(
+        env_ref.owner().clone(),
+        env_ref.name().clone(),
+        &flox.floxhub,
+    );
+
+    if !RemoteEnvironment::local_checkout_exists(flox, &pointer) {
+        bail!(formatdoc! {"
+            Did not find a local copy of remote environment {env_ref}.
+
+            A local copy is created by any command run with '--reference', such as 'flox activate --reference {env_ref}'.
+        "});
+    }
+
+    if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentDelete(
+        CliEnvironmentPayload::new(EnvDetail::remote(env_ref.to_string(), None)),
+    )) {
+        debug!(error = %err, "Failed to record v2 event");
+    }
+
+    let confirm = Dialog {
+        message: &formatdoc! {"
+            You are about to delete the local copy of {env_ref}.
+            The environment on FloxHub will not be deleted and will be downloaded again the next time you activate or pull it.
+            Are you sure?"
+        },
+        help_message: Some("Use '-f' to force deletion"),
+        typed: Confirm {
+            default: Some(false),
+        },
+    };
+
+    if !force {
+        // Fail closed rather than deleting unprompted: without a terminal the
+        // confirmation cannot be shown, and the caller has not opted out of it.
+        if !Dialog::can_prompt() {
+            bail!(formatdoc! {"
+                Cannot confirm deletion because this is not an interactive terminal.
+
+                Use '--force' to delete the local copy of {env_ref} without confirmation.
+            "});
+        }
+        if !confirm.prompt().await? {
+            bail!("Environment deletion cancelled.");
+        }
+    }
+
+    RemoteEnvironment::delete_local_checkout(flox, &pointer)?;
+
+    message::deleted(formatdoc! {"
+        Local copy of environment {env_ref} deleted.
+        The environment on FloxHub was not deleted; it will be downloaded again the next time you activate or pull {env_ref}."
+    });
+
+    Ok(())
 }

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -658,6 +658,9 @@ pub fn format_remote_error(err: &RemoteEnvironmentError) -> String {
         RemoteEnvironmentError::WriteNewOutlink(_) => display_chain(err),
         RemoteEnvironmentError::CreateGcRootDir(_) => display_chain(err),
         RemoteEnvironmentError::Generations(_) => display_chain(err),
+        RemoteEnvironmentError::DeregisterLocalCheckout(_) => display_chain(err),
+        RemoteEnvironmentError::DeleteLocalCheckout(_) => display_chain(err),
+        RemoteEnvironmentError::PruneFloxmetaBranch(_) => display_chain(err),
     }
 }
 

--- a/cli/flox/src/utils/errors.rs
+++ b/cli/flox/src/utils/errors.rs
@@ -666,6 +666,7 @@ pub fn format_remote_error(err: &RemoteEnvironmentError) -> String {
         RemoteEnvironmentError::WriteNewOutlink(_) => display_chain(err),
         RemoteEnvironmentError::CreateGcRootDir(_) => display_chain(err),
         RemoteEnvironmentError::Generations(_) => display_chain(err),
+        RemoteEnvironmentError::DeleteLocalCheckout(_) => display_chain(err),
     }
 }
 

--- a/cli/tests/environment-remote.bats
+++ b/cli/tests/environment-remote.bats
@@ -123,6 +123,42 @@ EOF
 }
 
 
+# bats test_tags=delete,remote,remote:delete
+@test "delete --reference removes the local copy of a remote environment" {
+  export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.yaml"
+  make_empty_remote_env
+
+  # Materialize a local copy of the remote environment in the cache.
+  run --separate-stderr "$FLOX_BIN" install hello --reference "$OWNER/test"
+  assert_success
+  assert [ -d "$FLOX_CACHE_DIR/remote/$OWNER/test/.flox" ]
+
+  # Delete only the local copy; the environment on FloxHub is untouched.
+  run "$FLOX_BIN" delete --reference "$OWNER/test" -f
+  assert_success
+  assert [ ! -e "$FLOX_CACHE_DIR/remote/$OWNER/test" ]
+
+  # Upstream still exists: operating on the reference re-creates the copy.
+  run --separate-stderr "$FLOX_BIN" list --name --reference "$OWNER/test"
+  assert_success
+  assert [ -d "$FLOX_CACHE_DIR/remote/$OWNER/test/.flox" ]
+}
+
+# bats test_tags=delete,remote,remote:delete
+@test "delete --reference errors when there is no local copy" {
+  run "$FLOX_BIN" delete --reference "$OWNER/test" -f
+  assert_failure
+  assert_output --partial "No local copy of remote environment"
+}
+
+# bats test_tags=delete,remote,remote:delete
+@test "delete -r cannot be combined with -d" {
+  run "$FLOX_BIN" delete -r "$OWNER/test" -d "$PROJECT_DIR" -f
+  assert_failure
+  assert_output --partial "cannot be combined with"
+}
+
+
 # bats test_tags=install,remote,remote:install
 @test "m1: install a package to a remote environment" {
   export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.yaml"

--- a/cli/tests/environment-remote.bats
+++ b/cli/tests/environment-remote.bats
@@ -124,6 +124,83 @@ EOF
 }
 
 
+# bats test_tags=delete,remote,remote:delete
+@test "delete --reference removes the local copy of a remote environment" {
+  export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.yaml"
+  make_empty_remote_env
+
+  # Materialize a local copy of the remote environment in the cache.
+  run --separate-stderr "$FLOX_BIN" install hello --reference "$OWNER/test"
+  assert_success
+  assert [ -d "$FLOX_CACHE_DIR/remote/$OWNER/test/.flox" ]
+
+  # Delete only the local copy; the environment on FloxHub is untouched.
+  run "$FLOX_BIN" delete --reference "$OWNER/test" -f
+  assert_success
+  assert [ ! -e "$FLOX_CACHE_DIR/remote/$OWNER/test" ]
+
+  # Upstream still exists: operating on the reference re-creates the copy.
+  run --separate-stderr "$FLOX_BIN" list --name --reference "$OWNER/test"
+  assert_success
+  assert [ -d "$FLOX_CACHE_DIR/remote/$OWNER/test/.flox" ]
+}
+
+# bats test_tags=delete,remote,remote:delete
+@test "delete --reference removes a local copy that can no longer be opened" {
+  export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.yaml"
+  make_empty_remote_env
+
+  run --separate-stderr "$FLOX_BIN" install hello --reference "$OWNER/test"
+  assert_success
+
+  # Leave the checkout directory in place but remove what makes it openable,
+  # as an interrupted first `--reference` command would.
+  rm -rf "$FLOX_CACHE_DIR/remote/$OWNER/test/.flox"
+  assert [ -d "$FLOX_CACHE_DIR/remote/$OWNER/test" ]
+
+  run "$FLOX_BIN" delete --reference "$OWNER/test" -f
+  assert_success
+  assert [ ! -e "$FLOX_CACHE_DIR/remote/$OWNER/test" ]
+}
+
+# bats test_tags=delete,remote,remote:delete
+@test "delete --reference errors when there is no local copy" {
+  run "$FLOX_BIN" delete --reference "$OWNER/test" -f
+  assert_failure
+  assert_output --partial "Did not find a local copy of remote environment"
+}
+
+# bats test_tags=delete,remote,remote:delete
+@test "delete --reference requires -f without a terminal" {
+  export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.yaml"
+  make_empty_remote_env
+
+  run --separate-stderr "$FLOX_BIN" install hello --reference "$OWNER/test"
+  assert_success
+
+  # No terminal to confirm on, and the caller did not pass `-f`: fail rather
+  # than delete unprompted.
+  run "$FLOX_BIN" delete --reference "$OWNER/test"
+  assert_failure
+  assert_output --partial "not an interactive terminal"
+  assert [ -d "$FLOX_CACHE_DIR/remote/$OWNER/test/.flox" ]
+}
+
+# bats test_tags=delete,remote,remote:delete
+@test "delete -r cannot be combined with -d" {
+  run "$FLOX_BIN" delete -r "$OWNER/test" -d "$PROJECT_DIR" -f
+  assert_failure
+  assert_output --partial "cannot be used at the same time as"
+}
+
+# bats test_tags=delete,remote,remote:delete
+@test "delete -r rejects a reference that escapes the cache directory" {
+  run "$FLOX_BIN" delete -r "../escape" -f
+  assert_failure
+  assert_output --partial "is invalid"
+}
+
+
 # bats test_tags=install,remote,remote:install
 @test "m1: install a package to a remote environment" {
   export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.yaml"


### PR DESCRIPTION
## Summary

Adds `flox delete -r <owner>/<name>` (also `-D`) to remove the **local copy** of a FloxHub environment — the checkout under `$FLOX_CACHE_DIR/remote/<owner>/<name>` that any `--reference` command materializes. The environment on FloxHub is not touched.

```console
$ flox delete --reference owner/name
$ flox delete -r owner/name -f   # skip confirmation
```

Closes #4051.

**What to review, in order:**

1. `RemoteEnvironment::delete_local_checkout` (`remote_environment.rs`) — the removal happens first and all metadata cleanup after it is best-effort. The ordering is load-bearing; the doc comment explains why, and it is the opposite of what a first reading suggests.
2. `Delete` now parses with the shared `EnvironmentSelect` instead of `DirEnvironmentSelect`, which is what retires the `-r`/`-d` runtime guard and the `#3391` TODO. This is the change that touches existing behaviour.
3. `EnvironmentOwner`/`EnvironmentName` parsing now rejects `..` (separate commit) — small, but it changes a type used everywhere.

<details>
<summary><b>Why the ordering in <code>delete_local_checkout</code> is deliberate</b></summary>

The operation has three steps: remove the checkout directory, prune the per-checkout floxmeta branch, deregister from the environment registry. Only the removal is fatal.

Deregistering first is the tempting order and it is wrong in both directions:

- `deregister` returns `UnknownKey` when the registry has no entry for the path, and `EnvNotRegistered` when the stored pointer doesn't match. Propagating either **before** the removal means the directory survives — precisely in the cases a user is most likely to be cleaning up after. `RemoteEnvironment::new_in` creates `.flox` before the fallible network work that would register it, so an interrupted first `--reference` command leaves a cached-but-unregistered checkout that could never be deleted.
- If the removal then fails (EPERM, EBUSY, read-only mount), an already-deregistered entry leaves a directory nothing will ever reclaim. `EnvRegistry::prune_nonexistent` only sweeps entries whose path is gone, so with no entry there is no sweep. Removal-first inverts this: a leftover registry entry is collected on the next `flox envs`.

`ManagedEnvironment::delete` already uses removal-first ordering, for the same reason.

Deregistration also now prefers the pointer recorded in the checkout's `env.json` over one rebuilt from current configuration. The registry matches on the whole `ManagedPointer`, including `floxhub_base_url`, so a `FLOX_FLOXHUB_URL` change between materializing and deleting would otherwise miss. It falls back to the constructed pointer when `.flox` is unreadable.
</details>

<details>
<summary><b>Why <code>EnvironmentSelect</code> instead of a dedicated flag</b></summary>

Routing `delete` through the shared selector rather than giving it a dedicated `-r` field gets four things:

- `-d` / `-r` / `-D` become mutually exclusive **at parse time** (`Usage: flox delete [-f] [-d=<path> | -r=<owner>/<name> | -D]`), so the invalid state is unrepresentable rather than guarded and tested.
- `-D`/`--default` works, pairing `delete` with every other environment command (DEV-33 added that alias everywhere else).
- The `// TODO: switch back to EnvironmentSelect once we implement #3391` comment is retired. A second `-r` declaration on `Delete` would have made that migration impossible to perform as written.
- The man page can use the shared `./include/environment-options.md` instead of a hand-copied block, which is what the removed placeholder comment asked for.

Resolution deliberately stops at the *reference*: `EnvironmentSelect::detect_concrete_environment` would call `RemoteEnvironment::new`, opening and possibly fetching the checkout before deleting it. The directory variants still route through `DirEnvironmentSelect` so an active remote environment is reported without a network round trip.

This does not implement #3391 (deleting the upstream environment); `--upstream` remains free for it.
</details>

<details>
<summary><b>Reference validation (separate commit)</b></summary>

`EnvironmentOwner`/`EnvironmentName` parsing rejected only spaces and `/`, so `..` and the empty string parsed. Since references are interpolated into paths and `PathBuf::join` does not normalize `..`, `flox delete -r ../scratch` resolved outside the cache directory. Rejecting it at the parse boundary fixes it for every consumer rather than just this one, and the error text now states the rule that is actually enforced instead of a stricter one that never was.

The proptest strategies generated single characters from `[^ /]`, which includes `.`; they now generate components the types accept.
</details>

<details>
<summary><b>Behaviour notes and non-goals</b></summary>

- **Non-interactive `-r` fails closed.** Without a terminal the confirmation cannot be shown, so `-f` is required rather than deleting unprompted. The directory path keeps its existing `can_prompt()` behaviour — changing it would break existing scripts, and it has users this flag does not.
- **Telemetry**: the `-r` path emits the v2 `CliEnvironmentDelete` event and no legacy `subcommand_metric!`, per the "all new CLI telemetry goes through the v2 events pipeline" rule in `AGENTS.md`. This is an existing event and payload with a new emit site — no new field or event type.
- **Not addressed here**: deleting a checkout while shells are activated against it. A remote checkout is a single machine-wide copy, so one delete can strand several shells — but `flox delete -d` has the same gap, and DEV-277 specs the guard uniformly across delete paths. Building a one-path version first would leave the two inconsistent.
- The bare `flox delete` dead end inside a remote activation now names `--reference` instead of stopping at "Remote environments on FloxHub cannot yet be deleted."

</details>

<details>
<summary><b>Testing</b></summary>

Unit (`flox-rust-sdk`), all asserting the registry entry rather than only the directory:
- `delete_local_checkout_removes_cached_copy` — checkout gone, branch pruned, registry entry gone.
- `delete_local_checkout_removes_unregistered_checkout` — registry file deleted first; removal still succeeds.
- `delete_local_checkout_removes_checkout_without_dot_flox` — no `.flox` to key off; directory still removed.

Unit (`flox-core`): `rejects_path_traversing_references`, `accepts_ordinary_references`.

Integration (`environment-remote.bats`, tagged `remote:delete`) — 6 tests: happy path with upstream intact, a copy that can no longer be opened, missing copy, `-f` required without a terminal, `-r`+`-d` rejected, `../escape` rejected.

Verified locally: `just build`, `cargo clippy --all --all-targets`, `cargo fmt --all --check`, `just unit-tests` (1906/1909; the 3 failures are `buildenv`/`flake_installable_locker` nixpkgs downloads failing with `Truncated tar archive`, unrelated to this change), `just integ-tests delete.bats` and the six `remote:delete` cases.
</details>

## Relationship to #4251

Thanks to @vvaswani for also tackling this in #4251 — both deliver `flox delete -r <owner>/<name>`. That PR's move to the shared `EnvironmentSelect` was the better call and this PR now does the same thing, so the two have converged on approach. What remains here on top of it:

- **Removes caches that can no longer be opened.** #4251 resolves the reference through `detect_concrete_environment`, which calls `RemoteEnvironment::new` and validates the generation lock before deleting. This PR never opens the environment, so a corrupt checkout is still removable — and gates on the checkout directory rather than on `.flox`, so a half-finished one is too.
- **Docs.** Updates `flox-delete(1)`, which still says remote environments aren't handled.
- **Integration coverage** in addition to unit tests.

Both prune the floxmeta branch locally; neither touches the network for that step.

## Release Notes

`flox delete` can now remove the local copy of a FloxHub environment with `flox delete --reference <owner>/<name>` (or `--default`). Only the copy cached on this machine is removed — the environment on FloxHub is not deleted and is downloaded again the next time you activate or pull the reference.
