### PR TITLE
feat(events): add producer_version, cli.authenticated, cli.update_prompted

### DIFF
--- a/cli/flox-events/src/client.rs
+++ b/cli/flox-events/src/client.rs
@@ -109,13 +109,22 @@ impl EventsClient {
     }
 
     pub fn record_event(&self, kind: EventKind) -> Result<()> {
+        self.record_event_with_auth_subject(kind, self.auth_subject.as_deref())
+    }
+
+    pub(crate) fn record_event_with_auth_subject(
+        &self,
+        kind: EventKind,
+        auth_subject: Option<&str>,
+    ) -> Result<()> {
         let event = Event {
             event_id: Uuid::new_v4(),
             event_timestamp: OffsetDateTime::now_utc(),
             source: "cli",
             invocation_id: self.invocation_id,
             device_id: self.device_id,
-            auth_subject: self.auth_subject.clone(),
+            auth_subject: auth_subject.map(str::to_owned),
+            producer_version: Some(self.shared_metadata.flox_version.clone()),
             kind,
         };
 

--- a/cli/flox-events/src/hub.rs
+++ b/cli/flox-events/src/hub.rs
@@ -72,6 +72,24 @@ impl EventsHub {
         })
     }
 
+    /// Record one event with an explicit authenticated subject.
+    ///
+    /// Passing `None` omits a subject instead of using the client snapshot.
+    pub fn record_event_with_auth_subject(
+        &self,
+        kind: EventKind,
+        auth_subject: Option<&str>,
+    ) -> Result<()> {
+        self.with_client(|client| {
+            let Some(client) = client else {
+                trace!("No v2 events client configured, skipping record");
+                return Ok(());
+            };
+
+            client.record_event_with_auth_subject(kind, auth_subject)
+        })
+    }
+
     /// Record a `cli.command_run` event for `subcommand`. No-op when no
     /// client is installed.
     pub fn record_command_run(&self, subcommand: String) -> Result<()> {

--- a/cli/flox-events/src/lib.rs
+++ b/cli/flox-events/src/lib.rs
@@ -32,7 +32,7 @@ const CLI_SOURCE: &str = "cli";
 /// `source` is always `"cli"`. `kind` carries the variant tag and its
 /// typed payload and is flattened into the envelope, so the wire shape
 /// is `{event_id, event_timestamp, source, invocation_id, device_id,
-/// auth_subject?, event_type, payload}`.
+/// auth_subject?, producer_version?, event_type, payload}`.
 ///
 /// The CLI serializes events for transport and deserializes the same shape to
 /// reload its local buffer.
@@ -62,6 +62,11 @@ pub struct Event {
     /// identifier contract.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub auth_subject: Option<String>,
+    /// Version of the producer identified by `source`.
+    ///
+    /// Absent only when reloading events buffered by an older CLI.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub producer_version: Option<String>,
     /// The event variant and its typed payload. Flattened into the
     /// envelope: the variant's `#[serde(rename)]` becomes `event_type`
     /// and the variant's payload struct becomes `payload`.
@@ -79,6 +84,7 @@ struct EventWire {
     invocation_id: Uuid,
     device_id: Uuid,
     auth_subject: Option<String>,
+    producer_version: Option<String>,
     #[serde(flatten)]
     kind: EventKind,
 }
@@ -103,6 +109,7 @@ impl<'de> Deserialize<'de> for Event {
             invocation_id: wire.invocation_id,
             device_id: wire.device_id,
             auth_subject: wire.auth_subject,
+            producer_version: wire.producer_version,
             kind: wire.kind,
         })
     }
@@ -186,6 +193,10 @@ pub enum EventKind {
     CliBuild(CliBuildPayload),
     #[serde(rename = "cli.search")]
     CliSearch(CliSearchPayload),
+    #[serde(rename = "cli.authenticated")]
+    CliAuthenticated {},
+    #[serde(rename = "cli.update_prompted")]
+    CliUpdatePrompted {},
 }
 
 /// Shared metadata fields stamped onto every `cli.*` command event payload.
