### PR TITLE
test: record executive logs at trace level

### DIFF
--- a/cli/tests/setup_suite.bash
+++ b/cli/tests/setup_suite.bash
@@ -195,6 +195,9 @@ flox_cli_vars_setup() {
   # stops a developer's real FLOX_FLOXHUB_TOKEN from leaking into tests.
   # Tests that exercise logged-out behavior `unset FLOX_FLOXHUB_TOKEN`.
   export FLOX_FLOXHUB_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3guZGV2L2hhbmRsZSI6InRlc3QiLCJleHAiOjk5OTk5OTk5OTl9.6-nbzFzQEjEX7dfWZFLE-I_qW2N_-9W2HFzzfsquI74"
+  # Record executive logs at trace level so they're useful when a test failure
+  # dumps them, e.g. from `wait_for_activations`.
+  export _FLOX_EXECUTIVE_VERBOSITY=3
 }
 
 # ---------------------------------------------------------------------------- #


### PR DESCRIPTION
Executive logs are dumped on some test failures (e.g. from
wait_for_activations) but were only recorded at info level. A trace-level
log for a simple command-mode activation is only ~35 lines, so
always record at trace to make those dumps useful.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
