### PR TITLE
ci: add a `/claude-review` command to re-run the automated review

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,33 +1,61 @@
 name: Claude Code Review
 
 on:
-  # Deliberately no `synchronize`: automated review is a checkpoint for when a
-  # PR arrives ready for eyes, not a gate on every push. It runs on `opened`
-  # for a non-draft PR and on `ready_for_review` when a draft is promoted.
+  # Two ways to *request* the review below; this file is the only place one is
+  # *performed*. Deliberately no `synchronize`: the automated pass is a
+  # checkpoint for when a PR arrives ready for eyes, not a gate on every push.
   #
-  # An on-demand re-review trigger is deliberately out of scope here; see the
-  # follow-up PR. `@claude` (claude-mention.yml) is NOT a substitute for this
-  # reviewer — it is a general-purpose interactive agent on a different model,
-  # effort, harness and prompt, with no inline-comment tooling. Use it for
-  # questions and scoped asks, not as the re-review path.
+  #   automatic  `opened` on a non-draft PR, `ready_for_review` on a promoted
+  #              draft — the first-look pass.
+  #   on demand  comment `/claude-review` on the PR — same model, effort,
+  #              prompt, plugin and inline-comment tooling, on the current head.
+  #
+  # `@claude` (claude-mention.yml) is NOT a substitute for either: it is a
+  # general-purpose interactive agent on a different model, effort, harness and
+  # prompt, with no inline-comment tooling. Use it for questions and scoped
+  # asks; use `/claude-review` when you want the review below.
+  #
+  # `issue_comment` is not an arbitrary choice of trigger. claude-code-action
+  # validates `track_progress` against a fixed event allow-list and throws on
+  # anything else, which rules out `labeled`, `workflow_dispatch` and
+  # `repository_dispatch`. Of the PR-local triggers, only this one keeps the
+  # tracking comment. See src/modes/detector.ts in the action.
   pull_request:
     types: [opened, ready_for_review]
+  issue_comment:
+    types: [created]
 
 # One review at a time per PR, and never interrupt one that is already running:
 # the review posts inline comments as it goes, so cancelling mid-flight leaves a
 # half-posted review behind — findings with no summary and no signal that
-# anything was dropped. A second trigger waits instead. Keyed by PR number
+# anything was dropped. A second request waits instead. Keyed by PR number
 # rather than head ref, because a branch name is not unique to a pull request
 # but the review's unit of work is exactly one.
 concurrency:
-  group: claude-review-pr-${{ github.event.pull_request.number }}
+  group: claude-review-pr-${{ github.event.pull_request.number || github.event.issue.number }}
   cancel-in-progress: false
 
 jobs:
   review:
