### PR TITLE
test(cli): default the bats suite to no auto-activation and no prompt hook

### DIFF
--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -969,6 +969,9 @@ EOF
 
 # bats test_tags=activate,activate:rc:zsh
 @test "zsh: deactivate restores pre-activation completions" {
+  # `deactivate --print-script` needs the marker that hook registration
+  # exports, so opt out of the suite-wide `disable_hook = true`.
+  enable_prompt_hook
   project_setup
   _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/fd.yaml" \
     "$FLOX_BIN" install fd
@@ -997,6 +1000,9 @@ EOF
 
 # bats test_tags=activate,activate:rc:zsh
 @test "zsh: deactivate inner activation cleans up completions" {
+  # `deactivate --print-script` needs the marker that hook registration
+  # exports, so opt out of the suite-wide `disable_hook = true`.
+  enable_prompt_hook
   # PROJECT_DIR (outer env): no packages — fd must NOT be available from
   # the outer env so we can verify the inner deactivation removes it.
   project_setup

--- a/cli/tests/deactivate.bats
+++ b/cli/tests/deactivate.bats
@@ -52,6 +52,11 @@ project_teardown() {
 
 setup() {
   common_test_setup
+  # Every test here deactivates, either with a plain `flox deactivate` serviced
+  # by the prompt hook or with `deactivate --print-script`, which needs the
+  # marker hook registration exports. Opt out of the suite-wide
+  # `disable_hook = true`.
+  enable_prompt_hook
   home_setup test
   user_dotfiles_setup
   setup_isolated_flox

--- a/cli/tests/deactivate_profile_e2e.bats
+++ b/cli/tests/deactivate_profile_e2e.bats
@@ -41,6 +41,10 @@ project_teardown() {
 
 setup() {
   common_test_setup
+  # `deactivate --print-script` after an in-place activation needs the
+  # `_FLOX_PROMPT_HOOK_VERSION` marker, so opt out of the suite-wide
+  # `disable_hook = true`.
+  enable_prompt_hook
   home_setup test
   setup_isolated_flox
   export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/empty.yaml"

--- a/cli/tests/hook.bats
+++ b/cli/tests/hook.bats
@@ -117,9 +117,11 @@ setup_file() {
 setup() {
   common_test_setup
   # This file exercises `prompt`-mode auto-activation (consent prompts and the
-  # default first-encounter behaviour), so override the suite-wide `allowlist`
-  # default back to `prompt` for every test here.
+  # default first-encounter behaviour) and the prompt hook itself, so override
+  # the suite-wide `disabled`/`disable_hook = true` defaults for every test
+  # here.
   export FLOX_AUTO_ACTIVATE=prompt
+  enable_prompt_hook
   setup_isolated_flox
   export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/empty.yaml"
 }

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -1710,6 +1710,12 @@ EOF
 
 # bats test_tags=services:auto-deactivate
 @test "services stop after auto-activated environment is deactivated" {
+  # The only services test that drives the prompt hook: it needs `_flox_hook`
+  # registered and auto-activation live for the env it allows below, so opt out
+  # of the suite-wide `disable_hook = true` / `auto_activate = disabled`.
+  enable_prompt_hook
+  export FLOX_AUTO_ACTIVATE=allowlist
+
   setup_sleeping_services
 
   "$FLOX_BIN" activate allow -d "$PROJECT_DIR"

--- a/cli/tests/shell-state-restoration.bats
+++ b/cli/tests/shell-state-restoration.bats
@@ -59,6 +59,10 @@ project_teardown() {
 
 setup() {
   common_test_setup
+  # `deactivate --print-script` after an in-place activation needs the
+  # `_FLOX_PROMPT_HOOK_VERSION` marker, so opt out of the suite-wide
+  # `disable_hook = true`.
+  enable_prompt_hook
   home_setup test
   setup_isolated_flox
   export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/empty.yaml"

--- a/cli/tests/test_support.bash
+++ b/cli/tests/test_support.bash
@@ -159,13 +159,34 @@ setup_file() { common_file_setup; }
 
 # Added for consistency with `teardown' routines.
 common_test_setup() {
-  # Auto-activation is on by default. Default the whole suite to `allowlist`
-  # mode so that walking past a discovered `.flox` never auto-activates or
-  # prompts unless a test explicitly allows it. This keeps tests hermetic and
-  # independent of the developer's own shell/config leaking in. Files that
-  # exercise `prompt`-mode behaviour override this to `prompt` file-wide.
-  export FLOX_AUTO_ACTIVATE=allowlist
+  # Auto-activation and the prompt hook are on by default. Turn both off for
+  # the whole suite so that neither can influence a test that is not about
+  # them: walking past a discovered `.flox` never auto-activates or prompts,
+  # and activation registers no prompt hook. This keeps tests hermetic and
+  # independent of the developer's own shell/config leaking in.
+  #
+  # Files that exercise this machinery opt back in:
+  #   - hook.bats overrides FLOX_AUTO_ACTIVATE to `prompt` file-wide.
+  #   - the deactivate and hook tests call `enable_prompt_hook` (see below).
+  export FLOX_AUTO_ACTIVATE=disabled
+  export FLOX_DISABLE_HOOK=true
 }
+
+# Undo the suite-wide `disable_hook = true` for tests that need activation to
+# register a prompt hook. Required by anything that runs a plain
+# `flox deactivate` (which refuses to run with the hook disabled) and by
+# anything that runs `flox deactivate --print-script` after an interactive or
+# in-place activation, since the emitted script is gated on the
+# `_FLOX_PROMPT_HOOK_VERSION` marker that only hook registration exports.
+#
+# Unsets rather than exporting `false`: environment variables outrank
+# `$FLOX_CONFIG_DIR/flox.toml`, so an exported value would defeat a test that
+# sets `disable_hook` itself via `flox config --set`. Unset falls through to
+# the shipped default, which is already `false`.
+enable_prompt_hook() {
+  unset FLOX_DISABLE_HOOK
+}
+
 setup() { common_test_setup; }
 
 # ---------------------------------------------------------------------------- #


### PR DESCRIPTION
There are a bunch of test flakes unrelated to any specific change - the best idea I have so far is that the prompt hook is firing throughout the test suite because we flipped the feature flag

I’m not sure if that’s actually what’s going on, but I don’t think we should be firing the prompt hook throughout the test suite anyways, so disabling it seems nonregrettable