### PR TITLE
feat(events): emit cli.environment.create at environment creation

### DIFF
--- a/cli/flox-events/src/buffer.rs
+++ b/cli/flox-events/src/buffer.rs
@@ -24,6 +24,13 @@ pub struct EventsBuffer {
     storage: File,
     _file_lock: LockFile,
     buffer: VecDeque<Event>,
+    /// Lines this binary could not parse, kept verbatim.
+    ///
+    /// Almost always an event type written by a newer flox sharing the same
+    /// data dir. They are carried through [`Self::overwrite_file`] unchanged
+    /// so that a binary which understands them can still send them, and so
+    /// that reading the buffer never destroys telemetry.
+    unknown: VecDeque<String>,
 }
 
 impl EventsBuffer {
@@ -67,21 +74,36 @@ impl EventsBuffer {
             .read_to_string(&mut buffer_json)
             .context("Could not read v2 events buffer file")?;
 
-        let buffer = serde_json::Deserializer::from_str(&buffer_json)
-            .into_iter::<Event>()
-            .filter_map(|event| match event {
-                Ok(event) => Some(event),
+        // Parse per line rather than as one stream. A `StreamDeserializer`
+        // stops at its first error and reports the rest of the input as
+        // consumed, so a single unreadable entry would silently take every
+        // later entry with it — and `overwrite_file` would then persist that
+        // loss.
+        let mut buffer = VecDeque::new();
+        let mut unknown = VecDeque::new();
+        for line in buffer_json.lines() {
+            if line.trim().is_empty() {
+                continue;
+            }
+            match serde_json::from_str::<Event>(line) {
+                Ok(event) => buffer.push_back(event),
                 Err(err) => {
-                    debug!(error = %err, "Skipping unreadable v2 event buffer entry");
-                    None
+                    debug!(error = %err, "Retaining unreadable v2 event buffer entry");
+                    unknown.push_back(line.to_string());
                 },
-            })
-            .collect();
+            }
+        }
+        // Retained lines are bounded like the parsed ones: a machine that
+        // permanently runs an older flox must not grow this file forever.
+        while unknown.len() >= MAX_BUFFER_SIZE {
+            unknown.pop_front();
+        }
 
         Ok(Self {
             storage: events_buffer_file,
             _file_lock: events_lock,
             buffer,
+            unknown,
         })
     }
 
@@ -118,6 +140,17 @@ impl EventsBuffer {
             self.storage
                 .write_all(serde_json::to_string(event)?.as_bytes())
                 .context("Could not write v2 event to buffer file")?;
+            self.storage
+                .write_all(b"\n")
+                .context("Could not write v2 event buffer newline")?;
+        }
+
+        // Entries this binary could not read are written back untouched, so a
+        // rewrite never drops what it could not interpret.
+        for line in &self.unknown {
+            self.storage
+                .write_all(line.as_bytes())
+                .context("Could not write retained v2 event to buffer file")?;
             self.storage
                 .write_all(b"\n")
                 .context("Could not write v2 event buffer newline")?;
@@ -177,5 +210,68 @@ impl EventsBuffer {
         while self.buffer.len() >= MAX_BUFFER_SIZE {
             self.buffer.pop_front();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A serialized envelope of `event_type`, as an older binary would find
+    /// it in a buffer written by a newer one.
+    fn envelope(event_type: &str) -> String {
+        format!(
+            r#"{{"event_id":"00000000-0000-0000-0000-000000000000","event_timestamp":0,"source":"cli","invocation_id":"00000000-0000-0000-0000-000000000000","device_id":"00000000-0000-0000-0000-000000000000","event_type":"{event_type}","payload":{{"env_kind":"path","env_ref_or_name":"myenv"}}}}"#
+        )
+    }
+
+    /// An entry this binary cannot parse — an event type added by a newer
+    /// flox — must not take the entries after it down with it.
+    #[test]
+    fn unreadable_entry_does_not_discard_later_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join(EVENTS_BUFFER_FILE_NAME),
+            format!(
+                "{}\n{}\n{}\n",
+                envelope("cli.environment.delete"),
+                envelope("cli.environment.from.the.future"),
+                envelope("cli.environment.list"),
+            ),
+        )
+        .unwrap();
+
+        let buffer = EventsBuffer::read(dir.path()).unwrap();
+
+        assert_eq!(buffer.buffer.len(), 2, "both readable entries survive");
+        assert_eq!(buffer.unknown.len(), 1, "the unreadable entry is retained");
+    }
+
+    /// Reading a buffer and rewriting it must never destroy an entry this
+    /// binary could not interpret: a newer flox has to still be able to send
+    /// it.
+    #[test]
+    fn unreadable_entry_survives_a_rewrite() {
+        let dir = tempfile::tempdir().unwrap();
+        let future = envelope("cli.environment.from.the.future");
+        std::fs::write(
+            dir.path().join(EVENTS_BUFFER_FILE_NAME),
+            format!("{}\n{}\n", envelope("cli.environment.delete"), future),
+        )
+        .unwrap();
+
+        {
+            let mut buffer = EventsBuffer::read(dir.path()).unwrap();
+            let sent = buffer.batch_size(usize::MAX);
+            buffer.drain_sent(sent);
+            buffer.overwrite_file().unwrap();
+        }
+
+        let contents = std::fs::read_to_string(dir.path().join(EVENTS_BUFFER_FILE_NAME)).unwrap();
+        assert_eq!(
+            contents.lines().collect::<Vec<_>>(),
+            vec![future.as_str()],
+            "the sent entry is drained and the unreadable one is written back"
+        );
     }
 }

--- a/cli/flox-events/src/buffer.rs
+++ b/cli/flox-events/src/buffer.rs
@@ -24,12 +24,9 @@ pub struct EventsBuffer {
     storage: File,
     _file_lock: LockFile,
     buffer: VecDeque<Event>,
-    /// Lines this binary could not parse, kept verbatim.
-    ///
-    /// Almost always an event type written by a newer flox sharing the same
-    /// data dir. They are carried through [`Self::overwrite_file`] unchanged
-    /// so that a binary which understands them can still send them, and so
-    /// that reading the buffer never destroys telemetry.
+    /// Lines this binary could not parse — almost always an event type
+    /// written by a newer flox sharing the data dir. Kept verbatim so a
+    /// binary that understands them can still send them.
     unknown: VecDeque<String>,
 }
 
@@ -74,11 +71,9 @@ impl EventsBuffer {
             .read_to_string(&mut buffer_json)
             .context("Could not read v2 events buffer file")?;
 
-        // Parse per line rather than as one stream. A `StreamDeserializer`
-        // stops at its first error and reports the rest of the input as
-        // consumed, so a single unreadable entry would silently take every
-        // later entry with it — and `overwrite_file` would then persist that
-        // loss.
+        // Per line, not one `StreamDeserializer`: that stops at its first
+        // error and reports the rest of the input as consumed, so one
+        // unreadable entry would take every later entry with it.
         let mut buffer = VecDeque::new();
         let mut unknown = VecDeque::new();
         for line in buffer_json.lines() {
@@ -93,8 +88,8 @@ impl EventsBuffer {
                 },
             }
         }
-        // Retained lines are bounded like the parsed ones: a machine that
-        // permanently runs an older flox must not grow this file forever.
+        // Bounded like the parsed ones: a machine permanently on an older
+        // flox must not grow this file forever.
         while unknown.len() >= MAX_BUFFER_SIZE {
             unknown.pop_front();
         }
@@ -145,8 +140,8 @@ impl EventsBuffer {
                 .context("Could not write v2 event buffer newline")?;
         }
 
-        // Entries this binary could not read are written back untouched, so a
-        // rewrite never drops what it could not interpret.
+        // Written back untouched, so a rewrite never drops what this binary
+        // could not interpret.
         for line in &self.unknown {
             self.storage
                 .write_all(line.as_bytes())
@@ -225,8 +220,6 @@ mod tests {
         )
     }
 
-    /// An entry this binary cannot parse — an event type added by a newer
-    /// flox — must not take the entries after it down with it.
     #[test]
     fn unreadable_entry_does_not_discard_later_entries() {
         let dir = tempfile::tempdir().unwrap();
@@ -247,9 +240,6 @@ mod tests {
         assert_eq!(buffer.unknown.len(), 1, "the unreadable entry is retained");
     }
 
-    /// Reading a buffer and rewriting it must never destroy an entry this
-    /// binary could not interpret: a newer flox has to still be able to send
-    /// it.
     #[test]
     fn unreadable_entry_survives_a_rewrite() {
         let dir = tempfile::tempdir().unwrap();

--- a/cli/flox-events/src/buffer.rs
+++ b/cli/flox-events/src/buffer.rs
@@ -88,8 +88,10 @@ impl EventsBuffer {
                 },
             }
         }
-        // Bounded like the parsed ones: a machine permanently on an older
-        // flox must not grow this file forever.
+        // Capped separately from the parsed entries, so the file holds up to
+        // 2 * MAX_BUFFER_SIZE lines. Anything unparseable lands here, not
+        // only newer-variant events: a line torn by a crash mid-append is
+        // also retained, and no binary will ever drain it.
         while unknown.len() >= MAX_BUFFER_SIZE {
             unknown.pop_front();
         }

--- a/cli/flox-events/src/lib.rs
+++ b/cli/flox-events/src/lib.rs
@@ -136,6 +136,8 @@ pub enum EventKind {
     CliPackageUninstall(CliPackagePayload),
     #[serde(rename = "cli.environment.containerize")]
     CliEnvironmentContainerize(CliEnvironmentPayload),
+    #[serde(rename = "cli.environment.create")]
+    CliEnvironmentCreate(CliEnvironmentPayload),
     #[serde(rename = "cli.environment.delete")]
     CliEnvironmentDelete(CliEnvironmentPayload),
     #[serde(rename = "cli.environment.edit")]
@@ -1108,6 +1110,30 @@ mod tests {
             "env_kind": "path",
             "env_ref_or_name": "myenv",
         }));