-    # Skip on fork PRs: the review needs CLAUDE_CODE_OAUTH_TOKEN, which isn't
-    # available to pull_request runs from forks, so it only fails.
-    if: ${{ !github.event.pull_request.draft && github.event.pull_request.head.repo.full_name == github.repository }}
+    # Automatic: non-draft, same-repo pull requests only — the review needs
+    # CLAUDE_CODE_OAUTH_TOKEN, which isn't available to `pull_request` runs from
+    # forks, so it only fails.
+    #
+    # On demand: a `/claude-review` comment, at the start of the body, on a pull
+    # request rather than an issue, from someone with write access. The fork
+    # check for this path can't be expressed here — `issue_comment` payloads
+    # carry no head repo — so it happens in the preflight step below.
+    if: |
+      (
+        github.event_name == 'pull_request' &&
+        !github.event.pull_request.draft &&
+        github.event.pull_request.head.repo.full_name == github.repository
+      ) || (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        startsWith(github.event.comment.body, '/claude-review') &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -36,16 +64,64 @@ jobs:
       id-token: write # Required in order for the Claude GitHub app to function
       actions: read # Required for Claude to read CI results on PRs
     steps:
+      # Resolves the one thing the two trigger paths disagree about — where the
+      # PR number lives — and applies the fork rule the job-level `if` can't
+      # reach on the comment path.
+      #
+      # `issue_comment` runs in the base repo with secrets even for fork PRs, so
+      # unlike `pull_request` this path *could* review them. It deliberately
+      # doesn't: turning an untrusted diff into input for an agent holding a
+      # write-scoped token is a security decision on its own merits, not
+      # something to acquire as a side effect of adding a re-review command.
+      - name: Preflight
+        id: preflight
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          EVENT: ${{ github.event_name }}
+          NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        run: |
+          echo "number=$NUMBER" >> "$GITHUB_OUTPUT"
+
+          if [ "$EVENT" != "issue_comment" ]; then
+            echo "review=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Acknowledge the command now: the tracking comment doesn't appear
+          # until the action starts, a Nix install later.
+          gh api --method POST --silent \
+            "repos/$GH_REPO/issues/comments/$COMMENT_ID/reactions" \
+            -f content=eyes || true
+
+          if [ "$(gh pr view "$NUMBER" --json isCrossRepository -q .isCrossRepository)" = "true" ]; then
+            echo "review=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::/claude-review is not available on fork PRs."
+            gh pr comment "$NUMBER" --body-file - <<'MSG'
+          :no_entry: `/claude-review` is not available on pull requests from forks — the review needs credentials that fork pull requests cannot safely be given.
+          MSG
+          else
+            echo "review=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout repository
+        if: steps.preflight.outputs.review == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1
+          # `pull_request` already checks out the merge ref; `issue_comment`
+          # defaults to the base branch, so name it explicitly. Both paths then
+          # review the same thing: the PR merged into its base, at current head.
+          ref: ${{ github.event_name == 'issue_comment' && format('refs/pull/{0}/merge', github.event.issue.number) || '' }}
 
       - name: Install Nix
+        if: steps.preflight.outputs.review == 'true'
         uses: cachix/install-nix-action@96951a368ba55167b55f1c916f7d416bac6505fe # v31
 
       - name: Run Claude Code Review
         id: claude-review
+        if: steps.preflight.outputs.review == 'true'
         uses: anthropics/claude-code-action@12531344451323133b0493233c759991ac61da12 # v1.0.174
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -70,7 +146,7 @@ jobs:
           plugins: 'superpowers@claude-plugins-official'
           track_progress: true
           prompt: |
-            Review PR #${{ github.event.pull_request.number }} in ${{ github.repository }}.
+            Review PR #${{ steps.preflight.outputs.number }} in ${{ github.repository }}.
 
             Conduct the review using the superpowers:requesting-code-review skill
             and its code-reviewer template, reviewing the PR's full diff against
@@ -86,3 +162,7 @@ jobs:
             - Finish by writing the review summary into the tracking comment.
               If there are no issues, say specifically what you reviewed and
               verified rather than a bare "no issues found".
+            - State the PR head commit you actually reviewed (from `gh pr view
+              --json headRefOid`) in that summary. A PR can be reviewed more
+              than once now, so the commit is what distinguishes this pass from
+              the one before it.


### PR DESCRIPTION
> Stacked on #4554 — base is `ci/optimize-claude-review`. Review that one first; it
> is the trigger hygiene, this one is the re-review path.

## Why

#4554 makes automated review a checkpoint rather than a per-push gate. That is the
right default, but it leaves a gap: after substantial changes there is no way to ask
for another pass.

The clean boundary is to separate **requesting** a review from **performing** one.
The implementation — Opus/xhigh, the Superpowers harness, the inline-comment MCP
tools, the tracking comment — should exist exactly once, and every entry point should
reach *that*. This PR adds a second entry point and no second implementation.

| Request | Trigger | Runs |
|---|---|---|
| First look | `opened` (non-draft), `ready_for_review` | the review below |
| On demand | comment `/claude-review` on the PR | the same review below |

Both paths get identical model, effort, prompt, plugin set, inline-comment tooling
and tracking comment, against the PR's current merge ref.

## Why `issue_comment` and not a label

A `claude-review` label is the nicer control, and it was the first thing tried. **It
cannot work.** `track_progress: true` makes `claude-code-action` validate the event
against a fixed allow-list, and throw before the app-token exchange. Observed on
`ci/optimize-claude-review`:

```
Action failed with error: track_progress for pull_request events is only supported
for actions: opened, synchronize, ready_for_review, reopened. Current action: labeled
```

From `src/modes/detector.ts` in the action — identical on the pinned SHA and on the
action's `main`, so it is not a version pin:

```ts
if (context.inputs.trackProgress) validateTrackProgressEvent(context);
// validEvents:  pull_request, issues, issue_comment,
//               pull_request_review_comment, pull_request_review
// and for pull_request:  opened, synchronize, ready_for_review, reopened
```

That rules out `labeled`, and equally `workflow_dispatch` and `repository_dispatch`,
which aren't in `validEvents` at all. Of the PR-local triggers only `issue_comment`
is accepted — so it is the only one that can host the review implementation
*unchanged*, which is the entire point. Dropping `track_progress` to keep the label
would have meant a second, lesser review path, which is the thing this design exists
to prevent.

## What the command does

```yaml
on:
  pull_request:
    types: [opened, ready_for_review]
  issue_comment:
    types: [created]
```

Guarded on all four of: it is a comment on a **pull request** (not an issue), the
body **starts with** `/claude-review`, the author is **OWNER/MEMBER/COLLABORATOR**,
and — from the preflight step — the PR is **not from a fork**.

- **Fork exclusion is deliberate, and is a tightening, not a carry-over.** Unlike
  `pull_request`, `issue_comment` runs in the base repo *with secrets* even for fork
  PRs, so this path could review them. It doesn't. Feeding an untrusted diff to an
  agent running `--dangerously-skip-permissions` with a write-scoped token is a
  security decision to take on its own merits, not to acquire as a side effect of
  adding a re-review command. A fork requester gets an explanatory comment rather
  than silence.
- **Explicit merge-ref checkout.** `pull_request` checks out `refs/pull/N/merge`
  automatically; `issue_comment` defaults to the base branch, so the command path
  names the merge ref. Both paths review the same thing.
- **Immediate acknowledgement.** The command gets a 👀 reaction in the preflight
  step, because the tracking comment doesn't appear until the action starts, a Nix
  install later. Best-effort — it never fails the run.
- **No conflict with `@claude`.** `claude-mention.yml` requires `@claude` in the
  body; `/claude-review` doesn't contain it, so exactly one workflow fires.

`@claude` stays available for interactive, scoped questions, and is now documented
as explicitly *not* the review: no `--model`/`--effort` override, no `plugins:`, no
inline-comment tooling, no review prompt, `pull-requests: read`.

## Validation

**Verified.** `actionlint` (including its shellcheck pass over the preflight script)
and `yamlfmt -lint` are clean; commit and pre-push hooks pass. The parsed YAML has
both triggers, the concurrency group resolves through
`pull_request.number || issue.number`, and the three review steps are gated on the
preflight output.

**Preflight exercised locally** against a stubbed `gh`, all three paths:

| Input | Result |
|---|---|
| `pull_request` event | `review=true`, no API calls |
| `issue_comment`, same-repo PR | 👀 reaction posted, `review=true` |
| `issue_comment`, fork PR | 👀 posted, explanatory comment posted, `review=false` |

**Observed.** The `labeled` failure quoted above is from a real run on the base
branch, which is what redirected this PR to `issue_comment`.

**Not exercisable before merge.** `workflow-must-match-default-branch` rejects the
app-token exchange while this workflow differs from the default branch. Note that
the action treats that as a *warning and exits successfully*, so a green
`Claude Code Review` run on a PR that touches this file means "skipped", not
"reviewed". First real `/claude-review` is a post-merge check.

## Deliberately not in scope

- **Scoped re-review** (`/claude-review just the auth changes`). Valuable, but it
  means interpolating commenter-authored text into the prompt; worth doing carefully
  and separately.
- **Bot requesters.** The `author_association` guard means `flox-forge-agent` cannot
  invoke the command, even though this workflow does allow reviewing Bob's PRs. Easy
  to add if Forge wants it; not guessed at here.
- **`workflow_dispatch` as an admin fallback.** Blocked by the same `track_progress`
  allow-list, so it would need its own reduced implementation.
