### PR TITLE
fix: add more context on non-existent state.json

### DIFF
--- a/cli/flox-activations/src/cli/executive/event_coordinator.rs
+++ b/cli/flox-activations/src/cli/executive/event_coordinator.rs
@@ -9,7 +9,7 @@ use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result, anyhow};
 use flox_core::activations::{PidWithExpiration, read_activations_json};
 use flox_core::proc_status::pid_is_running;
 
@@ -87,7 +87,10 @@ impl EventCoordinator {
     pub fn spawn_all_watchers(&mut self, state_json_path: impl AsRef<Path>) -> Result<()> {
         let (activations_json, _lock) = read_activations_json(&state_json_path)?;
         let Some(activations) = activations_json else {
-            bail!("executive shouldn't be running when state.json doesn't exist");
+            return Err(
+                anyhow!("executive shouldn't be running when state.json doesn't exist")
+                    .context("when spawning watchers"),
+            )?;
         };
 
         // Watch attached PIDs

--- a/cli/flox-activations/src/cli/executive/mod.rs
+++ b/cli/flox-activations/src/cli/executive/mod.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result, anyhow, bail};
 use clap::Args;
 use event_coordinator::{EventCoordinator, ExecutiveEvent};
 use flox_core::activate::context::{AttachCtx, AttachProjectCtx};
@@ -214,7 +214,10 @@ fn run_event_loop(
                 debug!("Received SIGUSR1, starting process-compose");
                 let (activations_json, lock) = read_activations_json(&state_json_path)?;
                 let Some(activations) = activations_json else {
-                    bail!("executive shouldn't be running when state.json doesn't exist");
+                    return Err(anyhow!(
+                        "executive shouldn't be running when state.json doesn't exist"
+                    )
+                    .context("when handling StartServices"))?;
                 };
 
                 match handle_start_services_signal(
@@ -237,7 +240,10 @@ fn run_event_loop(
                 debug!("state.json changed, checking for new PIDs to monitor");
                 let (state, lock) = read_activations_json(&state_json_path)?;
                 let Some(activations) = state else {
-                    bail!("executive shouldn't be running when state.json doesn't exist");
+                    return Err(anyhow!(
+                        "executive shouldn't be running when state.json doesn't exist"
+                    )
+                    .context("when handling StateFileChanged"))?;
                 };
                 coordinator
                     .ensure_monitoring_pids(activations.all_attached_pids_and_expiration())
@@ -349,7 +355,10 @@ fn handle_process_exited(
             // PIDs.
             let (activations_json, _lock) = read_activations_json(state_json_path)?;
             let Some(activations) = activations_json else {
-                bail!("executive shouldn't be running when state.json doesn't exist");
+                return Err(anyhow!(
+                    "executive shouldn't be running when state.json doesn't exist"
+                )
+                .context("when checking for re-attached PIDs"))?;
             };
             // Check if the PID that triggered this event is still in state
             let pid_reused = activations
@@ -415,10 +424,12 @@ fn handle_process_exited(
             Ok(cleaned_up)
         },
         Err(err) => {
-            info!("running cleanup after error");
+            info!(%err, "running cleanup after error");
             let (activations_json, lock) = read_activations_json(state_json_path)?;
             let Some(activations) = activations_json else {
-                bail!("executive shouldn't be running when state.json doesn't exist");
+                return Err(
+                    err.context("executive shouldn't be running when state.json doesn't exist")
+                )?;
             };
             let _ = cleanup_all(
                 (activations, lock),

--- a/cli/flox-activations/src/cli/executive/watcher.rs
+++ b/cli/flox-activations/src/cli/executive/watcher.rs
@@ -10,7 +10,7 @@
 
 use std::path::Path;
 
-use anyhow::{Result, bail};
+use anyhow::{Result, anyhow};
 use flox_core::activations::{ActivationState, read_activations_json, write_activations_json};
 use flox_core::proc_status::pid_is_running;
 use fslock::LockFile;
@@ -36,7 +36,10 @@ pub fn cleanup_pid(
 ) -> Result<Option<LockedActivationState>, Error> {
     let (activations_json, lock) = read_activations_json(state_json_path)?;
     let Some(mut activations) = activations_json else {
-        bail!("executive shouldn't be running when state.json doesn't exist");
+        return Err(
+            anyhow!("executive shouldn't be running when state.json doesn't exist")
+                .context(format!("when cleaning up PID {pid}")),
+        );
     };
 
     let now = OffsetDateTime::now_utc();


### PR DESCRIPTION
We've seen some "executive shouldn't be running when state.json doesn't
exist," but there's not a lot of actionable info. When running cleanup
after an error, we don't actually record the error, which we should do.

While we're at it, add some more context to errors with the same
message.