@@ -780,6 +791,7 @@ mod tests {
             invocation_id: Uuid::nil(),
             device_id: Uuid::nil(),
             auth_subject: None,
+            producer_version: Some("0.0.0-test".to_string()),
             kind,
         }
     }
@@ -817,6 +829,7 @@ mod tests {
             "source": "cli",
             "invocation_id": "00000000-0000-0000-0000-000000000000",
             "device_id": "00000000-0000-0000-0000-000000000000",
+            "producer_version": "0.0.0-test",
             "event_type": "cli.command_run",
             "payload": payload,
         })
@@ -883,6 +896,7 @@ mod tests {
             "source": "cli",
             "invocation_id": "00000000-0000-0000-0000-000000000000",
             "device_id": "00000000-0000-0000-0000-000000000000",
+            "producer_version": "0.0.0-test",
             "event_type": "cli.command_completed",
             "payload": {
                 "subcommand": "install",
@@ -930,6 +944,7 @@ mod tests {
             "source": "cli",
             "invocation_id": "00000000-0000-0000-0000-000000000000",
             "device_id": "00000000-0000-0000-0000-000000000000",
+            "producer_version": "0.0.0-test",
             "event_type": "cli.command_completed",
             "payload": {
                 "subcommand": "install",
@@ -955,10 +970,50 @@ mod tests {
             "invocation_id": "00000000-0000-0000-0000-000000000000",
             "device_id": "00000000-0000-0000-0000-000000000000",
             "auth_subject": "test-subject-7f3a",
+            "producer_version": "0.0.0-test",
             "event_type": "cli.command_run",
             "payload": expected_payload_json("install"),
         });
         assert_eq!(value, expected);
+    }
+
+    #[test]
+    fn authenticated_serializes_with_empty_payload() {
+        let mut event = fixed_event(EventKind::CliAuthenticated {});
+        event.auth_subject = Some("test-subject-7f3a".to_string());
+
+        let value = serde_json::to_value(event).expect("event serializes");
+        let expected = json!({
+            "event_id": "00000000-0000-0000-0000-000000000000",
+            "event_timestamp": EPOCH_UNIX_MS,
+            "source": "cli",
+            "invocation_id": "00000000-0000-0000-0000-000000000000",
+            "device_id": "00000000-0000-0000-0000-000000000000",
+            "auth_subject": "test-subject-7f3a",
+            "producer_version": "0.0.0-test",
+            "event_type": "cli.authenticated",
+            "payload": {},
+        });
+        assert_eq!(value, expected);
+    }
+
+    #[test]
+    fn buffered_event_without_producer_version_remains_without_it() {
+        let mut json = command_run_envelope_json(expected_payload_json("install"));
+        json.as_object_mut()
+            .expect("envelope object")
+            .remove("producer_version");
+
+        let event: Event = serde_json::from_value(json.clone()).expect("event deserializes");
+        let mut expected = fixed_event(EventKind::CliCommandRun(CliCommandRunPayload::new(
+            command_payload("install"),
+        )));
+        expected.producer_version = None;
+        assert_eq!(event, expected);
+        assert_eq!(
+            serde_json::to_value(event).expect("event reserializes"),
+            json
+        );
     }
 
     #[test]
@@ -997,6 +1052,7 @@ mod tests {
             "source": "cli",
             "invocation_id": "00000000-0000-0000-0000-000000000000",
             "device_id": "00000000-0000-0000-0000-000000000000",
+            "producer_version": "0.0.0-test",
             "event_type": "cli.environment.activate",
             "payload": payload,
         })
@@ -1147,6 +1203,7 @@ mod tests {
             "source": "cli",
             "invocation_id": "00000000-0000-0000-0000-000000000000",
             "device_id": "00000000-0000-0000-0000-000000000000",
+            "producer_version": "0.0.0-test",
             "event_type": "cli.environment.create",
             "payload": payload_json,
         });
