### PR TITLE
feat(events): add environment_id for local environments

### DIFF
--- a/cli/flox-events/src/lib.rs
+++ b/cli/flox-events/src/lib.rs
@@ -333,8 +333,9 @@ enum EnvIdentity {
         #[serde(rename = "env_ref_or_name")]
         name: String,
         /// Stable id for a local environment definition, minted at creation
-        /// and committed with `.flox`. Absent for local environments created
-        /// before the id existed.
+        /// and committed with `.flox`. Deliberately distinct from a
+        /// managed/remote environment's server-assigned id. Also absent for
+        /// local environments created before the id existed.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         local_environment_id: Option<Uuid>,
     },

--- a/cli/flox-events/src/lib.rs
+++ b/cli/flox-events/src/lib.rs
@@ -332,6 +332,11 @@ enum EnvIdentity {
     Path {
         #[serde(rename = "env_ref_or_name")]
         name: String,
+        /// Stable id for a local environment definition, minted at creation
+        /// and committed with `.flox`. Absent for local environments created
+        /// before the id existed.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        local_environment_id: Option<Uuid>,
     },
     Managed {
         #[serde(rename = "env_ref_or_name")]
@@ -367,9 +372,12 @@ pub struct EnvDetail {
 }
 
 impl EnvDetail {
-    pub fn path(name: impl Into<String>) -> Self {
+    pub fn path(name: impl Into<String>, local_environment_id: Option<Uuid>) -> Self {
         Self {
-            identity: EnvIdentity::Path { name: name.into() },
+            identity: EnvIdentity::Path {
+                name: name.into(),
+                local_environment_id,
+            },
             package_count: None,
         }
     }
@@ -911,7 +919,7 @@ mod tests {
 
     fn env_detail(kind: &str, ref_or_name: &str) -> EnvDetail {
         match kind {
-            "path" => EnvDetail::path(ref_or_name),
+            "path" => EnvDetail::path(ref_or_name, None),
             "managed" => EnvDetail::managed(ref_or_name, None),
             "remote" => EnvDetail::remote(ref_or_name, None),
             other => panic!("unexpected environment kind: {other}"),
@@ -971,6 +979,21 @@ mod tests {
             "env_ref_or_name": "alice/myenv",
             "generation_number": 3,
             "package_count": 7,
+        }));
+        assert_eq!(value, expected);
+    }
+
+    #[test]
+    fn cli_environment_activate_path_id_envelope_golden() {
+        let id = Uuid::from_u128(0x0123456789abcdef0123456789abcdef);
+        let detail = EnvDetail::path("myenv", Some(id));
+        let payload = CliEnvironmentActivatePayload::new(detail);
+        let value = serde_json::to_value(fixed_event(EventKind::CliEnvironmentActivate(payload)))
+            .expect("event serializes");
+        let expected = activate_envelope_json(json!({
+            "env_kind": "path",
+            "env_ref_or_name": "myenv",
+            "local_environment_id": id.to_string(),
         }));
         assert_eq!(value, expected);
     }
@@ -1916,7 +1939,7 @@ mod pipeline_tests {
         let hub = EventsHub::new();
         hub.set_client(client_with_connection(&tempdir, connection));
 
-        let env_detail = EnvDetail::path("myenv");
+        let env_detail = EnvDetail::path("myenv", None);
 
         hub.record_event(EventKind::CliEnvironmentEdit(
             CliEnvironmentEditPayload::new(env_detail.clone()),
@@ -1942,7 +1965,7 @@ mod pipeline_tests {
             assert_eq!(event.invocation_id, INVOCATION_ID);
             match &event.kind {
                 EventKind::CliEnvironmentEdit(p) => {
-                    assert_eq!(p.env_detail, EnvDetail::path("myenv"));
+                    assert_eq!(p.env_detail, EnvDetail::path("myenv", None));
                     match p.edited_includes {
                         None => eager_seen = true,
                         Some(true) => result_seen = true,

--- a/cli/flox/doc/flox-init.md
+++ b/cli/flox/doc/flox-init.md
@@ -35,6 +35,11 @@ The `--name` flag can be used to name a specific environment.
 By default, the environment will be created in the current directory.
 Flox will add a directory `$PWD/.flox` containing all relevant environment
 metadata.
+Local environments include a random identifier in `.flox/telemetry_id`.
+This file is committed with the environment so clones share the same
+environment identifier.
+It is created even when metrics collection is disabled; disabling metrics
+prevents the identifier from being submitted.
 The `--dir` flag can be used to create an environment in another location.
 
 If an environment already exists in the current directory,

--- a/cli/flox/doc/flox-init.md
+++ b/cli/flox/doc/flox-init.md
@@ -35,11 +35,12 @@ The `--name` flag can be used to name a specific environment.
 By default, the environment will be created in the current directory.
 Flox will add a directory `$PWD/.flox` containing all relevant environment
 metadata.
-Local environments include a random identifier in `.flox/telemetry_id`.
-This file is committed with the environment so clones share the same
-environment identifier.
-It is created even when metrics collection is disabled; disabling metrics
-prevents the identifier from being submitted.
+Flox stores a random identifier in `.flox/telemetry_id` to group metrics from
+commands that use the same local environment.
+The file is committed so the identifier stays with the environment when it is
+cloned.
+Flox always creates the file, but submits the identifier only when metrics
+collection is enabled.
 The `--dir` flag can be used to create an environment in another location.
 
 If an environment already exists in the current directory,

--- a/cli/flox/src/commands/init/mod.rs
+++ b/cli/flox/src/commands/init/mod.rs
@@ -244,7 +244,7 @@ async fn init_local_environment(
     // Give the new environment a stable local id for telemetry correlation,
     // committed with `.flox`. Idempotent and best-effort; read paths never
     // write it.
-    local_environment_id::mint(&env.path);
+    local_environment_id::ensure(&env.path);
 
     let env_in_git_repo = GitCommandProvider::discover(dir).is_ok();
 

--- a/cli/flox/src/commands/init/mod.rs
+++ b/cli/flox/src/commands/init/mod.rs
@@ -23,7 +23,7 @@ use tracing::{debug, info_span, instrument};
 use crate::commands::{SHELL_COMPLETION_DIR, ensure_auth, environment_description};
 use crate::subcommand_metric;
 use crate::utils::dialog::Dialog;
-use crate::utils::message;
+use crate::utils::{local_environment_id, message};
 
 mod go;
 mod node;
@@ -240,6 +240,11 @@ async fn init_local_environment(
         debug!("creating environment");
         PathEnvironment::init(path_pointer, dir, &customization, flox)?
     };
+
+    // Give the new environment a stable local id for telemetry correlation,
+    // committed with `.flox`. Idempotent and best-effort; read paths never
+    // write it.
+    local_environment_id::mint(&env.path);
 
     let env_in_git_repo = GitCommandProvider::discover(dir).is_ok();
 

--- a/cli/flox/src/commands/pull.rs
+++ b/cli/flox/src/commands/pull.rs
@@ -187,7 +187,7 @@ impl Pull {
                     let pointer = managed_environment.pointer().clone();
                     let path_env = managed_environment.into_path_environment(&flox)?;
                     // A copy is a new environment definition, so it gets its own id.
-                    local_environment_id::mint(&path_env.dot_flox_path());
+                    local_environment_id::ensure(&path_env.dot_flox_path());
 
                     message::created(formatdoc! {"
                         Created path environment from {owner}/{name}.
@@ -405,7 +405,7 @@ impl Pull {
                 Ok(env) => {
                     create_dot_flox_gitignore(env.dot_flox_path())?;
                     // A copy is a new environment definition, so it gets its own id.
-                    local_environment_id::mint(&dot_flox_path);
+                    local_environment_id::ensure(&env.dot_flox_path());
                 },
             }
         }

--- a/cli/flox/src/commands/pull.rs
+++ b/cli/flox/src/commands/pull.rs
@@ -36,7 +36,7 @@ use crate::commands::{EnvironmentSelect, environment_description, environment_se
 use crate::utils::dialog::{Dialog, Select};
 use crate::utils::errors::{display_chain, format_core_error};
 use crate::utils::events::env_detail_from_concrete;
-use crate::utils::message;
+use crate::utils::{local_environment_id, message};
 use crate::{environment_subcommand_metric, subcommand_metric};
 
 #[derive(Debug, Clone, Bpaf)]
@@ -185,7 +185,9 @@ impl Pull {
                     };
 
                     let pointer = managed_environment.pointer().clone();
-                    managed_environment.into_path_environment(&flox)?;
+                    let path_env = managed_environment.into_path_environment(&flox)?;
+                    // A copy is a new environment definition, so it gets its own id.
+                    local_environment_id::mint(&path_env.dot_flox_path());
 
                     message::created(formatdoc! {"
                         Created path environment from {owner}/{name}.
@@ -402,6 +404,8 @@ impl Pull {
                 },
                 Ok(env) => {
                     create_dot_flox_gitignore(env.dot_flox_path())?;
+                    // A copy is a new environment definition, so it gets its own id.
+                    local_environment_id::mint(&dot_flox_path);
                 },
             }
         }

--- a/cli/flox/src/utils/events.rs
+++ b/cli/flox/src/utils/events.rs
@@ -156,9 +156,9 @@ fn read_env_lineage_fields(flox: &Flox, env: &ConcreteEnvironment) -> EnvLineage
         ConcreteEnvironment::Path(environment) => {
             local_environment_id::read(&environment.dot_flox_path())
         },
-        // Managed/remote environments are identified downstream by owner/name,
-        // and by a server-assigned id under a different key, so the CLI emits
-        // no local id for them.
+        // The CLI has no server-assigned id for managed/remote environments.
+        // Their events carry owner/name in `env_ref_or_name`, so they emit no
+        // local id.
         ConcreteEnvironment::Managed(_) | ConcreteEnvironment::Remote(_) => None,
     };
 

--- a/cli/flox/src/utils/events.rs
+++ b/cli/flox/src/utils/events.rs
@@ -24,6 +24,7 @@ use flox_rust_sdk::utils::INVOCATION_SOURCES;
 use tracing::debug;
 use uuid::Uuid;
 
+use crate::utils::local_environment_id;
 use crate::utils::metrics::read_metrics_uuid;
 
 /// Stores the invocation_id resolved by [`resolve_invocation_id`] so detached
@@ -142,6 +143,7 @@ pub fn build_events_client(
 
 /// Lineage fields for the environment the current invocation operates on.
 struct EnvLineageFields {
+    local_environment_id: Option<Uuid>,
     generation_number: Option<u64>,
     package_count: Option<u64>,
 }
@@ -150,6 +152,16 @@ struct EnvLineageFields {
 /// a failure leaves the field absent and is logged at debug, never failing the
 /// command.
 fn read_env_lineage_fields(flox: &Flox, env: &ConcreteEnvironment) -> EnvLineageFields {
+    let local_environment_id = match env {
+        ConcreteEnvironment::Path(environment) => {
+            local_environment_id::read(&environment.dot_flox_path())
+        },
+        // Managed/remote environments are identified downstream by owner/name,
+        // and by a server-assigned id under a different key, so the CLI emits
+        // no local id for them.
+        ConcreteEnvironment::Managed(_) | ConcreteEnvironment::Remote(_) => None,
+    };
+
     // Managed/remote resolve their generation and lockfile in a single
     // metadata read; path envs have no generation and read their on-disk
     // lockfile.
@@ -184,6 +196,7 @@ fn read_env_lineage_fields(flox: &Flox, env: &ConcreteEnvironment) -> EnvLineage
         });
 
     EnvLineageFields {
+        local_environment_id,
         generation_number,
         package_count,
     }
@@ -193,9 +206,10 @@ fn read_env_lineage_fields(flox: &Flox, env: &ConcreteEnvironment) -> EnvLineage
 /// same env-kind / env-ref mapping as the legacy
 /// `environment_subcommand_metric!` macro. Shared across call sites so the
 /// per-kind match is not duplicated.
-fn env_detail_with_generation(
+fn env_detail_with_lineage(
     env: &ConcreteEnvironment,
     generation_number: Option<u64>,
+    local_environment_id: Option<Uuid>,
 ) -> EnvDetail {
     match env {
         ConcreteEnvironment::Remote(environment) => {
@@ -204,16 +218,17 @@ fn env_detail_with_generation(
         ConcreteEnvironment::Managed(environment) => {
             EnvDetail::managed(environment.env_ref().to_string(), generation_number)
         },
-        ConcreteEnvironment::Path(environment) => {
-            EnvDetail::path(Environment::name(environment).to_string())
-        },
+        ConcreteEnvironment::Path(environment) => EnvDetail::path(
+            Environment::name(environment).to_string(),
+            local_environment_id,
+        ),
     }
 }
 
 /// Build environment identity without reading lineage. Used by eager events
 /// that must emit before locking or trust decisions.
 pub fn env_detail_from_concrete_without_lineage(env: &ConcreteEnvironment) -> EnvDetail {
-    env_detail_with_generation(env, None)
+    env_detail_with_lineage(env, None, None)
 }
 
 /// Build environment detail, reading lineage only when an events client is
@@ -223,8 +238,8 @@ pub fn env_detail_from_concrete(flox: &Flox, env: &ConcreteEnvironment) -> EnvDe
     else {
         return env_detail_from_concrete_without_lineage(env);
     };
-
-    let mut detail = env_detail_with_generation(env, fields.generation_number);
+    let mut detail =
+        env_detail_with_lineage(env, fields.generation_number, fields.local_environment_id);
     if let Some(package_count) = fields.package_count {
         detail = detail.with_package_count(package_count);
     }

--- a/cli/flox/src/utils/local_environment_id.rs
+++ b/cli/flox/src/utils/local_environment_id.rs
@@ -1,0 +1,76 @@
+//! The local environment's stable id, stored as a bare UUID string in
+//! `.flox/telemetry_id`.
+//!
+//! Minted in the CLI layer when a path environment is created (`flox init`,
+//! `flox pull --copy`) and read at event-emit time to populate
+//! `local_environment_id`. It lives in the committed `.flox` alongside
+//! `env.json`, so it travels with a git-clone or folder-copy, but it is
+//! deliberately not part of the environment pointer, and the SDK is not
+//! involved in minting or reading it.
+
+use std::path::Path;
+
+use flox_core::write_atomically;
+use tracing::debug;
+use uuid::Uuid;
+
+/// File inside `.flox` holding the environment's stable local id.
+pub(crate) const TELEMETRY_ID_FILENAME: &str = "telemetry_id";
+
+/// Read the local environment id from `<dot_flox>/telemetry_id`. Best-effort
+/// and read-only: a missing or malformed file yields `None`, never an error,
+/// and reading never writes.
+pub(crate) fn read(dot_flox: &Path) -> Option<Uuid> {
+    let contents = std::fs::read_to_string(dot_flox.join(TELEMETRY_ID_FILENAME)).ok()?;
+    Uuid::try_parse(contents.trim()).ok()
+}
+
+/// Mint a stable local id for a newly created path environment and write it to
+/// `<dot_flox>/telemetry_id`, returning it. Idempotent: if a valid id already
+/// exists it is returned unchanged, so calling this on an already-identified
+/// environment never regenerates the id. Best-effort: a write failure is
+/// logged, and that environment then carries no id for its lifetime (reads
+/// never write, so nothing recreates it).
+pub(crate) fn mint(dot_flox: &Path) -> Uuid {
+    if let Some(existing) = read(dot_flox) {
+        return existing;
+    }
+    let id = Uuid::new_v4();
+    if let Err(err) = write_atomically(dot_flox.join(TELEMETRY_ID_FILENAME), format!("{id}\n")) {
+        debug!(error = %err, "could not write local_environment_id");
+    }
+    id
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[test]
+    fn mint_then_read_round_trips() {
+        let dir = tempdir().unwrap();
+        assert_eq!(read(dir.path()), None, "no id before minting");
+        let id = mint(dir.path());
+        assert_eq!(read(dir.path()), Some(id), "read returns the minted id");
+    }
+
+    #[test]
+    fn mint_is_idempotent() {
+        let dir = tempdir().unwrap();
+        let first = mint(dir.path());
+        assert_eq!(
+            mint(dir.path()),
+            first,
+            "a second mint keeps the existing id"
+        );
+    }
+
+    #[test]
+    fn malformed_file_reads_as_absent() {
+        let dir = tempdir().unwrap();
+        std::fs::write(dir.path().join(TELEMETRY_ID_FILENAME), "not-a-uuid").unwrap();
+        assert_eq!(read(dir.path()), None);
+    }
+}

--- a/cli/flox/src/utils/local_environment_id.rs
+++ b/cli/flox/src/utils/local_environment_id.rs
@@ -10,6 +10,7 @@
 
 use std::path::Path;
 
+use flox_core::data::CanonicalPath;
 use flox_core::write_atomically;
 use tracing::debug;
 use uuid::Uuid;
@@ -25,21 +26,19 @@ pub(crate) fn read(dot_flox: &Path) -> Option<Uuid> {
     Uuid::try_parse(contents.trim()).ok()
 }
 
-/// Mint a stable local id for a newly created path environment and write it to
-/// `<dot_flox>/telemetry_id`, returning it. Idempotent: if a valid id already
-/// exists it is returned unchanged, so calling this on an already-identified
-/// environment never regenerates the id. Best-effort: a write failure is
-/// logged, and that environment then carries no id for its lifetime (reads
-/// never write, so nothing recreates it).
-pub(crate) fn mint(dot_flox: &Path) -> Uuid {
-    if let Some(existing) = read(dot_flox) {
-        return existing;
+/// Ensure a newly created path environment has a stable local id at
+/// `<dot_flox>/telemetry_id`. Idempotent: an already-identified environment
+/// keeps its existing id. Best-effort: a write failure is logged, and that
+/// environment then carries no id for its lifetime (reads never write, so
+/// nothing recreates it).
+pub(crate) fn ensure(dot_flox: &CanonicalPath) {
+    if read(dot_flox).is_some() {
+        return;
     }
     let id = Uuid::new_v4();
     if let Err(err) = write_atomically(dot_flox.join(TELEMETRY_ID_FILENAME), format!("{id}\n")) {
         debug!(error = %err, "could not write local_environment_id");
     }
-    id
 }
 
 #[cfg(test)]
@@ -49,21 +48,25 @@ mod tests {
     use super::*;
 
     #[test]
-    fn mint_then_read_round_trips() {
+    fn ensure_creates_readable_id() {
         let dir = tempdir().unwrap();
+        let dot_flox = CanonicalPath::new(dir.path()).unwrap();
         assert_eq!(read(dir.path()), None, "no id before minting");
-        let id = mint(dir.path());
-        assert_eq!(read(dir.path()), Some(id), "read returns the minted id");
+        ensure(&dot_flox);
+        assert_ne!(read(dir.path()), None, "id exists after ensuring");
     }
 
     #[test]
-    fn mint_is_idempotent() {
+    fn ensure_keeps_existing_id() {
         let dir = tempdir().unwrap();
-        let first = mint(dir.path());
+        let dot_flox = CanonicalPath::new(dir.path()).unwrap();
+        ensure(&dot_flox);
+        let first = read(dir.path());
+        ensure(&dot_flox);
         assert_eq!(
-            mint(dir.path()),
+            read(dir.path()),
             first,
-            "a second mint keeps the existing id"
+            "ensuring again keeps the existing id"
         );
     }
 

--- a/cli/flox/src/utils/local_environment_id.rs
+++ b/cli/flox/src/utils/local_environment_id.rs
@@ -8,8 +8,6 @@
 //! deliberately not part of the environment pointer, and the SDK is not
 //! involved in minting or reading it.
 
-use std::path::Path;
-
 use flox_core::data::CanonicalPath;
 use flox_core::write_atomically;
 use tracing::debug;
@@ -21,7 +19,7 @@ pub(crate) const TELEMETRY_ID_FILENAME: &str = "telemetry_id";
 /// Read the local environment id from `<dot_flox>/telemetry_id`. Best-effort
 /// and read-only: a missing or malformed file yields `None`, never an error,
 /// and reading never writes.
-pub(crate) fn read(dot_flox: &Path) -> Option<Uuid> {
+pub(crate) fn read(dot_flox: &CanonicalPath) -> Option<Uuid> {
     let contents = std::fs::read_to_string(dot_flox.join(TELEMETRY_ID_FILENAME)).ok()?;
     Uuid::try_parse(contents.trim()).ok()
 }
@@ -51,9 +49,9 @@ mod tests {
     fn ensure_creates_readable_id() {
         let dir = tempdir().unwrap();
         let dot_flox = CanonicalPath::new(dir.path()).unwrap();
-        assert_eq!(read(dir.path()), None, "no id before minting");
+        assert_eq!(read(&dot_flox), None, "no id before minting");
         ensure(&dot_flox);
-        assert_ne!(read(dir.path()), None, "id exists after ensuring");
+        assert_ne!(read(&dot_flox), None, "id exists after ensuring");
     }
 
     #[test]
@@ -61,10 +59,10 @@ mod tests {
         let dir = tempdir().unwrap();
         let dot_flox = CanonicalPath::new(dir.path()).unwrap();
         ensure(&dot_flox);
-        let first = read(dir.path());
+        let first = read(&dot_flox);
         ensure(&dot_flox);
         assert_eq!(
-            read(dir.path()),
+            read(&dot_flox),
             first,
             "ensuring again keeps the existing id"
         );
@@ -73,7 +71,8 @@ mod tests {
     #[test]
     fn malformed_file_reads_as_absent() {
         let dir = tempdir().unwrap();
+        let dot_flox = CanonicalPath::new(dir.path()).unwrap();
         std::fs::write(dir.path().join(TELEMETRY_ID_FILENAME), "not-a-uuid").unwrap();
-        assert_eq!(read(dir.path()), None);
+        assert_eq!(read(&dot_flox), None);
     }
 }

--- a/cli/flox/src/utils/mod.rs
+++ b/cli/flox/src/utils/mod.rs
@@ -14,6 +14,7 @@ pub mod didyoumean;
 pub mod errors;
 pub mod events;
 pub mod init;
+pub mod local_environment_id;
 pub mod message;
 pub mod metrics;
 pub mod openers;

--- a/cli/tests/init.bats
+++ b/cli/tests/init.bats
@@ -117,6 +117,12 @@ EOF
   run cat .flox/.gitattributes
   assert_success
   assert_line "env/manifest.lock linguist-generated=true linguist-language=JSON"
+
+  # A stable local environment id is minted and committed with .flox
+  assert [ -e ".flox/telemetry_id" ]
+  run cat .flox/telemetry_id
+  assert_success
+  assert_output --regexp '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
 }
 
 @test "c7: tips omit 'flox push' when within a git repo" {

--- a/cli/tests/pull.bats
+++ b/cli/tests/pull.bats
@@ -55,9 +55,17 @@ function make_dummy_env() {
 
   pushd "$(mktemp -d)" >/dev/null || return
   "$FLOX_BIN" init --name "$ENV_NAME"
+  SOURCE_LOCAL_ENVIRONMENT_ID="$(cat .flox/telemetry_id)"
   "$FLOX_BIN" push --owner "$OWNER"
   "$FLOX_BIN" delete --force
   popd >/dev/null || return
+}
+
+function assert_fresh_local_environment_id() {
+  run cat .flox/telemetry_id
+  assert_success
+  assert_output --regexp '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+  assert_not_equal "$output" "$SOURCE_LOCAL_ENVIRONMENT_ID"
 }
 
 # push an update to floxhub from another peer
@@ -411,6 +419,7 @@ function add_incompatible_package() {
   assert [ $(cat .flox/env.json | jq -r '.owner') == "null" ]
   assert [ -f .flox/.gitignore ]
   assert_output --partial "Created path environment from owner/name"
+  assert_fresh_local_environment_id
 }
 
 # bats test_tags=pull:copy:new:error-if-incompatible
@@ -432,6 +441,7 @@ function add_incompatible_package() {
   assert [ -e ".flox/env.lock" ]
   assert [ $(cat .flox/env.json | jq -r '.name') == "name" ]
   assert [ $(cat .flox/env.json | jq -r '.owner') == "owner" ]
+  assert [ ! -e ".flox/telemetry_id" ]
 
   run "$FLOX_BIN" pull --copy
   assert_success
@@ -439,6 +449,7 @@ function add_incompatible_package() {
   assert [ $(cat .flox/env.json | jq -r '.name') == "name" ]
   assert [ $(cat .flox/env.json | jq -r '.owner') == "null" ]
   assert_output --partial "Created path environment from owner/name"
+  assert_fresh_local_environment_id
 }
 
 # `flox pull --copy` is the recommended way to push an environment to a new name


### PR DESCRIPTION
## Proposed Changes

Gives local (path) environments a durable, committed identifier —
`local_environment_id` — so `cli.environment.*` telemetry events can be
correlated per environment over time. The id is a v4 UUID minted when the
environment's `.flox` is created (by any creation path), stored as a bare UUID
string in a committed `.flox/telemetry_id` file, and emitted as
`local_environment_id` on `cli.environment.*` events for path environments.

It is named `local_environment_id` — not `environment_id` — deliberately: a
managed/remote environment already has a server-assigned id emitted under a
different key, and the two are different things (see "Local only" below).

## What the id identifies, and why

`local_environment_id` identifies an environment *definition* — the committed
`.flox` — not a particular working copy of it. This lets us answer "how is this
one environment used over its lifetime" by grouping events, which an
environment's kind + reference alone can't do (a local `default` environment,
for instance, has no distinguishing reference).

Because it identifies the definition:

- **A `git clone` or folder-copy inherits the id** — they're checkouts of one
  definition, and the id lives in the committed `.flox` alongside `env.json`.
- **A fresh `flox init` mints a new id** — that's a new definition.
- **`flox pull --copy` also mints a new id** — a copy is a new definition, and
  minting happens wherever `.flox` is materialized, so copies are covered too.
  (Recording a `forked_from` lineage link across the copy is a follow-up.)

## Key design decisions

**A random UUID, not a fingerprint.** The id is a random v4 UUID, not a hash of
the path or contents. A derived fingerprint (e.g. a path hash) was considered
and rejected: it collides for same-path environments across containers, VMs, or
machines — every `~/project/.flox` default environment would hash identically —
and would falsely merge distinct environments. A random UUID is a true identity
with no such collisions, and encodes no path or machine information.

**Off the environment pointer.** The id is deliberately *not* part of
`EnvironmentPointer` / `env.json`. The pointer derives `Eq`/`Ord`; folding an id
into it would change environment-equality semantics and force a hand-written
`Eq`. Keeping the id in a separate `.flox/telemetry_id` file leaves the pointer
— and everything that compares pointers — untouched.

**Minted at creation, by a small CLI helper.** The id is minted when a local
environment is created — at `flox init` and `flox pull --copy` — by a helper in
the CLI layer; the SDK is not involved in minting or reading it. The mint is
idempotent, so an environment that already has an id keeps it. Only creation
writes the file; read paths never write. Write-on-read would be a surprising
side effect and, worse, would let two clones of the same environment each mint a
*different* id on first use, splitting one environment's history in two.
Mint-once-at-creation keeps the id deterministic and merge-conflict-free.

**Minting is unconditional; emission is gated.** The UUID is written regardless
of the metrics opt-out, because it's a property of the environment, not of
consent. What's gated on an installed events client is *emission*: with metrics
disabled, nothing is reported. The id file itself is committed to `.flox`, so —
like the rest of the environment — it travels with the repo (a clone or a
teammate gets it); it simply is never sent as telemetry when metrics are off.
The file is named `telemetry_id` so its presence in a committed tree is
self-explanatory.

**Local only; managed/remote correlate downstream.** The CLI emits no id for
managed or remote environments. The CLI syncs those over git, not an HTTP API,
so it has no server-assigned id to read at emit time. Managed/remote
environments are instead correlated downstream by their `owner/name` (which
their events already carry), so this change needs no server or API dependency. A
rename-stable, server-side identifier is a separate, larger effort.

## Scope

- **No path-hash fallback and no backfill.** Environments created before this
  change (no `telemetry_id` file) emit no id. Every environment created after it
  — via `init`, `pull --copy`, or any other path that materializes `.flox` —
  gets one. Backfilling old environments on read or write would reintroduce the
  write-on-read / split-history problems above.
- **Nothing on `EnvironmentPointer`** — `env.json` and the derived `Eq`/`Ord`
  are unchanged.

## Wire compatibility

`local_environment_id` is an optional `EnvDetail` field with
`skip_serializing_if`, so rows from older binaries round-trip through the new
struct unchanged, and an absent field stays meaningful (a path environment with
no file yet, or a managed/remote environment).

## Security

The id carries no PII and no path or machine information — it's a random UUID.
It is client-side telemetry (inherently spoofable) used for correlation, not an
authorization key; environment authorization is unchanged and remains
owner/namespace-based.

## Release Notes

Telemetry only; no user-facing behavior change.

---

Redesign of the environment_id half of #4541 (which this supersedes). Stacks on
#4552.
