### PR TITLE
ci: scope the heavy CI jobs to changes that need them (CLI-168)

### DIFF
--- a/.github/scripts/classify-ci-scope.sh
+++ b/.github/scripts/classify-ci-scope.sh
@@ -19,6 +19,28 @@
 # newline-separated paths on stdin to exercise the allowlist without git.
 #
 # ---------------------------------------------------------------------------- #
+#
+# Why this is not `dorny/paths-filter`.
+#
+# That action answers "did *any* changed file match this pattern?". This gate
+# needs the opposite quantifier — "did *every* changed file match the inert
+# allowlist?" — and the two are not interchangeable, because getting the
+# polarity backwards fails towards skipping CI rather than towards running it.
+#
+# The action can be coerced into the universal form with
+# `predicate-quantifier: every` over a list of negated globs, but the two rules
+# that carry the actual risk do not fit in a filter block at all: the
+# `cli/flox/doc/*` carve-out below is a disjunction, and "an empty diff is
+# heavy" is not a pattern. Both would end up in a hand-written boolean over
+# three filter outputs in the job's `outputs:`, which is exactly the logic that
+# most needs a test and is the one place no test can reach. The
+# never-exit-non-zero posture would still have to be added on top.
+#
+# So the safety-relevant surface would not shrink, it would move somewhere less
+# legible and stop being testable. `--classify-only` above is what buys the
+# allowlist a test suite that runs without CI.
+#
+# ---------------------------------------------------------------------------- #
 
 set -uo pipefail
 