@@ -1168,6 +1225,7 @@ mod tests {
             "source": "cli",
             "invocation_id": "00000000-0000-0000-0000-000000000000",
             "device_id": "00000000-0000-0000-0000-000000000000",
+            "producer_version": "0.0.0-test",
             "event_type": "cli.environment.push",
             "payload": payload_json,
         });
@@ -1192,6 +1250,7 @@ mod tests {
             "source": "cli",
             "invocation_id": "00000000-0000-0000-0000-000000000000",
             "device_id": "00000000-0000-0000-0000-000000000000",
+            "producer_version": "0.0.0-test",
             "event_type": "cli.environment.pull",
             "payload": payload_json,
         });
@@ -1209,6 +1268,7 @@ mod tests {
             "source": "cli",
             "invocation_id": "00000000-0000-0000-0000-000000000000",
             "device_id": "00000000-0000-0000-0000-000000000000",
+            "producer_version": "0.0.0-test",
             "event_type": event_type,
             "payload": payload_json,
         })
@@ -1263,6 +1323,7 @@ mod tests {
             "source": "cli",
             "invocation_id": "00000000-0000-0000-0000-000000000000",
             "device_id": "00000000-0000-0000-0000-000000000000",
+            "producer_version": "0.0.0-test",
             "event_type": event_type,
             "payload": payload_json,
         })
@@ -1275,6 +1336,7 @@ mod tests {
             "source": "cli",
             "invocation_id": "00000000-0000-0000-0000-000000000000",
             "device_id": "00000000-0000-0000-0000-000000000000",
+            "producer_version": "0.0.0-test",
             "event_type": "cli.build",
             "payload": payload,
         })
@@ -1494,6 +1556,7 @@ mod tests {
             "source": "cli",
             "invocation_id": "00000000-0000-0000-0000-000000000000",
             "device_id": "00000000-0000-0000-0000-000000000000",
+            "producer_version": "0.0.0-test",
             "event_type": "cli.build",
             "payload": { "has_expression_build": true, "has_manifest_build": false },
         });
@@ -1561,6 +1624,7 @@ mod tests {
             "source": "cli",
             "invocation_id": "00000000-0000-0000-0000-000000000000",
             "device_id": "00000000-0000-0000-0000-000000000000",
+            "producer_version": "0.0.0-test",
             "event_type": "cli.search",
             "payload": payload_json,
         });
@@ -1589,6 +1653,7 @@ mod pipeline_tests {
             invocation_id: INVOCATION_ID,
             device_id: DEVICE_ID,
             auth_subject: None,
+            producer_version: Some("0.0.0-test".to_string()),
             kind,
         }
     }
@@ -1668,6 +1733,40 @@ mod pipeline_tests {
     }
 
     #[test]
+    fn one_event_auth_subject_override_does_not_mutate_client() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let client = EventsClient::new_with_connection(
+            DEVICE_ID,
+            tempdir.path(),
+            INVOCATION_ID,
+            Some("previous-subject".to_string()),
+            shared_metadata(),
+            MockEventsConnection::default(),
+        );
+
+        client
+            .record_event_with_auth_subject(EventKind::CliAuthenticated {}, Some("fresh-subject"))
+            .expect("record fresh subject");
+        client
+            .record_event_with_auth_subject(EventKind::CliAuthenticated {}, None)
+            .expect("record anonymous event");
+        client
+            .record_event(EventKind::CliUpdatePrompted {})
+            .expect("record client snapshot");
+
+        let buffer = EventsBuffer::read(tempdir.path()).expect("read buffer");
+        let recorded: Vec<_> = buffer
+            .iter()
+            .map(|event| (event.auth_subject.as_deref(), &event.kind))
+            .collect();
+        assert_eq!(recorded, vec![
+            (Some("fresh-subject"), &EventKind::CliAuthenticated {},),
+            (None, &EventKind::CliAuthenticated {}),
+            (Some("previous-subject"), &EventKind::CliUpdatePrompted {},),
+        ]);
+    }
+
+    #[test]
     fn events_buffer_round_trips_entries_from_disk() {
         let tempdir = tempfile::tempdir().expect("tempdir");
         let first = fixed_event(command_run_kind());
@@ -1736,6 +1835,7 @@ mod pipeline_tests {
         assert_eq!(event.invocation_id, INVOCATION_ID);
         assert_eq!(event.device_id, DEVICE_ID);
         assert_eq!(event.auth_subject, None);
+        assert_eq!(event.producer_version.as_deref(), Some("0.0.0-test"));
         assert_eq!(event.kind, command_completed_kind());
     }
 

--- a/cli/flox/src/commands/auth.rs
+++ b/cli/flox/src/commands/auth.rs
@@ -6,6 +6,7 @@ use bpaf::Bpaf;
 use chrono::offset::Utc;
 use chrono::{DateTime, Duration};
 use flox_config::{Config, FLOX_CONFIG_FILE, TokenStorageMode};
+use flox_events::{EventKind, EventsHub};
 use flox_rust_sdk::flox::{FLOX_VERSION, Flox, FloxhubToken};
 use floxhub_client::{AuthContext, AuthFailure};
 use indoc::{formatdoc, indoc};
@@ -529,6 +530,13 @@ fn complete_login(
         }
     }
 
