### PR TITLE
ci: avoid automatic Claude review on every PR push

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,8 +1,15 @@
 name: Claude Code Review
 
 on:
+  # Deliberately no `synchronize`: automated review is an initial/ready
+  # checkpoint, not a per-push gate. Request a re-review after substantial
+  # changes by commenting `@claude` (see claude-mention.yml).
   pull_request:
-    types: [opened, synchronize, ready_for_review]
+    types: [opened, ready_for_review]
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.head_ref || github.sha }}"
+  cancel-in-progress: true
 
 jobs:
   review:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,44 +1,33 @@
 name: Claude Code Review
 
 on:
-  # There are several ways to *request* a review; this file is the only place
-  # one is *performed*. Deliberately no `synchronize` — the automated pass is a
-  # checkpoint when a PR arrives ready for eyes, plus an explicit follow-up
-  # whenever someone asks for one, not a gate on every push.
+  # Deliberately no `synchronize`: automated review is a checkpoint for when a
+  # PR arrives ready for eyes, not a gate on every push. It runs on `opened`
+  # for a non-draft PR and on `ready_for_review` when a draft is promoted.
   #
-  # To request another review, add the `claude-review` label to the PR. The
-  # workflow consumes the label before reviewing, so it re-arms immediately and
-  # can be applied as often as you like.
-  #
-  # `@claude` (claude-mention.yml) is NOT this reviewer: it is a
-  # general-purpose interactive agent on a different model, effort, harness and
-  # prompt, with no inline-comment tooling. Use it for questions and scoped
-  # asks; use the label when you want the review below.
+  # An on-demand re-review trigger is deliberately out of scope here; see the
+  # follow-up PR. `@claude` (claude-mention.yml) is NOT a substitute for this
+  # reviewer — it is a general-purpose interactive agent on a different model,
+  # effort, harness and prompt, with no inline-comment tooling. Use it for
+  # questions and scoped asks, not as the re-review path.
   pull_request:
-    types: [opened, ready_for_review, labeled]
+    types: [opened, ready_for_review]
 
 # One review at a time per PR, and never interrupt one that is already running:
-# it posts inline comments as it goes, so cancelling mid-flight leaves a
-# half-posted review behind. A request arriving mid-review waits its turn.
+# the review posts inline comments as it goes, so cancelling mid-flight leaves a
+# half-posted review behind — findings with no summary and no signal that
+# anything was dropped. A second trigger waits instead. Keyed by PR number
+# rather than head ref, because a branch name is not unique to a pull request
+# but the review's unit of work is exactly one.
 concurrency:
   group: claude-review-pr-${{ github.event.pull_request.number }}
   cancel-in-progress: false
 
 jobs:
   review:
