### PR TITLE
feat(events): add generation_number and package_count to environment events

### DIFF
--- a/cli/flox-events/src/hub.rs
+++ b/cli/flox-events/src/hub.rs
@@ -36,22 +36,22 @@ impl EventsHub {
 
     pub fn set_client(&self, new_client: EventsClient) -> Option<EventsClient> {
         self.completed_recorded.store(false, Ordering::SeqCst);
-        self.lock_client(|client| client.replace(new_client))
+        self.with_client(|client| client.replace(new_client))
     }
 
     pub fn clear_client(&self) -> Option<EventsClient> {
         self.completed_recorded.store(false, Ordering::SeqCst);
-        self.lock_client(Option::take)
+        self.with_client(Option::take)
     }
 
     /// Run `f` only when a client is installed, for work that only feeds
     /// event payloads and would otherwise be wasted.
     pub fn when_client_set<T>(&self, f: impl FnOnce() -> T) -> Option<T> {
-        self.lock_client(|client| client.is_some()).then(f)
+        self.with_client(|client| client.is_some()).then(f)
     }
 
     pub fn flush(&self, force: bool) -> Result<()> {
-        self.lock_client(|client| {
+        self.with_client(|client| {
             if let Some(client) = client {
                 client.flush(force)
             } else {
@@ -62,7 +62,7 @@ impl EventsHub {
     }
 
     pub fn record_event(&self, kind: EventKind) -> Result<()> {
-        self.lock_client(|client| {
+        self.with_client(|client| {
             let Some(client) = client else {
                 trace!("No v2 events client configured, skipping record");
                 return Ok(());
@@ -75,7 +75,7 @@ impl EventsHub {
     /// Record a `cli.command_run` event for `subcommand`. No-op when no
     /// client is installed.
     pub fn record_command_run(&self, subcommand: String) -> Result<()> {
-        self.lock_client(|client| {
+        self.with_client(|client| {
             let Some(client) = client else {
                 trace!("No v2 events client configured, skipping command_run record");
                 return Ok(());
@@ -97,7 +97,7 @@ impl EventsHub {
             debug!("command_completed already recorded for this client install, skipping");
             return Ok(());
         }
-        self.lock_client(|client| {
+        self.with_client(|client| {
             let Some(client) = client else {
                 trace!("No v2 events client configured, skipping command_completed record");
                 return Ok(());
@@ -121,7 +121,7 @@ impl EventsHub {
         Ok(EventsGuard::from_hub(self.clone()))
     }
 
-    fn lock_client<T>(&self, f: impl FnOnce(&mut Option<EventsClient>) -> T) -> T {
+    fn with_client<T>(&self, f: impl FnOnce(&mut Option<EventsClient>) -> T) -> T {
         let mut client = self
             .client
             .lock()

--- a/cli/flox-events/src/hub.rs
+++ b/cli/flox-events/src/hub.rs
@@ -36,16 +36,22 @@ impl EventsHub {
 
     pub fn set_client(&self, new_client: EventsClient) -> Option<EventsClient> {
         self.completed_recorded.store(false, Ordering::SeqCst);
-        self.with_client(|client| client.replace(new_client))
+        self.lock_client(|client| client.replace(new_client))
     }
 
     pub fn clear_client(&self) -> Option<EventsClient> {
         self.completed_recorded.store(false, Ordering::SeqCst);
-        self.with_client(Option::take)
+        self.lock_client(Option::take)
+    }
+
+    /// Run `f` only when a client is installed, for work that only feeds
+    /// event payloads and would otherwise be wasted.
+    pub fn when_client_set<T>(&self, f: impl FnOnce() -> T) -> Option<T> {
+        self.lock_client(|client| client.is_some()).then(f)
     }
 
     pub fn flush(&self, force: bool) -> Result<()> {
-        self.with_client(|client| {
+        self.lock_client(|client| {
             if let Some(client) = client {
                 client.flush(force)
             } else {
@@ -56,7 +62,7 @@ impl EventsHub {
     }
 
     pub fn record_event(&self, kind: EventKind) -> Result<()> {
-        self.with_client(|client| {
+        self.lock_client(|client| {
             let Some(client) = client else {
                 trace!("No v2 events client configured, skipping record");
                 return Ok(());
@@ -69,7 +75,7 @@ impl EventsHub {
     /// Record a `cli.command_run` event for `subcommand`. No-op when no
     /// client is installed.
     pub fn record_command_run(&self, subcommand: String) -> Result<()> {
-        self.with_client(|client| {
+        self.lock_client(|client| {
             let Some(client) = client else {
                 trace!("No v2 events client configured, skipping command_run record");
                 return Ok(());
@@ -91,7 +97,7 @@ impl EventsHub {
             debug!("command_completed already recorded for this client install, skipping");
             return Ok(());
         }
-        self.with_client(|client| {
+        self.lock_client(|client| {
             let Some(client) = client else {
                 trace!("No v2 events client configured, skipping command_completed record");
                 return Ok(());
@@ -115,7 +121,7 @@ impl EventsHub {
         Ok(EventsGuard::from_hub(self.clone()))
     }
 
-    fn with_client<T>(&self, f: impl FnOnce(&mut Option<EventsClient>) -> T) -> T {
+    fn lock_client<T>(&self, f: impl FnOnce(&mut Option<EventsClient>) -> T) -> T {
         let mut client = self
             .client
             .lock()

--- a/cli/flox-events/src/lib.rs
+++ b/cli/flox-events/src/lib.rs
@@ -336,8 +336,10 @@ pub struct EnvDetail {
     /// for remote and managed environments, and `Environment::name(...)`
     /// for path environments. Matches the value the legacy macros emit.
     env_ref_or_name: String,
-    /// Current generation the command started from. Absent for path
-    /// environments, which have no generations.
+    /// The generation the command operated on — the pinned generation when
+    /// opened at one (e.g. `flox activate --generation`), otherwise the
+    /// environment's current generation. Absent for path environments (which
+    /// have no generations) and whenever the generation can't be read.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     generation_number: Option<u64>,
     /// Number of packages locked for the invoking system when the command

--- a/cli/flox-events/src/lib.rs
+++ b/cli/flox-events/src/lib.rs
@@ -336,6 +336,14 @@ pub struct EnvDetail {
     /// for remote and managed environments, and `Environment::name(...)`
     /// for path environments. Matches the value the legacy macros emit.
     env_ref_or_name: String,
+    /// Current generation the command started from. Absent for path
+    /// environments, which have no generations.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    generation_number: Option<u64>,
+    /// Number of packages locked for the invoking system when the command
+    /// started. Absent when no lockfile is available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    package_count: Option<u64>,
 }
 
 impl EnvDetail {
@@ -343,7 +351,19 @@ impl EnvDetail {
         Self {
             env_kind: env_kind.into(),
             env_ref_or_name: env_ref_or_name.into(),
+            generation_number: None,
+            package_count: None,
         }
+    }
+
+    pub fn with_generation_number(mut self, generation_number: u64) -> Self {
+        self.generation_number = Some(generation_number);
+        self
+    }
+
+    pub fn with_package_count(mut self, package_count: u64) -> Self {
+        self.package_count = Some(package_count);
+        self
     }
 }
 
@@ -855,6 +875,8 @@ mod tests {
         EnvDetail {
             env_kind: kind.to_string(),
             env_ref_or_name: ref_or_name.to_string(),
+            generation_number: None,
+            package_count: None,
         }
     }
 
@@ -898,6 +920,39 @@ mod tests {
             "has_includes": true,
         }));
         assert_eq!(value, expected);
+    }
+
+    #[test]
+    fn cli_environment_activate_managed_lineage_fields_envelope_golden() {
+        let detail = env_detail("managed", "alice/myenv")
+            .with_generation_number(3)
+            .with_package_count(7);
+        let payload = CliEnvironmentActivatePayload::new(detail);
+        let value = serde_json::to_value(fixed_event(EventKind::CliEnvironmentActivate(payload)))
+            .expect("event serializes");
+        let expected = activate_envelope_json(json!({
+            "env_kind": "managed",
+            "env_ref_or_name": "alice/myenv",
+            "generation_number": 3,
+            "package_count": 7,
+        }));
+        assert_eq!(value, expected);
+    }
+
+    /// A buffered environment-event row recorded by a binary that predates
+    /// the lineage fields must deserialize and re-serialize unchanged —
+    /// absent fields stay absent, nothing is fabricated.
+    #[test]
+    fn environment_row_without_lineage_fields_round_trips() {
+        let old_row = env_envelope_json("cli.environment.delete");
+        let event: Event =
+            serde_json::from_value(old_row.clone()).expect("old-shape row deserializes");
+        let EventKind::CliEnvironmentDelete(ref payload) = event.kind else {
+            panic!("expected cli.environment.delete");
+        };
+        assert_eq!(payload, &CliEnvironmentPayload::new(managed_env_detail()));
+        let reserialized = serde_json::to_value(event).expect("event re-serializes");
+        assert_eq!(reserialized, old_row);
     }
 
     #[test]
@@ -1828,6 +1883,8 @@ mod pipeline_tests {
         let env_detail = EnvDetail {
             env_kind: "path".to_string(),
             env_ref_or_name: "myenv".to_string(),
+            generation_number: None,
+            package_count: None,
         };
 
         hub.record_event(EventKind::CliEnvironmentEdit(

--- a/cli/flox-events/src/lib.rs
+++ b/cli/flox-events/src/lib.rs
@@ -506,6 +506,11 @@ impl CliPackagePayload {
 /// Payload for [`EventKind::CliEnvironmentEdit`]. Emitted once eagerly
 /// with env detail; a manifest edit that changes the manifest emits a
 /// second row carrying `edited_includes`.
+///
+/// `env_detail` is the pre-edit snapshot on both rows (the generation the
+/// command started from), so the two rows agree on lineage. The result-known
+/// row's `manifest_version` describes the post-edit manifest, so lineage and
+/// the result fields are deliberately different epochs, not one snapshot.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CliEnvironmentEditPayload {
     #[serde(flatten)]

--- a/cli/flox-events/src/lib.rs
+++ b/cli/flox-events/src/lib.rs
@@ -322,26 +322,44 @@ impl CliCommandCompletedPayload {
     }
 }
 
-/// Environment kind a `cli.environment.*` event touched, matching the three
-/// legacy `environment_subcommand_metric!` arms (`remote_environment` /
-/// `managed_environment` / `path_environment`).
+/// Identity of the environment a `cli.environment.*` event touched.
+///
+/// The internally tagged representation preserves the existing flat wire
+/// shape while ensuring path environments cannot carry generation fields.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "env_kind", rename_all = "lowercase")]
+enum EnvIdentity {
+    Path {
+        #[serde(rename = "env_ref_or_name")]
+        name: String,
+    },
+    Managed {
+        #[serde(rename = "env_ref_or_name")]
+        env_ref: String,
+        /// The generation the command operated on — the pinned generation
+        /// when opened at one (e.g. `flox activate --generation`), otherwise
+        /// the environment's current generation. Absent whenever the
+        /// generation can't be read.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        generation_number: Option<u64>,
+    },
+    Remote {
+        #[serde(rename = "env_ref_or_name")]
+        env_ref: String,
+        /// The generation the command operated on — the pinned generation
+        /// when opened at one (e.g. `flox activate --generation`), otherwise
+        /// the environment's current generation. Absent whenever the
+        /// generation can't be read.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        generation_number: Option<u64>,
+    },
+}
+
+/// Environment detail shared by every `cli.environment.*` event.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct EnvDetail {
-    /// One of `"remote"`, `"managed"`, `"path"` — the environment variant
-    /// the command operated on. `"managed"` is also used for `flox pull`'s
-    /// `NewAbbreviated` branch, where only the remote ref is known at
-    /// emission time.
-    env_kind: String,
-    /// The environment's identifier — the result of `env_ref().to_string()`
-    /// for remote and managed environments, and `Environment::name(...)`
-    /// for path environments. Matches the value the legacy macros emit.
-    env_ref_or_name: String,
-    /// The generation the command operated on — the pinned generation when
-    /// opened at one (e.g. `flox activate --generation`), otherwise the
-    /// environment's current generation. Absent for path environments (which
-    /// have no generations) and whenever the generation can't be read.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    generation_number: Option<u64>,
+    #[serde(flatten)]
+    identity: EnvIdentity,
     /// Number of packages locked for the invoking system when the command
     /// started. Absent when no lockfile is available.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -349,18 +367,31 @@ pub struct EnvDetail {
 }
 
 impl EnvDetail {
-    pub fn new(env_kind: impl Into<String>, env_ref_or_name: impl Into<String>) -> Self {
+    pub fn path(name: impl Into<String>) -> Self {
         Self {
-            env_kind: env_kind.into(),
-            env_ref_or_name: env_ref_or_name.into(),
-            generation_number: None,
+            identity: EnvIdentity::Path { name: name.into() },
             package_count: None,
         }
     }
 
-    pub fn with_generation_number(mut self, generation_number: u64) -> Self {
-        self.generation_number = Some(generation_number);
-        self
+    pub fn managed(env_ref: impl Into<String>, generation_number: Option<u64>) -> Self {
+        Self {
+            identity: EnvIdentity::Managed {
+                env_ref: env_ref.into(),
+                generation_number,
+            },
+            package_count: None,
+        }
+    }
+
+    pub fn remote(env_ref: impl Into<String>, generation_number: Option<u64>) -> Self {
+        Self {
+            identity: EnvIdentity::Remote {
+                env_ref: env_ref.into(),
+                generation_number,
+            },
+            package_count: None,
+        }
     }
 
     pub fn with_package_count(mut self, package_count: u64) -> Self {
@@ -879,11 +910,11 @@ mod tests {
     }
 
     fn env_detail(kind: &str, ref_or_name: &str) -> EnvDetail {
-        EnvDetail {
-            env_kind: kind.to_string(),
-            env_ref_or_name: ref_or_name.to_string(),
-            generation_number: None,
-            package_count: None,
+        match kind {
+            "path" => EnvDetail::path(ref_or_name),
+            "managed" => EnvDetail::managed(ref_or_name, None),
+            "remote" => EnvDetail::remote(ref_or_name, None),
+            other => panic!("unexpected environment kind: {other}"),
         }
     }
 
@@ -931,9 +962,7 @@ mod tests {
 
     #[test]
     fn cli_environment_activate_managed_lineage_fields_envelope_golden() {
-        let detail = env_detail("managed", "alice/myenv")
-            .with_generation_number(3)
-            .with_package_count(7);
+        let detail = EnvDetail::managed("alice/myenv", Some(3)).with_package_count(7);
         let payload = CliEnvironmentActivatePayload::new(detail);
         let value = serde_json::to_value(fixed_event(EventKind::CliEnvironmentActivate(payload)))
             .expect("event serializes");
@@ -1887,12 +1916,7 @@ mod pipeline_tests {
         let hub = EventsHub::new();
         hub.set_client(client_with_connection(&tempdir, connection));
 
-        let env_detail = EnvDetail {
-            env_kind: "path".to_string(),
-            env_ref_or_name: "myenv".to_string(),
-            generation_number: None,
-            package_count: None,
-        };
+        let env_detail = EnvDetail::path("myenv");
 
         hub.record_event(EventKind::CliEnvironmentEdit(
             CliEnvironmentEditPayload::new(env_detail.clone()),
@@ -1918,7 +1942,7 @@ mod pipeline_tests {
             assert_eq!(event.invocation_id, INVOCATION_ID);
             match &event.kind {
                 EventKind::CliEnvironmentEdit(p) => {
-                    assert_eq!(p.env_detail.env_kind, "path");
+                    assert_eq!(p.env_detail, EnvDetail::path("myenv"));
                     match p.edited_includes {
                         None => eager_seen = true,
                         Some(true) => result_seen = true,

--- a/cli/flox-rust-sdk/src/models/environment/generations.rs
+++ b/cli/flox-rust-sdk/src/models/environment/generations.rs
@@ -608,6 +608,11 @@ pub trait GenerationsExt {
         &self,
     ) -> Result<WithOtherFields<AllGenerationsMetadata>, GenerationsError>;
 
+    /// The generation the environment operates on: the pinned generation when
+    /// opened at one (e.g. `flox activate --generation`), otherwise the current
+    /// generation.
+    fn generation(&self) -> Result<Option<GenerationId>, EnvironmentError>;
+
     /// The operating generation and its lockfile, read in a single metadata
     /// pass for telemetry. Best-effort: a generation whose lockfile can't be
     /// read still yields its id.

--- a/cli/flox-rust-sdk/src/models/environment/generations.rs
+++ b/cli/flox-rust-sdk/src/models/environment/generations.rs
@@ -166,6 +166,21 @@ impl<S> Generations<S> {
         Ok(lockfile_osstr.to_string_lossy().to_string())
     }
 
+    /// Read and parse the lockfile of a generation without first re-reading
+    /// metadata to check the generation exists — the caller already resolved
+    /// the generation, so a missing one surfaces as a `git show` error.
+    pub fn lockfile_unchecked(&self, generation: usize) -> Result<Lockfile, GenerationsError> {
+        let lockfile_osstr = self
+            .repo
+            .show(&format!(
+                "{}:{}/{}/{}",
+                self.branch, generation, ENV_DIR_NAME, LOCKFILE_FILENAME
+            ))
+            .map_err(GenerationsError::ShowLockfile)?;
+        Lockfile::from_str(lockfile_osstr.to_string_lossy().as_ref())
+            .map_err(GenerationsError::Lockfile)
+    }
+
     /// Read the manifest of the current generation and return its contents as a string
     pub fn current_gen_manifest_contents(&self) -> Result<String, GenerationsError> {
         let metadata = self.metadata()?;
@@ -592,6 +607,13 @@ pub trait GenerationsExt {
     fn generations_metadata(
         &self,
     ) -> Result<WithOtherFields<AllGenerationsMetadata>, GenerationsError>;
+
+    /// The operating generation and its lockfile, read in a single metadata
+    /// pass for telemetry. Best-effort: a generation whose lockfile can't be
+    /// read still yields its id.
+    fn generation_and_existing_lockfile(
+        &self,
+    ) -> Result<(Option<GenerationId>, Option<Lockfile>), EnvironmentError>;
 
     fn switch_generation(
         &mut self,

--- a/cli/flox-rust-sdk/src/models/environment/generations.rs
+++ b/cli/flox-rust-sdk/src/models/environment/generations.rs
@@ -155,6 +155,10 @@ impl<S> Generations<S> {
         if !metadata.generations().contains_key(&generation.into()) {
             return Err(GenerationsError::GenerationNotFound(generation));
         }
+        self.show_lockfile_contents(generation)
+    }
+
+    fn show_lockfile_contents(&self, generation: usize) -> Result<String, GenerationsError> {
         let lockfile_osstr = self
             .repo
             .show(&format!(
@@ -170,15 +174,8 @@ impl<S> Generations<S> {
     /// metadata to check the generation exists — the caller already resolved
     /// the generation, so a missing one surfaces as a `git show` error.
     pub fn lockfile_unchecked(&self, generation: usize) -> Result<Lockfile, GenerationsError> {
-        let lockfile_osstr = self
-            .repo
-            .show(&format!(
-                "{}:{}/{}/{}",
-                self.branch, generation, ENV_DIR_NAME, LOCKFILE_FILENAME
-            ))
-            .map_err(GenerationsError::ShowLockfile)?;
-        Lockfile::from_str(lockfile_osstr.to_string_lossy().as_ref())
-            .map_err(GenerationsError::Lockfile)
+        let contents = self.show_lockfile_contents(generation)?;
+        Lockfile::from_str(&contents).map_err(GenerationsError::Lockfile)
     }
 
     /// Read the manifest of the current generation and return its contents as a string

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -1771,6 +1771,7 @@ mod test {
 
     use flox_core::Version;
     use flox_manifest::interfaces::{AsLatestSchema, AsTypedOnlyManifest};
+    use flox_manifest::lockfile::PackageToList;
     use flox_manifest::lockfile::test_helpers::fake_catalog_package_lock;
     use flox_manifest::parsed::Inner;
     use flox_manifest::parsed::latest::{self, ManifestLatest};
@@ -2014,9 +2015,9 @@ mod test {
         );
 
         // The combined read resolves the generation and, for this unlocked
-        // fixture (no committed lockfile), yields no lockfile — best-effort.
-        // TODO: a locked fixture should also assert Some(lockfile) with a known
-        // package_count to fully cover the managed lineage read.
+        // fixture (no committed lockfile), yields no lockfile — best-effort. A
+        // locked env's package_count is covered by
+        // `generation_and_lockfile_reads_locked_packages`.
         let (generation, lockfile) = managed_env.generation_and_existing_lockfile().unwrap();
         assert_eq!(
             generation, current,
@@ -2032,6 +2033,52 @@ mod test {
         assert!(
             !managed_env.path.join(super::ENV_DIR_NAME).exists(),
             "reading the lockfile must not materialize the checkout"
+        );
+    }
+
+    /// A managed environment locked with packages reports its lineage: the
+    /// combined read returns the current generation and a lockfile whose
+    /// per-system package count matches what was installed.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn generation_and_lockfile_reads_locked_packages() {
+        let owner = "owner".parse().unwrap();
+        let (mut flox, tempdir) = flox_instance_with_optional_floxhub(Some(&owner));
+
+        let initial_manifest = indoc! {r#"
+            version = 1
+            [install]
+        "#};
+        let mut environment =
+            mock_managed_environment_in(&flox, initial_manifest, owner, &tempdir, Some("test-env"));
+
+        flox.floxhub_client =
+            catalog_replay_client(GENERATED_DATA.join("resolve/hello.yaml")).await;
+        environment
+            .install(
+                &[PackageToInstall::parse(&flox.system, "hello").unwrap()],
+                &flox,
+            )
+            .unwrap();
+
+        let (generation, lockfile) = environment.generation_and_existing_lockfile().unwrap();
+        assert_eq!(
+            generation,
+            environment.generations_metadata().unwrap().current_gen(),
+            "the combined read resolves the current generation"
+        );
+        let lockfile = lockfile.expect("a locked managed env has a readable lockfile");
+        let packages = lockfile.list_packages(&flox.system).unwrap();
+        let install_ids: Vec<&str> = packages
+            .iter()
+            .map(|package| match package {
+                PackageToList::Catalog(_, locked) => locked.install_id.as_str(),
+                _ => panic!("expected a catalog package"),
+            })
+            .collect();
+        assert_eq!(
+            install_ids,
+            ["hello"],
+            "the combined read reports the installed package by identity"
         );
     }
 

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -652,6 +652,19 @@ impl GenerationsExt for ManagedEnvironment {
         self.generations().metadata()
     }
 
+    fn generation_and_existing_lockfile(
+        &self,
+    ) -> Result<(Option<GenerationId>, Option<Lockfile>), EnvironmentError> {
+        let Some(generation) = self.generation()? else {
+            return Ok((None, None));
+        };
+        // The generation came from metadata (or a pin), so read its lockfile
+        // directly without re-reading metadata to validate it. Best-effort: a
+        // generation whose lockfile can't be read still yields its id.
+        let lockfile = self.generations().lockfile_unchecked(*generation).ok();
+        Ok((Some(generation), lockfile))
+    }
+
     fn switch_generation(
         &mut self,
         flox: &Flox,
@@ -1188,21 +1201,6 @@ impl ManagedEnvironment {
             .generations_metadata()
             .map_err(ManagedEnvironmentError::Generations)?
             .current_gen())
-    }
-
-    /// The lockfile for the generation this environment operates on
-    /// ([`Self::generation`]), read straight from generation metadata so it
-    /// never materializes the local checkout. `None` when the environment
-    /// has no current generation.
-    pub fn existing_lockfile_without_checkout(&self) -> Result<Option<Lockfile>, EnvironmentError> {
-        let Some(generation) = self.generation()? else {
-            return Ok(None);
-        };
-        self.generations()
-            .lockfile(*generation)
-            .map_err(ManagedEnvironmentError::Generations)
-            .map_err(EnvironmentError::from)
-            .map(Some)
     }
 
     pub(crate) fn generations(&self) -> Generations {
@@ -1995,7 +1993,7 @@ mod test {
     }
 
     #[test]
-    fn existing_lockfile_without_checkout_never_materializes() {
+    fn generation_and_lockfile_never_materializes() {
         let owner = EnvironmentOwner::from_str("owner").unwrap();
         let (flox, _temp_dir_handle) = flox_instance_with_optional_floxhub(Some(&owner));
 
@@ -2018,9 +2016,22 @@ mod test {
             "unpinned resolves to the current generation"
         );
 
+        // The combined read resolves the generation and, for this unlocked
+        // fixture (no committed lockfile), yields no lockfile — best-effort.
+        // TODO: a locked fixture should also assert Some(lockfile) with a known
+        // package_count to fully cover the managed lineage read.
+        let (generation, lockfile) = managed_env.generation_and_existing_lockfile().unwrap();
+        assert_eq!(
+            generation, current,
+            "the combined read resolves the current generation"
+        );
+        assert!(
+            lockfile.is_none(),
+            "the unlocked fixture has no committed lockfile"
+        );
+
         // Reading the lineage lockfile is a metadata read — it must never
         // materialize the local checkout.
-        let _ = managed_env.existing_lockfile_without_checkout();
         assert!(
             !managed_env.path.join(super::ENV_DIR_NAME).exists(),
             "reading the lockfile must not materialize the checkout"

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -652,6 +652,16 @@ impl GenerationsExt for ManagedEnvironment {
         self.generations().metadata()
     }
 
+    fn generation(&self) -> Result<Option<GenerationId>, EnvironmentError> {
+        if let Some(generation) = self.generation {
+            return Ok(Some(generation));
+        }
+        Ok(self
+            .generations_metadata()
+            .map_err(ManagedEnvironmentError::Generations)?
+            .current_gen())
+    }
+
     fn generation_and_existing_lockfile(
         &self,
     ) -> Result<(Option<GenerationId>, Option<Lockfile>), EnvironmentError> {
@@ -1188,19 +1198,6 @@ impl ManagedEnvironment {
     /// Return the managed pointer
     pub fn pointer(&self) -> &ManagedPointer {
         &self.pointer
-    }
-
-    /// The generation this environment operates on: the pinned generation
-    /// when opened at one (e.g. `flox activate --generation`), otherwise the
-    /// current generation.
-    pub fn generation(&self) -> Result<Option<GenerationId>, EnvironmentError> {
-        if let Some(generation) = self.generation {
-            return Ok(Some(generation));
-        }
-        Ok(self
-            .generations_metadata()
-            .map_err(ManagedEnvironmentError::Generations)?
-            .current_gen())
     }
 
     pub(crate) fn generations(&self) -> Generations {

--- a/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/managed_environment.rs
@@ -1177,6 +1177,34 @@ impl ManagedEnvironment {
         &self.pointer
     }
 
+    /// The generation this environment operates on: the pinned generation
+    /// when opened at one (e.g. `flox activate --generation`), otherwise the
+    /// current generation.
+    pub fn generation(&self) -> Result<Option<GenerationId>, EnvironmentError> {
+        if let Some(generation) = self.generation {
+            return Ok(Some(generation));
+        }
+        Ok(self
+            .generations_metadata()
+            .map_err(ManagedEnvironmentError::Generations)?
+            .current_gen())
+    }
+
+    /// The lockfile for the generation this environment operates on
+    /// ([`Self::generation`]), read straight from generation metadata so it
+    /// never materializes the local checkout. `None` when the environment
+    /// has no current generation.
+    pub fn existing_lockfile_without_checkout(&self) -> Result<Option<Lockfile>, EnvironmentError> {
+        let Some(generation) = self.generation()? else {
+            return Ok(None);
+        };
+        self.generations()
+            .lockfile(*generation)
+            .map_err(ManagedEnvironmentError::Generations)
+            .map_err(EnvironmentError::from)
+            .map(Some)
+    }
+
     pub(crate) fn generations(&self) -> Generations {
         self.floxmeta_branch.generations()
     }
@@ -1963,6 +1991,39 @@ mod test {
         assert_eq!(
             local_manifest.as_writable().to_string(),
             locally_edited_content
+        );
+    }
+
+    #[test]
+    fn existing_lockfile_without_checkout_never_materializes() {
+        let owner = EnvironmentOwner::from_str("owner").unwrap();
+        let (flox, _temp_dir_handle) = flox_instance_with_optional_floxhub(Some(&owner));
+
+        let managed_env = test_helpers::mock_managed_environment_unlocked(
+            &flox,
+            &toml_edit::ser::to_string_pretty(&Manifest::default()).unwrap(),
+            owner,
+        );
+
+        // An unpinned environment resolves to its current generation, and
+        // `generation()` must agree with the metadata's current generation.
+        let current = managed_env.generations_metadata().unwrap().current_gen();
+        assert!(
+            current.is_some(),
+            "a freshly pushed environment has a current generation"
+        );
+        assert_eq!(
+            managed_env.generation().unwrap(),
+            current,
+            "unpinned resolves to the current generation"
+        );
+
+        // Reading the lineage lockfile is a metadata read — it must never
+        // materialize the local checkout.
+        let _ = managed_env.existing_lockfile_without_checkout();
+        assert!(
+            !managed_env.path.join(super::ENV_DIR_NAME).exists(),
+            "reading the lockfile must not materialize the checkout"
         );
     }
 

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -188,6 +188,16 @@ impl PathEnvironment {
     fn path_hash(&self) -> String {
         path_hash(&self.path)
     }
+
+    /// The existing lockfile without a `Flox` instance. Path environments keep
+    /// their lockfile on disk and resolve nothing to read it — the [Environment]
+    /// trait's `existing_lockfile` already ignores its `flox` argument — so
+    /// callers that lack a `Flox` can read the lockfile through this.
+    pub fn existing_lockfile_without_flox(&self) -> Result<Option<Lockfile>, EnvironmentError> {
+        self.as_core_environment()?
+            .existing_lockfile()
+            .map_err(EnvironmentError::Core)
+    }
 }
 
 impl Environment for PathEnvironment {

--- a/cli/flox-rust-sdk/src/models/environment/path_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/path_environment.rs
@@ -188,16 +188,6 @@ impl PathEnvironment {
     fn path_hash(&self) -> String {
         path_hash(&self.path)
     }
-
-    /// The existing lockfile without a `Flox` instance. Path environments keep
-    /// their lockfile on disk and resolve nothing to read it — the [Environment]
-    /// trait's `existing_lockfile` already ignores its `flox` argument — so
-    /// callers that lack a `Flox` can read the lockfile through this.
-    pub fn existing_lockfile_without_flox(&self) -> Result<Option<Lockfile>, EnvironmentError> {
-        self.as_core_environment()?
-            .existing_lockfile()
-            .map_err(EnvironmentError::Core)
-    }
 }
 
 impl Environment for PathEnvironment {

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -294,11 +294,6 @@ impl RemoteEnvironment {
         self.inner.generation()
     }
 
-    /// See [ManagedEnvironment::existing_lockfile_without_checkout].
-    pub fn existing_lockfile_without_checkout(&self) -> Result<Option<Lockfile>, EnvironmentError> {
-        self.inner.existing_lockfile_without_checkout()
-    }
-
     /// Push local changes to FloxHub for this remote environment
     ///
     /// This pushes any local changes made to the cached remote environment back to FloxHub.
@@ -523,6 +518,12 @@ impl GenerationsExt for RemoteEnvironment {
         &self,
     ) -> Result<WithOtherFields<AllGenerationsMetadata>, GenerationsError> {
         self.inner.generations_metadata()
+    }
+
+    fn generation_and_existing_lockfile(
+        &self,
+    ) -> Result<(Option<GenerationId>, Option<Lockfile>), EnvironmentError> {
+        self.inner.generation_and_existing_lockfile()
     }
 
     fn switch_generation(

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -289,6 +289,16 @@ impl RemoteEnvironment {
         self.inner.pointer()
     }
 
+    /// See [ManagedEnvironment::generation].
+    pub fn generation(&self) -> Result<Option<GenerationId>, EnvironmentError> {
+        self.inner.generation()
+    }
+
+    /// See [ManagedEnvironment::existing_lockfile_without_checkout].
+    pub fn existing_lockfile_without_checkout(&self) -> Result<Option<Lockfile>, EnvironmentError> {
+        self.inner.existing_lockfile_without_checkout()
+    }
+
     /// Push local changes to FloxHub for this remote environment
     ///
     /// This pushes any local changes made to the cached remote environment back to FloxHub.

--- a/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
+++ b/cli/flox-rust-sdk/src/models/environment/remote_environment.rs
@@ -289,11 +289,6 @@ impl RemoteEnvironment {
         self.inner.pointer()
     }
 
-    /// See [ManagedEnvironment::generation].
-    pub fn generation(&self) -> Result<Option<GenerationId>, EnvironmentError> {
-        self.inner.generation()
-    }
-
     /// Push local changes to FloxHub for this remote environment
     ///
     /// This pushes any local changes made to the cached remote environment back to FloxHub.
@@ -518,6 +513,10 @@ impl GenerationsExt for RemoteEnvironment {
         &self,
     ) -> Result<WithOtherFields<AllGenerationsMetadata>, GenerationsError> {
         self.inner.generations_metadata()
+    }
+
+    fn generation(&self) -> Result<Option<GenerationId>, EnvironmentError> {
+        self.inner.generation()
     }
 
     fn generation_and_existing_lockfile(

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -235,7 +235,7 @@ impl Activate {
         // *outcome* is carried on `cli.command_completed` (exit_code), not by
         // the presence of this dispatch-time event, so emitting before a
         // possible trust decline is intentional, not a logged false success.
-        let v2_env_detail = env_detail_from_concrete(&concrete_environment);
+        let v2_env_detail = env_detail_from_concrete(&flox, &concrete_environment);
         let v2_mode = options
             .mode
             .clone()
@@ -421,7 +421,7 @@ impl ActivateOptions {
         // this activation locked — a never-locked path env has no lockfile until
         // now — and so a declined-trust or lock-error abort above performs no
         // lineage git I/O for an event that is never emitted.
-        let v2_env_detail = env_detail_from_concrete(&concrete_environment);
+        let v2_env_detail = env_detail_from_concrete(&flox, &concrete_environment);
 
         if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentActivate(
             CliEnvironmentActivatePayload::new(v2_env_detail.clone())

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -386,7 +386,6 @@ impl ActivateOptions {
         ensure_prompt_hook_version_compatible_for_activate()?;
 
         let now_active = UninitializedEnvironment::from_concrete_environment(&concrete_environment);
-        let v2_env_detail = env_detail_from_concrete(&concrete_environment);
 
         let lockfile = match concrete_environment.lockfile(&flox)? {
             LockResult::Changed(lockfile) => {
@@ -417,6 +416,12 @@ impl ActivateOptions {
         // breadcrumb metric to estimate use of composition
         let has_includes = lockfile.compose.is_some();
         subcommand_metric!("activate", "has_includes" = has_includes);
+
+        // Read env detail after locking so package_count reflects the packages
+        // this activation locked — a never-locked path env has no lockfile until
+        // now — and so a declined-trust or lock-error abort above performs no
+        // lineage git I/O for an event that is never emitted.
+        let v2_env_detail = env_detail_from_concrete(&concrete_environment);
 
         if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentActivate(
             CliEnvironmentActivatePayload::new(v2_env_detail.clone())

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -386,6 +386,7 @@ impl ActivateOptions {
         ensure_prompt_hook_version_compatible_for_activate()?;
 
         let now_active = UninitializedEnvironment::from_concrete_environment(&concrete_environment);
+        let v2_env_detail = env_detail_from_concrete(&concrete_environment);
 
         let lockfile = match concrete_environment.lockfile(&flox)? {
             LockResult::Changed(lockfile) => {
@@ -418,7 +419,7 @@ impl ActivateOptions {
         subcommand_metric!("activate", "has_includes" = has_includes);
 
         if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentActivate(
-            CliEnvironmentActivatePayload::new(env_detail_from_concrete(&concrete_environment))
+            CliEnvironmentActivatePayload::new(v2_env_detail.clone())
                 .with_has_includes(has_includes),
         )) {
             debug!(error = %err, "Failed to record v2 event");
@@ -454,7 +455,7 @@ impl ActivateOptions {
         // subcommand and rides `lockfile_version` on a real
         // `cli.environment.activate` event instead.
         if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentActivate(
-            CliEnvironmentActivatePayload::new(env_detail_from_concrete(&concrete_environment))
+            CliEnvironmentActivatePayload::new(v2_env_detail.clone())
                 .with_lockfile_version(lockfile_version.to_string())
                 .with_manifest_version(lockfile.manifest_schema_version().to_string()),
         )) {
@@ -577,8 +578,7 @@ impl ActivateOptions {
         // synchronously by the pre-exec emit + flush block below
         // (spec AC #5).
         if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentActivate(
-            CliEnvironmentActivatePayload::new(env_detail_from_concrete(&concrete_environment))
-                .with_shell(shell.to_string()),
+            CliEnvironmentActivatePayload::new(v2_env_detail.clone()).with_shell(shell.to_string()),
         )) {
             debug!(error = %err, "Failed to record v2 event");
         }

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -65,7 +65,7 @@ use crate::commands::{
 };
 use crate::utils::detect_shell::{detect_shell_for_in_place, detect_shell_for_subshell};
 use crate::utils::errors::format_diverged_metadata;
-use crate::utils::events::env_detail_from_concrete;
+use crate::utils::events::{env_detail_from_concrete, env_detail_from_concrete_without_lineage};
 use crate::utils::message;
 use crate::utils::upgrade_output::{count_upgrade_categories, format_upgrade_summary};
 use crate::{Exit, environment_subcommand_metric, subcommand_metric, utils};
@@ -235,7 +235,7 @@ impl Activate {
         // *outcome* is carried on `cli.command_completed` (exit_code), not by
         // the presence of this dispatch-time event, so emitting before a
         // possible trust decline is intentional, not a logged false success.
-        let v2_env_detail = env_detail_from_concrete(&flox, &concrete_environment);
+        let v2_env_detail = env_detail_from_concrete_without_lineage(&concrete_environment);
         let v2_mode = options
             .mode
             .clone()

--- a/cli/flox/src/commands/containerize/mod.rs
+++ b/cli/flox/src/commands/containerize/mod.rs
@@ -71,7 +71,7 @@ impl Containerize {
             .await?;
         environment_subcommand_metric!("containerize", env);
         if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentContainerize(
-            CliEnvironmentPayload::new(env_detail_from_concrete(&env)),
+            CliEnvironmentPayload::new(env_detail_from_concrete(&flox, &env)),
         )) {
             debug!(error = %err, "Failed to record v2 event");
         }

--- a/cli/flox/src/commands/delete.rs
+++ b/cli/flox/src/commands/delete.rs
@@ -34,7 +34,7 @@ impl Delete {
 
         environment_subcommand_metric!("delete", environment);
         if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentDelete(
-            CliEnvironmentPayload::new(env_detail_from_concrete(&environment)),
+            CliEnvironmentPayload::new(env_detail_from_concrete(&flox, &environment)),
         )) {
             debug!(error = %err, "Failed to record v2 event");
         }

--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -7,7 +7,7 @@ use std::process::Command;
 use anyhow::{Context, Result, bail};
 use bpaf::Bpaf;
 use flox_core::data::environment_ref::EnvironmentName;
-use flox_events::{CliEnvironmentEditPayload, EventKind, EventsHub};
+use flox_events::{CliEnvironmentEditPayload, EnvDetail, EventKind, EventsHub};
 use flox_manifest::interfaces::{AsWritableManifest, WriteManifest};
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::generations::{
@@ -101,8 +101,12 @@ impl Edit {
             Err(e) => Err(e)?,
         };
         environment_subcommand_metric!("edit", detected_environment);
+        // Capture the environment detail once, before the edit can create a new
+        // generation, so both cli.environment.edit events for this invocation
+        // report the generation the command started from (as `activate` does).
+        let env_detail = env_detail_from_concrete(&detected_environment);
         if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentEdit(
-            CliEnvironmentEditPayload::new(env_detail_from_concrete(&detected_environment)),
+            CliEnvironmentEditPayload::new(env_detail.clone()),
         )) {
             debug!(error = %err, "Failed to record v2 event");
         }
@@ -115,7 +119,7 @@ impl Edit {
 
                 let contents = Self::provided_manifest_contents(file)?;
 
-                Self::edit_manifest(&flox, &mut detected_environment, contents).await?
+                Self::edit_manifest(&flox, &mut detected_environment, contents, env_detail).await?
             },
             EditAction::Rename { name } => {
                 let span = tracing::info_span!("rename");
@@ -207,6 +211,7 @@ impl Edit {
         flox: &Flox,
         environment: &mut ConcreteEnvironment,
         contents: Option<String>,
+        env_detail: EnvDetail,
     ) -> Result<()> {
         if let ConcreteEnvironment::Managed(environment) = environment
             && environment.has_local_changes(flox)?
@@ -270,7 +275,7 @@ impl Edit {
                 let edited_includes = old_includes != new_includes;
                 subcommand_metric!("edit", "edited_includes" = edited_includes);
                 if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentEdit(
-                    CliEnvironmentEditPayload::new(env_detail_from_concrete(environment))
+                    CliEnvironmentEditPayload::new(env_detail)
                         .with_edited_includes(edited_includes)
                         .with_manifest_version(new_lockfile.manifest_schema_version().to_string()),
                 )) {
@@ -831,7 +836,9 @@ mod tests {
         // edit the local manifest
         fs::write(environment.manifest_path(&flox).unwrap(), new_contents).unwrap();
 
-        let err = Edit::edit_manifest(&flox, &mut ConcreteEnvironment::Managed(environment), None)
+        let mut concrete = ConcreteEnvironment::Managed(environment);
+        let env_detail = env_detail_from_concrete(&concrete);
+        let err = Edit::edit_manifest(&flox, &mut concrete, None, env_detail)
             .await
             .expect_err("edit should fail");
 
@@ -863,10 +870,13 @@ mod tests {
         // edit the local manifest
         fs::write(environment.manifest_path(&flox).unwrap(), new_contents).unwrap();
 
+        let mut concrete = ConcreteEnvironment::Managed(environment);
+        let env_detail = env_detail_from_concrete(&concrete);
         Edit::edit_manifest(
             &flox,
-            &mut ConcreteEnvironment::Managed(environment),
+            &mut concrete,
             Some(new_contents.to_string()),
+            env_detail,
         )
         .await
         .expect("edit should succeed");

--- a/cli/flox/src/commands/edit.rs
+++ b/cli/flox/src/commands/edit.rs
@@ -104,7 +104,7 @@ impl Edit {
         // Capture the environment detail once, before the edit can create a new
         // generation, so both cli.environment.edit events for this invocation
         // report the generation the command started from (as `activate` does).
-        let env_detail = env_detail_from_concrete(&detected_environment);
+        let env_detail = env_detail_from_concrete(&flox, &detected_environment);
         if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentEdit(
             CliEnvironmentEditPayload::new(env_detail.clone()),
         )) {
@@ -837,7 +837,7 @@ mod tests {
         fs::write(environment.manifest_path(&flox).unwrap(), new_contents).unwrap();
 
         let mut concrete = ConcreteEnvironment::Managed(environment);
-        let env_detail = env_detail_from_concrete(&concrete);
+        let env_detail = env_detail_from_concrete(&flox, &concrete);
         let err = Edit::edit_manifest(&flox, &mut concrete, None, env_detail)
             .await
             .expect_err("edit should fail");
@@ -871,7 +871,7 @@ mod tests {
         fs::write(environment.manifest_path(&flox).unwrap(), new_contents).unwrap();
 
         let mut concrete = ConcreteEnvironment::Managed(environment);
-        let env_detail = env_detail_from_concrete(&concrete);
+        let env_detail = env_detail_from_concrete(&flox, &concrete);
         Edit::edit_manifest(
             &flox,
             &mut concrete,

--- a/cli/flox/src/commands/generations/history.rs
+++ b/cli/flox/src/commands/generations/history.rs
@@ -56,7 +56,7 @@ impl History {
         environment_subcommand_metric!("generations::history", env);
         if let Err(err) =
             EventsHub::global().record_event(EventKind::CliEnvironmentGenerationsHistory(
-                CliEnvironmentPayload::new(env_detail_from_concrete(&env)),
+                CliEnvironmentPayload::new(env_detail_from_concrete(&flox, &env)),
             ))
         {
             debug!(error = %err, "Failed to record v2 event");

--- a/cli/flox/src/commands/generations/list.rs
+++ b/cli/flox/src/commands/generations/list.rs
@@ -62,7 +62,7 @@ impl List {
         environment_subcommand_metric!("generations::list", env, request_tree = request_tree);
         if let Err(err) =
             EventsHub::global().record_event(EventKind::CliEnvironmentGenerationsList(
-                CliEnvironmentGenerationsListPayload::new(env_detail_from_concrete(&env))
+                CliEnvironmentGenerationsListPayload::new(env_detail_from_concrete(&flox, &env))
                     .with_request_tree(request_tree),
             ))
         {

--- a/cli/flox/src/commands/generations/rollback.rs
+++ b/cli/flox/src/commands/generations/rollback.rs
@@ -39,7 +39,7 @@ impl Rollback {
         environment_subcommand_metric!("generations::rollback", env);
         if let Err(err) =
             EventsHub::global().record_event(EventKind::CliEnvironmentGenerationsRollback(
-                CliEnvironmentPayload::new(env_detail_from_concrete(&env)),
+                CliEnvironmentPayload::new(env_detail_from_concrete(&flox, &env)),
             ))
         {
             debug!(error = %err, "Failed to record v2 event");

--- a/cli/flox/src/commands/generations/switch.rs
+++ b/cli/flox/src/commands/generations/switch.rs
@@ -35,7 +35,7 @@ impl Switch {
         environment_subcommand_metric!("generations::switch", env);
         if let Err(err) =
             EventsHub::global().record_event(EventKind::CliEnvironmentGenerationsSwitch(
-                CliEnvironmentPayload::new(env_detail_from_concrete(&env)),
+                CliEnvironmentPayload::new(env_detail_from_concrete(&flox, &env)),
             ))
         {
             debug!(error = %err, "Failed to record v2 event");

--- a/cli/flox/src/commands/include.rs
+++ b/cli/flox/src/commands/include.rs
@@ -77,7 +77,7 @@ impl Upgrade {
 
         environment_subcommand_metric!("include::upgrade", environment);
         if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentIncludeUpgrade(
-            CliEnvironmentPayload::new(env_detail_from_concrete(&environment)),
+            CliEnvironmentPayload::new(env_detail_from_concrete(&flox, &environment)),
         )) {
             debug!(error = %err, "Failed to record v2 event");
         }

--- a/cli/flox/src/commands/install.rs
+++ b/cli/flox/src/commands/install.rs
@@ -185,7 +185,7 @@ impl Install {
         };
         environment_subcommand_metric!("install", concrete_environment);
         if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentInstall(
-            CliEnvironmentPayload::new(env_detail_from_concrete(&concrete_environment)),
+            CliEnvironmentPayload::new(env_detail_from_concrete(&flox, &concrete_environment)),
         )) {
             debug!(error = %err, "Failed to record v2 event");
         }

--- a/cli/flox/src/commands/list.rs
+++ b/cli/flox/src/commands/list.rs
@@ -69,7 +69,7 @@ impl List {
             .await?;
         environment_subcommand_metric!("list", env);
         if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentList(
-            CliEnvironmentPayload::new(env_detail_from_concrete(&env)),
+            CliEnvironmentPayload::new(env_detail_from_concrete(&flox, &env)),
         )) {
             debug!(error = %err, "Failed to record v2 event");
         }

--- a/cli/flox/src/commands/publish.rs
+++ b/cli/flox/src/commands/publish.rs
@@ -139,7 +139,7 @@ impl Publish {
             .detect_concrete_environment(&mut flox, "Publish")?;
         environment_subcommand_metric!("publish", env);
         if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentPublish(
-            CliEnvironmentPublishPayload::new(env_detail_from_concrete(&env)),
+            CliEnvironmentPublishPayload::new(env_detail_from_concrete(&flox, &env)),
         )) {
             debug!(error = %err, "Failed to record v2 event");
         }
@@ -185,7 +185,7 @@ impl Publish {
         let handle = ensure_auth(&mut flox).await?;
         let catalog_name = publish_config.cache_args.org.clone().unwrap_or(handle);
 
-        let env_detail = env_detail_from_concrete(&env);
+        let env_detail = env_detail_from_concrete(&flox, &env);
         let path_env = match env {
             ConcreteEnvironment::Path(path_env) => path_env,
             ConcreteEnvironment::Managed(_) => {

--- a/cli/flox/src/commands/pull.rs
+++ b/cli/flox/src/commands/pull.rs
@@ -157,7 +157,7 @@ impl Pull {
                 // contract). Outcome rides on `cli.command_completed`
                 // (exit_code), so emitting before the bail is intentional.
                 if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentPull(
-                    CliEnvironmentPayload::new(env_detail_from_concrete(&environment)),
+                    CliEnvironmentPayload::new(env_detail_from_concrete(&flox, &environment)),
                 )) {
                     debug!(error = %err, "Failed to record v2 event");
                 }

--- a/cli/flox/src/commands/pull.rs
+++ b/cli/flox/src/commands/pull.rs
@@ -108,7 +108,7 @@ impl Pull {
                 // detail directly from the `RemoteRef` to match the
                 // legacy `managed_environment = remote.to_string()`
                 // extra above (spec AC #2).
-                let env_detail = EnvDetail::new("managed", remote.to_string());
+                let env_detail = EnvDetail::managed(remote.to_string(), None);
                 if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentPull(
                     CliEnvironmentPayload::new(env_detail),
                 )) {

--- a/cli/flox/src/commands/push.rs
+++ b/cli/flox/src/commands/push.rs
@@ -86,7 +86,7 @@ impl Push {
         environment_subcommand_metric!("push", env);
 
         if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentPush(
-            CliEnvironmentPayload::new(env_detail_from_concrete(&env)),
+            CliEnvironmentPayload::new(env_detail_from_concrete(&flox, &env)),
         )) {
             debug!(error = %err, "Failed to record v2 event");
         }

--- a/cli/flox/src/commands/services/logs.rs
+++ b/cli/flox/src/commands/services/logs.rs
@@ -42,7 +42,7 @@ impl Logs {
             ServicesEnvironment::from_environment_selection(&mut flox, &self.environment).await?;
         environment_subcommand_metric!("services::logs", env.environment);
         if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentServicesLogs(
-            CliEnvironmentPayload::new(env_detail_from_concrete(&env.environment)),
+            CliEnvironmentPayload::new(env_detail_from_concrete(&flox, &env.environment)),
         )) {
             debug!(error = %err, "Failed to record v2 event");
         }

--- a/cli/flox/src/commands/services/persist.rs
+++ b/cli/flox/src/commands/services/persist.rs
@@ -39,7 +39,7 @@ impl Persist {
         environment_subcommand_metric!("services::persist", env.environment);
         if let Err(err) =
             EventsHub::global().record_event(EventKind::CliEnvironmentServicesPersist(
-                CliEnvironmentPayload::new(env_detail_from_concrete(&env.environment)),
+                CliEnvironmentPayload::new(env_detail_from_concrete(&flox, &env.environment)),
             ))
         {
             debug!(error = %err, "Failed to record v2 event");

--- a/cli/flox/src/commands/services/restart.rs
+++ b/cli/flox/src/commands/services/restart.rs
@@ -47,7 +47,7 @@ impl Restart {
         environment_subcommand_metric!("services::restart", env.environment);
         if let Err(err) =
             EventsHub::global().record_event(EventKind::CliEnvironmentServicesRestart(
-                CliEnvironmentPayload::new(env_detail_from_concrete(&env.environment)),
+                CliEnvironmentPayload::new(env_detail_from_concrete(&flox, &env.environment)),
             ))
         {
             debug!(error = %err, "Failed to record v2 event");

--- a/cli/flox/src/commands/services/start.rs
+++ b/cli/flox/src/commands/services/start.rs
@@ -42,7 +42,7 @@ impl Start {
             ServicesEnvironment::from_environment_selection(&mut flox, &self.environment).await?;
         environment_subcommand_metric!("services::start", env.environment);
         if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentServicesStart(
-            CliEnvironmentPayload::new(env_detail_from_concrete(&env.environment)),
+            CliEnvironmentPayload::new(env_detail_from_concrete(&flox, &env.environment)),
         )) {
             debug!(error = %err, "Failed to record v2 event");
         }

--- a/cli/flox/src/commands/services/status.rs
+++ b/cli/flox/src/commands/services/status.rs
@@ -43,7 +43,7 @@ impl Status {
             ServicesEnvironment::from_environment_selection(&mut flox, &self.environment).await?;
         environment_subcommand_metric!("services::status", env.environment);
         if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentServicesStatus(
-            CliEnvironmentPayload::new(env_detail_from_concrete(&env.environment)),
+            CliEnvironmentPayload::new(env_detail_from_concrete(&flox, &env.environment)),
         )) {
             debug!(error = %err, "Failed to record v2 event");
         }

--- a/cli/flox/src/commands/services/stop.rs
+++ b/cli/flox/src/commands/services/stop.rs
@@ -29,7 +29,7 @@ impl Stop {
             ServicesEnvironment::from_environment_selection(&mut flox, &self.environment).await?;
         environment_subcommand_metric!("services::stop", env.environment);
         if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentServicesStop(
-            CliEnvironmentPayload::new(env_detail_from_concrete(&env.environment)),
+            CliEnvironmentPayload::new(env_detail_from_concrete(&flox, &env.environment)),
         )) {
             debug!(error = %err, "Failed to record v2 event");
         }

--- a/cli/flox/src/commands/uninstall.rs
+++ b/cli/flox/src/commands/uninstall.rs
@@ -72,7 +72,7 @@ impl Uninstall {
         };
         environment_subcommand_metric!("uninstall", concrete_environment);
         if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentUninstall(
-            CliEnvironmentPayload::new(env_detail_from_concrete(&concrete_environment)),
+            CliEnvironmentPayload::new(env_detail_from_concrete(&flox, &concrete_environment)),
         )) {
             debug!(error = %err, "Failed to record v2 event");
         }

--- a/cli/flox/src/commands/upgrade.rs
+++ b/cli/flox/src/commands/upgrade.rs
@@ -53,7 +53,7 @@ impl Upgrade {
             .await?;
         environment_subcommand_metric!("upgrade", concrete_environment);
         if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentUpgrade(
-            CliEnvironmentPayload::new(env_detail_from_concrete(&concrete_environment)),
+            CliEnvironmentPayload::new(env_detail_from_concrete(&flox, &concrete_environment)),
         )) {
             debug!(error = %err, "Failed to record v2 event");
         }

--- a/cli/flox/src/utils/events.rs
+++ b/cli/flox/src/utils/events.rs
@@ -18,6 +18,7 @@ use std::sync::{LazyLock, OnceLock};
 use flox_config::Config;
 use flox_events::{EnvDetail, EventsClient, EventsHub, SharedMetadataTemplate};
 use flox_rust_sdk::flox::FLOX_VERSION;
+use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::{ConcreteEnvironment, Environment};
 use flox_rust_sdk::utils::INVOCATION_SOURCES;
 use tracing::debug;
@@ -148,7 +149,7 @@ struct EnvLineageFields {
 /// Read the lineage fields for `env`. Every read is best-effort and read-only:
 /// a failure leaves the field absent and is logged at debug, never failing the
 /// command.
-fn read_env_lineage_fields(env: &ConcreteEnvironment) -> EnvLineageFields {
+fn read_env_lineage_fields(flox: &Flox, env: &ConcreteEnvironment) -> EnvLineageFields {
     let generation_number = match env {
         ConcreteEnvironment::Managed(environment) => environment.generation(),
         ConcreteEnvironment::Remote(environment) => environment.generation(),
@@ -160,7 +161,7 @@ fn read_env_lineage_fields(env: &ConcreteEnvironment) -> EnvLineageFields {
     .map(|generation| *generation as u64);
 
     let package_count = match env {
-        ConcreteEnvironment::Path(environment) => environment.existing_lockfile_without_flox(),
+        ConcreteEnvironment::Path(environment) => environment.existing_lockfile(flox),
         ConcreteEnvironment::Managed(environment) => {
             environment.existing_lockfile_without_checkout()
         },
@@ -175,7 +176,7 @@ fn read_env_lineage_fields(env: &ConcreteEnvironment) -> EnvLineageFields {
         lockfile
             .packages
             .iter()
-            .filter(|package| package.system().as_str() == env!("NIX_TARGET_SYSTEM"))
+            .filter(|package| package.system().as_str() == flox.system.as_str())
             .count() as u64
     });
 
@@ -190,7 +191,7 @@ fn read_env_lineage_fields(env: &ConcreteEnvironment) -> EnvLineageFields {
 /// `environment_subcommand_metric!` macro. Shared across call sites so the
 /// per-kind match is not duplicated. The lineage fields are only read when an
 /// events client is installed.
-pub fn env_detail_from_concrete(env: &ConcreteEnvironment) -> EnvDetail {
+pub fn env_detail_from_concrete(flox: &Flox, env: &ConcreteEnvironment) -> EnvDetail {
     let (env_kind, env_ref_or_name) = match env {
         ConcreteEnvironment::Remote(environment) => ("remote", environment.env_ref().to_string()),
         ConcreteEnvironment::Managed(environment) => ("managed", environment.env_ref().to_string()),
@@ -199,7 +200,7 @@ pub fn env_detail_from_concrete(env: &ConcreteEnvironment) -> EnvDetail {
         },
     };
     let mut detail = EnvDetail::new(env_kind, env_ref_or_name);
-    if let Some(fields) = EventsHub::global().when_client_set(|| read_env_lineage_fields(env)) {
+    if let Some(fields) = EventsHub::global().when_client_set(|| read_env_lineage_fields(flox, env)) {
         if let Some(generation_number) = fields.generation_number {
             detail = detail.with_generation_number(generation_number);
         }

--- a/cli/flox/src/utils/events.rs
+++ b/cli/flox/src/utils/events.rs
@@ -17,8 +17,8 @@ use std::sync::{LazyLock, OnceLock};
 
 use flox_config::Config;
 use flox_events::{EnvDetail, EventsClient, EventsHub, SharedMetadataTemplate};
-use flox_rust_sdk::flox::FLOX_VERSION;
-use flox_rust_sdk::flox::Flox;
+use flox_rust_sdk::flox::{FLOX_VERSION, Flox};
+use flox_rust_sdk::models::environment::generations::GenerationsExt;
 use flox_rust_sdk::models::environment::{ConcreteEnvironment, Environment};
 use flox_rust_sdk::utils::INVOCATION_SOURCES;
 use tracing::debug;
@@ -150,35 +150,38 @@ struct EnvLineageFields {
 /// a failure leaves the field absent and is logged at debug, never failing the
 /// command.
 fn read_env_lineage_fields(flox: &Flox, env: &ConcreteEnvironment) -> EnvLineageFields {
-    let generation_number = match env {
-        ConcreteEnvironment::Managed(environment) => environment.generation(),
-        ConcreteEnvironment::Remote(environment) => environment.generation(),
-        ConcreteEnvironment::Path(_) => Ok(None),
-    }
-    .map_err(|err| debug!(error = %err, "v2 events: could not read generation"))
-    .ok()
-    .flatten()
-    .map(|generation| *generation as u64);
-
-    let package_count = match env {
-        ConcreteEnvironment::Path(environment) => environment.existing_lockfile(flox),
+    // Managed/remote resolve their generation and lockfile in a single
+    // metadata read; path envs have no generation and read their on-disk
+    // lockfile.
+    let (generation, lockfile) = match env {
+        ConcreteEnvironment::Path(environment) => (None, environment.existing_lockfile(flox)),
         ConcreteEnvironment::Managed(environment) => {
-            environment.existing_lockfile_without_checkout()
+            match environment.generation_and_existing_lockfile() {
+                Ok((generation, lockfile)) => (generation, Ok(lockfile)),
+                Err(err) => (None, Err(err)),
+            }
         },
         ConcreteEnvironment::Remote(environment) => {
-            environment.existing_lockfile_without_checkout()
+            match environment.generation_and_existing_lockfile() {
+                Ok((generation, lockfile)) => (generation, Ok(lockfile)),
+                Err(err) => (None, Err(err)),
+            }
         },
-    }
-    .map_err(|err| debug!(error = %err, "v2 events: could not read lockfile"))
-    .ok()
-    .flatten()
-    .map(|lockfile| {
-        lockfile
-            .packages
-            .iter()
-            .filter(|package| package.system().as_str() == flox.system.as_str())
-            .count() as u64
-    });
+    };
+
+    let generation_number = generation.map(|generation| *generation as u64);
+
+    let package_count = lockfile
+        .map_err(|err| debug!(error = %err, "v2 events: could not read lockfile"))
+        .ok()
+        .flatten()
+        .map(|lockfile| {
+            lockfile
+                .packages
+                .iter()
+                .filter(|package| package.system().as_str() == flox.system.as_str())
+                .count() as u64
+        });
 
     EnvLineageFields {
         generation_number,
@@ -200,7 +203,8 @@ pub fn env_detail_from_concrete(flox: &Flox, env: &ConcreteEnvironment) -> EnvDe
         },
     };
     let mut detail = EnvDetail::new(env_kind, env_ref_or_name);
-    if let Some(fields) = EventsHub::global().when_client_set(|| read_env_lineage_fields(flox, env)) {
+    if let Some(fields) = EventsHub::global().when_client_set(|| read_env_lineage_fields(flox, env))
+    {
         if let Some(generation_number) = fields.generation_number {
             detail = detail.with_generation_number(generation_number);
         }

--- a/cli/flox/src/utils/events.rs
+++ b/cli/flox/src/utils/events.rs
@@ -192,25 +192,41 @@ fn read_env_lineage_fields(flox: &Flox, env: &ConcreteEnvironment) -> EnvLineage
 /// Build an [`EnvDetail`] for the supplied [`ConcreteEnvironment`], using the
 /// same env-kind / env-ref mapping as the legacy
 /// `environment_subcommand_metric!` macro. Shared across call sites so the
-/// per-kind match is not duplicated. The lineage fields are only read when an
-/// events client is installed.
-pub fn env_detail_from_concrete(flox: &Flox, env: &ConcreteEnvironment) -> EnvDetail {
-    let (env_kind, env_ref_or_name) = match env {
-        ConcreteEnvironment::Remote(environment) => ("remote", environment.env_ref().to_string()),
-        ConcreteEnvironment::Managed(environment) => ("managed", environment.env_ref().to_string()),
-        ConcreteEnvironment::Path(environment) => {
-            ("path", Environment::name(environment).to_string())
+/// per-kind match is not duplicated.
+fn env_detail_with_generation(
+    env: &ConcreteEnvironment,
+    generation_number: Option<u64>,
+) -> EnvDetail {
+    match env {
+        ConcreteEnvironment::Remote(environment) => {
+            EnvDetail::remote(environment.env_ref().to_string(), generation_number)
         },
+        ConcreteEnvironment::Managed(environment) => {
+            EnvDetail::managed(environment.env_ref().to_string(), generation_number)
+        },
+        ConcreteEnvironment::Path(environment) => {
+            EnvDetail::path(Environment::name(environment).to_string())
+        },
+    }
+}
+
+/// Build environment identity without reading lineage. Used by eager events
+/// that must emit before locking or trust decisions.
+pub fn env_detail_from_concrete_without_lineage(env: &ConcreteEnvironment) -> EnvDetail {
+    env_detail_with_generation(env, None)
+}
+
+/// Build environment detail, reading lineage only when an events client is
+/// installed.
+pub fn env_detail_from_concrete(flox: &Flox, env: &ConcreteEnvironment) -> EnvDetail {
+    let Some(fields) = EventsHub::global().when_client_set(|| read_env_lineage_fields(flox, env))
+    else {
+        return env_detail_from_concrete_without_lineage(env);
     };
-    let mut detail = EnvDetail::new(env_kind, env_ref_or_name);
-    if let Some(fields) = EventsHub::global().when_client_set(|| read_env_lineage_fields(flox, env))
-    {
-        if let Some(generation_number) = fields.generation_number {
-            detail = detail.with_generation_number(generation_number);
-        }
-        if let Some(package_count) = fields.package_count {
-            detail = detail.with_package_count(package_count);
-        }
+
+    let mut detail = env_detail_with_generation(env, fields.generation_number);
+    if let Some(package_count) = fields.package_count {
+        detail = detail.with_package_count(package_count);
     }
     detail
 }

--- a/cli/flox/src/utils/events.rs
+++ b/cli/flox/src/utils/events.rs
@@ -16,7 +16,7 @@ use std::str::FromStr;
 use std::sync::{LazyLock, OnceLock};
 
 use flox_config::Config;
-use flox_events::{EnvDetail, EventsClient, SharedMetadataTemplate};
+use flox_events::{EnvDetail, EventsClient, EventsHub, SharedMetadataTemplate};
 use flox_rust_sdk::flox::FLOX_VERSION;
 use flox_rust_sdk::models::environment::{ConcreteEnvironment, Environment};
 use flox_rust_sdk::utils::INVOCATION_SOURCES;
@@ -139,22 +139,75 @@ pub fn build_events_client(
     ))
 }
 
+/// Lineage fields for the environment the current invocation operates on.
+struct EnvLineageFields {
+    generation_number: Option<u64>,
+    package_count: Option<u64>,
+}
+
+/// Read the lineage fields for `env`. Every read is best-effort and read-only:
+/// a failure leaves the field absent and is logged at debug, never failing the
+/// command.
+fn read_env_lineage_fields(env: &ConcreteEnvironment) -> EnvLineageFields {
+    let generation_number = match env {
+        ConcreteEnvironment::Managed(environment) => environment.generation(),
+        ConcreteEnvironment::Remote(environment) => environment.generation(),
+        ConcreteEnvironment::Path(_) => Ok(None),
+    }
+    .map_err(|err| debug!(error = %err, "v2 events: could not read generation"))
+    .ok()
+    .flatten()
+    .map(|generation| *generation as u64);
+
+    let package_count = match env {
+        ConcreteEnvironment::Path(environment) => environment.existing_lockfile_without_flox(),
+        ConcreteEnvironment::Managed(environment) => {
+            environment.existing_lockfile_without_checkout()
+        },
+        ConcreteEnvironment::Remote(environment) => {
+            environment.existing_lockfile_without_checkout()
+        },
+    }
+    .map_err(|err| debug!(error = %err, "v2 events: could not read lockfile"))
+    .ok()
+    .flatten()
+    .map(|lockfile| {
+        lockfile
+            .packages
+            .iter()
+            .filter(|package| package.system().as_str() == env!("NIX_TARGET_SYSTEM"))
+            .count() as u64
+    });
+
+    EnvLineageFields {
+        generation_number,
+        package_count,
+    }
+}
+
 /// Build an [`EnvDetail`] for the supplied [`ConcreteEnvironment`], using the
 /// same env-kind / env-ref mapping as the legacy
 /// `environment_subcommand_metric!` macro. Shared across call sites so the
-/// per-kind match is not duplicated.
+/// per-kind match is not duplicated. The lineage fields are only read when an
+/// events client is installed.
 pub fn env_detail_from_concrete(env: &ConcreteEnvironment) -> EnvDetail {
-    match env {
-        ConcreteEnvironment::Remote(environment) => {
-            EnvDetail::new("remote", environment.env_ref().to_string())
-        },
-        ConcreteEnvironment::Managed(environment) => {
-            EnvDetail::new("managed", environment.env_ref().to_string())
-        },
+    let (env_kind, env_ref_or_name) = match env {
+        ConcreteEnvironment::Remote(environment) => ("remote", environment.env_ref().to_string()),
+        ConcreteEnvironment::Managed(environment) => ("managed", environment.env_ref().to_string()),
         ConcreteEnvironment::Path(environment) => {
-            EnvDetail::new("path", Environment::name(environment).to_string())
+            ("path", Environment::name(environment).to_string())
         },
+    };
+    let mut detail = EnvDetail::new(env_kind, env_ref_or_name);
+    if let Some(fields) = EventsHub::global().when_client_set(|| read_env_lineage_fields(env)) {
+        if let Some(generation_number) = fields.generation_number {
+            detail = detail.with_generation_number(generation_number);
+        }
+        if let Some(package_count) = fields.package_count {
+            detail = detail.with_package_count(package_count);
+        }
     }
+    detail
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Proposed Changes

Adds two optional dimensions to the `cli.environment.*` telemetry events:
`generation_number` (the generation the command operated on) and
`package_count` (packages locked for the invoking system). Both are optional
and omitted when unknown, so an old row round-trips through the new struct
unchanged and an absent field is skipped on the wire.

**What the fields mean**

- `generation_number` — the pinned generation when the environment was opened
  at one (`flox activate --generation N`), otherwise the current generation.
  Managed and remote environments only; absent for path environments (no
  generations) and whenever the generation can't be read.
- `package_count` — the environment's locked packages filtered to the invoking
  system (`flox.system`), read straight from generation metadata without
  materializing the managed checkout. Read-only and best-effort; not read at
  all when metrics are off.

**How they're read**

- For managed/remote environments the generation and its lockfile are resolved
  in a single generation-metadata pass
  (`GenerationsExt::generation_and_existing_lockfile`), so a lineage read spawns
  two `git show` subprocesses rather than four.
- The read is threaded a `&Flox`, so it filters by the runtime `flox.system`
  and reads path-env lockfiles through the standard `Environment::existing_lockfile`
  rather than a bespoke flox-less helper.
- `package_count` is a lightweight inline count, not `flox list`'s
  `list_packages()` — it applies the same per-system filter but avoids that path
  because it can fail with `MissingPackageDescriptor`, which a best-effort
  telemetry read must not surface. The two agree for well-formed lockfiles.

**Emission consistency**

- `flox activate` reads the detail after locking, so `package_count` reflects
  the packages the activation locked (a never-locked path env is no longer
  reported as empty), and a declined-trust or lock-error abort does no lineage
  I/O.
- `flox edit` reports the started-from generation on both of its events, so the
  two rows for one invocation agree. `generation_number`/`package_count`
  describe the pre-edit environment; `manifest_version` on the result event
  describes the post-edit manifest — a documented, deliberate epoch split.

## Release Notes

None (internal telemetry only; no user-facing behavior change).