--- a/.github/scripts/classify-ci-scope.sh
+++ b/.github/scripts/classify-ci-scope.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# ============================================================================ #
+#
+# Classify the change under test as "heavy" or not.
+#
+# A heavy change needs the full build and test fleet — including the remote
+# Darwin builders, which are a scarce shared resource. A change that only
+# touches documentation or repository chrome does not.
+#
+# The classification is default-deny: `heavy=true` unless *every* changed file
+# matches the inert allowlist below. Every error path also lands on
+# `heavy=true`. An over-run costs CI minutes; an under-run costs correctness,
+# so the two are not symmetric and this script always errs towards running.
+#
+# Consumed by the `scope` job in .github/workflows/ci.yml, which exposes the
+# result as `needs.scope.outputs.heavy`.
+#
+# Run `./.github/scripts/classify-ci-scope.sh --classify-only` and feed it
+# newline-separated paths on stdin to exercise the allowlist without git.
+#
+# ---------------------------------------------------------------------------- #
+
+set -uo pipefail
+
+# ---------------------------------------------------------------------------- #
+
+# Report the verdict and stop. Always exits 0: a non-zero exit would fail the
+# `scope` job, which would in turn skip every job that depends on it — and a
+# required check that never posts a status leaves the merge queue waiting
+# forever.
+emit() {
+  local heavy="$1" reason="$2"
+
+  echo "heavy=$heavy (reason: $reason)" >&2
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    echo "heavy=$heavy" >> "$GITHUB_OUTPUT"
+  fi
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    echo "\`heavy=$heavy\` — $reason" >> "$GITHUB_STEP_SUMMARY"
+  fi
+  echo "heavy=$heavy"
+  exit 0
+}
+
+# ---------------------------------------------------------------------------- #
+
+# Does this path, on its own, leave the heavy jobs with nothing to do?
+#
+# Anything not listed here is heavy, so a newly added workflow, action, or
+# source directory fails safe rather than silently opting out of CI.
+is_inert() {
+  case "$1" in
+    # Not inert despite being markdown: pkgs/flox-manpages compiles every
+    # `*.md` under this directory into a manpage that is bundled into the
+    # `flox` package, so these are build inputs.
+    cli/flox/doc/*) return 1 ;;
+
+    *.md) return 0 ;;
+    docs/*) return 0 ;;
+
+    .github/ISSUE_TEMPLATE/*) return 0 ;;
+    PULL_REQUEST_TEMPLATE*) return 0 ;;
+    .github/PULL_REQUEST_TEMPLATE*) return 0 ;;
+
+    # Workflows that only govern bots and labelling. Deliberately *not*
+    # ci.yml, nix-managed-lints.yml or build-examples-tests.yml, which decide
+    # what CI itself does.
+    .github/workflows/claude-review.yml) return 0 ;;
+    .github/workflows/claude-mention.yml) return 0 ;;
+    .github/workflows/auto-label.yml) return 0 ;;
+
+    CODEOWNERS | .github/CODEOWNERS) return 0 ;;
+    LICENSE | LICENSE.*) return 0 ;;
+
+    *) return 1 ;;
+  esac
+}
+
+# Read newline-separated paths on stdin and emit the verdict.
+classify() {
+  local path
+  local -i seen=0
+
+  while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    seen+=1
+    if ! is_inert "$path"; then
+      emit true "'$path' is not on the inert allowlist"
+    fi
+  done
+
+  # An empty diff is not a licence to skip: it more likely means the range was
+  # computed wrongly than that a pull request changed nothing.
+  if [ "$seen" -eq 0 ]; then
+    emit true "the computed diff is empty"
+  fi
+
+  emit false "all $seen changed files are documentation or repository chrome"
+}
+
+# ---------------------------------------------------------------------------- #
+
+# Print the changed paths for this event, or return non-zero if the range
+# cannot be established.
+#
+# `--no-renames` lists both the old and the new path of a rename, so a file
+# moved out of the allowlist is still seen.
+changed_files() {
+  local base head
+
+  case "${GITHUB_EVENT_NAME:-}" in
+    merge_group)
+      base="${MERGE_GROUP_BASE_SHA:-}"
+      [ -n "$base" ] || return 1
+      git cat-file -e "${base}^{commit}" 2> /dev/null ||
+        git fetch --no-tags origin "$base" || return 1
+      git diff --no-renames --name-only "${base}...HEAD" || return 1
+      ;;
+
+    pull_request | pull_request_target)
+      # `github.event.pull_request.base.sha` is the base branch tip as of when
+      # the pull request was last synchronised, so it drifts as the base branch
+      # moves and would report unrelated files. Use the merge base instead.
+      #
+      # The head branch may live in a fork, so it is not guaranteed to exist on
+      # `origin`. Fetch it through `refs/pull/<number>/head`, which GitHub
+      # maintains on the base repository for every pull request.
+      [ -n "${PR_BASE_REF:-}" ] && [ -n "${PR_NUMBER:-}" ] || return 1
+      git fetch --atomic --no-tags --force origin \
+        "refs/heads/${PR_BASE_REF}:refs/ci-scope/base" \
+        "refs/pull/${PR_NUMBER}/head:refs/ci-scope/head" || return 1
+      base="$(git merge-base refs/ci-scope/base refs/ci-scope/head)" || return 1
+      head="$(git rev-parse refs/ci-scope/head)" || return 1
+      git diff --no-renames --name-only "$base" "$head" || return 1
+      ;;
+
+    *) return 1 ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------- #
+
+main() {
+  local files
+
+  if [ "${1:-}" = "--classify-only" ]; then
+    classify
+    return
+  fi
+
+  # `push`, `schedule` and `workflow_dispatch` runs are the record of what main
+  # actually builds, and a manual dispatch is by definition someone asking for
+  # the full suite. They are never scoped down.
+  case "${GITHUB_EVENT_NAME:-}" in
+    push | schedule | workflow_dispatch)
+      emit true "the '${GITHUB_EVENT_NAME}' event always runs the full suite"
+      ;;
+  esac
+
+  if ! files="$(changed_files)"; then
+    emit true "could not compute the diff range for the '${GITHUB_EVENT_NAME:-unknown}' event"
+  fi
+
+  classify <<< "$files"
+}
+
+main "$@"
+
+# ---------------------------------------------------------------------------- #
+#
+#
+#
+# ============================================================================ #

--- a/.github/scripts/classify-ci-scope.sh
+++ b/.github/scripts/classify-ci-scope.sh
@@ -37,8 +37,14 @@
 # never-exit-non-zero posture would still have to be added on top.
 #
 # So the safety-relevant surface would not shrink, it would move somewhere less
-# legible and stop being testable. `--classify-only` above is what buys the
-# allowlist a test suite that runs without CI.
+# legible and stop being testable. `--classify-only` above is what makes the
+# allowlist testable without CI, and the `scope` job runs a canary over it on
+# every run so the always-heavy invariant is checked by the same pull request
+# that would widen the allowlist. There is no shell-test harness anywhere in
+# this repository — `shellcheck` and `shfmt` are disabled in
+# `pkgs/pre-commit-check/default.nix` and there is no `actionlint` — so a full
+# suite means inventing the first one. Worth doing, and a follow-up rather than
+# a prerequisite for this gate.
 #
 # ---------------------------------------------------------------------------- #
 
@@ -46,10 +52,9 @@ set -uo pipefail
 
 # ---------------------------------------------------------------------------- #
 
-# Report the verdict and stop. Always exits 0: a non-zero exit would fail the
-# `scope` job, which would in turn skip every job that depends on it — and a
-# required check that never posts a status leaves the merge queue waiting
-# forever.
+# Report the verdict and stop. Always exits 0, so the `scope` job cannot fail;
+# see the `scope` job in .github/workflows/ci.yml for why a required check that
+# never posts a status is the failure mode being avoided.
 emit() {
   local heavy="$1" reason="$2"
 
@@ -72,17 +77,36 @@ emit() {
 # source directory fails safe rather than silently opting out of CI.
 is_inert() {
   case "$1" in
-    # Not inert despite being markdown: pkgs/flox-manpages compiles every
-    # `*.md` under this directory into a manpage that is bundled into the
-    # `flox` package, so these are build inputs.
+    # Not inert despite being markdown, and for two independent reasons.
+    # pkgs/flox-manpages compiles every `*.md` under this directory into a
+    # manpage bundled into the `flox` package, so these are build inputs; and
+    # `manifest.toml.md` is read at test time by
+    # `cli/flox-manifest/src/parsed/common.rs::man_page_lists_all_schema_versions`,
+    # so without this arm editing it would skip `cli-unit` — the job containing
+    # the very test that guards it.
+    #
+    # This is not the only markdown that is a build input, only the one whose
+    # blast radius is wide enough to earn an arm: `pkgs/flox-interpreter`
+    # substitutes over all of `assets/environment-interpreter`, which contains
+    # `activate/activate.d/zdotdir/README.md`. That one is narrow enough (a
+    # stray `@token@` in prose) to leave classified inert. The exception list
+    # below is hand-maintained and has to be revisited whenever markdown lands
+    # inside a nix `src`.
     cli/flox/doc/*) return 1 ;;
 
     *.md) return 0 ;;
     docs/*) return 0 ;;
 
     .github/ISSUE_TEMPLATE/*) return 0 ;;
-    PULL_REQUEST_TEMPLATE*) return 0 ;;
-    .github/PULL_REQUEST_TEMPLATE*) return 0 ;;
+
+    # GitHub's pull-request template locations. `*.md` already covers the
+    # markdown spellings; these arms are enumerated rather than globbed
+    # because `*` spans `/` in a `case` pattern, so the previous
+    # `PULL_REQUEST_TEMPLATE*` also matched
+    # `PULL_REQUEST_TEMPLATE_x/src/main.rs` and broke default-deny.
+    PULL_REQUEST_TEMPLATE | PULL_REQUEST_TEMPLATE.md) return 0 ;;
+    .github/PULL_REQUEST_TEMPLATE | .github/PULL_REQUEST_TEMPLATE.md) return 0 ;;
+    .github/PULL_REQUEST_TEMPLATE/*) return 0 ;;
 
     # Workflows that only govern bots and labelling. Deliberately *not*
     # ci.yml, nix-managed-lints.yml or build-examples-tests.yml, which decide
@@ -92,7 +116,9 @@ is_inert() {
     .github/workflows/auto-label.yml) return 0 ;;
 
     CODEOWNERS | .github/CODEOWNERS) return 0 ;;
-    LICENSE | LICENSE.*) return 0 ;;
+    # Enumerated for the same reason as the template arms above: `LICENSE.*`
+    # matched `LICENSE.d/cli/flox/src/main.rs`.
+    LICENSE | LICENSE.md | LICENSE.txt) return 0 ;;
 
     *) return 1 ;;
   esac
@@ -103,7 +129,12 @@ classify() {
   local path
   local -i seen=0
 
-  while IFS= read -r path; do
+  # `|| [ -n "$path" ]` keeps the final line when the input has no trailing
+  # newline. `classify <<< "$files"` below always terminates, but
+  # `--classify-only` is the advertised way to check the allowlist by hand, and
+  # a fixture written with `printf` or `< paths.txt` would otherwise silently
+  # drop its last path — failing open, not safe.
+  while IFS= read -r path || [ -n "$path" ]; do
     [ -n "$path" ] || continue
     seen+=1
     if ! is_inert "$path"; then
@@ -127,6 +158,13 @@ classify() {
 #
 # `--no-renames` lists both the old and the new path of a rename, so a file
 # moved out of the allowlist is still seen.
+#
+# `core.quotePath=false` stops git C-quoting non-ASCII bytes. Without it
+# `docs/ü.md` arrives as `"docs/\303\274.md"`, which matches no allowlist arm,
+# so an accented documentation filename would opt the whole diff back into the
+# full fleet. Paths containing a literal `"`, `\` or control character are still
+# quoted and still classify heavy; that residue fails towards running CI, which
+# is the direction this script is allowed to fail in.
 changed_files() {
   local base head
 
@@ -136,10 +174,10 @@ changed_files() {
       [ -n "$base" ] || return 1
       git cat-file -e "${base}^{commit}" 2> /dev/null ||
         git fetch --no-tags origin "$base" || return 1
-      git diff --no-renames --name-only "${base}...HEAD" || return 1
+      git -c core.quotePath=false diff --no-renames --name-only "${base}...HEAD" || return 1
       ;;
 
-    pull_request | pull_request_target)
+    pull_request)
       # `github.event.pull_request.base.sha` is the base branch tip as of when
       # the pull request was last synchronised, so it drifts as the base branch
       # moves and would report unrelated files. Use the merge base instead.
@@ -147,13 +185,19 @@ changed_files() {
       # The head branch may live in a fork, so it is not guaranteed to exist on
       # `origin`. Fetch it through `refs/pull/<number>/head`, which GitHub
       # maintains on the base repository for every pull request.
+      #
+      # Fetched, never checked out and never executed: this arm only ever runs
+      # `merge-base`, `rev-parse` and `diff --name-only` over the ref. Keep it
+      # that way — `pull_request_target` was deliberately dropped from this
+      # pattern because `ci.yml` does not declare it, and re-adding the trigger
+      # would hand attacker-authored head content to whatever this arm runs.
       [ -n "${PR_BASE_REF:-}" ] && [ -n "${PR_NUMBER:-}" ] || return 1
       git fetch --atomic --no-tags --force origin \
         "refs/heads/${PR_BASE_REF}:refs/ci-scope/base" \
         "refs/pull/${PR_NUMBER}/head:refs/ci-scope/head" || return 1
       base="$(git merge-base refs/ci-scope/base refs/ci-scope/head)" || return 1
       head="$(git rev-parse refs/ci-scope/head)" || return 1
-      git diff --no-renames --name-only "$base" "$head" || return 1
+      git -c core.quotePath=false diff --no-renames --name-only "$base" "$head" || return 1
       ;;
 
     *) return 1 ;;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -463,7 +463,7 @@ jobs:
     # Spelled out rather than left implicit so that a failed `scope` cannot
     # skip this required check: `nix-build` succeeding is the only precondition,
     # exactly as before. A skipped `nix-build` (fork PR) still skips this job.
-    if: ${{ needs.nix-build.result == 'success' }}
+    if: ${{ !cancelled() && needs.nix-build.result == 'success' }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,10 +48,57 @@ env:
   FLOX_RUNNING_RELEASE: "${{ startsWith(github.head_ref, 'release-') || startsWith(github.base_ref, 'release-') }}"
 
 jobs:
+  # Classify the change under test so the expensive jobs below can no-op on
+  # changes that cannot possibly affect them — most importantly, so that a
+  # documentation-only pull request does not occupy the shared remote Darwin
+  # builders.
+  #
+  # This job is deliberately *not* a gate. Nothing below is skipped at the job
+  # level on the strength of its output: every required check still runs and
+  # still posts a status, and only the steps inside those jobs are gated. A
+  # required check that never reports leaves the merge queue waiting forever,
+  # so the wiring below is careful to make that impossible.
+  scope:
+    name: "Scope"
+    runs-on: "ubuntu-latest"
+    timeout-minutes: 10
+
+    permissions:
+      contents: read
+
+    outputs:
+      heavy: "${{ steps.classify.outputs.heavy }}"
+
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          # `git merge-base` needs history on both sides of the comparison.
+          fetch-depth: 0
+
+      - name: "Classify the diff"
+        id: "classify"
+        # Context values are passed via `env:` and referenced as shell
+        # variables rather than interpolated directly into `run:`, to avoid
+        # script injection from attacker-controlled values such as branch names.
+        env:
+          MERGE_GROUP_BASE_SHA: "${{ github.event.merge_group.base_sha }}"
+          PR_BASE_REF: "${{ github.base_ref }}"
+          PR_NUMBER: "${{ github.event.pull_request.number }}"
+        run: ./.github/scripts/classify-ci-scope.sh
+
   nix-plugins-dev:
     name: "Nix Plugins"
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
+
+    needs:
+      - "scope"
+
+    # Run even if `scope` failed, so this required check always posts a status.
+    # The step conditions below default to running the heavy steps whenever
+    # `scope` did not explicitly report `heavy=false`.
+    if: ${{ !cancelled() }}
 
     strategy:
       fail-fast: false
@@ -79,6 +126,7 @@ jobs:
           wait-timeout-minutes: 15
 
       - name: "Setup"
+        if: ${{ needs.scope.outputs.heavy != 'false' }}
         uses: "./.github/actions/common-setup"
         with:
           GITHUB_ACCESS_TOKEN: "${{ secrets.MANAGED_FLOXBOT_GITHUB_ACCESS_TOKEN_REPO_SCOPE }}"
@@ -89,9 +137,11 @@ jobs:
           SSH_KEY: "${{ secrets.MANAGED_FLOXBOT_SSH_KEY }}"
 
       - name: "Build"
+        if: ${{ needs.scope.outputs.heavy != 'false' }}
         run: nix develop -L --no-update-lock-file --command just build-nix-plugins
 
       - name: "Test"
+        if: ${{ needs.scope.outputs.heavy != 'false' }}
         run: nix develop -L --no-update-lock-file --command just test-nix-plugins
 
   nef-dev:
@@ -135,6 +185,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
 
+    needs:
+      - "scope"
+
+    # See `nix-plugins-dev`: always runs, only its steps are gated.
+    if: ${{ !cancelled() }}
+
     permissions:
       id-token: write # Needed for CodeCov
 
@@ -158,6 +214,7 @@ jobs:
           wait-timeout-minutes: 15
 
       - name: "Setup"
+        if: ${{ needs.scope.outputs.heavy != 'false' }}
         uses: "./.github/actions/common-setup"
         with:
           GITHUB_ACCESS_TOKEN: "${{ secrets.MANAGED_FLOXBOT_GITHUB_ACCESS_TOKEN_REPO_SCOPE }}"
@@ -168,6 +225,7 @@ jobs:
           SSH_KEY: "${{ secrets.MANAGED_FLOXBOT_SSH_KEY }}"
 
       - name: "Cache Cargo"
+        if: ${{ needs.scope.outputs.heavy != 'false' }}
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
           path: |
@@ -180,16 +238,19 @@ jobs:
           restore-keys: "cargo-${{ runner.os }}-"
 
       - name: "Build"
+        if: ${{ needs.scope.outputs.heavy != 'false' }}
         run: nix develop -L --no-update-lock-file --command just build-cli
 
       - name: "CLI Unit Tests"
         # Only run unit tests if when not running specialized integration tests
         id: unit-tests
+        if: ${{ needs.scope.outputs.heavy != 'false' }}
         env:
           RUST_BACKTRACE: 1
         run: nix develop -L --no-update-lock-file --command just impure-tests
 
       - name: "Check schemas are up to date"
+        if: ${{ needs.scope.outputs.heavy != 'false' }}
         run: |
           nix develop -L --no-update-lock-file --command just gen-schemas
           if ! git diff --quiet cli/schemas; then
@@ -205,9 +266,15 @@ jobs:
     # it can only fail. The required "Nix build (*)" contexts are posted on the
     # same commit by the maintainer-run community-ci draft PR (CONTRIBUTING.md).
     # Pushes, merge-queue runs, and same-repo PRs are unaffected.
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    #
+    # `!cancelled()` keeps the pre-existing fork condition as the *only* reason
+    # this job is ever skipped: a failed `scope` must not silence it.
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: "ubuntu-latest"
     timeout-minutes: 120
+
+    needs:
+      - "scope"
 
     permissions:
       id-token: write # Needed for AWS Creds
@@ -244,6 +311,7 @@ jobs:
           wait-timeout-minutes: 15
 
       - name: "Setup"
+        if: ${{ needs.scope.outputs.heavy != 'false' }}
         uses: "./.github/actions/common-setup"
         with:
           GITHUB_ACCESS_TOKEN: "${{ secrets.MANAGED_FLOXBOT_GITHUB_ACCESS_TOKEN_REPO_SCOPE }}"
@@ -259,6 +327,7 @@ jobs:
           SETUP_NIX: "false"
 
       - name: "Configure AWS Credentials"
+        if: ${{ needs.scope.outputs.heavy != 'false' }}
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6
         with:
           role-to-assume: "arn:aws:iam::759020684799:role/github-oidc-role-flox-cache-public"
@@ -269,6 +338,7 @@ jobs:
 
       - name: "Build"
         id: "build"
+        if: ${{ needs.scope.outputs.heavy != 'false' }}
         env:
           NIX_SUBSTITUTER: "${{ vars.MANAGED_CACHE_PUBLIC_S3_BUCKET }}"
           NIX_SUBSTITUTER_KEY: ${{ secrets.MANAGED_CACHE_PUBLIC_SECRET_KEY }}"
@@ -387,7 +457,13 @@ jobs:
       id-token: write # Needed for CodeCov
 
     needs:
+      - "scope"
       - "nix-build"
+
+    # Spelled out rather than left implicit so that a failed `scope` cannot
+    # skip this required check: `nix-build` succeeding is the only precondition,
+    # exactly as before. A skipped `nix-build` (fork PR) still skips this job.
+    if: ${{ needs.nix-build.result == 'success' }}
 
     strategy:
       fail-fast: false
@@ -426,6 +502,7 @@ jobs:
           wait-timeout-minutes: 15
 
       - name: "Setup"
+        if: ${{ needs.scope.outputs.heavy != 'false' }}
         uses: "./.github/actions/common-setup"
         with:
           GITHUB_ACCESS_TOKEN: "${{ secrets.MANAGED_FLOXBOT_GITHUB_ACCESS_TOKEN_REPO_SCOPE }}"
@@ -441,6 +518,7 @@ jobs:
 
       - name: "Run Bats Tests (./#flox-cli-tests)"
         timeout-minutes: 30
+        if: ${{ needs.scope.outputs.heavy != 'false' }}
         env:
           MATRIX_SYSTEM: ${{ matrix.system }}
           MATRIX_TEST_TAGS: ${{ matrix.test-tags }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,13 +55,31 @@ jobs:
   #
   # This job is deliberately *not* a gate. Nothing below is skipped at the job
   # level on the strength of its output: every required check still runs and
-  # still posts a status, and only the steps inside those jobs are gated. A
-  # required check that never reports leaves the merge queue waiting forever,
-  # so the wiring below is careful to make that impossible.
+  # still posts a status, and only the steps inside those jobs are gated.
+  #
+  # That is not a precaution against a hypothetical — it is a verified property
+  # of this repository. A job-level skip does not post the per-leg contexts the
+  # branch protection requires: on fork PR #4488, skipping `nix-build` at the
+  # job level produced exactly one check run named `Nix build`, with no matrix
+  # suffix and zero per-leg contexts; all four `Nix build (<system>)` contexts
+  # on that commit came from the separate community-ci run. 14 of the 16
+  # contexts in the `Main ruleset` are matrix legs owned by the four jobs gated
+  # here, so a job-level skip does not leave a required context pending — it
+  # means the context is never *created*, and the merge queue ejects the pull
+  # request on a status-check timeout.
   scope:
     name: "Scope"
     runs-on: "ubuntu-latest"
     timeout-minutes: 10
+
+    # Only `pull_request` and `merge_group` can be scoped down at all; the
+    # classifier's first act on any other event is to emit the constant
+    # `heavy=true`. Skipping the job outright on those events is safe under this
+    # design's own rule — a skipped `scope` yields `heavy == ''`, which
+    # satisfies every `!= 'false'` step condition below — and it keeps a
+    # transient `scope` failure on `main` from satisfying `failure()` in
+    # `report-failure` and paging Slack.
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
 
     permissions:
       contents: read
@@ -73,8 +91,36 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          # `git merge-base` needs history on both sides of the comparison.
+          # `git merge-base` needs history on both sides of the comparison, so
+          # the depth has to stay: a shallow clone makes `merge-base` fail,
+          # which lands on `heavy=true` and turns this into a silent no-op gate.
           fetch-depth: 0
+          # The classifier reads path names and commit topology, never file
+          # contents, so the ~36 MiB of blobs across ~5800 commits is pure cost
+          # on the critical path of four jobs. `blob:none` rather than `tree:0`
+          # because `actions/checkout` materialises a working tree, and `tree:0`
+          # would force that back out as on-demand tree fetches.
+          filter: "blob:none"
+
+      - name: "Verify the classifier"
+        # Canary, not a test suite: a pull request that widens the allowlist
+        # necessarily edits `classify-ci-scope.sh`, which is itself always
+        # heavy, so this runs against the change that could break it. Keeping
+        # `GITHUB_OUTPUT`/`GITHUB_STEP_SUMMARY` empty stops the canary writing
+        # a verdict into either.
+        env:
+          GITHUB_OUTPUT: ""
+          GITHUB_STEP_SUMMARY: ""
+        run: |
+          printf 'cli/flox/src/main.rs\n' |
+            ./.github/scripts/classify-ci-scope.sh --classify-only |
+            grep -qx 'heavy=true'
+          printf 'README.md\ndocs/guide.md\n' |
+            ./.github/scripts/classify-ci-scope.sh --classify-only |
+            grep -qx 'heavy=false'
+          printf 'cli/flox/doc/manifest.toml.md\n' |
+            ./.github/scripts/classify-ci-scope.sh --classify-only |
+            grep -qx 'heavy=true'
 
       - name: "Classify the diff"
         id: "classify"
@@ -95,9 +141,9 @@ jobs:
     needs:
       - "scope"
 
-    # Run even if `scope` failed, so this required check always posts a status.
-    # The step conditions below default to running the heavy steps whenever
-    # `scope` did not explicitly report `heavy=false`.
+    # See `scope`: this job always runs, and only its steps are gated. The step
+    # conditions below default to running whenever `scope` did not explicitly
+    # report `heavy=false`, which covers a failed or skipped `scope`.
     if: ${{ !cancelled() }}
 
     strategy:
@@ -267,8 +313,8 @@ jobs:
     # same commit by the maintainer-run community-ci draft PR (CONTRIBUTING.md).
     # Pushes, merge-queue runs, and same-repo PRs are unaffected.
     #
-    # `!cancelled()` keeps the pre-existing fork condition as the *only* reason
-    # this job is ever skipped: a failed `scope` must not silence it.
+    # See `scope`: `!cancelled()` keeps the pre-existing fork condition as the
+    # *only* reason this job is ever skipped.
     if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: "ubuntu-latest"
     timeout-minutes: 120
@@ -460,9 +506,10 @@ jobs:
       - "scope"
       - "nix-build"
 
-    # Spelled out rather than left implicit so that a failed `scope` cannot
-    # skip this required check: `nix-build` succeeding is the only precondition,
-    # exactly as before. A skipped `nix-build` (fork PR) still skips this job.
+    # See `scope`. Spelled out rather than left implicit because without a
+    # status-check function GitHub adds `success()` over *every* `needs`:
+    # `nix-build` succeeding is the only precondition, exactly as before, and a
+    # skipped `nix-build` (fork PR) still skips this job.
     if: ${{ !cancelled() && needs.nix-build.result == 'success' }}
 
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,7 +341,7 @@ jobs:
         if: ${{ needs.scope.outputs.heavy != 'false' }}
         env:
           NIX_SUBSTITUTER: "${{ vars.MANAGED_CACHE_PUBLIC_S3_BUCKET }}"
-          NIX_SUBSTITUTER_KEY: ${{ secrets.MANAGED_CACHE_PUBLIC_SECRET_KEY }}"
+          NIX_SUBSTITUTER_KEY: "${{ secrets.MANAGED_CACHE_PUBLIC_SECRET_KEY }}"
         run: |
           export AWS_ACCESS_KEY_ID
           export AWS_SECRET_ACCESS_KEY


### PR DESCRIPTION
Implements **Change 2** of [CLI-168](https://linear.app/floxdotdev/issue/CLI-168/proposal-scope-ci-so-the-darwin-builder-fleet-is-only-used-when-its), per the discussion in `#committee-cli` where Matthew and Yannik both weighed in.

## What this does

The remote Darwin builders are a scarce shared resource, and today a pull request that only edits markdown occupies them for as long as one that rewrites the resolver.

This adds a lightweight `scope` job that classifies the diff, and gates the **expensive steps** of `nix-plugins-dev`, `cli-unit`, `nix-build` and `nix-build-bats-tests` on its verdict.

`Project Lints` / `Nix Git Hooks` (`nix-managed-lints.yml`) is deliberately untouched and keeps running in full. It is what still catches problems in markdown, YAML and formatting on the changes this gate scopes out.

## Required jobs are never skipped

This is the caveat Yannik raised in the thread, and the design is built around it.

Every guarded job **always runs and always posts its status**. Only the steps inside it are gated with `if: ${{ needs.scope.outputs.heavy != 'false' }}`. Nothing is gated at `jobs.<job_id>.if` on the strength of the scope verdict. A job-level skip stops that job posting a status at all, which leaves the merge queue waiting indefinitely for a required check that never reports — exactly what has bitten us before.

Two extra precautions beyond the ticket text, both in the same direction:

- The guarded jobs carry `if: ${{ !cancelled() }}` so that a **failure in `scope` itself** cannot skip them. Without it, adding `needs: scope` would introduce a brand new way for a required check to go silent — the very failure mode we are trying to avoid.
- The step condition is `!= 'false'` rather than `== 'true'`, so a missing or empty verdict (scope failed, was skipped, errored) degrades to a **full CI run** rather than to a silent no-op.
- `.github/scripts/classify-ci-scope.sh` never exits non-zero for the same reason.

The set of required contexts is unchanged: all 16 still exist and none gained a new skip path. `nix-build`'s pre-existing fork-PR condition and `nix-build-bats-tests`' dependence on `nix-build` succeeding both behave exactly as before.

## Classification

Default-deny. `heavy=true` unless *every* changed file is on the inert allowlist, and `heavy=true` unconditionally on `push`, `schedule` and `workflow_dispatch`.

| inert (heavy steps no-op) | always heavy |
|---|---|
| `**/*.md`, `docs/**` | `.github/workflows/ci.yml` |
| `.github/ISSUE_TEMPLATE/**`, `PULL_REQUEST_TEMPLATE*` | `.github/actions/**`, `.github/scripts/**` |
| `claude-review.yml`, `claude-mention.yml`, `auto-label.yml` | `nix-managed-lints.yml`, `build-examples-tests.yml` |
| `CODEOWNERS`, `LICENSE` | everything else |

Anything not on the list is heavy, so a newly added workflow or source directory fails safe rather than silently opting out of CI.

**One deviation from the ticket, for correctness:** `cli/flox/doc/**` is treated as heavy even though it is markdown. `pkgs/flox-manpages` compiles every `*.md` under that directory into a manpage that is bundled into the `flox` package (`pkgs/flox-manpages/default.nix:42,56`), so those files are genuine build inputs and a blanket `**/*.md` rule would under-run.

## Diff range

Computed per event, since an over-run costs minutes but an under-run costs correctness:

- `merge_group` → base is `github.event.merge_group.base_sha`
- `pull_request` → `git merge-base` against the base branch, **not** `base.sha`, which drifts as the base branch moves. The head is fetched via `refs/pull/<n>/head` so fork PRs work, mirroring what `nix-managed-lints.yml` already does.
- any other event, or any error computing the diff → `heavy=true`
- an empty diff → `heavy=true` (more likely a bad range than a genuinely empty PR)

## Verification

The classifier is factored so the allowlist can be exercised without git (`--classify-only`, reading paths on stdin). Locally:

- 19 allowlist cases pass, including: doc-only → `heavy=false`; `cli/**` → `heavy=true`; a new unlisted workflow → `heavy=true`; one heavy file among many inert ones → `heavy=true`; `cli/flox/doc/*.md` → `heavy=true`.
- End-to-end against real git repos: the `merge_group` path returns `false` for a doc-only range and `true` for a code range; the `pull_request` path returns `false` for a doc-only PR **even when the base branch has since gained unrelated code commits** (the drift case that motivates using `merge-base`), and `true` for a `cli/**` PR.
- Every error path — bogus base SHA, missing base SHA, missing PR number, nonexistent PR ref, unknown event, no event — returns `heavy=true` and exit code 0.
- `actionlint` reports no new findings versus `origin/main` (the existing ones about runner labels, `steps.closure` and SC2086 are pre-existing). `yamlfmt` reports no changes. `shellcheck` is clean apart from one false-positive SC2317.
- Job-graph analysis confirms 19 contexts total, of which 16 are the required ones — unchanged from `origin/main`.

**Limitation:** the `merge_group` path cannot be exercised from a plain pull request, so it is covered by local simulation against real git objects rather than by a live run. Also note this PR touches `.github/workflows/ci.yml` and `.github/scripts/**`, both always-heavy, so its own CI run is a full one — which does exercise the `pull_request` classification path end to end. Confirmed on this PR: `Scope` completed in 9s, fetched `refs/heads/main` and `refs/pull/4558/head`, and reported

```
heavy=true (reason: '.github/scripts/classify-ci-scope.sh' is not on the inert allowlist)
```

with every guarded job then running its full step list as before.

**Residual cost:** step-level gating still allocates the runner for each guarded job, so the `macos-14-xlarge` runners for `nix-plugins-dev` and `cli-unit` are still spun up on an inert change; they just exit almost immediately. The remote Darwin builder fleet, which is the resource the ticket is actually about, is reached only from `nix-build` and `nix-build-bats-tests` on `ubuntu-latest`, and is fully avoided.

## Out of scope

**Change 1** (gating `x86_64-darwin` to post-merge only) is **not** included here. Matthew flagged it in `#committee-cli` as a duplicate of CLI-148, and it was deferred there.