+    if let Err(err) = EventsHub::global().record_event_with_auth_subject(
+        EventKind::CliAuthenticated {},
+        flox.auth_context.user_subject(),
+    ) {
+        debug!(error = %err, "Failed to record v2 cli.authenticated event");
+    }
+
     Ok(handle)
 }
 
@@ -625,11 +633,46 @@ mod tests {
     use std::fs;
 
     use flox_config::FLOX_CONFIG_FILE;
+    use flox_events::{EventsBuffer, EventsClient, SharedMetadataTemplate};
     use flox_rust_sdk::flox::test_helpers::{create_test_token, flox_instance};
-    use floxhub_client::test_helpers::FAKE_EXPIRED_TOKEN;
+    use floxhub_client::test_helpers::{FAKE_EXPIRED_TOKEN, FAKE_TOKEN_WITH_SUB};
     use httpmock::MockServer;
+    use serial_test::serial;
+    use uuid::Uuid;
 
     use super::*;
+
+    struct EventsClientReset(Option<EventsClient>);
+
+    impl Drop for EventsClientReset {
+        fn drop(&mut self) {
+            EventsHub::global().clear_client();
+            if let Some(previous) = self.0.take() {
+                EventsHub::global().set_client(previous);
+            }
+        }
+    }
+
+    fn install_events_client(flox: &Flox) -> EventsClientReset {
+        let client = EventsClient::new(
+            Uuid::new_v4(),
+            &flox.data_dir,
+            "",
+            "",
+            Uuid::new_v4(),
+            Some("previous-subject".to_string()),
+            SharedMetadataTemplate {
+                flox_version: "0.0.0-test".to_string(),
+                os_family: None,
+                os_family_release: None,
+                os: None,
+                os_version: None,
+                empty_flags: vec![],
+                invocation_sources: vec![],
+            },
+        );
+        EventsClientReset(EventsHub::global().set_client(client))
+    }
 
     /// Point the Flox instance's client at a mock `/me` server.
     fn override_client(flox: &mut Flox, server: &MockServer) {
@@ -675,6 +718,68 @@ mod tests {
             assert_eq!(stored.secret(), token.secret());
         })
         .await;
+    }
+
+    #[test]
+    #[serial(global_events_client)]
+    fn complete_login_records_fresh_auth0_subject_and_omits_pat_subject() {
+        temp_env::with_var("_FLOX_DISABLE_KEYRING", Some("true"), || {
+            let (mut flox, _temp_dir) = flox_instance();
+            let _reset = install_events_client(&flox);
+
+            complete_login(
+                &mut flox,
+                AuthContext::Auth0(Some(
+                    FloxhubToken::new(FAKE_TOKEN_WITH_SUB.to_string()).expect("token parses"),
+                )),
+                "test".to_string(),
+                false,
+                false,
+                TokenStorageMode::Keyring,
+            )
+            .expect("Auth0 login completes");
+            complete_login(
+                &mut flox,
+                AuthContext::new_from_token(Some("flox_pat_secret")).expect("PAT parses"),
+                "pat-user".to_string(),
+                false,
+                false,
+                TokenStorageMode::Keyring,
+            )
+            .expect("PAT login completes");
+
+            let buffer = EventsBuffer::read(&flox.data_dir).expect("read events");
+            let recorded: Vec<_> = buffer
+                .iter()
+                .map(|event| (event.auth_subject.as_deref(), &event.kind))
+                .collect();
+            assert_eq!(recorded, vec![
+                (Some("github|424242"), &EventKind::CliAuthenticated {},),
+                (None, &EventKind::CliAuthenticated {}),
+            ]);
+        });
+    }
+
+    #[tokio::test]
+    #[serial(global_events_client)]
+    async fn failed_login_records_no_authenticated_event() {
+        let (mut flox, _temp_dir) = flox_instance();
+        let _reset = install_events_client(&flox);
+        let token_file = flox.temp_dir.join("token");
+        fs::write(&token_file, "not-a-jwt").unwrap();
+
+        login_with_token_file(
+            &mut flox,
+            &token_file,
+            false,
+            false,
+            TokenStorageMode::Keyring,
+        )
+        .await
+        .expect_err("malformed token fails");
+
+        let buffer = EventsBuffer::read(&flox.data_dir).expect("read events");
+        assert_eq!(buffer.iter().count(), 0);
     }
 
     #[tokio::test]

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -41,6 +41,7 @@ use flox_config::{Config, EnvironmentTrust, FLOX_DIR_NAME, TokenStorageMode};
 use flox_core::data::environment_ref::{self, DEFAULT_NAME, RemoteEnvironmentRef};
 use flox_core::floxhub::{DEFAULT_FLOXHUB_URL, Floxhub};
 use flox_core::vars::FLOX_DISABLE_METRICS_VAR;
