### PR TITLE
feat(events): add build outcome fields to cli.build

### DIFF
--- a/cli/flox-core/src/lib.rs
+++ b/cli/flox-core/src/lib.rs
@@ -24,11 +24,18 @@ pub use version::Version;
 
 pub const N_HASH_CHARS: usize = 8;
 
+/// Full 64-char blake3 hex digest of `bytes`. The primitive behind
+/// [`path_hash`] and callers that fingerprint content (e.g. a lockfile's
+/// canonical serialization); callers own which bytes they hash.
+pub fn blake3_hex(bytes: &[u8]) -> String {
+    blake3::hash(bytes).to_hex().to_string()
+}
+
 /// Returns the truncated hash of a [Path]
 pub fn path_hash(p: impl AsRef<Path>) -> String {
-    let mut chars = blake3::hash(p.as_ref().as_os_str().as_bytes()).to_hex();
-    chars.truncate(N_HASH_CHARS);
-    chars.to_string()
+    let mut hash = blake3_hex(p.as_ref().as_os_str().as_bytes());
+    hash.truncate(N_HASH_CHARS);
+    hash
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -125,4 +132,16 @@ pub fn maybe_traceable_path(maybe_path: &Option<PathBuf>) -> impl tracing::Value
 /// Returns a log file name, or glob pattern, for upgrade-check logs.
 pub fn log_file_format_upgrade_check(index: impl Display) -> String {
     format!("upgrade-check.{}.log", index)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn blake3_hex_is_a_full_hex_digest() {
+        let hash = blake3_hex(b"flox");
+        assert_eq!(hash.len(), 64);
+        assert!(hash.chars().all(|c| c.is_ascii_hexdigit()));
+    }
 }

--- a/cli/flox-events/src/lib.rs
+++ b/cli/flox-events/src/lib.rs
@@ -490,43 +490,41 @@ impl CliEnvironmentActivatePayload {
     }
 }
 