-    # Runs when a non-draft PR is opened, when a draft is marked ready, or when
-    # the `claude-review` label is added. The label is an explicit request, so
-    # it is honoured on drafts too — otherwise the label would stick with
-    # nothing to consume it.
-    #
-    # Skip on fork PRs either way: the review needs CLAUDE_CODE_OAUTH_TOKEN,
-    # which isn't available to pull_request runs from forks, so it only fails.
-    if: |
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      (
-        (github.event.action == 'labeled' && github.event.label.name == 'claude-review') ||
-        (github.event.action != 'labeled' && !github.event.pull_request.draft)
-      )
+    # Skip on fork PRs: the review needs CLAUDE_CODE_OAUTH_TOKEN, which isn't
+    # available to pull_request runs from forks, so it only fails.
+    if: ${{ !github.event.pull_request.draft && github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -47,24 +36,6 @@ jobs:
       id-token: write # Required in order for the Claude GitHub app to function
       actions: read # Required for Claude to read CI results on PRs
     steps:
-      # Consumed *before* the expensive review, which is what makes the label a
-      # reusable button: it can be re-applied the moment a review starts rather
-      # than only once one finishes. Label events raised by GITHUB_TOKEN do not
-      # trigger workflows, so this cannot recurse.
-      - name: Consume the claude-review label
-        if: contains(github.event.pull_request.labels.*.name, 'claude-review')
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          PR: ${{ github.event.pull_request.number }}
-        run: |
-          if gh api --method DELETE --silent \
-            "repos/$REPO/issues/$PR/labels/claude-review"; then
-            echo "::notice::Consumed the claude-review label. Re-apply it to request another review."
-          else
-            echo "::warning::Could not remove the claude-review label. Remove it by hand, or the next request won't fire."
-          fi
-
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -115,7 +86,3 @@ jobs:
             - Finish by writing the review summary into the tracking comment.
               If there are no issues, say specifically what you reviewed and
               verified rather than a bare "no issues found".
-            - State the PR head commit you actually reviewed (from `gh pr view
-              --json headRefOid`) in that summary. Reviews can be requested
-              again while one is in flight, so the commit is what distinguishes
-              a follow-up review from the one before it.

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,21 +1,44 @@
 name: Claude Code Review
 
 on:
-  # Deliberately no `synchronize`: automated review is an initial/ready
-  # checkpoint, not a per-push gate. Request a re-review after substantial
-  # changes by commenting `@claude` (see claude-mention.yml).
+  # There are several ways to *request* a review; this file is the only place
+  # one is *performed*. Deliberately no `synchronize` — the automated pass is a
+  # checkpoint when a PR arrives ready for eyes, plus an explicit follow-up
+  # whenever someone asks for one, not a gate on every push.
+  #
+  # To request another review, add the `claude-review` label to the PR. The
+  # workflow consumes the label before reviewing, so it re-arms immediately and
+  # can be applied as often as you like.
+  #
+  # `@claude` (claude-mention.yml) is NOT this reviewer: it is a
+  # general-purpose interactive agent on a different model, effort, harness and
+  # prompt, with no inline-comment tooling. Use it for questions and scoped
+  # asks; use the label when you want the review below.
   pull_request:
-    types: [opened, ready_for_review]
+    types: [opened, ready_for_review, labeled]
 
+# One review at a time per PR, and never interrupt one that is already running:
+# it posts inline comments as it goes, so cancelling mid-flight leaves a
+# half-posted review behind. A request arriving mid-review waits its turn.
 concurrency:
-  group: "${{ github.workflow }}-${{ github.head_ref || github.sha }}"
-  cancel-in-progress: true
+  group: claude-review-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
 
 jobs:
   review:
-    # Skip on fork PRs: the review needs CLAUDE_CODE_OAUTH_TOKEN, which isn't
-    # available to pull_request runs from forks, so it only fails.
-    if: ${{ !github.event.pull_request.draft && github.event.pull_request.head.repo.full_name == github.repository }}
+    # Runs when a non-draft PR is opened, when a draft is marked ready, or when
+    # the `claude-review` label is added. The label is an explicit request, so
+    # it is honoured on drafts too — otherwise the label would stick with
+    # nothing to consume it.
+    #
+    # Skip on fork PRs either way: the review needs CLAUDE_CODE_OAUTH_TOKEN,
+    # which isn't available to pull_request runs from forks, so it only fails.
+    if: |
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      (
+        (github.event.action == 'labeled' && github.event.label.name == 'claude-review') ||
+        (github.event.action != 'labeled' && !github.event.pull_request.draft)
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -24,6 +47,24 @@ jobs:
       id-token: write # Required in order for the Claude GitHub app to function
       actions: read # Required for Claude to read CI results on PRs
     steps:
+      # Consumed *before* the expensive review, which is what makes the label a
+      # reusable button: it can be re-applied the moment a review starts rather
+      # than only once one finishes. Label events raised by GITHUB_TOKEN do not
+      # trigger workflows, so this cannot recurse.
+      - name: Consume the claude-review label
+        if: contains(github.event.pull_request.labels.*.name, 'claude-review')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          if gh api --method DELETE --silent \
+            "repos/$REPO/issues/$PR/labels/claude-review"; then
+            echo "::notice::Consumed the claude-review label. Re-apply it to request another review."
+          else
+            echo "::warning::Could not remove the claude-review label. Remove it by hand, or the next request won't fire."
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -74,3 +115,7 @@ jobs:
             - Finish by writing the review summary into the tracking comment.
               If there are no issues, say specifically what you reviewed and
               verified rather than a bare "no issues found".
+            - State the PR head commit you actually reviewed (from `gh pr view
+              --json headRefOid`) in that summary. Reviews can be requested
+              again while one is in flight, so the commit is what distinguishes
+              a follow-up review from the one before it.


### PR DESCRIPTION
## Problem

`claude-review.yml` triggered on `[opened, synchronize, ready_for_review]`, and the
review runs at `--model opus --effort xhigh` over the PR's **full diff against its
base** — not just the incremental push.

1. **Every push paid for a full review.** A one-line fixup, a typo correction, or a
   rebase re-reviewed the entire diff from scratch at the most expensive tier. On a
   PR with a dozen pushes, that is a dozen full reviews of largely the same code.
2. **Rapid pushes produced overlapping runs.** Nothing serialised the workflow, so
   two pushes in quick succession left two reviews racing to post inline comments on
   the same lines — duplicate findings, duplicate threads, and a tracking comment
   written by whichever run finished last.

## Change

Treat automated review as an **initial/ready checkpoint** rather than a per-push
gate, and make the events that remain serialise safely.

```diff
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review]
+    types: [opened, ready_for_review]
+
+concurrency:
+  group: claude-review-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
```

- **Dropping `synchronize`** means the review fires once when a PR arrives ready for
  eyes — on `opened` for a non-draft PR, or on `ready_for_review` when a draft is
  promoted — and not again on subsequent pushes.
- **`cancel-in-progress: false`.** The review posts inline comments as it goes, so
  cancelling it mid-flight leaves a half-posted review on the PR: findings with no
  summary, and no signal that anything was dropped. Cancellation is only safe before
  externally visible work begins, and this job has no such stage. A second trigger
  waits instead. GitHub allows one running and one pending run per group, so
  triggers coalesce rather than pile up.
- **Keyed by PR number, not `head_ref`.** A branch name is not unique to a pull
  request — the same branch can back more than one open PR — but the review's unit
  of work is exactly one PR.

Nothing about the review prompt, model, effort, plugin set, or permissions changes.

## Scope: requesting a review vs. performing one

The right long-term shape is that the expensive implementation — Opus/xhigh, the
Superpowers harness, the inline-comment MCP tools, the tracking comment — exists
exactly once, and that several triggers can reach it. **This PR is only the trigger
hygiene.** The on-demand re-review path lands as a follow-up.

That split is not just staging. An earlier revision of this PR tried a
`claude-review` label as the re-review button, and **it cannot work**:
`track_progress: true` makes `claude-code-action` validate the `pull_request` action
and throw before the app-token exchange. Observed on this branch:

```
Action failed with error: track_progress for pull_request events is only supported
for actions: opened, synchronize, ready_for_review, reopened. Current action: labeled
```

The allow-list (`src/modes/detector.ts`) is identical on the action's `main`, so it
is not a version pin, and it also excludes `workflow_dispatch` and
`repository_dispatch`. Of the PR-local triggers only `issue_comment` is accepted —
so the follow-up adds a **`/claude-review` command**, which keeps `track_progress`,
tag mode and the tracking comment intact. That is one implementation, reached two
ways.

`@claude` (`claude-mention.yml`) is unchanged and stays available for interactive,
scoped questions. It is explicitly **not** the re-review path, and the earlier
revision of this PR was wrong to present it as one: it has no `--model`/`--effort`
override, no `plugins:`, no inline-comment tooling, no review prompt, and only
`pull-requests: read`. The workflow comments now say so.

## Validation

**Observed on this branch.** Force-pushing fired a `synchronize` event, which
produced new `CI` and `Project Lints` runs at the new SHA and **no** new
`Claude Code Review` run:

```
Project Lints       | pull_request | in_progress        | 5c57714cc  <- after synchronize
CI                  | pull_request | queued             | 5c57714cc  <- after synchronize
Claude Code Review  | pull_request | completed/skipped  | 56273964b  <- from `opened` only
```

Two workflows re-ran on the push and the expensive one did not — which is the whole
point of the change, in one listing.

**Verified locally.** `actionlint` clean on `claude-review.yml` and
`claude-mention.yml`; `treefmt`/`yamlfmt` report no changes and the pre-push hook
passes. The parsed YAML is `pull_request.types: [opened, ready_for_review]` with
concurrency group `claude-review-pr-<number>` and `cancel-in-progress: false`. The
job-level `if` guard (`!draft` and same-repo head) is untouched.

| Scenario | Expected | Status |
|---|---|---|
| Non-draft PR opened | Review runs | Observed (event fired; job skipped on draft as designed) |
| Draft promoted to ready | Review runs | Reasoned — `ready_for_review` subscribed, `draft` false by then |
| Push to an open PR | No run at all | **Observed** |
| Fork PR | Skipped | Unchanged guard |
| Two triggers for one PR | Second waits; running review not interrupted | Reasoned — `cancel-in-progress: false` |

**Not exercisable before merge.** The Claude GitHub App's
`workflow-must-match-default-branch` validation rejects the app-token exchange while
this workflow differs from the default branch (see the comment at
`claude-review.yml:52-55`). Worth knowing when reading this PR's run history: the
action treats that as a **warning and exits the job successfully**, so a green
`Claude Code Review` run on this branch means "skipped", not "reviewed". Confirming a
review actually posts is a post-merge check on the next PR opened against `main`.

## Notes for reviewers

- Reverting is still a one-line restoration of `synchronize`; the concurrency block
  is worth keeping either way.
- The branch carries a commit that added the label trigger and a commit that backs
  it out, so the intermediate design and the evidence against it stay in the
  history. The net diff is the four-line change above.