+use flox_events::{EventKind, EventsHub};
 use flox_manifest::interfaces::AsLatestSchema;
 use flox_manifest::{Manifest, TypedOnly};
 use flox_rust_sdk::flox::{AuthContext, FLOX_VERSION, Flox, FloxhubTokenError};
@@ -265,11 +266,18 @@ impl FloxArgs {
             .unwrap_or_default();
             let active_environments = activated_environments();
             print_welcome_message(envs, active_environments);
-            UpdateNotification::check_for_and_print_update_notification(
+            let update_prompted = UpdateNotification::check_for_and_print_update_notification(
                 &config.flox.cache_dir,
                 &update_channel,
             )
             .await;
+            if update_prompted
+                && let Some(events_client) =
+                    build_events_client(&config, resolve_invocation_id(), None)
+                && let Err(err) = events_client.record_event(EventKind::CliUpdatePrompted {})
+            {
+                debug!(error = %err, "Failed to record v2 cli.update_prompted event");
+            }
             return Ok(());
         }
 
@@ -364,7 +372,7 @@ impl FloxArgs {
             resolve_invocation_id(),
             credential.user_subject().map(String::from),
         ) {
-            flox_events::EventsHub::global().set_client(events_client);
+            EventsHub::global().set_client(events_client);
         }
 
         // Emit the v2 `cli.command_run` once at dispatch start. The matching
@@ -385,9 +393,7 @@ impl FloxArgs {
             .as_ref()
             .map(Commands::subcommand_name)
             .unwrap_or("help");
-        if let Err(err) =
-            flox_events::EventsHub::global().record_command_run(v2_subcommand.to_string())
-        {
+        if let Err(err) = EventsHub::global().record_command_run(v2_subcommand.to_string()) {
             debug!(error = %err, "Failed to record v2 cli.command_run event");
         }
 
@@ -472,7 +478,14 @@ impl FloxArgs {
             // but I'm not sure it's worth a refactor.
             match check_for_update_handle.await {
                 Ok(update_notification) => {
-                    UpdateNotification::handle_update_result(update_notification, &update_channel);
+                    if UpdateNotification::handle_update_result(
+                        update_notification,
+                        &update_channel,
+                    ) && let Err(err) =
+                        EventsHub::global().record_event(EventKind::CliUpdatePrompted {})
+                    {
+                        debug!(error = %err, "Failed to record v2 cli.update_prompted event");
+                    }
                 },
                 Err(e) => debug!("Failed to check for CLI update: {}", display_chain(&e)),
             }

--- a/cli/flox/src/utils/update_notifications.rs
+++ b/cli/flox/src/utils/update_notifications.rs
@@ -86,7 +86,7 @@ impl UpdateNotification {
     pub async fn check_for_and_print_update_notification(
         cache_dir: impl AsRef<Path>,
         release_channel: &Option<InstallerChannel>,
-    ) {
+    ) -> bool {
         Self::handle_update_result(
             Self::check_for_update(cache_dir, release_channel).await,
             release_channel,
@@ -173,25 +173,29 @@ impl UpdateNotification {
     pub fn handle_update_result(
         update_notification: Result<UpdateCheckResult, UpdateNotificationError>,
         release_env: &Option<InstallerChannel>,
-    ) {
+    ) -> bool {
         match update_notification {
-            Ok(UpdateCheckResult::Skipped) => {},
+            Ok(UpdateCheckResult::Skipped) => false,
             Ok(UpdateCheckResult::RefreshNotificationFile(notification_file)) => {
                 Self::write_notification_file(notification_file);
+                false
             },
             Ok(UpdateCheckResult::UpdateAvailable(update_notification)) => {
                 Self::write_notification_file(&update_notification.notification_file);
                 update_notification.print_new_version_available(release_env);
+                true
             },
             Err(UpdateNotificationError::WeMayHaveMessedUp(e)) => {
                 debug!("Failed to check for CLI updates. Sending error to Sentry if enabled");
                 capture_anyhow(&anyhow!("Failed to check for CLI updates: {e}"));
+                false
             },
             Err(e) => {
                 debug!(
                     "Failed to check for CLI update. Ignoring error: {}",
                     display_chain(&e)
                 );
+                false
             },
         }
     }
@@ -345,7 +349,7 @@ mod tests {
         let temp_dir = tempdir().unwrap();
         let notification_file = temp_dir.path().join("notification_file");
 
-        UpdateNotification::handle_update_result(
+        let displayed = UpdateNotification::handle_update_result(
             Ok(UpdateCheckResult::UpdateAvailable(UpdateNotification {
                 new_version: "new_version".to_string(),
                 notification_file: notification_file.clone(),
@@ -355,6 +359,7 @@ mod tests {
 
         serde_json::from_str::<LastUpdateCheck>(&fs::read_to_string(notification_file).unwrap())
             .unwrap();
+        assert!(displayed);
     }
 
     /// [UpdateNotification::handle_update_result] should write notification_file,
@@ -364,7 +369,7 @@ mod tests {
         let temp_dir = tempdir().unwrap();
         let notification_file = temp_dir.path().join("notification_file");
 
-        UpdateNotification::handle_update_result(
+        let displayed = UpdateNotification::handle_update_result(
             Ok(UpdateCheckResult::RefreshNotificationFile(
                 notification_file.clone(),
             )),
@@ -373,6 +378,15 @@ mod tests {
 
         serde_json::from_str::<LastUpdateCheck>(&fs::read_to_string(notification_file).unwrap())
             .unwrap();
+        assert!(!displayed);
+    }
+
+    #[test]
+    fn handle_update_result_reports_skipped_as_not_displayed() {
+        assert!(!UpdateNotification::handle_update_result(
+            Ok(UpdateCheckResult::Skipped),
+            &Some(InstallerChannel::Stable),
+        ));
     }
 
     /// [UpdateNotificationError::WeMayHaveMessedUp] errors should be sent to sentry


### PR DESCRIPTION
> Stacked on #4566 (`cli.environment.create`).

- **feat(events): add producer_version, cli.authenticated, cli.update_prompted**

  Stamps every event envelope with the version of the CLI that produced
  it, and adds two event kinds that close gaps in the `cli.*` family:
  one for authentication, one for the update prompt.

  ### `producer_version` on the envelope

  Every envelope now carries `producer_version`, the version of the
  producer named by `source` (always `"cli"` today). It is sourced from
  the client's `SharedMetadataTemplate`, the same value that command
  payloads already report as `flox_version`.

  The field belongs on the envelope rather than in each payload because
  not every event has a payload to put it in. Command events flatten
  shared metadata into their payload and so already report a version,
  but the two kinds added here carry empty payloads by design — without
  an envelope-level field they would be the only events in the stream
  that cannot be attributed to a CLI version, which is exactly what a
  consumer needs when a release changes emission behaviour.

  `producer_version` is `Option<String>` with
  `skip_serializing_if = "Option::is_none"`. The CLI reloads its own
  buffered events from disk, and a buffer written by an older CLI has no
  such key; making it optional lets those events deserialize, and
  skipping serialization when absent means a reloaded old event
  round-trips unchanged rather than acquiring a version it was never
  produced with. A golden test pins that round-trip.

  This is an additive, optional key. Consumers must tolerate its
  absence, both for events buffered before this change and for any
  future producer that does not set it.

  ### `cli.authenticated`

  Emitted from `complete_login` once a login has succeeded.

  It is recorded through a new `record_event_with_auth_subject` rather
  than the usual `record_event`, because the events client snapshots
  `auth_subject` when it is constructed — at dispatch start, before the
  login it is about to describe has happened. Recording the login's own
  event through that snapshot would label it with the *previous*
  subject, or with none at all on a first login. The override passes the
  subject resolved from the freshly minted credential instead, and it is
  per-call: the client's snapshot is left untouched, so later events in
  the same invocation are unaffected.

  PAT logins pass `None`. A PAT carries no `sub` claim, so there is no
  pseudonymous subject to report, and recording the authentication
  anonymously is preferable to labelling it with a subject it does not
  have. Failed logins return before the emit and record nothing.

  ### `cli.update_prompted`

  Emitted when an update notification is actually shown to the user, not
  merely when the update check runs. `handle_update_result` previously
  returned `()` and folded "displayed a notification", "refreshed the
  notification file", and "checked and found nothing" into one path; it
  now returns whether it displayed, and only the display case emits.

  There are two call sites because the CLI checks for updates in two
  places. The normal dispatch path records through the global events
  hub. The bare `flox` path (no subcommand) returns before the hub's
  client is installed, so it builds a one-off client for the emit;
  recording writes to the on-disk buffer, so the event is flushed by a
  later invocation rather than lost.

  Both emits are best-effort: a recording failure is logged at debug and
  never fails the command, consistent with the rest of the `cli.*`
  family.

  ## Testing

  `flox-events` passes 62/62 and the `flox` binary suite passes 452/452,
  including nine `commands::auth` tests. Clippy and rustfmt are clean for
  both touched crates. All runs were inside `nix develop`.

  The envelope field reaches every golden in the suite, including the
  `cli.build` assertions #4553 added — those route through a shared
  `cli_build_envelope_json` helper, so they are covered at one site
  rather than three.

  New coverage: a golden pinning the `cli.authenticated` envelope with a
  subject; a golden asserting that a buffered event without
  `producer_version` deserializes and re-serializes without gaining one;
  a pipeline test asserting the per-call subject override does not mutate
  the client snapshot, by recording an override, an anonymous event, and
  a snapshot event in sequence and checking all three; a unit test
  driving `complete_login` through both an Auth0 token and a PAT and
  asserting the recorded subjects are the fresh `sub` and `None`
  respectively; a test asserting a malformed-token login records nothing;
  and a case pinning `UpdateCheckResult::Skipped` as not-displayed.

  Known gap: the two new events have no BATS coverage. Nothing in
  `cli/tests` exercises the login or update-notification display paths,
  so they are verified at unit level only.