+        assert_eq!(value, expected);
+    }
+
+    #[test]
+    fn cli_environment_create_envelope_golden() {
+        let local_environment_id = Uuid::from_u128(0x11111111_1111_1111_1111_111111111111);
+        let detail = EnvDetail::path("myenv", Some(local_environment_id));
+        let payload = CliEnvironmentPayload::new(detail);
+        let value = serde_json::to_value(fixed_event(EventKind::CliEnvironmentCreate(payload)))
+            .expect("event serializes");
+        let payload_json = json!({
+            "env_kind": "path",
+            "env_ref_or_name": "myenv",
+            "local_environment_id": "11111111-1111-1111-1111-111111111111",
+        });
+        let expected = json!({
+            "event_id": "00000000-0000-0000-0000-000000000000",
+            "event_timestamp": EPOCH_UNIX_MS,
+            "source": "cli",
+            "invocation_id": "00000000-0000-0000-0000-000000000000",
+            "device_id": "00000000-0000-0000-0000-000000000000",
+            "event_type": "cli.environment.create",
+            "payload": payload_json,
+        });
         assert_eq!(value, expected);
     }
 

--- a/cli/flox-events/src/lib.rs
+++ b/cli/flox-events/src/lib.rs
@@ -136,6 +136,20 @@ pub enum EventKind {
     CliPackageUninstall(CliPackagePayload),
     #[serde(rename = "cli.environment.containerize")]
     CliEnvironmentContainerize(CliEnvironmentPayload),
+    /// An environment definition came into existence.
+    ///
+    /// Emitted once, where a definition starts: `flox init`, `flox init -r`,
+    /// the first-run `flox install` flow when it creates the user's default
+    /// environment, and `flox pull --copy` when the copy is a definition of
+    /// its own. For path environments that is exactly when a new
+    /// `local_environment_id` is minted, so a create row and a first-seen id
+    /// coincide.
+    ///
+    /// Changing form is not creating. `flox push` promotes an existing
+    /// definition to a managed one, and `flox pull` without `--copy`
+    /// materializes a local checkout of a definition that already exists;
+    /// neither mints an id and neither emits. Counting either as a create
+    /// would report one environment twice.
     #[serde(rename = "cli.environment.create")]
     CliEnvironmentCreate(CliEnvironmentPayload),
     #[serde(rename = "cli.environment.delete")]
@@ -412,7 +426,7 @@ impl EnvDetail {
 }
 
 /// Payload shared by every environment event that carries env detail and
-/// nothing else (push, pull, containerize, delete, include.upgrade,
+/// nothing else (create, push, pull, containerize, delete, include.upgrade,
 /// install, list, uninstall, upgrade, the `services.*` events, and the
 /// non-list `generations.*` events). The [`EventKind`] variant is the
 /// discriminant.

--- a/cli/flox-events/src/lib.rs
+++ b/cli/flox-events/src/lib.rs
@@ -136,20 +136,14 @@ pub enum EventKind {
     CliPackageUninstall(CliPackagePayload),
     #[serde(rename = "cli.environment.containerize")]
     CliEnvironmentContainerize(CliEnvironmentPayload),
-    /// An environment definition came into existence.
+    /// An environment definition came into existence — not an existing one
+    /// changing form. `flox push` promotes a definition to a managed one and
+    /// `flox pull` without `--copy` checks one out locally; counting either
+    /// would report one environment twice.
     ///
-    /// Emitted once, where a definition starts: `flox init`, `flox init -r`,
-    /// the first-run `flox install` flow when it creates the user's default
-    /// environment, and `flox pull --copy` when the copy is a definition of
-    /// its own. For path environments that is exactly when a new
+    /// For path environments this is exactly when a new
     /// `local_environment_id` is minted, so a create row and a first-seen id
     /// coincide.
-    ///
-    /// Changing form is not creating. `flox push` promotes an existing
-    /// definition to a managed one, and `flox pull` without `--copy`
-    /// materializes a local checkout of a definition that already exists;
-    /// neither mints an id and neither emits. Counting either as a create
-    /// would report one environment twice.
     #[serde(rename = "cli.environment.create")]
     CliEnvironmentCreate(CliEnvironmentPayload),
     #[serde(rename = "cli.environment.delete")]

--- a/cli/flox-events/src/lib.rs
+++ b/cli/flox-events/src/lib.rs
@@ -758,6 +758,14 @@ mod tests {
 
     use super::*;
 
+    // The `*_envelope_golden` tests below pin the serialized wire shape, not
+    // serde's behavior. Their consumer is the analytics ingestion (S3Queue
+    // into ClickHouse) in another repo, with no compile-time link back here,
+    // so renaming or dropping a field breaks nothing locally: these tests are
+    // the only signal. A failing golden means the contract moved and the
+    // consumer needs a migration. Update the expected JSON once that is
+    // arranged, not to make the test pass.
+
     /// The wire form of `OffsetDateTime::from_unix_timestamp(0)` under
     /// `TimestampMilliSeconds<i64>` — milliseconds since the Unix
     /// epoch, where 1970-01-01T00:00:00Z is exactly 0.

--- a/cli/flox/src/commands/init/mod.rs
+++ b/cli/flox/src/commands/init/mod.rs
@@ -249,6 +249,13 @@ async fn init_local_environment(
     local_environment_id::ensure(&env.path);
 
     let env = ConcreteEnvironment::Path(env);
+    // Unlike the sibling `cli.environment.*` events, which emit at dispatch and
+    // let `cli.command_completed` carry the outcome, a create event is emitted
+    // after the creating call succeeds: there is no environment to describe
+    // until then, and the id above must exist to ride along on the payload.
+    // Emitting here rather than at the end of this function is deliberate — the
+    // environment exists on disk from `PathEnvironment::init` onward, so a
+    // later failure in the reporting below does not un-create it.
     if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentCreate(
         CliEnvironmentPayload::new(env_detail_from_concrete(flox, &env)),
     )) {
@@ -721,12 +728,15 @@ fn group_for_single_package(attr_path: &str, version: Option<&str>) -> PackageGr
 mod tests {
 
     use flox_core::data::environment_ref::EnvironmentOwner;
+    use flox_events::test_helpers::MockEventsConnection;
+    use flox_events::{EventsClient, SharedMetadataTemplate};
     use flox_rust_sdk::flox::test_helpers::flox_instance_with_optional_floxhub;
     use flox_rust_sdk::models::environment::ManagedPointer;
     use flox_rust_sdk::utils::logging::test_helpers::test_subscriber_message_only;
     use indoc::indoc;
     use pretty_assertions::assert_eq;
     use serial_test::serial;
+    use uuid::Uuid;
 
     use super::*;
 
@@ -1004,5 +1014,70 @@ mod tests {
 
         RemoteEnvironment::new(&flox, ManagedPointer::new(owner, name, &flox.floxhub), None)
             .expect("find initialized remote environment");
+    }
+
+    /// `flox init -r` records exactly one `cli.environment.create` naming the
+    /// environment it created. Without this the emit could be deleted outright
+    /// and every other test would still pass.
+    #[test]
+    #[serial(global_events_client)]
+    fn init_floxhub_environment_records_create_event() {
+        let owner = EnvironmentOwner::from_str("test").unwrap();
+        let name = EnvironmentName::from_str("foo").unwrap();
+        let env_ref = RemoteEnvironmentRef::new_from_parts(owner.clone(), name.clone());
+
+        let (flox, _tempdir_handle) = flox_instance_with_optional_floxhub(Some(&owner));
+
+        let buffer_dir = tempfile::tempdir().expect("tempdir");
+        let connection = MockEventsConnection::default();
+        let sent_batches = connection.sent_batches();
+        let client = EventsClient::new_with_connection(
+            Uuid::new_v4(),
+            buffer_dir.path(),
+            Uuid::new_v4(),
+            None,
+            SharedMetadataTemplate {
+                flox_version: "0.0.0-test".to_string(),
+                os_family: Some("Linux".to_string()),
+                os_family_release: None,
+                os: None,
+                os_version: None,
+                empty_flags: vec![],
+                invocation_sources: vec!["shell".to_string()],
+            },
+            connection,
+        );
+        let previous = EventsHub::global().set_client(client);
+
+        let result = init_floxhub_environment_decorated(&flox, env_ref.clone(), false);
+        let flushed = EventsHub::global().flush(true);
+
+        // Restore the previous client before asserting, so a failure here
+        // doesn't leak the mock client into the next test in this process.
+        EventsHub::global().clear_client();
+        if let Some(previous) = previous {
+            EventsHub::global().set_client(previous);
+        }
+
+        result.expect("environment initializes");
+        flushed.expect("flush");
+
+        let events: Vec<_> = sent_batches
+            .lock()
+            .unwrap()
+            .clone()
+            .into_iter()
+            .flatten()
+            .map(|event| serde_json::to_value(event).expect("event serializes"))
+            .filter(|event| event["event_type"] == "cli.environment.create")
+            .collect();
+
+        assert_eq!(events.len(), 1, "exactly one create event");
+        assert_eq!(events[0]["payload"]["env_kind"], "remote");
+        assert_eq!(
+            events[0]["payload"]["env_ref_or_name"],
+            env_ref.to_string(),
+            "the create event names the environment that was created"
+        );
     }
 }

--- a/cli/flox/src/commands/init/mod.rs
+++ b/cli/flox/src/commands/init/mod.rs
@@ -246,19 +246,21 @@ async fn init_local_environment(
     // Give the new environment a stable local id for telemetry correlation,
     // committed with `.flox`. Idempotent and best-effort; read paths never
     // write it.
-    local_environment_id::ensure(&env.path);
+    let definition = local_environment_id::ensure(&env.path);
 
     let env = ConcreteEnvironment::Path(env);
-    // Unlike the sibling `cli.environment.*` events, which emit at dispatch and
-    // let `cli.command_completed` carry the outcome, a create event is emitted
-    // after the creating call succeeds: there is no environment to describe
-    // until then, and the id above must exist to ride along on the payload.
-    // Emitting here rather than at the end of this function is deliberate — the
-    // environment exists on disk from `PathEnvironment::init` onward, so a
-    // later failure in the reporting below does not un-create it.
-    if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentCreate(
-        CliEnvironmentPayload::new(env_detail_from_concrete(flox, &env)),
-    )) {
+    // Emitted after the creating call succeeds, unlike the sibling
+    // `cli.environment.*` events that emit at dispatch and let
+    // `cli.command_completed` carry the outcome: there is no environment to
+    // describe until then, and the id above must exist to ride along on the
+    // payload. Emitting here rather than at the end of this function is
+    // deliberate — the environment exists on disk from `PathEnvironment::init`
+    // onward, so a later failure in the reporting below does not un-create it.
+    if definition == local_environment_id::Definition::New
+        && let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentCreate(
+            CliEnvironmentPayload::new(env_detail_from_concrete(flox, &env)),
+        ))
+    {
         debug!(error = %err, "Failed to record v2 event");
     }
 
@@ -727,15 +729,18 @@ fn group_for_single_package(attr_path: &str, version: Option<&str>) -> PackageGr
 #[cfg(test)]
 mod tests {
 
+    use std::sync::{Arc, Mutex};
+
     use flox_core::data::environment_ref::EnvironmentOwner;
     use flox_events::test_helpers::MockEventsConnection;
-    use flox_events::{EventsClient, SharedMetadataTemplate};
-    use flox_rust_sdk::flox::test_helpers::flox_instance_with_optional_floxhub;
-    use flox_rust_sdk::models::environment::ManagedPointer;
+    use flox_events::{EnvDetail, Event, EventsClient, SharedMetadataTemplate};
+    use flox_rust_sdk::flox::test_helpers::{flox_instance, flox_instance_with_optional_floxhub};
+    use flox_rust_sdk::models::environment::{DOT_FLOX, ManagedPointer};
     use flox_rust_sdk::utils::logging::test_helpers::test_subscriber_message_only;
     use indoc::indoc;
     use pretty_assertions::assert_eq;
     use serial_test::serial;
+    use tempfile::TempDir;
     use uuid::Uuid;
 
     use super::*;
@@ -1016,9 +1021,99 @@ mod tests {
             .expect("find initialized remote environment");
     }
 
+    /// A mock-backed events client installed on the global hub, restored on
+    /// drop so a panicking assertion cannot leak the mock into the next test
+    /// in this process. Tests holding one must be `#[serial]` on
+    /// `global_events_client`.
+    struct MockHub {
+        previous: Option<EventsClient>,
+        sent_batches: Arc<Mutex<Vec<Vec<Event>>>>,
+        _buffer_dir: TempDir,
+    }
+
+    impl MockHub {
+        fn install() -> Self {
+            let buffer_dir = tempfile::tempdir().expect("tempdir");
+            let connection = MockEventsConnection::default();
+            let sent_batches = connection.sent_batches();
+            let client = EventsClient::new_with_connection(
+                Uuid::new_v4(),
+                buffer_dir.path(),
+                Uuid::new_v4(),
+                None,
+                SharedMetadataTemplate {
+                    flox_version: "0.0.0-test".to_string(),
+                    os_family: Some("Linux".to_string()),
+                    os_family_release: None,
+                    os: None,
+                    os_version: None,
+                    empty_flags: vec![],
+                    invocation_sources: vec!["shell".to_string()],
+                },
+                connection,
+            );
+            Self {
+                previous: EventsHub::global().set_client(client),
+                sent_batches,
+                _buffer_dir: buffer_dir,
+            }
+        }
+
+        /// Flush the hub and return every `cli.environment.create` payload
+        /// that reached the connection.
+        fn create_payloads(&self) -> Vec<CliEnvironmentPayload> {
+            EventsHub::global().flush(true).expect("flush");
+            self.sent_batches
+                .lock()
+                .unwrap()
+                .iter()
+                .flatten()
+                .filter_map(|event| match &event.kind {
+                    EventKind::CliEnvironmentCreate(payload) => Some(payload.clone()),
+                    _ => None,
+                })
+                .collect()
+        }
+    }
+
+    impl Drop for MockHub {
+        fn drop(&mut self) {
+            EventsHub::global().clear_client();
+            if let Some(previous) = self.previous.take() {
+                EventsHub::global().set_client(previous);
+            }
+        }
+    }
+
+    /// `flox init` records exactly one `cli.environment.create`, carrying the
+    /// `local_environment_id` that was just minted into `.flox`. This is the
+    /// highest-volume emit site and the only one whose payload carries a real
+    /// id, so without this the emit could be deleted outright and the rest of
+    /// the suite would stay green.
+    #[tokio::test]
+    #[serial(global_events_client)]
+    async fn init_local_environment_records_create_event_with_local_id() {
+        let (flox, _tempdir_handle) = flox_instance();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let name = EnvironmentName::from_str("myenv").unwrap();
+
+        let hub = MockHub::install();
+        init_local_environment(&flox, dir.path(), &name, true, AutoSetupBehavior::Skip)
+            .await
+            .expect("environment initializes");
+
+        let minted = std::fs::read_to_string(dir.path().join(DOT_FLOX).join("telemetry_id"))
+            .expect("id file written");
+        let minted = Uuid::try_parse(minted.trim()).expect("id is a uuid");
+
+        assert_eq!(hub.create_payloads(), vec![CliEnvironmentPayload::new(
+            EnvDetail::path(name.to_string(), Some(minted)).with_package_count(0)
+        )]);
+    }
+
     /// `flox init -r` records exactly one `cli.environment.create` naming the
-    /// environment it created. Without this the emit could be deleted outright
-    /// and every other test would still pass.
+    /// environment it created. A remote environment has no CLI-side id, so the
+    /// payload pins that `local_environment_id` is absent rather than invented.
     #[test]
     #[serial(global_events_client)]
     fn init_floxhub_environment_records_create_event() {
@@ -1028,56 +1123,12 @@ mod tests {
 
         let (flox, _tempdir_handle) = flox_instance_with_optional_floxhub(Some(&owner));
 
-        let buffer_dir = tempfile::tempdir().expect("tempdir");
-        let connection = MockEventsConnection::default();
-        let sent_batches = connection.sent_batches();
-        let client = EventsClient::new_with_connection(
-            Uuid::new_v4(),
-            buffer_dir.path(),
-            Uuid::new_v4(),
-            None,
-            SharedMetadataTemplate {
-                flox_version: "0.0.0-test".to_string(),
-                os_family: Some("Linux".to_string()),
-                os_family_release: None,
-                os: None,
-                os_version: None,
-                empty_flags: vec![],
-                invocation_sources: vec!["shell".to_string()],
-            },
-            connection,
-        );
-        let previous = EventsHub::global().set_client(client);
+        let hub = MockHub::install();
+        init_floxhub_environment_decorated(&flox, env_ref.clone(), false)
+            .expect("environment initializes");
 
-        let result = init_floxhub_environment_decorated(&flox, env_ref.clone(), false);
-        let flushed = EventsHub::global().flush(true);
-
-        // Restore the previous client before asserting, so a failure here
-        // doesn't leak the mock client into the next test in this process.
-        EventsHub::global().clear_client();
-        if let Some(previous) = previous {
-            EventsHub::global().set_client(previous);
-        }
-
-        result.expect("environment initializes");
-        flushed.expect("flush");
-
-        let events: Vec<_> = sent_batches
-            .lock()
-            .unwrap()
-            .clone()
-            .into_iter()
-            .flatten()
-            .map(|event| serde_json::to_value(event).expect("event serializes"))
-            .filter(|event| event["event_type"] == "cli.environment.create")
-            .collect();
-
-        assert_eq!(events.len(), 1, "exactly one create event");
-        assert_eq!(events[0]["payload"]["env_kind"], "remote");
-        assert_eq!(
-            events[0]["payload"]["env_ref_or_name"],
-            env_ref.to_string(),
-            "the create event names the environment that was created"
-        );
+        assert_eq!(hub.create_payloads(), vec![CliEnvironmentPayload::new(
+            EnvDetail::remote(env_ref.to_string(), Some(1)).with_package_count(0)
+        )]);
     }
 }

--- a/cli/flox/src/commands/init/mod.rs
+++ b/cli/flox/src/commands/init/mod.rs
@@ -249,13 +249,9 @@ async fn init_local_environment(
     let definition = local_environment_id::ensure(&env.path);
 
     let env = ConcreteEnvironment::Path(env);
-    // Emitted after the creating call succeeds, unlike the sibling
-    // `cli.environment.*` events that emit at dispatch and let
-    // `cli.command_completed` carry the outcome: there is no environment to
-    // describe until then, and the id above must exist to ride along on the
-    // payload. Emitting here rather than at the end of this function is
-    // deliberate — the environment exists on disk from `PathEnvironment::init`
-    // onward, so a later failure in the reporting below does not un-create it.
+    // Emitted here rather than at the end of the function: the environment
+    // exists from `PathEnvironment::init` onward, so a later failure in the
+    // reporting below does not un-create it.
     if definition == local_environment_id::Definition::New
         && let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentCreate(
             CliEnvironmentPayload::new(env_detail_from_concrete(flox, &env)),
@@ -1021,10 +1017,9 @@ mod tests {
             .expect("find initialized remote environment");
     }
 
-    /// A mock-backed events client installed on the global hub, restored on
-    /// drop so a panicking assertion cannot leak the mock into the next test
-    /// in this process. Tests holding one must be `#[serial]` on
-    /// `global_events_client`.
+    /// A mock-backed events client on the global hub, restored on drop so a
+    /// panicking assertion cannot leak it into the next test. Holders must be
+    /// `#[serial(global_events_client)]`.
     struct MockHub {
         previous: Option<EventsClient>,
         sent_batches: Arc<Mutex<Vec<Vec<Event>>>>,
@@ -1059,8 +1054,7 @@ mod tests {
             }
         }
 
-        /// Flush the hub and return every `cli.environment.create` payload
-        /// that reached the connection.
+        /// Flushes, then returns the create payloads that were sent.
         fn create_payloads(&self) -> Vec<CliEnvironmentPayload> {
             EventsHub::global().flush(true).expect("flush");
             self.sent_batches
@@ -1085,11 +1079,6 @@ mod tests {
         }
     }
 
-    /// `flox init` records exactly one `cli.environment.create`, carrying the
-    /// `local_environment_id` that was just minted into `.flox`. This is the
-    /// highest-volume emit site and the only one whose payload carries a real
-    /// id, so without this the emit could be deleted outright and the rest of
-    /// the suite would stay green.
     #[tokio::test]
     #[serial(global_events_client)]
     async fn init_local_environment_records_create_event_with_local_id() {
@@ -1111,9 +1100,8 @@ mod tests {
         )]);
     }
 
-    /// `flox init -r` records exactly one `cli.environment.create` naming the
-    /// environment it created. A remote environment has no CLI-side id, so the
-    /// payload pins that `local_environment_id` is absent rather than invented.
+    /// A remote environment has no CLI-side id, so this pins that
+    /// `local_environment_id` is absent rather than invented.
     #[test]
     #[serial(global_events_client)]
     fn init_floxhub_environment_records_create_event() {

--- a/cli/flox/src/commands/init/mod.rs
+++ b/cli/flox/src/commands/init/mod.rs
@@ -6,6 +6,7 @@ use anyhow::{Context, Result, anyhow, bail};
 use bpaf::Bpaf;
 use flox_core::activate::mode::ActivateMode;
 use flox_core::data::environment_ref::{DEFAULT_NAME, EnvironmentName, RemoteEnvironmentRef};
+use flox_events::{CliEnvironmentPayload, EventKind, EventsHub};
 use flox_manifest::raw::{CatalogPackage, PackageToInstall};
 use flox_rust_sdk::data::AttrPath;
 use flox_rust_sdk::flox::Flox;
@@ -23,6 +24,7 @@ use tracing::{debug, info_span, instrument};
 use crate::commands::{SHELL_COMPLETION_DIR, ensure_auth, environment_description};
 use crate::subcommand_metric;
 use crate::utils::dialog::Dialog;
+use crate::utils::events::env_detail_from_concrete;
 use crate::utils::{local_environment_id, message};
 
 mod go;
@@ -246,6 +248,13 @@ async fn init_local_environment(
     // write it.
     local_environment_id::ensure(&env.path);
 
+    let env = ConcreteEnvironment::Path(env);
+    if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentCreate(
+        CliEnvironmentPayload::new(env_detail_from_concrete(flox, &env)),
+    )) {
+        debug!(error = %err, "Failed to record v2 event");
+    }
+
     let env_in_git_repo = GitCommandProvider::discover(dir).is_ok();
 
     message::created(format!(
@@ -254,7 +263,7 @@ async fn init_local_environment(
         system = flox.system
     ));
     if let Some(packages) = customization.packages {
-        let description = environment_description(&ConcreteEnvironment::Path(env))?;
+        let description = environment_description(&env)?;
         for package in packages {
             message::package_installed(&PackageToInstall::Catalog(package), &description);
         }
@@ -292,7 +301,16 @@ fn init_floxhub_environment_decorated(
     env_ref: RemoteEnvironmentRef,
     bare: bool,
 ) -> Result<()> {
-    RemoteEnvironment::init_floxhub_environment(flox, env_ref.clone(), bare)?;
+    let env = ConcreteEnvironment::Remote(RemoteEnvironment::init_floxhub_environment(
+        flox,
+        env_ref.clone(),
+        bare,
+    )?);
+    if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentCreate(
+        CliEnvironmentPayload::new(env_detail_from_concrete(flox, &env)),
+    )) {
+        debug!(error = %err, "Failed to record v2 event");
+    }
     message::created(format!("Created environment '{env_ref}'"));
     message::plain(formatdoc! {"
 
@@ -708,6 +726,7 @@ mod tests {
     use flox_rust_sdk::utils::logging::test_helpers::test_subscriber_message_only;
     use indoc::indoc;
     use pretty_assertions::assert_eq;
+    use serial_test::serial;
 
     use super::*;
 
@@ -957,6 +976,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(global_events_client)]
     fn init_floxhub_environment_initializes_and_prints_message() {
         let owner = EnvironmentOwner::from_str("test").unwrap();
         let name = EnvironmentName::from_str("foo").unwrap();

--- a/cli/flox/src/commands/init/mod.rs
+++ b/cli/flox/src/commands/init/mod.rs
@@ -246,13 +246,13 @@ async fn init_local_environment(
     // Give the new environment a stable local id for telemetry correlation,
     // committed with `.flox`. Idempotent and best-effort; read paths never
     // write it.
-    let definition = local_environment_id::ensure(&env.path);
+    let origin = local_environment_id::ensure(&env.path);
 
     let env = ConcreteEnvironment::Path(env);
     // Emitted here rather than at the end of the function: the environment
     // exists from `PathEnvironment::init` onward, so a later failure in the
     // reporting below does not un-create it.
-    if definition == local_environment_id::Definition::New
+    if origin == local_environment_id::Origin::Minted
         && let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentCreate(
             CliEnvironmentPayload::new(env_detail_from_concrete(flox, &env)),
         ))

--- a/cli/flox/src/commands/install.rs
+++ b/cli/flox/src/commands/install.rs
@@ -649,7 +649,7 @@ async fn try_create_default_environment_interactive(
 
     // Creates a default environment for the user, skipping checks for init
     // customizations and skipping the normal `init` output.
-    let (env, newly_created) = {
+    let env = {
         // ensure user is logged in
         let handle = ensure_auth(flox).await?;
         let owner = handle
@@ -664,28 +664,30 @@ async fn try_create_default_environment_interactive(
         match RemoteEnvironment::new(flox, pointer, None) {
             Ok(existing_env) => {
                 debug!("environment already exists -- will not init again");
-                (existing_env, false)
+                ConcreteEnvironment::Remote(existing_env)
             },
             Err(RemoteEnvironmentError::OpenManagedEnvironment(
                 ManagedEnvironmentError::UpstreamNotFound { env_ref, .. },
-            )) => (
-                RemoteEnvironment::init_floxhub_environment(flox, env_ref.clone(), false)
-                    .with_context(|| {
-                        format!("Failed to initialize FloxHub environment '{env_ref}'")
-                    })?,
-                true,
-            ),
+            )) => {
+                let env = ConcreteEnvironment::Remote(
+                    RemoteEnvironment::init_floxhub_environment(flox, env_ref.clone(), false)
+                        .with_context(|| {
+                            format!("Failed to initialize FloxHub environment '{env_ref}'")
+                        })?,
+                );
+                // Emitted inside this arm because it is the only one that
+                // creates the environment: opening a pre-existing default
+                // records nothing.
+                if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentCreate(
+                    CliEnvironmentPayload::new(env_detail_from_concrete(flox, &env)),
+                )) {
+                    debug!(error = %err, "Failed to record v2 event");
+                }
+                env
+            },
             Err(e) => Err(e)?,
         }
     };
-    let env = ConcreteEnvironment::Remote(env);
-    if newly_created
-        && let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentCreate(
-            CliEnvironmentPayload::new(env_detail_from_concrete(flox, &env)),
-        ))
-    {
-        debug!(error = %err, "Failed to record v2 event");
-    }
 
     // record that we created default env
     // Note: we record this _after_ attempting to create the default env,

--- a/cli/flox/src/commands/install.rs
+++ b/cli/flox/src/commands/install.rs
@@ -649,7 +649,7 @@ async fn try_create_default_environment_interactive(
 
     // Creates a default environment for the user, skipping checks for init
     // customizations and skipping the normal `init` output.
-    let env = {
+    let (env, newly_created) = {
         // ensure user is logged in
         let handle = ensure_auth(flox).await?;
         let owner = handle
@@ -664,15 +664,28 @@ async fn try_create_default_environment_interactive(
         match RemoteEnvironment::new(flox, pointer, None) {
             Ok(existing_env) => {
                 debug!("environment already exists -- will not init again");
-                existing_env
+                (existing_env, false)
             },
             Err(RemoteEnvironmentError::OpenManagedEnvironment(
                 ManagedEnvironmentError::UpstreamNotFound { env_ref, .. },
-            )) => RemoteEnvironment::init_floxhub_environment(flox, env_ref.clone(), false)
-                .with_context(|| format!("Failed to initialize FloxHub environment '{env_ref}'"))?,
+            )) => (
+                RemoteEnvironment::init_floxhub_environment(flox, env_ref.clone(), false)
+                    .with_context(|| {
+                        format!("Failed to initialize FloxHub environment '{env_ref}'")
+                    })?,
+                true,
+            ),
             Err(e) => Err(e)?,
         }
     };
+    let env = ConcreteEnvironment::Remote(env);
+    if newly_created
+        && let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentCreate(
+            CliEnvironmentPayload::new(env_detail_from_concrete(flox, &env)),
+        ))
+    {
+        debug!(error = %err, "Failed to record v2 event");
+    }
 
     // record that we created default env
     // Note: we record this _after_ attempting to create the default env,
@@ -683,7 +696,7 @@ async fn try_create_default_environment_interactive(
 
     prompt_to_modify_rc_file()?;
 
-    Ok(ConcreteEnvironment::Remote(env))
+    Ok(env)
 }
 /// Returns a formatted string representing a possibly truncated list of
 /// packages to install.

--- a/cli/flox/src/commands/install.rs
+++ b/cli/flox/src/commands/install.rs
@@ -675,9 +675,6 @@ async fn try_create_default_environment_interactive(
                             format!("Failed to initialize FloxHub environment '{env_ref}'")
                         })?,
                 );
-                // Emitted inside this arm because it is the only one that
-                // creates the environment: opening a pre-existing default
-                // records nothing.
                 if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentCreate(
                     CliEnvironmentPayload::new(env_detail_from_concrete(flox, &env)),
                 )) {

--- a/cli/flox/src/commands/pull.rs
+++ b/cli/flox/src/commands/pull.rs
@@ -186,17 +186,23 @@ impl Pull {
 
                     let pointer = managed_environment.pointer().clone();
                     let path_env = managed_environment.into_path_environment(&flox)?;
-                    // A copy is a new environment definition, so it gets its own id.
-                    local_environment_id::ensure(&path_env.dot_flox_path());
+                    // A copy is a new environment definition, so it gets its
+                    // own id — unless this `.flox` already had one. The
+                    // conversion happens in place, so a directory that was
+                    // `flox init`-ed and then pushed keeps its original id:
+                    // that definition is coming home, not starting.
+                    let definition = local_environment_id::ensure(&path_env.dot_flox_path());
 
-                    // A copy brings a new environment definition into
-                    // existence, so it is a creation for the same reason it
-                    // mints its own id above.
+                    // Hence a creation only when the id starts here; otherwise
+                    // this environment already recorded its create at `init`
+                    // and emitting again would count it twice.
                     let path_env = ConcreteEnvironment::Path(path_env);
-                    if let Err(err) =
-                        EventsHub::global().record_event(EventKind::CliEnvironmentCreate(
-                            CliEnvironmentPayload::new(env_detail_from_concrete(&flox, &path_env)),
-                        ))
+                    if definition == local_environment_id::Definition::New
+                        && let Err(err) = EventsHub::global().record_event(
+                            EventKind::CliEnvironmentCreate(CliEnvironmentPayload::new(
+                                env_detail_from_concrete(&flox, &path_env),
+                            )),
+                        )
                     {
                         debug!(error = %err, "Failed to record v2 event");
                     }
@@ -417,15 +423,17 @@ impl Pull {
                 Ok(env) => {
                     create_dot_flox_gitignore(env.dot_flox_path())?;
                     // A copy is a new environment definition, so it gets its own id.
-                    local_environment_id::ensure(&env.dot_flox_path());
+                    // This `.flox` was just materialized by the pull above, so
+                    // the id always starts here.
+                    let definition = local_environment_id::ensure(&env.dot_flox_path());
 
-                    // As above: a copy is a new definition, so it is a
-                    // creation.
+                    // As above: a creation only when the id starts here.
                     let env = ConcreteEnvironment::Path(env);
-                    if let Err(err) =
-                        EventsHub::global().record_event(EventKind::CliEnvironmentCreate(
-                            CliEnvironmentPayload::new(env_detail_from_concrete(flox, &env)),
-                        ))
+                    if definition == local_environment_id::Definition::New
+                        && let Err(err) =
+                            EventsHub::global().record_event(EventKind::CliEnvironmentCreate(
+                                CliEnvironmentPayload::new(env_detail_from_concrete(flox, &env)),
+                            ))
                     {
                         debug!(error = %err, "Failed to record v2 event");
                     }

--- a/cli/flox/src/commands/pull.rs
+++ b/cli/flox/src/commands/pull.rs
@@ -189,6 +189,18 @@ impl Pull {
                     // A copy is a new environment definition, so it gets its own id.
                     local_environment_id::ensure(&path_env.dot_flox_path());
 
+                    // A copy brings a new environment definition into
+                    // existence, so it is a creation for the same reason it
+                    // mints its own id above.
+                    let path_env = ConcreteEnvironment::Path(path_env);
+                    if let Err(err) =
+                        EventsHub::global().record_event(EventKind::CliEnvironmentCreate(
+                            CliEnvironmentPayload::new(env_detail_from_concrete(&flox, &path_env)),
+                        ))
+                    {
+                        debug!(error = %err, "Failed to record v2 event");
+                    }
+
                     message::created(formatdoc! {"
                         Created path environment from {owner}/{name}.
                     ", owner = pointer.owner, name = pointer.name});
@@ -406,6 +418,17 @@ impl Pull {
                     create_dot_flox_gitignore(env.dot_flox_path())?;
                     // A copy is a new environment definition, so it gets its own id.
                     local_environment_id::ensure(&env.dot_flox_path());
+
+                    // As above: a copy is a new definition, so it is a
+                    // creation.
+                    let env = ConcreteEnvironment::Path(env);
+                    if let Err(err) =
+                        EventsHub::global().record_event(EventKind::CliEnvironmentCreate(
+                            CliEnvironmentPayload::new(env_detail_from_concrete(flox, &env)),
+                        ))
+                    {
+                        debug!(error = %err, "Failed to record v2 event");
+                    }
                 },
             }
         }

--- a/cli/flox/src/commands/pull.rs
+++ b/cli/flox/src/commands/pull.rs
@@ -186,16 +186,8 @@ impl Pull {
 
                     let pointer = managed_environment.pointer().clone();
                     let path_env = managed_environment.into_path_environment(&flox)?;
-                    // A copy is a new environment definition, so it gets its
-                    // own id — unless this `.flox` already had one. The
-                    // conversion happens in place, so a directory that was
-                    // `flox init`-ed and then pushed keeps its original id:
-                    // that definition is coming home, not starting.
                     let definition = local_environment_id::ensure(&path_env.dot_flox_path());
 
-                    // Hence a creation only when the id starts here; otherwise
-                    // this environment already recorded its create at `init`
-                    // and emitting again would count it twice.
                     let path_env = ConcreteEnvironment::Path(path_env);
                     if definition == local_environment_id::Definition::New
                         && let Err(err) = EventsHub::global().record_event(
@@ -422,12 +414,8 @@ impl Pull {
                 },
                 Ok(env) => {
                     create_dot_flox_gitignore(env.dot_flox_path())?;
-                    // A copy is a new environment definition, so it gets its own id.
-                    // This `.flox` was just materialized by the pull above, so
-                    // the id always starts here.
                     let definition = local_environment_id::ensure(&env.dot_flox_path());
 
-                    // As above: a creation only when the id starts here.
                     let env = ConcreteEnvironment::Path(env);
                     if definition == local_environment_id::Definition::New
                         && let Err(err) =

--- a/cli/flox/src/commands/pull.rs
+++ b/cli/flox/src/commands/pull.rs
@@ -186,10 +186,10 @@ impl Pull {
 
                     let pointer = managed_environment.pointer().clone();
                     let path_env = managed_environment.into_path_environment(&flox)?;
-                    let definition = local_environment_id::ensure(&path_env.dot_flox_path());
+                    let origin = local_environment_id::ensure(&path_env.dot_flox_path());
 
                     let path_env = ConcreteEnvironment::Path(path_env);
-                    if definition == local_environment_id::Definition::New
+                    if origin == local_environment_id::Origin::Minted
                         && let Err(err) = EventsHub::global().record_event(
                             EventKind::CliEnvironmentCreate(CliEnvironmentPayload::new(
                                 env_detail_from_concrete(&flox, &path_env),
@@ -414,10 +414,10 @@ impl Pull {
                 },
                 Ok(env) => {
                     create_dot_flox_gitignore(env.dot_flox_path())?;
-                    let definition = local_environment_id::ensure(&env.dot_flox_path());
+                    let origin = local_environment_id::ensure(&env.dot_flox_path());
 
                     let env = ConcreteEnvironment::Path(env);
-                    if definition == local_environment_id::Definition::New
+                    if origin == local_environment_id::Origin::Minted
                         && let Err(err) =
                             EventsHub::global().record_event(EventKind::CliEnvironmentCreate(
                                 CliEnvironmentPayload::new(env_detail_from_concrete(flox, &env)),

--- a/cli/flox/src/commands/push.rs
+++ b/cli/flox/src/commands/push.rs
@@ -137,6 +137,13 @@ async fn handle_path_environment_push(
 
     let pointer = ManagedPointer::new(owner.clone(), path_environment.name(), &flox.floxhub);
 
+    // Deliberately no `cli.environment.create` here, even though this does
+    // create the environment on FloxHub: a push promotes an environment that
+    // already exists locally — and that already recorded its creation when
+    // `flox init` made it — so emitting again would count one environment
+    // twice. The `false` argument below is `initializing`, which records the
+    // generation as `HistoryKind::Import` rather than `HistoryKind::Initialize`
+    // for the same reason.
     let managed_environment =
         ManagedEnvironment::push_new(flox, path_environment, owner, force, false)
             .map_err(|err| convert_error(err, pointer, true))?;

--- a/cli/flox/src/commands/push.rs
+++ b/cli/flox/src/commands/push.rs
@@ -138,12 +138,12 @@ async fn handle_path_environment_push(
     let pointer = ManagedPointer::new(owner.clone(), path_environment.name(), &flox.floxhub);
 
     // Deliberately no `cli.environment.create` here, even though this does
-    // create the environment on FloxHub: a push promotes an environment that
-    // already exists locally — and that already recorded its creation when
-    // `flox init` made it — so emitting again would count one environment
-    // twice. The `false` argument below is `initializing`, which records the
-    // generation as `HistoryKind::Import` rather than `HistoryKind::Initialize`
-    // for the same reason.
+    // create the environment on FloxHub — see `EventKind::CliEnvironmentCreate`
+    // for the rule. Where the local definition predates this telemetry, or was
+    // created with metrics off, no create row exists to pair with: the
+    // `cli.environment.push` event emitted by `Push::handle` above still
+    // carries the environment's `local_environment_id`, because it is built
+    // while the environment is still a path environment.
     let managed_environment =
         ManagedEnvironment::push_new(flox, path_environment, owner, force, false)
             .map_err(|err| convert_error(err, pointer, true))?;

--- a/cli/flox/src/commands/push.rs
+++ b/cli/flox/src/commands/push.rs
@@ -137,13 +137,9 @@ async fn handle_path_environment_push(
 
     let pointer = ManagedPointer::new(owner.clone(), path_environment.name(), &flox.floxhub);
 
-    // Deliberately no `cli.environment.create` here, even though this does
-    // create the environment on FloxHub — see `EventKind::CliEnvironmentCreate`
-    // for the rule. Where the local definition predates this telemetry, or was
-    // created with metrics off, no create row exists to pair with: the
-    // `cli.environment.push` event emitted by `Push::handle` above still
-    // carries the environment's `local_environment_id`, because it is built
-    // while the environment is still a path environment.
+    // No `cli.environment.create`, though this does create the environment on
+    // FloxHub: a push promotes a definition that already exists. See
+    // `EventKind::CliEnvironmentCreate`.
     let managed_environment =
         ManagedEnvironment::push_new(flox, path_environment, owner, force, false)
             .map_err(|err| convert_error(err, pointer, true))?;

--- a/cli/flox/src/utils/local_environment_id.rs
+++ b/cli/flox/src/utils/local_environment_id.rs
@@ -24,19 +24,36 @@ pub(crate) fn read(dot_flox: &CanonicalPath) -> Option<Uuid> {
     Uuid::try_parse(contents.trim()).ok()
 }
 
+/// Whether [`ensure`] found an id already in place.
+///
+/// Distinguishes a definition that starts here from one that merely changed
+/// form. `flox pull --copy` can convert a managed environment back to a path
+/// environment in the existing `.flox`, so a directory that was `flox init`-ed
+/// and then pushed still carries its original id: that definition is the same
+/// one coming home, not a new one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Definition {
+    /// No id was present, so this call minted one. A write failure still
+    /// reports `New`: the definition is new, it simply carries no id.
+    New,
+    /// An id was already present and was kept.
+    Existing,
+}
+
 /// Ensure a newly created path environment has a stable local id at
-/// `<dot_flox>/telemetry_id`. Idempotent: an already-identified environment
-/// keeps its existing id. Best-effort: a write failure is logged, and that
-/// environment then carries no id for its lifetime (reads never write, so
-/// nothing recreates it).
-pub(crate) fn ensure(dot_flox: &CanonicalPath) {
+/// `<dot_flox>/telemetry_id`, reporting whether that id starts here.
+/// Idempotent: an already-identified environment keeps its existing id.
+/// Best-effort: a write failure is logged, and that environment then carries
+/// no id for its lifetime (reads never write, so nothing recreates it).
+pub(crate) fn ensure(dot_flox: &CanonicalPath) -> Definition {
     if read(dot_flox).is_some() {
-        return;
+        return Definition::Existing;
     }
     let id = Uuid::new_v4();
     if let Err(err) = write_atomically(dot_flox.join(TELEMETRY_ID_FILENAME), format!("{id}\n")) {
         debug!(error = %err, "could not write local_environment_id");
     }
+    Definition::New
 }
 
 #[cfg(test)]
@@ -50,7 +67,7 @@ mod tests {
         let dir = tempdir().unwrap();
         let dot_flox = CanonicalPath::new(dir.path()).unwrap();
         assert_eq!(read(&dot_flox), None, "no id before minting");
-        ensure(&dot_flox);
+        assert_eq!(ensure(&dot_flox), Definition::New);
         assert_ne!(read(&dot_flox), None, "id exists after ensuring");
     }
 
@@ -58,9 +75,13 @@ mod tests {
     fn ensure_keeps_existing_id() {
         let dir = tempdir().unwrap();
         let dot_flox = CanonicalPath::new(dir.path()).unwrap();
-        ensure(&dot_flox);
+        assert_eq!(ensure(&dot_flox), Definition::New);
         let first = read(&dot_flox);
-        ensure(&dot_flox);
+        assert_eq!(
+            ensure(&dot_flox),
+            Definition::Existing,
+            "a second ensure reports the definition already existed"
+        );
         assert_eq!(
             read(&dot_flox),
             first,

--- a/cli/flox/src/utils/local_environment_id.rs
+++ b/cli/flox/src/utils/local_environment_id.rs
@@ -24,27 +24,22 @@ pub(crate) fn read(dot_flox: &CanonicalPath) -> Option<Uuid> {
     Uuid::try_parse(contents.trim()).ok()
 }
 
-/// Whether [`ensure`] found an id already in place.
-///
-/// Distinguishes a definition that starts here from one that merely changed
-/// form. `flox pull --copy` can convert a managed environment back to a path
-/// environment in the existing `.flox`, so a directory that was `flox init`-ed
-/// and then pushed still carries its original id: that definition is the same
-/// one coming home, not a new one.
+/// Whether an environment definition starts at this `.flox` or was already
+/// identified. `flox pull --copy` can convert in place, so a directory that
+/// was `flox init`-ed and then pushed keeps its original id.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Definition {
     /// No id was present, so this call minted one. A write failure still
     /// reports `New`: the definition is new, it simply carries no id.
     New,
-    /// An id was already present and was kept.
     Existing,
 }
 
 /// Ensure a newly created path environment has a stable local id at
-/// `<dot_flox>/telemetry_id`, reporting whether that id starts here.
-/// Idempotent: an already-identified environment keeps its existing id.
-/// Best-effort: a write failure is logged, and that environment then carries
-/// no id for its lifetime (reads never write, so nothing recreates it).
+/// `<dot_flox>/telemetry_id`. Idempotent: an already-identified environment
+/// keeps its existing id. Best-effort: a write failure is logged, and that
+/// environment then carries no id for its lifetime (reads never write, so
+/// nothing recreates it).
 pub(crate) fn ensure(dot_flox: &CanonicalPath) -> Definition {
     if read(dot_flox).is_some() {
         return Definition::Existing;

--- a/cli/flox/src/utils/local_environment_id.rs
+++ b/cli/flox/src/utils/local_environment_id.rs
@@ -24,14 +24,15 @@ pub(crate) fn read(dot_flox: &CanonicalPath) -> Option<Uuid> {
     Uuid::try_parse(contents.trim()).ok()
 }
 
-/// Whether an environment definition starts at this `.flox` or was already
-/// identified. `flox pull --copy` can convert in place, so a directory that
-/// was `flox init`-ed and then pushed keeps its original id.
+/// Where the id at a `.flox` came from. `flox pull --copy` can convert in
+/// place, so a directory that was `flox init`-ed and then pushed arrives here
+/// already carrying one.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum Definition {
-    /// No id was present, so this call minted one. A write failure still
-    /// reports `New`: the definition is new, it simply carries no id.
-    New,
+pub(crate) enum Origin {
+    /// Nothing was there, so this call minted one. A failed write still
+    /// reports `Minted` — the environment is new, it just carries no id.
+    Minted,
+    /// An id was already present and was kept.
     Existing,
 }
 
@@ -40,15 +41,15 @@ pub(crate) enum Definition {
 /// keeps its existing id. Best-effort: a write failure is logged, and that
 /// environment then carries no id for its lifetime (reads never write, so
 /// nothing recreates it).
-pub(crate) fn ensure(dot_flox: &CanonicalPath) -> Definition {
+pub(crate) fn ensure(dot_flox: &CanonicalPath) -> Origin {
     if read(dot_flox).is_some() {
-        return Definition::Existing;
+        return Origin::Existing;
     }
     let id = Uuid::new_v4();
     if let Err(err) = write_atomically(dot_flox.join(TELEMETRY_ID_FILENAME), format!("{id}\n")) {
         debug!(error = %err, "could not write local_environment_id");
     }
-    Definition::New
+    Origin::Minted
 }
 
 #[cfg(test)]
@@ -62,7 +63,7 @@ mod tests {
         let dir = tempdir().unwrap();
         let dot_flox = CanonicalPath::new(dir.path()).unwrap();
         assert_eq!(read(&dot_flox), None, "no id before minting");
-        assert_eq!(ensure(&dot_flox), Definition::New);
+        assert_eq!(ensure(&dot_flox), Origin::Minted);
         assert_ne!(read(&dot_flox), None, "id exists after ensuring");
     }
 
@@ -70,12 +71,12 @@ mod tests {
     fn ensure_keeps_existing_id() {
         let dir = tempdir().unwrap();
         let dot_flox = CanonicalPath::new(dir.path()).unwrap();
-        assert_eq!(ensure(&dot_flox), Definition::New);
+        assert_eq!(ensure(&dot_flox), Origin::Minted);
         let first = read(&dot_flox);
         assert_eq!(
             ensure(&dot_flox),
-            Definition::Existing,
-            "a second ensure reports the definition already existed"
+            Origin::Existing,
+            "a second ensure reports the id was already there"
         );
         assert_eq!(
             read(&dot_flox),

--- a/cli/tests/containerize.bats
+++ b/cli/tests/containerize.bats
@@ -90,6 +90,22 @@ podman_setup() {
   mkdir -p "$XDG_RUNTIME_DIR"
   mkdir -p "$XDG_CONFIG_HOME"
 
+  # PROBE (revert if it does not help): keep podman off the host's systemd.
+  # crun asks systemd over sd-bus to set up the cgroup, and some GitHub runner
+  # images deny that, failing every `podman run` with
+  # "crun: sd-bus call: Permission denied". cgroupfs needs no bus, and the file
+  # events logger avoids journald for the same reason. Linux only: on macOS
+  # podman runs inside its own VM, where the host's systemd is not involved.
+  if is_linux; then
+    export CONTAINERS_CONF="$XDG_CONFIG_HOME/containers/containers.conf"
+    mkdir -p "$(dirname "$CONTAINERS_CONF")"
+    cat > "$CONTAINERS_CONF" << 'EOF'
+[engine]
+cgroup_manager = "cgroupfs"
+events_logger = "file"
+EOF
+  fi
+
   # Set the flox-specific directories to point to this home-tempdir
   export FLOX_CACHE_DIR="$XDG_CACHE_HOME/flox"
   export FLOX_CONFIG_DIR="$XDG_CONFIG_HOME/flox"

--- a/cli/tests/containerize.bats
+++ b/cli/tests/containerize.bats
@@ -90,22 +90,6 @@ podman_setup() {
   mkdir -p "$XDG_RUNTIME_DIR"
   mkdir -p "$XDG_CONFIG_HOME"
 
-  # PROBE (revert if it does not help): keep podman off the host's systemd.
-  # crun asks systemd over sd-bus to set up the cgroup, and some GitHub runner
-  # images deny that, failing every `podman run` with
-  # "crun: sd-bus call: Permission denied". cgroupfs needs no bus, and the file
-  # events logger avoids journald for the same reason. Linux only: on macOS
-  # podman runs inside its own VM, where the host's systemd is not involved.
-  if is_linux; then
-    export CONTAINERS_CONF="$XDG_CONFIG_HOME/containers/containers.conf"
-    mkdir -p "$(dirname "$CONTAINERS_CONF")"
-    cat > "$CONTAINERS_CONF" << 'EOF'
-[engine]
-cgroup_manager = "cgroupfs"
-events_logger = "file"
-EOF
-  fi
-
   # Set the flox-specific directories to point to this home-tempdir
   export FLOX_CACHE_DIR="$XDG_CACHE_HOME/flox"
   export FLOX_CONFIG_DIR="$XDG_CONFIG_HOME/flox"


### PR DESCRIPTION
> Stacked on #4557 (`local_environment_id` for path environments).

- **feat(events): emit cli.environment.create at environment creation**

  Adds `cli.environment.create` to the existing `cli.environment.*` event
  family and emits it where an environment definition starts. The payload
  reuses `CliEnvironmentPayload`, so creation rows carry the same environment
  reference and optional lineage fields as the rest of the family. Path
  environments include the `local_environment_id` introduced by #4557; remote
  environments omit it because the CLI does not receive FloxHub's
  server-assigned environment identifier.

  ## What counts as a creation

  A definition starting, not an environment changing form. For path
  environments that is exactly when a new `local_environment_id` is minted, so
  a create row and a first-seen id coincide — the emit is gated on the mint,
  which makes the rule enforceable rather than a convention.

  Emitting sites:

  - local `flox init`;
  - remote `flox init -r`, after the SDK returns the validated remote
    environment;
  - the first-run `flox install` flow, only when its `UpstreamNotFound` branch
    creates the user's default remote environment; and
  - `flox pull --copy`, where the copy is a definition of its own.

  Deliberately silent:

  - **`flox push`** promotes an existing definition to a managed one. It mints
    no id and the environment already recorded its creation at `flox init`, so
    emitting would report one environment twice. Where the local definition
    predates this telemetry, or was created with metrics off, there is no
    create row to pair with — but `cli.environment.push` still carries that
    environment's `local_environment_id`, because it is built while the
    environment is still a path environment.
  - **`flox pull` without `--copy`** materializes a local checkout of a
    definition that already exists.
  - **`flox pull --copy` converting in place.** The conversion rewrites the
    existing `.flox` rather than materializing a new one, so a directory that
    was `flox init`-ed and then pushed keeps its original id. That definition
    is coming home, not starting, and re-emitting would double-count it. Copying
    into a new directory does materialize a new `.flox`, mints a fresh id, and
    does emit.

  The rule is documented once on `EventKind::CliEnvironmentCreate`; call sites
  point at it rather than restating it.

  ## Relationship to FloxEM

  These events do not duplicate FloxHub's own `floxem.environment.created`,
  which is emitted only from the REST create endpoint. The CLI never uses it —
  it creates FloxHub environments by pushing a floxmeta repository over git —
  so CLI-created environments are otherwise absent from that stream.

  ## Emission semantics

  Opening an existing default environment does not emit, and failures return
  before emission. Event recording remains best-effort and cannot fail the
  command. Emission is deliberately post-operation and success-conditional,
  unlike the sibling `cli.environment.*` events that emit at dispatch and let
  `cli.command_completed` carry the outcome: there is no environment to
  describe until the creating call returns, and the id must already exist to
  ride along on the payload. The local-init emit is not deferred to the end of
  its function — the environment exists on disk from `PathEnvironment::init`
  onward, so a later failure in the reporting that follows does not un-create
  it.

  A remote push that succeeds but fails the SDK's subsequent validation remains
  a known undercount: the CLI never receives a validated environment to emit,
  and moving the emission into the SDK is outside this CLI-only change.

  This is additive telemetry. Existing `subcommand_metric!` calls and the legacy
  stream are unchanged.

  ## Unrelated fix carried here: buffer entries an older flox cannot read

  Unrelated to the create event, but triggered by it, so it rides along rather
  than landing after. Adding any `EventKind` variant makes the on-disk buffer
  unparseable to an older flox sharing the same data dir — and that binary then
  destroys events it never sent.

  `EventsBuffer::read` parsed the whole file with a single `StreamDeserializer`
  and a `filter_map` that reads as "skip the unreadable entry". It does not
  skip: the deserializer stops at its first error and reports the rest of the
  input as consumed, so every later entry disappears with it. A probe over
  valid / unknown / valid recovered **1 of 3**. `flush` then sends that prefix,
  `drain_sent` removes it, and `overwrite_file` truncates the file and writes
  back only what parsed — so the loss is persisted, not just skipped for one
  run. A user with two flox versions installed, or who rolls back after an
  upgrade, loses whole spans of buffered telemetry across *all* event types,
  with a single `debug!` line as evidence.

  The read is now per line, and entries this binary cannot parse are kept
  verbatim so `overwrite_file` writes them back and a binary that understands
  them can still send them. Retained lines are bounded like parsed ones, so a
  machine permanently running an older flox cannot grow the file without limit.
  A `#[serde(other)]` fallback on `EventKind` was considered and rejected: it
  admits only a unit variant, so the payload would be dropped and the rewrite
  would corrupt the unknown event rather than preserve it.

  Two regression tests cover it, both checked against the old behavior —
  restoring the stop-at-first-error read fails them.

  This can be split into its own PR if a reviewer would rather keep the diff
  single-purpose; it touches only `flox-events`, no call sites.

  ## Testing

  A full-envelope golden pins the new event name and path payload with
  `local_environment_id`. Two unit tests install a mock-backed events client on
  the global hub and compare whole payloads:

  - `init_local_environment_records_create_event_with_local_id` — the
    highest-volume site and the only one whose payload carries a real id;
    asserts one create whose `local_environment_id` equals the value minted
    into `.flox/telemetry_id`.
  - `init_floxhub_environment_records_create_event` — pins that a remote
    creation carries no local id rather than an invented one.

  Both were checked against their own mutation: with the emit removed, or the
  mint gate inverted, they fail. The mock-hub setup restores the previous
  client on drop, so a panicking assertion cannot leak it into the next test.

  The focused `flox-events` suite passes 56/56 and the focused `flox` suite
  passes 449/449. `cargo clippy --tests --workspace -- -D warnings` is clean.
  Earlier local capture observed exactly one create event for normal and bare
  init, a matching `local_environment_id`, no create event on re-init failure,
  and no event with metrics disabled. The `pull --copy` paths are covered by
  the mint-gate unit tests rather than a fresh manual capture; an end-to-end
  `init` → `push` → `pull --copy` capture would be the strongest confirmation
  that the in-place case stays silent. The full BATS suite remains blocked
  locally: no Podman VM is configured, so containerize setup fails and ten
  tests do not run. A diagnostic TTY run also exposed four unrelated
  interactive deactivation environment-diff failures around `NO_COLOR`. This
  diff touches neither area; the full suite still needs a green run with its
  local infrastructure prerequisites available.

  ## Release Notes

  Telemetry only; no user-facing behavior change.