-/// Outcome of an individual package's install / upgrade / uninstall
-/// attempt within a single `flox <command>` invocation.
-///
-/// Recorded best-effort from a single error-handling site (e.g.
-/// `Install::handle_error` in `cli/flox/src/commands/install.rs`); the
-/// outcome value is ambiguous in two directions and consumers must
-/// account for both:
-///
-/// - **Absence of `Success` is not proof of failure.** A `?`-propagated
-///   early exit from inside the install pipeline skips the success-branch
-///   emit; no per-package record is written for any package the
-///   invocation attempted.
-/// - **Presence of `Failure` is not proof that *that specific package*
-///   failed.** On a partial-failure invocation the failure-branch emit
-///   marks every attempted package `Failure` because the partition of
-///   succeeded vs failed packages has not been computed at that site —
-///   matching the legacy packed `failed_packages` string's semantics.
+/// Success or failure of a `cli.*` operation. Shared across events (the
+/// per-package install / upgrade / uninstall verbs and `cli.build`); the
+/// per-event meaning of each value lives on the individual payload's
+/// `outcome` field.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
-pub enum PackageOutcome {
+pub enum Outcome {
     Success,
     Failure,
 }
 
 /// Payload shared by the per-package events (`cli.package.install` /
-/// `.upgrade` / `.uninstall`). One event is emitted per package; see
-/// [`PackageOutcome`] for the outcome semantics.
+/// `.upgrade` / `.uninstall`). One event is emitted per package.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CliPackagePayload {
     /// Per-package identifier matching what the legacy `failed_packages`
     /// string packed (catalog `pkg_path`, flake URL, or store path).
     package: String,
-    outcome: PackageOutcome,
+    /// Outcome of this package's attempt within the invocation. Recorded
+    /// best-effort from a single error-handling site (e.g.
+    /// `Install::handle_error` in `cli/flox/src/commands/install.rs`), so the
+    /// value is ambiguous in two directions and consumers must account for
+    /// both:
+    /// - **Absence of `Success` is not proof of failure.** A `?`-propagated
+    ///   early exit skips the success-branch emit; no per-package record is
+    ///   written for any package the invocation attempted.
+    /// - **Presence of `Failure` is not proof that *that specific package*
+    ///   failed.** The failure-branch emit marks every attempted package
+    ///   `Failure` because the succeeded-vs-failed partition is not computed
+    ///   at that site — matching the legacy packed `failed_packages` string.
+    outcome: Outcome,
 }
 
 impl CliPackagePayload {
-    pub fn new(package: String, outcome: PackageOutcome) -> Self {
+    pub fn new(package: String, outcome: Outcome) -> Self {
         Self { package, outcome }
     }
 }
@@ -658,11 +656,30 @@ impl CliEnvironmentGenerationsListPayload {
 // table; search hits the catalog without a resolved environment).
 
 /// Payload for [`EventKind::CliBuild`]. Carries `flox build`'s
-/// per-invocation build-kind detection flags.
+/// per-invocation build-kind detection flags, plus the build outcome
+/// once the build step has run.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CliBuildPayload {
     has_expression_build: bool,
     has_manifest_build: bool,
+    /// Whether the build step succeeded or failed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    outcome: Option<Outcome>,
+    /// Wall-clock ms for the build step only (not the whole invocation).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    duration_ms: Option<u64>,
+    /// Classified `ManifestBuilderError` slug (e.g. `build.build_failure`)
+    /// on failure — never the raw error message or build output.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    error_kind: Option<String>,
+    /// blake3 fingerprint of the locked state that was built (the in-memory
+    /// `Lockfile`'s canonical serialization). It identifies *what was built*
+    /// and is stable within a CLI version — but it is NOT the on-disk
+    /// lockfile bytes, NOT a durable cross-version identity, and NOT a
+    /// package-set identity (its preimage includes vars, hooks, and build
+    /// scripts). Consumers comparing it must hash through the same helper.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    lockfile_hash: Option<String>,
 }
 
 impl CliBuildPayload {
@@ -670,7 +687,35 @@ impl CliBuildPayload {
         Self {
             has_expression_build,
             has_manifest_build,
+            outcome: None,
+            duration_ms: None,
+            error_kind: None,
+            lockfile_hash: None,
         }
+    }
+
+    pub fn with_outcome(mut self, value: Outcome) -> Self {
+        self.outcome = Some(value);
+        self
+    }
+
+    pub fn with_duration_ms(mut self, value: u64) -> Self {
+        self.duration_ms = Some(value);
+        self
+    }
+
+    /// `&'static str` (not `impl Into<String>`) so only compile-time slugs —
+    /// e.g. a `strum::IntoStaticStr` derivation — can populate `error_kind`;
+    /// a runtime-rendered error string is a compile error, keeping the field
+    /// leak-proof by construction.
+    pub fn with_error_kind(mut self, value: &'static str) -> Self {
+        self.error_kind = Some(value.to_string());
+        self
+    }
+
+    pub fn with_lockfile_hash(mut self, value: impl Into<String>) -> Self {
+        self.lockfile_hash = Some(value.into());
+        self
     }
 }
 
@@ -1105,7 +1150,7 @@ mod tests {
 
     #[test]
     fn cli_package_install_success_envelope_golden() {
-        let payload = CliPackagePayload::new("hello".to_string(), PackageOutcome::Success);
+        let payload = CliPackagePayload::new("hello".to_string(), Outcome::Success);
         let value = serde_json::to_value(fixed_event(EventKind::CliPackageInstall(payload)))
             .expect("event serializes");
         let expected = package_envelope_json("cli.package.install", "hello", "success");
@@ -1114,7 +1159,7 @@ mod tests {
 
     #[test]
     fn cli_package_install_failure_envelope_golden() {
-        let payload = CliPackagePayload::new("nope".to_string(), PackageOutcome::Failure);
+        let payload = CliPackagePayload::new("nope".to_string(), Outcome::Failure);
         let value = serde_json::to_value(fixed_event(EventKind::CliPackageInstall(payload)))
             .expect("event serializes");
         let expected = package_envelope_json("cli.package.install", "nope", "failure");
@@ -1123,7 +1168,7 @@ mod tests {
 
     #[test]
     fn cli_package_upgrade_envelope_golden() {
-        let payload = CliPackagePayload::new("hello".to_string(), PackageOutcome::Success);
+        let payload = CliPackagePayload::new("hello".to_string(), Outcome::Success);
         let value = serde_json::to_value(fixed_event(EventKind::CliPackageUpgrade(payload)))
             .expect("event serializes");
         let expected = package_envelope_json("cli.package.upgrade", "hello", "success");
@@ -1132,7 +1177,7 @@ mod tests {
 
     #[test]
     fn cli_package_uninstall_envelope_golden() {
-        let payload = CliPackagePayload::new("hello".to_string(), PackageOutcome::Success);
+        let payload = CliPackagePayload::new("hello".to_string(), Outcome::Success);
         let value = serde_json::to_value(fixed_event(EventKind::CliPackageUninstall(payload)))
             .expect("event serializes");
         let expected = package_envelope_json("cli.package.uninstall", "hello", "success");
@@ -1154,6 +1199,18 @@ mod tests {
             "device_id": "00000000-0000-0000-0000-000000000000",
             "event_type": event_type,
             "payload": payload_json,
+        })
+    }
+
+    fn cli_build_envelope_json(payload: serde_json::Value) -> serde_json::Value {
+        json!({
+            "event_id": "00000000-0000-0000-0000-000000000000",
+            "event_timestamp": EPOCH_UNIX_MS,
+            "source": "cli",
+            "invocation_id": "00000000-0000-0000-0000-000000000000",
+            "device_id": "00000000-0000-0000-0000-000000000000",
+            "event_type": "cli.build",
+            "payload": payload,
         })
     }
 
@@ -1353,19 +1410,72 @@ mod tests {
         let payload = CliBuildPayload::new(true, false);
         let value = serde_json::to_value(fixed_event(EventKind::CliBuild(payload)))
             .expect("event serializes");
-        let payload_json = json!({
+        let expected = cli_build_envelope_json(json!({
             "has_expression_build": true,
             "has_manifest_build": false,
-        });
-        let expected = json!({
+        }));
+        assert_eq!(value, expected);
+    }
+
+    #[test]
+    fn cli_build_row_without_outcome_fields_round_trips() {
+        // A row buffered by a binary predating the outcome fields (two bools,
+        // no outcome/duration/error/hash) must deserialize with those absent
+        // and re-serialize unchanged.
+        let old_row = json!({
             "event_id": "00000000-0000-0000-0000-000000000000",
             "event_timestamp": EPOCH_UNIX_MS,
             "source": "cli",
             "invocation_id": "00000000-0000-0000-0000-000000000000",
             "device_id": "00000000-0000-0000-0000-000000000000",
             "event_type": "cli.build",
-            "payload": payload_json,
+            "payload": { "has_expression_build": true, "has_manifest_build": false },
         });
+        let event: Event =
+            serde_json::from_value(old_row.clone()).expect("old-shape row deserializes");
+        let EventKind::CliBuild(ref payload) = event.kind else {
+            panic!("expected cli.build");
+        };
+        assert_eq!(payload, &CliBuildPayload::new(true, false));
+        let reserialized = serde_json::to_value(event).expect("event re-serializes");
+        assert_eq!(reserialized, old_row);
+    }
+
+    #[test]
+    fn cli_build_success_envelope_golden() {
+        let payload = CliBuildPayload::new(true, true)
+            .with_duration_ms(1234)
+            .with_lockfile_hash("d5f2b8")
+            .with_outcome(Outcome::Success);
+        let value = serde_json::to_value(fixed_event(EventKind::CliBuild(payload)))
+            .expect("event serializes");
+        let expected = cli_build_envelope_json(json!({
+            "has_expression_build": true,
+            "has_manifest_build": true,
+            "outcome": "success",
+            "duration_ms": 1234,
+            "lockfile_hash": "d5f2b8",
+        }));
+        assert_eq!(value, expected);
+    }
+
+    #[test]
+    fn cli_build_failure_envelope_golden() {
+        let payload = CliBuildPayload::new(false, true)
+            .with_duration_ms(50)
+            .with_lockfile_hash("d5f2b8")
+            .with_outcome(Outcome::Failure)
+            .with_error_kind("build.build_failure");
+        let value = serde_json::to_value(fixed_event(EventKind::CliBuild(payload)))
+            .expect("event serializes");
+        let expected = cli_build_envelope_json(json!({
+            "has_expression_build": false,
+            "has_manifest_build": true,
+            "outcome": "failure",
+            "duration_ms": 50,
+            "lockfile_hash": "d5f2b8",
+            "error_kind": "build.build_failure",
+        }));
         assert_eq!(value, expected);
     }
 
@@ -1828,12 +1938,12 @@ mod pipeline_tests {
 
         hub.record_event(EventKind::CliPackageInstall(CliPackagePayload::new(
             "pkgA".to_string(),
-            PackageOutcome::Success,
+            Outcome::Success,
         )))
         .expect("record pkgA");
         hub.record_event(EventKind::CliPackageInstall(CliPackagePayload::new(
             "pkgB".to_string(),
-            PackageOutcome::Success,
+            Outcome::Success,
         )))
         .expect("record pkgB");
         hub.flush(true).expect("flush events");
@@ -1850,7 +1960,7 @@ mod pipeline_tests {
         for event in &events {
             match &event.kind {
                 EventKind::CliPackageInstall(p) => {
-                    assert_eq!(p.outcome, PackageOutcome::Success);
+                    assert_eq!(p.outcome, Outcome::Success);
                     packages.push(p.package.clone());
                 },
                 other => panic!("expected CliPackageInstall, got {other:?}"),
@@ -1878,7 +1988,7 @@ mod pipeline_tests {
         for package in ["pkgA", "nope"] {
             hub.record_event(EventKind::CliPackageInstall(CliPackagePayload::new(
                 package.to_string(),
-                PackageOutcome::Failure,
+                Outcome::Failure,
             )))
             .expect("record failure");
         }
@@ -1895,7 +2005,7 @@ mod pipeline_tests {
         for event in &events {
             match &event.kind {
                 EventKind::CliPackageInstall(p) => {
-                    assert_eq!(p.outcome, PackageOutcome::Failure);
+                    assert_eq!(p.outcome, Outcome::Failure);
                 },
                 other => panic!("expected CliPackageInstall, got {other:?}"),
             }

--- a/cli/flox-manifest/src/lockfile/mod.rs
+++ b/cli/flox-manifest/src/lockfile/mod.rs
@@ -86,6 +86,19 @@ impl Lockfile {
         serde_json::from_slice(&contents).map_err(LockfileError::ParseJson)
     }
 
+    /// A blake3 fingerprint of the locked state, over the same canonical JSON
+    /// the lockfile is written to disk with (`to_string_pretty`). It
+    /// identifies *what was built* — the in-memory lockfile, which may have
+    /// been re-locked to differ from the on-disk file — and is stable within a
+    /// CLI version (it fingerprints the serialization, not the on-disk bytes,
+    /// and is deterministic only while every serialized map stays ordered).
+    /// `None` if serialization fails.
+    pub fn content_hash(&self) -> Option<String> {
+        serde_json::to_string_pretty(self)
+            .ok()
+            .map(|json| flox_core::blake3_hex(json.as_bytes()))
+    }
+
     pub fn version(&self) -> u8 {
         1
     }
@@ -611,6 +624,20 @@ pub(crate) mod tests {
     use crate::interfaces::AsTypedOnlyManifest;
     use crate::parsed::Inner;
     use crate::parsed::latest::{ManifestLatest, ManifestPackageDescriptor};
+
+    #[test]
+    fn content_hash_is_a_deterministic_digest() {
+        use flox_test_utils::GENERATED_DATA;
+        let path = CanonicalPath::new(GENERATED_DATA.join("envs/hello/manifest.lock")).unwrap();
+        let lockfile = Lockfile::read_from_file(&path).unwrap();
+        let hash = lockfile.content_hash().unwrap();
+        assert_eq!(hash.len(), 64);
+        // Round-trip through serialize → parse → hash: a non-ordered map in the
+        // lockfile tree would reorder keys and change the digest.
+        let round_tripped: Lockfile =
+            serde_json::from_str(&serde_json::to_string(&lockfile).unwrap()).unwrap();
+        assert_eq!(round_tripped.content_hash().unwrap(), hash);
+    }
 
     #[test]
     fn test_list_packages_catalog() {

--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -82,7 +82,8 @@ pub trait ManifestBuilder {
     fn clean(self, package: &[PackageTargetName]) -> Result<(), ManifestBuilderError>;
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, strum::IntoStaticStr, strum::EnumCount)]
+#[strum(serialize_all = "snake_case", prefix = "build.")]
 pub enum ManifestBuilderError {
     #[error("failed to call package builder: {0}")]
     CallBuilderError(#[source] std::io::Error),
@@ -108,8 +109,11 @@ pub enum ManifestBuilderError {
     #[error("failed to clean up build artifacts: {status}")]
     RunClean { status: ExitStatus },
 
+    // Carries the child's `ExitStatus` so callers can tell a genuine build
+    // failure from a signal-terminated one (e.g. Ctrl-C, which reaches the
+    // whole process group).
     #[error("Build failed")]
-    BuildFailure,
+    BuildFailure { status: ExitStatus },
 }
 
 #[derive(Debug, PartialEq, Deserialize, Default, derive_more::Deref)]
@@ -428,7 +432,7 @@ impl ManifestBuilder for FloxBuildMk<'_> {
             .map_err(ManifestBuilderError::CallBuilderError)?;
 
         if !status.success() {
-            return Err(ManifestBuilderError::BuildFailure);
+            return Err(ManifestBuilderError::BuildFailure { status });
         }
 
         // TODO: should we bubble up errors through the channel?
@@ -1230,6 +1234,7 @@ mod license_tests {
 mod tests {
     use std::fs::{self, File};
     use std::os::unix::fs::PermissionsExt;
+    use std::os::unix::process::ExitStatusExt;
 
     use anyhow::Context;
     use flox_manifest::interfaces::{AsWritableManifest, WriteManifest};
@@ -1246,6 +1251,23 @@ mod tests {
     use crate::models::environment::{Environment, copy_dir_recursive};
     use crate::providers::catalog::test_helpers::catalog_replay_client;
     use crate::providers::git::{GitCommandProvider, GitProvider};
+
+    #[test]
+    fn build_failure_slug_is_namespaced() {
+        use strum::EnumCount;
+
+        // A new variant must get a deliberate look at its telemetry slug
+        // (cli.build `error_kind`): this count trips so the wire value isn't
+        // shipped unreviewed.
+        assert_eq!(ManifestBuilderError::COUNT, 9);
+
+        // A rename of the emitted variant would silently change the slug.
+        let err = ManifestBuilderError::BuildFailure {
+            status: ExitStatus::from_raw(1 << 8),
+        };
+        let slug: &'static str = (&err).into();
+        assert_eq!(slug, "build.build_failure");
+    }
 
     #[test]
     fn build_returns_failure_when_package_not_defined() {

--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -82,7 +82,7 @@ pub trait ManifestBuilder {
     fn clean(self, package: &[PackageTargetName]) -> Result<(), ManifestBuilderError>;
 }
 
-#[derive(Debug, Error, strum::IntoStaticStr, strum::EnumCount)]
+#[derive(Debug, Error, strum::IntoStaticStr)]
 #[strum(serialize_all = "snake_case", prefix = "build.")]
 pub enum ManifestBuilderError {
     #[error("failed to call package builder: {0}")]
@@ -1254,14 +1254,8 @@ mod tests {
 
     #[test]
     fn build_failure_slug_is_namespaced() {
-        use strum::EnumCount;
-
-        // A new variant must get a deliberate look at its telemetry slug
-        // (cli.build `error_kind`): this count trips so the wire value isn't
-        // shipped unreviewed.
-        assert_eq!(ManifestBuilderError::COUNT, 9);
-
-        // A rename of the emitted variant would silently change the slug.
+        // `BuildFailure`'s slug goes out on the wire as the cli.build
+        // `error_kind`; a rename of the variant would silently change it.
         let err = ManifestBuilderError::BuildFailure {
             status: ExitStatus::from_raw(1 << 8),
         };

--- a/cli/flox/src/commands/build.rs
+++ b/cli/flox/src/commands/build.rs
@@ -1,11 +1,13 @@
 use std::env;
+use std::os::unix::process::ExitStatusExt;
 use std::path::Path;
 use std::process::Stdio;
+use std::time::Instant;
 
 use anyhow::{Context, Result, bail};
 use bpaf::Bpaf;
 use flox_core::data::CanonicalPath;
-use flox_events::{CliBuildPayload, EventKind, EventsHub};
+use flox_events::{CliBuildPayload, EventKind, EventsHub, Outcome};
 use flox_manifest::lockfile::Lockfile;
 use flox_manifest::{Manifest, MigratedTypedOnly};
 use flox_rust_sdk::flox::Flox;
@@ -14,6 +16,7 @@ use flox_rust_sdk::providers::build::{
     COMMON_NIXPKGS_URL,
     FloxBuildMk,
     ManifestBuilder,
+    ManifestBuilderError,
     PackageTarget,
     PackageTargetKind,
     PackageTargets,
@@ -33,6 +36,7 @@ use tracing::{debug, instrument, trace};
 use url::Url;
 
 use super::{DirEnvironmentSelect, dir_environment_select};
+use crate::utils::events::duration_to_ms;
 use crate::utils::message;
 use crate::{environment_subcommand_metric, subcommand_metric};
 
@@ -312,13 +316,9 @@ impl Build {
             "has_expression_build" = has_expression_build,
             "has_manifest_build" = has_manifest_build
         );
-        if let Err(err) = EventsHub::global().record_event(EventKind::CliBuild(
-            CliBuildPayload::new(has_expression_build, has_manifest_build),
-        )) {
-            debug!(error = %err, "Failed to record v2 event");
-        }
 
         let builder = FloxBuildMk::new(&flox, &base_dir, &expression_ref, &built_environments);
+        let build_start = Instant::now();
         let results = builder.build(
             &base_nixpkgs_url,
             &FLOX_INTERPRETER,
@@ -326,7 +326,40 @@ impl Build {
             nef_stability,
             None,
             system_override,
-        )?;
+        );
+        let build_duration_ms = duration_to_ms(build_start.elapsed());
+
+        // A build cut short by a signal — Ctrl-C sends SIGINT to the whole
+        // process group — has no genuine outcome, so it must not be recorded as
+        // a build failure. Only `BuildFailure` carries the child's status.
+        let interrupted = matches!(
+            &results,
+            Err(ManifestBuilderError::BuildFailure { status }) if status.signal().is_some()
+        );
+        if !interrupted {
+            // Gate the payload work — notably the lockfile serialization and
+            // hash — on an installed client, as env-detail lineage fields are.
+            let payload = EventsHub::global().when_client_set(|| {
+                let mut payload = CliBuildPayload::new(has_expression_build, has_manifest_build)
+                    .with_duration_ms(build_duration_ms);
+                if let Some(lockfile_hash) = lockfile.content_hash() {
+                    payload = payload.with_lockfile_hash(lockfile_hash);
+                }
+                match &results {
+                    Ok(_) => payload.with_outcome(Outcome::Success),
+                    Err(err) => payload
+                        .with_outcome(Outcome::Failure)
+                        .with_error_kind(err.into()),
+                }
+            });
+            if let Some(payload) = payload
+                && let Err(err) = EventsHub::global().record_event(EventKind::CliBuild(payload))
+            {
+                debug!(error = %err, "Failed to record v2 event");
+            }
+        }
+
+        let results = results?;
 
         let current_dir = env::current_dir()
             .context("could not get current directory")?

--- a/cli/flox/src/commands/build.rs
+++ b/cli/flox/src/commands/build.rs
@@ -4,6 +4,9 @@ use std::path::Path;
 use std::process::Stdio;
 use std::time::Instant;
 
+// `::` selects the extern `nix` crate rather than the
+// `flox_rust_sdk::providers::nix` module that is also in scope.
+use ::nix::sys::signal::Signal;
 use anyhow::{Context, Result, bail};
 use bpaf::Bpaf;
 use flox_core::data::CanonicalPath;
@@ -329,32 +332,33 @@ impl Build {
         );
         let build_duration_ms = duration_to_ms(build_start.elapsed());
 
-        // A build cut short by a signal — Ctrl-C sends SIGINT to the whole
-        // process group — has no genuine outcome, so it must not be recorded as
-        // a build failure. Only `BuildFailure` carries the child's status.
-        let interrupted = matches!(
+        // A build the user cancelled has no genuine outcome, so it must not be
+        // recorded as a build failure — Ctrl-C sends SIGINT to the whole process
+        // group, and we treat the sibling cancellation/termination-request
+        // signals (SIGQUIT, SIGHUP, SIGTERM) the same way. A build the OOM killer
+        // takes down (SIGKILL) or whose builder crashes (SIGSEGV/SIGABRT/…) is a
+        // real failure and is still recorded. Only `BuildFailure` carries status.
+        let cancelled = matches!(
             &results,
-            Err(ManifestBuilderError::BuildFailure { status }) if status.signal().is_some()
+            Err(ManifestBuilderError::BuildFailure { status })
+                if matches!(
+                    status.signal().and_then(|s| Signal::try_from(s).ok()),
+                    Some(Signal::SIGINT | Signal::SIGQUIT | Signal::SIGHUP | Signal::SIGTERM)
+                )
         );
-        if !interrupted {
-            // Gate the payload work — notably the lockfile serialization and
-            // hash — on an installed client, as env-detail lineage fields are.
-            let payload = EventsHub::global().when_client_set(|| {
-                let mut payload = CliBuildPayload::new(has_expression_build, has_manifest_build)
-                    .with_duration_ms(build_duration_ms);
-                if let Some(lockfile_hash) = lockfile.content_hash() {
-                    payload = payload.with_lockfile_hash(lockfile_hash);
-                }
-                match &results {
-                    Ok(_) => payload.with_outcome(Outcome::Success),
-                    Err(err) => payload
-                        .with_outcome(Outcome::Failure)
-                        .with_error_kind(err.into()),
-                }
-            });
-            if let Some(payload) = payload
-                && let Err(err) = EventsHub::global().record_event(EventKind::CliBuild(payload))
-            {
+        if !cancelled {
+            let mut payload = CliBuildPayload::new(has_expression_build, has_manifest_build)
+                .with_duration_ms(build_duration_ms);
+            if let Some(lockfile_hash) = lockfile.content_hash() {
+                payload = payload.with_lockfile_hash(lockfile_hash);
+            }
+            let payload = match &results {
+                Ok(_) => payload.with_outcome(Outcome::Success),
+                Err(err) => payload
+                    .with_outcome(Outcome::Failure)
+                    .with_error_kind(err.into()),
+            };
+            if let Err(err) = EventsHub::global().record_event(EventKind::CliBuild(payload)) {
                 debug!(error = %err, "Failed to record v2 event");
             }
         }

--- a/cli/flox/src/commands/install.rs
+++ b/cli/flox/src/commands/install.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result, anyhow, bail};
 use bpaf::Bpaf;
 use flox_core::data::environment_ref::DEFAULT_NAME;
-use flox_events::{CliEnvironmentPayload, CliPackagePayload, EventKind, EventsHub, PackageOutcome};
+use flox_events::{CliEnvironmentPayload, CliPackagePayload, EventKind, EventsHub, Outcome};
 use flox_manifest::compose::{
     COMPOSER_MANIFEST_ID,
     new_package_overrides,
@@ -298,12 +298,9 @@ impl Install {
         // nothing per-package on success.
         let hub = EventsHub::global();
         for package in &packages_to_install {
-            if let Err(err) =
-                hub.record_event(EventKind::CliPackageInstall(CliPackagePayload::new(
-                    Install::package_identifier(package),
-                    PackageOutcome::Success,
-                )))
-            {
+            if let Err(err) = hub.record_event(EventKind::CliPackageInstall(
+                CliPackagePayload::new(Install::package_identifier(package), Outcome::Success),
+            )) {
                 debug!(error = %err, "Failed to record v2 event");
             }
         }
@@ -493,12 +490,9 @@ impl Install {
 
         let hub = EventsHub::global();
         for package in packages {
-            if let Err(err) =
-                hub.record_event(EventKind::CliPackageInstall(CliPackagePayload::new(
-                    Install::package_identifier(package),
-                    PackageOutcome::Failure,
-                )))
-            {
+            if let Err(err) = hub.record_event(EventKind::CliPackageInstall(
+                CliPackagePayload::new(Install::package_identifier(package), Outcome::Failure),
+            )) {
                 debug!(error = %err, "Failed to record v2 event");
             }
         }

--- a/cli/flox/src/commands/uninstall.rs
+++ b/cli/flox/src/commands/uninstall.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use bpaf::Bpaf;
-use flox_events::{CliEnvironmentPayload, CliPackagePayload, EventKind, EventsHub, PackageOutcome};
+use flox_events::{CliEnvironmentPayload, CliPackagePayload, EventKind, EventsHub, Outcome};
 use flox_manifest::parsed::latest::SelectedOutputs;
 use flox_manifest::raw::PackageModification;
 use flox_rust_sdk::flox::Flox;
@@ -137,7 +137,7 @@ impl Uninstall {
                 continue;
             }
             if let Err(err) = hub.record_event(EventKind::CliPackageUninstall(
-                CliPackagePayload::new(modification.install_id.clone(), PackageOutcome::Success),
+                CliPackagePayload::new(modification.install_id.clone(), Outcome::Success),
             )) {
                 debug!(error = %err, "Failed to record v2 event");
             }

--- a/cli/flox/src/commands/upgrade.rs
+++ b/cli/flox/src/commands/upgrade.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use bpaf::Bpaf;
 use crossterm::style::Stylize;
-use flox_events::{CliEnvironmentPayload, CliPackagePayload, EventKind, EventsHub, PackageOutcome};
+use flox_events::{CliEnvironmentPayload, CliPackagePayload, EventKind, EventsHub, Outcome};
 use flox_manifest::lockfile::LockedPackage;
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::{Environment, SingleSystemUpgradeDiff};
@@ -159,7 +159,7 @@ impl Upgrade {
         let hub = EventsHub::global();
         for (_, (before, _)) in diff_for_system.iter() {
             if let Err(err) = hub.record_event(EventKind::CliPackageUpgrade(
-                CliPackagePayload::new(before.install_id().to_string(), PackageOutcome::Success),
+                CliPackagePayload::new(before.install_id().to_string(), Outcome::Success),
             )) {
                 debug!(error = %err, "Failed to record v2 event");
             }

--- a/cli/flox/src/main.rs
+++ b/cli/flox/src/main.rs
@@ -35,6 +35,7 @@ use crate::utils::errors::{
     format_managed_error,
     format_remote_error,
 };
+use crate::utils::events::duration_to_ms;
 use crate::utils::init::init_telemetry_uuid;
 use crate::utils::metrics::{Hub, read_metrics_uuid};
 
@@ -260,12 +261,6 @@ where
     for<'a> &'a T: Into<&'static str>,
 {
     e.into()
-}
-
-/// Saturate a duration into whole ms (u64::MAX ms is ~584M years — a
-/// ceiling only).
-fn duration_to_ms(elapsed: std::time::Duration) -> u64 {
-    u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX)
 }
 
 /// Fixed bash completion script that replaces bpaf's generated version.

--- a/cli/flox/src/utils/events.rs
+++ b/cli/flox/src/utils/events.rs
@@ -78,6 +78,12 @@ pub fn current_invocation_id() -> Option<Uuid> {
     RESOLVED_INVOCATION_ID.get().copied()
 }
 
+/// Saturate a duration into whole ms (u64::MAX ms is ~584M years — a
+/// ceiling only).
+pub(crate) fn duration_to_ms(elapsed: std::time::Duration) -> u64 {
+    u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX)
+}
+
 /// Build the [`SharedMetadataTemplate`] stamped onto every v2 event emitted
 /// by this process. The fields mirror the legacy
 /// [`crate::utils::metrics::MetricEntry`] so downstream consumers can


### PR DESCRIPTION
# feat(events): add build outcome fields to cli.build

> Stacked on #4552 (environment lineage fields); retarget to `main` when
> it merges.

Today `cli.build` fires *before* the build runs, carrying only the two
build-kind flags — it can't say whether the build succeeded or how long
it took. This relocates the emit to after the build step and adds four
optional fields to `CliBuildPayload`. Field names follow the existing
telemetry vocabulary — `outcome` (as on `cli.package.*`), `duration_ms`
and `error_kind` (as on `cli.command_completed`) — discriminated by
`event_type`, not by a domain prefix. The wire change is additive (all
four fields are optional/skip-if-none), and the legacy v1 stream is
unchanged. Because `cli.build` now populates the shared `duration_ms`/
`error_kind`/`outcome` columns, it needs a coordinated flox-analytics
view change so those command-level columns aren't conflated with
build-step values (flox-analytics PR 22).

- **feat(events): add build outcome fields to cli.build**

  - `outcome` — `success` / `failure`, via a shared `Outcome` enum
    (this PR generalizes the former `PackageOutcome` so `cli.package.*`
    and `cli.build` share one type; the package-partition ambiguity doc
    moves onto `CliPackagePayload`'s field). A build cut short by a
    signal has
    no genuine outcome and is **not** recorded: flox catches Ctrl-C
    (SIGINT reaches the whole process group and kills the build child),
    so `builder.build()` returns `Err(BuildFailure)` — which now carries
    the child's `ExitStatus`; the emit site checks for signal
    termination (`status.signal().is_some()`) and skips the event, so
    cancellations don't inflate the failure rate. The v1 stream still
    counts the attempt.
  - `duration_ms` — times only the `builder.build()` call, reusing the
    `duration_to_ms` helper (moved from `main.rs` to `utils::events`
    now that it has a second consumer).
  - `error_kind` — on failure, the classified `ManifestBuilderError`
    variant slug via a namespaced strum derive
    (`#[strum(serialize_all = "snake_case", prefix = "build.")]`, e.g.
    `build.build_failure`). It is the variant *name* only —
    structurally never the error message or build output, which can
    contain paths or secrets. Same namespaced-slug scheme as
    `cli.command_completed`'s `error_kind` (`environment.*`,
    `service.*`). This is also the *only* place the specific
    build-failure class surfaces: `ManifestBuilderError` isn't in
    `main.rs`'s `error_kind` ladder, so the invocation's
    `cli.command_completed.error_kind` is `uncategorized` for a build
    failure — the two are complementary, not redundant.
  - `lockfile_hash` — `Lockfile::content_hash`: a blake3 fingerprint of
    the lockfile's own canonical serialization (the same `to_string_pretty`
    it writes to disk), hashed via the `flox_core::blake3_hex` primitive
    (`path_hash` now shares it). The lockfile owns how it fingerprints
    itself, so nothing is open-coded and a second caller stays
    byte-for-byte comparable. It hashes the in-memory `Lockfile` used for
    this build (which `env.lockfile()` may re-lock to differ from disk). Caveats it deliberately does NOT provide: it is
    **stable only within a CLI version** (fingerprints the serialization,
    not the on-disk bytes), and it is **not a package-set identity** —
    its preimage includes `[vars]`, hooks, and build scripts, so a
    different hash does not imply different packages. Computed only when
    a metrics client is installed (gated through the hub), so opted-out
    users don't pay the serialization + hash.

  The build error is re-propagated unchanged after emission (exit code
  and message identical), and the v1 `subcommand_metric!` stays where it
  is. Fields are optional/skip-if-none, so old buffered rows stay valid.

  Tests: two envelope goldens (`cli_build_success_envelope_golden`,
  `cli_build_failure_envelope_golden`), the retained bare golden, an
  old-row round-trip test, an SDK slug test pinning the emitted
  `build.build_failure` wire value against a rename, and flox-core
  `content_hash` tests that observe a real digest and pin ordered-map
  determinism. Verified on the #4552 base: `cargo clippy --workspace
  --tests --no-deps -- -D warnings` clean, `cargo fmt --check` clean,
  `flox` + `flox-events` + `flox-core` 560/560, `flox-rust-sdk` build
  module 142/142.

  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
