### PR TITLE
fix(auth): warn unconditionally when the user is not logged in

### DIFF
--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -542,6 +542,11 @@ impl FloxArgs {
     /// Parse and validate the configured `floxhub_token`, building the
     /// [AuthContext] and emitting any user-facing warnings as a side effect.
     ///
+    /// A user who is not logged in — no token, or a parsed token that has
+    /// expired — is reminded to run 'flox auth login'. The reminder is
+    /// suppressed for `flox auth` subcommands, the prompt-hook flow, and
+    /// invocations nested inside an activation.
+    ///
     /// The token is not consumed when the configured authn mode does not use
     /// it (e.g. Kerberos) — construction cannot fail there, so warning about
     /// the token's state — or rewriting the user's config — never happens.
@@ -551,7 +556,7 @@ impl FloxArgs {
     ///
     /// A `flox_pat_` token is opaque: it is never parsed, never wiped as
     /// invalid, and its expiry is unknown until it is lazily resolved via
-    /// /me — so no startup warning applies to it.
+    /// /me — so it counts as logged in and no startup warning applies to it.
     fn resolve_auth_context(&self, config: &Config, stores: &CredentialStores) -> AuthContext {
         // Kerberos does not use FloxHub tokens; the stored token is not
         // consumed (and none of the token warnings below apply).
@@ -586,17 +591,20 @@ impl FloxArgs {
                 AuthContext::Auth0(None)
             },
             Ok(auth_context) => {
-                if let AuthContext::Auth0(Some(token)) = &auth_context
-                    && token.is_expired()
-                {
-                    let reauthenticating = matches!(
-                        self.command,
-                        Some(Commands::Admin(AdminCommands::Auth(
-                            auth::Auth::Login { .. }
-                        )))
-                    );
-                    // The token is account-global, so the reminder only needs to
-                    // appear once per shell session. The outermost activation
+                let logged_out = match &auth_context {
+                    AuthContext::Auth0(None) => true,
+                    AuthContext::Auth0(Some(token)) => token.is_expired(),
+                    _ => false,
+                };
+                if logged_out {
+                    // Every `flox auth` subcommand either logs the user in
+                    // (`login`) or already reports the logged-out state itself
+                    // (`status`, `logout`, `token`), so the reminder would be
+                    // redundant there.
+                    let is_auth_command =
+                        matches!(self.command, Some(Commands::Admin(AdminCommands::Auth(_))));
+                    // The logged-out state is account-global, so the reminder only
+                    // needs to appear once per shell session. The outermost activation
                     // surfaces it; any `flox` invocation already running inside an
                     // activation — a nested `flox activate`, or a command in an
                     // activated shell whose rc re-activates an environment — stays
@@ -604,9 +612,9 @@ impl FloxArgs {
                     // shell, including in-place `eval "$(flox activate)"` ones, so
                     // it is a reliable signal even across the parent shell.
                     let nested = activated_environments().last_active().is_some();
-                    if !reauthenticating && !self.is_prompt_hook_flow() && !nested {
+                    if !is_auth_command && !self.is_prompt_hook_flow() && !nested {
                         message::warning(
-                            "Your FloxHub token has expired. Run 'flox auth login' to re-authenticate.",
+                            "You are not logged in to FloxHub. Run 'flox auth login' to log in.",
                         );
                     }
                 }
@@ -1808,9 +1816,9 @@ pub(super) async fn ensure_auth(flox: &mut Flox) -> Result<String> {
 ///
 /// Unlike [`ensure_auth`], an expired Auth0 token is not a hard failure: the
 /// handle is still readable from the token, and [`FloxArgs::resolve_auth_context`]
-/// has already warned about the expiry, so activation proceeds with the handle
-/// rather than blocking. FloxHub still validates the token on the actual
-/// request. Missing credentials (not logged in / no Kerberos ticket) fall back
+/// has already warned that the user is not logged in, so activation proceeds
+/// with the handle rather than blocking. FloxHub still validates the token on
+/// the actual request. Missing credentials (not logged in / no Kerberos ticket) fall back
 /// to [`ensure_auth`] and its recovery flow.
 async fn ensure_auth_allowing_expired(flox: &mut Flox) -> Result<String> {
     // An expired identity still carries its handle; only a missing identity

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -384,7 +384,9 @@ EOF
 
   # Current recommendation for isolating environments:
   # https://github.com/flox/flox/issues/2447
-  run env -i FLOX_DISABLE_METRICS=true "$FLOX_BIN" activate -d "$PROJECT_DIR" -- hello
+  # Thread the suite's dummy token through `env -i` so the run stays "logged
+  # in" and the startup reminder doesn't break the exact output assertion.
+  run env -i FLOX_DISABLE_METRICS=true FLOX_FLOXHUB_TOKEN="$FLOX_FLOXHUB_TOKEN" "$FLOX_BIN" activate -d "$PROJECT_DIR" -- hello
   assert_success
   assert_output "Hello, world!"
 }

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -5665,7 +5665,7 @@ success"
   run "$FLOX_BIN" activate -D -- echo "activated"
   assert_success
   assert_output --partial "activated"
-  assert_output --partial "Your FloxHub token has expired."
+  assert_output --partial "You are not logged in to FloxHub. Run 'flox auth login' to log in."
 }
 
 # bats test_tags=activate,activate:idempotent

--- a/cli/tests/auth-pat.bats
+++ b/cli/tests/auth-pat.bats
@@ -67,6 +67,8 @@ teardown() {
   assert_success
   refute_output --partial "token is invalid"
   refute_output --partial "token has expired"
+  # An opaque token counts as logged in: no startup reminder.
+  refute_output --partial "not logged in to FloxHub"
 }
 
 # bats test_tags=auth:pat:owner

--- a/cli/tests/catalog-auth-warnings.bats
+++ b/cli/tests/catalog-auth-warnings.bats
@@ -47,6 +47,8 @@ teardown() {
 # ---------------------------------------------------------------------------- #
 
 @test "'flox init' prints auth deprecation warning when logged out" {
+  # The suite runs "logged in" by default; this test needs the logged-out state.
+  unset FLOX_FLOXHUB_TOKEN
   run "$FLOX_BIN" init
   assert_success
   assert_output --partial "$AUTH_WARNING"
@@ -76,6 +78,8 @@ teardown() {
 }
 
 @test "'flox activate' without lockfile prints lock warning" {
+  # The suite runs "logged in" by default; this test needs the logged-out state.
+  unset FLOX_FLOXHUB_TOKEN
   "$FLOX_BIN" init
   # flox init always creates a lockfile; remove it to simulate a pre-lockfile env
   rm .flox/env/manifest.lock

--- a/cli/tests/catalog-live.bats
+++ b/cli/tests/catalog-live.bats
@@ -24,6 +24,26 @@ teardown_file() {
 
 # ---------------------------------------------------------------------------- #
 
+setup() {
+  common_test_setup
+  # These tests hit the real preview catalog anonymously; the suite-wide
+  # dummy JWT would be rejected with 401.
+  unset FLOX_FLOXHUB_TOKEN
+  # Isolate each test in its own directory so a failure can never strand a
+  # `.flox` in the shared bats cwd, where later prompt-hook tests would
+  # discover it.
+  export PROJECT_DIR="${BATS_TEST_TMPDIR?}/project-${BATS_TEST_NUMBER?}"
+  mkdir -p "$PROJECT_DIR"
+  pushd "$PROJECT_DIR" > /dev/null || return
+}
+
+teardown() {
+  popd > /dev/null || return
+  rm -rf "${PROJECT_DIR?}"
+  unset PROJECT_DIR
+  common_test_teardown
+}
+
 @test "'flox search' works with catalog server" {
 
   run "$FLOX_BIN" search hello -vvv

--- a/cli/tests/environment-remote.bats
+++ b/cli/tests/environment-remote.bats
@@ -332,11 +332,11 @@ EOF
   # Use an expired token (exp: 2024-01-01T00:00:00+00:00, handle: "test")
   export FLOX_FLOXHUB_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3guZGV2L2hhbmRsZSI6InRlc3QiLCJleHAiOjE3MDQwNjM2MDB9.-5VCofPtmYQuvh21EV1nEJhTFV_URkRP0WFu4QDPFxY"
 
-  # The expired token warning should appear, but activation should succeed
+  # The logged-out warning should appear, but activation should succeed
   # because the user handle from the expired token matches the environment owner.
   run "$FLOX_BIN" activate --reference "$OWNER/test" -- true
   assert_success
-  assert_output --partial "Your FloxHub token has expired."
+  assert_output --partial "You are not logged in to FloxHub."
 }
 
 # bats test_tags=remote,activate,trust,remote:activate:trust-flox

--- a/cli/tests/hook.bats
+++ b/cli/tests/hook.bats
@@ -171,6 +171,9 @@ EXPIRED_FLOXHUB_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3gu
 # and rewriting config on every prompt.
 # bats test_tags=hook:hook-env
 @test "'flox hook-env' defers invalid token cleanup to user-invoked commands" {
+  # The suite-wide env token would shadow the invalid file token (env wins over
+  # the user config file), so drop it for this test.
+  unset FLOX_FLOXHUB_TOKEN
   mkdir -p "$FLOX_CONFIG_DIR"
   echo 'floxhub_token = "not-a-jwt"' >> "$FLOX_CONFIG_DIR/flox.toml"
 
@@ -198,7 +201,7 @@ EXPIRED_FLOXHUB_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3gu
     run --separate-stderr "$FLOX_BIN" deactivate
   assert_success
   refute_regex "$stderr" "as the FloxHub git endpoint"
-  refute_regex "$stderr" "token has expired"
+  refute_regex "$stderr" "not logged in to FloxHub"
 }
 
 # Pin that the suppression is scoped to the prompt-hook flow: user-invoked
@@ -210,15 +213,15 @@ EXPIRED_FLOXHUB_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3gu
     run --separate-stderr "$FLOX_BIN" config
   assert_success
   assert_regex "$stderr" "Using https://git.example.invalid/ as the FloxHub git endpoint"
-  assert_regex "$stderr" "Your FloxHub token has expired"
+  assert_regex "$stderr" "You are not logged in to FloxHub"
 }
 
-# The expired-token reminder is account-global, so a single user action that
+# The logged-out reminder is account-global, so a single user action that
 # nests `flox` invocations — e.g. `flox activate` whose shell rc runs
 # `flox activate` again — should surface it only once. The outermost activation
 # warns; anything already inside an activation stays quiet.
 # bats test_tags=hook:hook-env
-@test "expired-token advisory is shown once across nested 'flox' invocations" {
+@test "logged-out advisory is shown once across nested 'flox' invocations" {
   project_setup
 
   FLOX_FLOXHUB_TOKEN="$EXPIRED_FLOXHUB_TOKEN" \
@@ -226,7 +229,7 @@ EXPIRED_FLOXHUB_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3gu
     "$FLOX_BIN" activate -d "$PROJECT_DIR" -- true
   assert_success
   # Once for the outer activation, and not again for the nested one.
-  run grep -c "Your FloxHub token has expired" <<< "$output"
+  run grep -c "You are not logged in to FloxHub" <<< "$output"
   assert_output "1"
 
   project_teardown
@@ -237,17 +240,45 @@ EXPIRED_FLOXHUB_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3gu
 # same shell. The in-place activation exports `_FLOX_ACTIVE_ENVIRONMENTS`, so the
 # second command sees it is nested and does not repeat the reminder.
 # bats test_tags=hook:hook-env
-@test "expired-token advisory is not repeated after an in-place activation" {
+@test "logged-out advisory is not repeated after an in-place activation" {
   project_setup
 
   FLOX_FLOXHUB_TOKEN="$EXPIRED_FLOXHUB_TOKEN" \
     run bash -c "eval \"\$('$FLOX_BIN' activate -d '$PROJECT_DIR')\"; '$FLOX_BIN' config"
   assert_success
   # Once for the in-place activation, and not again for the later command.
-  run grep -c "Your FloxHub token has expired" <<< "$output"
+  run grep -c "You are not logged in to FloxHub" <<< "$output"
   assert_output "1"
 
   project_teardown
+}
+
+# A user who never logged in gets the same reminder as one whose token expired.
+# bats test_tags=hook:hook-env
+@test "user-invoked commands warn when not logged in" {
+  unset FLOX_FLOXHUB_TOKEN
+  run --separate-stderr "$FLOX_BIN" config
+  assert_success
+  assert_regex "$stderr" "You are not logged in to FloxHub. Run 'flox auth login' to log in."
+}
+
+# bats test_tags=hook:hook-env
+@test "'flox hook-env' suppresses the logged-out advisory when no token is set" {
+  unset FLOX_FLOXHUB_TOKEN
+  run --separate-stderr "$FLOX_BIN" hook-env --shell bash --shell-pid "$$"
+  assert_success
+  assert_equal "$stderr" ""
+  assert_output ""
+}
+
+# `flox auth` subcommands either log the user in or already report the
+# logged-out state themselves, so the reminder must not be stacked on top.
+# bats test_tags=hook:hook-env
+@test "'flox auth' subcommands do not repeat the logged-out advisory" {
+  unset FLOX_FLOXHUB_TOKEN
+  run "$FLOX_BIN" auth status
+  assert_output --partial "You are not currently logged in to FloxHub."
+  refute_output --partial "Run 'flox auth login'"
 }
 
 # ---------------------------------------------------------------------------- #

--- a/cli/tests/hook.bats
+++ b/cli/tests/hook.bats
@@ -158,6 +158,10 @@ EXPIRED_FLOXHUB_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3gu
 # would be eval'd by the shell.
 # bats test_tags=hook:hook-env
 @test "'flox hook-env' suppresses advisory preamble output" {
+  # An empty cwd keeps this hermetic: a `.flox` littered into the shared bats
+  # cwd by an unrelated test would give hook-env auto-activation work and trip
+  # its stale-prompt-hook check instead of exercising the advisory suppression.
+  cd "$BATS_TEST_TMPDIR"
   _FLOX_FLOXHUB_GIT_URL="https://git.example.invalid/" \
     FLOX_FLOXHUB_TOKEN="$EXPIRED_FLOXHUB_TOKEN" \
     run --separate-stderr "$FLOX_BIN" hook-env --shell bash --shell-pid "$$"
@@ -171,6 +175,8 @@ EXPIRED_FLOXHUB_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3gu
 # and rewriting config on every prompt.
 # bats test_tags=hook:hook-env
 @test "'flox hook-env' defers invalid token cleanup to user-invoked commands" {
+  # See the empty-cwd note in the first hook-env test.
+  cd "$BATS_TEST_TMPDIR"
   # The suite-wide env token would shadow the invalid file token (env wins over
   # the user config file), so drop it for this test.
   unset FLOX_FLOXHUB_TOKEN
@@ -264,6 +270,8 @@ EXPIRED_FLOXHUB_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3gu
 
 # bats test_tags=hook:hook-env
 @test "'flox hook-env' suppresses the logged-out advisory when no token is set" {
+  # See the empty-cwd note in the first hook-env test.
+  cd "$BATS_TEST_TMPDIR"
   unset FLOX_FLOXHUB_TOKEN
   run --separate-stderr "$FLOX_BIN" hook-env --shell bash --shell-pid "$$"
   assert_success

--- a/cli/tests/push.bats
+++ b/cli/tests/push.bats
@@ -57,13 +57,13 @@ teardown() {
 }
 
 # bats test_tags=push:h1:expired
-@test "h2: push login: running flox with an expired token prompts re-authentication" {
+@test "h2: push login: running flox with an expired token prompts login" {
   # set an expired token
   export FLOX_FLOXHUB_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3guZGV2L2hhbmRsZSI6InRlc3QiLCJleHAiOjE3MDQwNjM2MDB9.-5VCofPtmYQuvh21EV1nEJhTFV_URkRP0WFu4QDPFxY"
 
   run "$FLOX_BIN" init
-  assert_output --partial 'Your FloxHub token has expired.'
-  assert_output --partial "Run 'flox auth login' to re-authenticate."
+  assert_output --partial 'You are not logged in to FloxHub.'
+  assert_output --partial "Run 'flox auth login' to log in."
 
   # Redirect stdin from /dev/null to ensure non-interactive mode
   run "$FLOX_BIN" push --owner owner < /dev/null

--- a/cli/tests/setup_suite.bash
+++ b/cli/tests/setup_suite.bash
@@ -189,6 +189,12 @@ flox_cli_vars_setup() {
   # isolated by FLOX_CONFIG_DIR), so e.g. auth logout / invalid-token migration
   # cannot read or clobber the real hub.flox.dev credential.
   export _FLOX_DISABLE_KEYRING='true'
+  # All tests run "logged in" by default, with the same valid dummy JWT that
+  # floxhub_setup() sets ({ "https://flox.dev/handle": "test", "exp": 9999999999 }).
+  # This keeps the suite quiet under the startup "not logged in" reminder and
+  # stops a developer's real FLOX_FLOXHUB_TOKEN from leaking into tests.
+  # Tests that exercise logged-out behavior `unset FLOX_FLOXHUB_TOKEN`.
+  export FLOX_FLOXHUB_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3guZGV2L2hhbmRsZSI6InRlc3QiLCJleHAiOjk5OTk5OTk5OTl9.6-nbzFzQEjEX7dfWZFLE-I_qW2N_-9W2HFzzfsquI74"
 }
 
 # ---------------------------------------------------------------------------- #


### PR DESCRIPTION
Closes DEV-202.

## What

The startup advisory previously fired only when a stored FloxHub JWT had expired ("Your FloxHub token has expired. Run 'flox auth login' to re-authenticate."). Users who never logged in got no nudge at all.

Now any user who is not logged in — no token, or an expired token — sees one unified reminder:

```
⚠️  You are not logged in to FloxHub. Run 'flox auth login' to log in.
```

## Details

- An opaque `flox_pat_` token counts as logged in: its expiry is unknowable locally and is verified lazily via `/me`. Kerberos mode is unaffected.
- Suppression is broadened from `flox auth login` to all `flox auth` subcommands — they either log the user in (`login`) or already report the logged-out state themselves (`status`, `logout`, `token`), so the reminder would be redundant or nonsensical there.
- The existing prompt-hook-flow and nested-activation guards are unchanged, so the reminder appears at most once per shell session.
- The invalid-token branch and the deeper `ensure_auth` failure messages keep their specific wording.

## Testing

Most bats tests ran token-less and would now trip the warning, so the suite exports the valid dummy JWT globally (`setup_suite.bash`) — tests are "logged in" by default, and tests exercising logged-out behavior `unset FLOX_FLOXHUB_TOKEN` (the invalid-token cleanup test in `hook.bats` needed a new `unset` since the env token shadows the planted file token). This also stops a developer's real `FLOX_FLOXHUB_TOKEN` from leaking into the suite.

New coverage in `hook.bats`: the no-token warning fires for user-invoked commands, is suppressed for `hook-env`, and is not stacked on top of `flox auth` subcommands' own output. Existing expired-token tests were generalized to the new wording.

Ran locally: hook.bats, push.bats, auth.bats, auth-pat.bats, pull.bats, environment-remote.bats, the activate `-D` expired-token test, plus usage/version/init/list/delete and edit/generations/include/uninstall/show — all green.

## Release Notes

- `flox` now reminds users who are not logged in to FloxHub to run `flox auth login`, instead of only warning when a previously stored token had expired. The reminder appears once per shell session and is suppressed for `flox auth` commands and prompt hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
