### PR TITLE
feat(events): record previous_version on cli.package.upgrade

### DIFF
--- a/cli/flox-events/src/lib.rs
+++ b/cli/flox-events/src/lib.rs
@@ -138,7 +138,7 @@ pub enum EventKind {
     #[serde(rename = "cli.package.install")]
     CliPackageInstall(CliPackagePayload),
     #[serde(rename = "cli.package.upgrade")]
-    CliPackageUpgrade(CliPackagePayload),
+    CliPackageUpgrade(CliPackageUpgradePayload),
     #[serde(rename = "cli.package.uninstall")]
     CliPackageUninstall(CliPackagePayload),
     #[serde(rename = "cli.environment.containerize")]
@@ -554,12 +554,14 @@ pub enum Outcome {
     Failure,
 }
 
-/// Payload shared by the per-package events (`cli.package.install` /
-/// `.upgrade` / `.uninstall`). One event is emitted per package.
+/// Payload shared by `cli.package.install` and `cli.package.uninstall`.
+/// One event is emitted per package.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CliPackagePayload {
-    /// Per-package identifier matching what the legacy `failed_packages`
-    /// string packed (catalog `pkg_path`, flake URL, or store path).
+    /// Per-package identifier. Install events carry the coordinate as the
+    /// user wrote it (catalog pkg path, flake installable, or store path —
+    /// what the legacy `failed_packages` string packed); uninstall events
+    /// currently carry the manifest install id instead.
     package: String,
     /// Outcome of this package's attempt within the invocation. Recorded
     /// best-effort from a single error-handling site (e.g.
@@ -579,6 +581,60 @@ pub struct CliPackagePayload {
 impl CliPackagePayload {
     pub fn new(package: String, outcome: Outcome) -> Self {
         Self { package, outcome }
+    }
+}
+
+/// Payload for [`EventKind::CliPackageUpgrade`]. One event per upgraded
+/// package, for the current system only — upgrades applied for other
+/// systems in the same invocation emit nothing.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CliPackageUpgradePayload {
+    /// The package coordinate as written in the manifest (catalog pkg
+    /// path, flake installable, or store path) — stable across upgrades
+    /// and shared with the install events. Not unique within an
+    /// invocation: one coordinate installed under several install ids
+    /// upgrades as several rows.
+    package: String,
+    /// See [`CliPackagePayload::outcome`]; upgrade rows are emitted from
+    /// the success path only.
+    outcome: Outcome,
+    /// The manifest install id this row's package was upgraded under —
+    /// the per-invocation unique key.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    install_id: Option<String>,
+    /// Version before the upgrade; absent when unknown.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    previous_version: Option<String>,
+    /// Version after the upgrade; absent when unknown. A rebuild without
+    /// a version change carries the same value in both version fields.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    version: Option<String>,
+}
+
+impl CliPackageUpgradePayload {
+    pub fn new(package: String, outcome: Outcome) -> Self {
+        Self {
+            package,
+            outcome,
+            install_id: None,
+            previous_version: None,
+            version: None,
+        }
+    }
+
+    pub fn with_install_id(mut self, value: impl Into<String>) -> Self {
+        self.install_id = Some(value.into());
+        self
+    }
+
+    pub fn with_previous_version(mut self, value: impl Into<String>) -> Self {
+        self.previous_version = Some(value.into());
+        self
+    }
+
+    pub fn with_version(mut self, value: impl Into<String>) -> Self {
+        self.version = Some(value.into());
+        self
     }
 }
 
@@ -1345,6 +1401,35 @@ mod tests {
     }
 
     #[test]
+    fn cli_package_upgrade_full_envelope_golden() {
+        let payload = CliPackageUpgradePayload::new("hello".to_string(), Outcome::Success)
+            .with_install_id("greeting")
+            .with_previous_version("2.10.1")
+            .with_version("2.12.3");
+        let value = serde_json::to_value(fixed_event(EventKind::CliPackageUpgrade(payload)))
+            .expect("event serializes");
+        let mut expected = package_envelope_json("cli.package.upgrade", "hello", "success");
+        expected["payload"]["install_id"] = json!("greeting");
+        expected["payload"]["previous_version"] = json!("2.10.1");
+        expected["payload"]["version"] = json!("2.12.3");
+        assert_eq!(value, expected);
+    }
+
+    #[test]
+    fn cli_package_upgrade_payload_without_optional_keys_deserializes() {
+        // Rows buffered by an older producer carry only package + outcome;
+        // they must stay field-additive and read back with every optional
+        // field `None`.
+        let payload: CliPackageUpgradePayload =
+            serde_json::from_value(json!({ "package": "hello", "outcome": "success" }))
+                .expect("payload without optional keys deserializes");
+        assert_eq!(
+            payload,
+            CliPackageUpgradePayload::new("hello".to_string(), Outcome::Success)
+        );
+    }
+
+    #[test]
     fn cli_package_install_success_envelope_golden() {
         let payload = CliPackagePayload::new("hello".to_string(), Outcome::Success);
         let value = serde_json::to_value(fixed_event(EventKind::CliPackageInstall(payload)))
@@ -1364,7 +1449,8 @@ mod tests {
 
     #[test]
     fn cli_package_upgrade_envelope_golden() {
-        let payload = CliPackagePayload::new("hello".to_string(), Outcome::Success);
+        // Optional fields omitted entirely when unset — never null.
+        let payload = CliPackageUpgradePayload::new("hello".to_string(), Outcome::Success);
         let value = serde_json::to_value(fixed_event(EventKind::CliPackageUpgrade(payload)))
             .expect("event serializes");
         let expected = package_envelope_json("cli.package.upgrade", "hello", "success");

--- a/cli/flox-manifest/src/parsed/v1_10_0/package_descriptor.rs
+++ b/cli/flox-manifest/src/parsed/v1_10_0/package_descriptor.rs
@@ -39,6 +39,17 @@ impl ManifestPackageDescriptor {
             _ => false,
         }
     }
+
+    /// The package coordinate as written in the manifest (catalog pkg path,
+    /// flake installable, or store path) — independent of the user-chosen
+    /// install id, and stable across upgrades.
+    pub fn package_identifier(&self) -> &str {
+        match self {
+            ManifestPackageDescriptor::Catalog(pkg) => &pkg.pkg_path,
+            ManifestPackageDescriptor::FlakeRef(pkg) => &pkg.flake,
+            ManifestPackageDescriptor::StorePath(pkg) => &pkg.store_path,
+        }
+    }
 }
 
 impl ManifestPackageDescriptor {
@@ -348,5 +359,27 @@ impl From<v1::ManifestPackageDescriptor> for ManifestPackageDescriptor {
                 ManifestPackageDescriptor::StorePath(old)
             },
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn package_identifier_is_the_manifest_coordinate() {
+        let catalog: ManifestPackageDescriptor =
+            serde_json::from_value(json!({ "pkg-path": "python313Packages.pip" })).unwrap();
+        assert_eq!(catalog.package_identifier(), "python313Packages.pip");
+
+        let flake: ManifestPackageDescriptor =
+            serde_json::from_value(json!({ "flake": "github:NixOS/nixpkgs#hello" })).unwrap();
+        assert_eq!(flake.package_identifier(), "github:NixOS/nixpkgs#hello");
+
+        let store_path: ManifestPackageDescriptor =
+            serde_json::from_value(json!({ "store-path": "/nix/store/abc-hello" })).unwrap();
+        assert_eq!(store_path.package_identifier(), "/nix/store/abc-hello");
     }
 }

--- a/cli/flox/src/commands/upgrade.rs
+++ b/cli/flox/src/commands/upgrade.rs
@@ -1,8 +1,10 @@
 use anyhow::Result;
 use bpaf::Bpaf;
 use crossterm::style::Stylize;
-use flox_events::{CliEnvironmentPayload, CliPackagePayload, EventKind, EventsHub, Outcome};
+use flox_events::{CliEnvironmentPayload, CliPackageUpgradePayload, EventKind, EventsHub, Outcome};
+use flox_manifest::interfaces::{AsLatestSchema, PackageLookup};
 use flox_manifest::lockfile::LockedPackage;
+use flox_manifest::parsed::latest::ManifestPackageDescriptor;
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::{Environment, SingleSystemUpgradeDiff};
 use indoc::formatdoc;
@@ -157,16 +159,47 @@ impl Upgrade {
         warn_manifest_changes_for_services(&flox, &concrete_environment);
 
         let hub = EventsHub::global();
-        for (_, (before, _)) in diff_for_system.iter() {
-            if let Err(err) = hub.record_event(EventKind::CliPackageUpgrade(
-                CliPackagePayload::new(before.install_id().to_string(), Outcome::Success),
-            )) {
-                debug!(error = %err, "Failed to record v2 event");
+        hub.when_client_set(|| {
+            let manifest = result.new_lockfile.migrated_manifest().ok();
+            let manifest = manifest.as_ref().map(AsLatestSchema::as_latest_schema);
+            for (install_id, (before, after)) in diff_for_system.iter() {
+                let descriptor =
+                    manifest.and_then(|manifest| manifest.pkg_descriptor_with_id(install_id));
+                let payload = upgrade_payload(descriptor.as_ref(), install_id, before, after);
+                if let Err(err) = hub.record_event(EventKind::CliPackageUpgrade(payload)) {
+                    debug!(error = %err, "Failed to record v2 event");
+                }
             }
-        }
+        });
 
         Ok(())
     }
+}
+
+/// Build the per-package payload for a `cli.package.upgrade` event.
+///
+/// The package key is the manifest descriptor's coordinate — stable across
+/// upgrades and shared with the install events — falling back to the
+/// install id when the descriptor cannot be found. Empty version strings
+/// collapse to absent.
+fn upgrade_payload(
+    descriptor: Option<&ManifestPackageDescriptor>,
+    install_id: &str,
+    before: &LockedPackage,
+    after: &LockedPackage,
+) -> CliPackageUpgradePayload {
+    let package = descriptor
+        .map(|descriptor| descriptor.package_identifier().to_string())
+        .unwrap_or_else(|| install_id.to_string());
+    let mut payload =
+        CliPackageUpgradePayload::new(package, Outcome::Success).with_install_id(install_id);
+    if let Some(version) = before.version().filter(|version| !version.is_empty()) {
+        payload = payload.with_previous_version(version);
+    }
+    if let Some(version) = after.version().filter(|version| !version.is_empty()) {
+        payload = payload.with_version(version);
+    }
+    payload
 }
 
 /// Render a diff of locked packages before and after an upgrade.
@@ -220,6 +253,12 @@ fn rebuild_detail(before: &LockedPackage, after: &LockedPackage) -> Option<Strin
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use flox_events::test_helpers::MockEventsConnection;
+    use flox_events::{Event, EventsClient, SharedMetadataTemplate};
+    use flox_manifest::lockfile::test_helpers::fake_catalog_package_lock;
+    use flox_manifest::parsed::latest::PackageDescriptorCatalog;
     use flox_manifest::raw::PackageToInstall;
     use flox_rust_sdk::flox::test_helpers::flox_instance;
     use flox_rust_sdk::models::environment::Environment;
@@ -231,13 +270,168 @@ mod tests {
     use flox_rust_sdk::utils::logging::test_helpers::test_subscriber_message_only;
     use flox_test_utils::GENERATED_DATA;
     use indoc::indoc;
+    use serial_test::serial;
+    use tempfile::TempDir;
     use tracing::instrument::WithSubscriber;
+    use uuid::Uuid;
 
     use super::*;
     use crate::commands::EnvironmentSelect;
 
+    /// A mock-backed events client on the global hub, restored on drop so a
+    /// panicking assertion cannot leak it into the next test. Holders must
+    /// be `#[serial(global_events_client)]`.
+    struct MockHub {
+        previous: Option<EventsClient>,
+        sent_batches: Arc<Mutex<Vec<Vec<Event>>>>,
+        _buffer_dir: TempDir,
+    }
+
+    impl MockHub {
+        fn install() -> Self {
+            let buffer_dir = tempfile::tempdir().expect("tempdir");
+            let connection = MockEventsConnection::default();
+            let sent_batches = connection.sent_batches();
+            let client = EventsClient::new_with_connection(
+                Uuid::new_v4(),
+                buffer_dir.path(),
+                Uuid::new_v4(),
+                None,
+                SharedMetadataTemplate {
+                    flox_version: "0.0.0-test".to_string(),
+                    os_family: Some("Linux".to_string()),
+                    os_family_release: None,
+                    os: None,
+                    os_version: None,
+                    os_platform_version: None,
+                    shell: None,
+                    architecture: None,
+                    empty_flags: vec![],
+                    invocation_sources: vec!["shell".to_string()],
+                },
+                connection,
+            );
+            Self {
+                previous: EventsHub::global().set_client(client),
+                sent_batches,
+                _buffer_dir: buffer_dir,
+            }
+        }
+
+        /// Flushes, then returns the package-upgrade payloads that were sent.
+        fn package_upgrade_payloads(&self) -> Vec<CliPackageUpgradePayload> {
+            EventsHub::global().flush(true).expect("flush");
+            self.sent_batches
+                .lock()
+                .unwrap()
+                .iter()
+                .flatten()
+                .filter_map(|event| match &event.kind {
+                    EventKind::CliPackageUpgrade(payload) => Some(payload.clone()),
+                    _ => None,
+                })
+                .collect()
+        }
+    }
+
+    impl Drop for MockHub {
+        fn drop(&mut self) {
+            EventsHub::global().clear_client();
+            if let Some(previous) = self.previous.take() {
+                EventsHub::global().set_client(previous);
+            }
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[serial(global_events_client)]
+    async fn upgrade_records_previous_version_on_package_events() {
+        let (mut flox, _tempdir) = flox_instance();
+        let mut environment = new_named_path_environment(&flox, "version = 1", "name");
+
+        let response_path = if cfg!(target_os = "macos") {
+            "resolve/old_darwin_hello.yaml"
+        } else {
+            "resolve/old_linux_hello.yaml"
+        };
+        flox.floxhub_client = catalog_replay_client(GENERATED_DATA.join(response_path)).await;
+        // The replay fixtures were recorded with install id == pkg path, so
+        // the two coincide here; the coordinate-vs-id distinction is pinned
+        // by the upgrade_payload unit tests.
+        environment
+            .install(
+                &[PackageToInstall::parse(&flox.system, "hello").unwrap()],
+                &flox,
+            )
+            .unwrap();
+
+        flox.floxhub_client =
+            catalog_replay_client(GENERATED_DATA.join("resolve/hello.yaml")).await;
+
+        let hub = MockHub::install();
+        Upgrade {
+            environment: EnvironmentSelect::Dir(environment.parent_path().unwrap()),
+            dry_run: false,
+            groups_or_iids: Vec::new(),
+        }
+        .handle(flox)
+        .await
+        .unwrap();
+
+        assert_eq!(hub.package_upgrade_payloads(), vec![
+            CliPackageUpgradePayload::new("hello".to_string(), Outcome::Success)
+                .with_install_id("hello")
+                .with_previous_version("2.10.1")
+                .with_version("2.12.3")
+        ]);
+    }
+
+    #[test]
+    fn upgrade_payload_collapses_unknown_versions_and_falls_back_to_install_id() {
+        // The catalog fake locks version "" — the empty string must read as
+        // unknown on the wire, and a missing descriptor falls back to the
+        // install id as the package key.
+        let (install_id, _, locked) = fake_catalog_package_lock("hello", None);
+        let before = LockedPackage::Catalog(locked.clone());
+        let after = LockedPackage::Catalog(locked);
+        assert_eq!(
+            upgrade_payload(None, &install_id, &before, &after),
+            CliPackageUpgradePayload::new(install_id.clone(), Outcome::Success)
+                .with_install_id(&install_id)
+        );
+    }
+
+    #[test]
+    fn upgrade_payload_carries_descriptor_coordinate_and_both_versions() {
+        let (_, _, mut locked_before) = fake_catalog_package_lock("hello", None);
+        let mut locked_after = locked_before.clone();
+        locked_before.version = "2.10.1".to_string();
+        locked_after.version = "2.12.3".to_string();
+        let descriptor = ManifestPackageDescriptor::Catalog(PackageDescriptorCatalog {
+            pkg_path: "hello".to_string(),
+            pkg_group: None,
+            priority: None,
+            version: None,
+            systems: None,
+            outputs: None,
+        });
+        assert_eq!(
+            upgrade_payload(
+                Some(&descriptor),
+                "greeting",
+                &LockedPackage::Catalog(locked_before),
+                &LockedPackage::Catalog(locked_after),
+            ),
+            CliPackageUpgradePayload::new("hello".to_string(), Outcome::Success)
+                .with_install_id("greeting")
+                .with_previous_version("2.10.1")
+                .with_version("2.12.3")
+        );
+    }
+
     /// Check message printed when there are no upgrades available
     #[tokio::test(flavor = "multi_thread")]
+    #[serial(global_events_client)]
     async fn confirmation_when_up_to_date() {
         let (mut flox, _tempdir) = flox_instance();
         let (subscriber, writer) = test_subscriber_message_only();
@@ -303,6 +497,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    #[serial(global_events_client)]
     async fn upgrade_on_other_system() {
         assert_eq!(
             run_upgrade_with_upgrades_on_other_system(false).await,
@@ -315,6 +510,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    #[serial(global_events_client)]
     async fn upgrade_dry_run_on_other_system() {
         assert_eq!(
             run_upgrade_with_upgrades_on_other_system(true).await,
@@ -540,6 +736,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    #[serial(global_events_client)]
     async fn dry_run_shows_version_change_summary() {
         assert_eq!(run_dry_run_with_version_change().await, indoc! {"
             Dry run: 1 version change in 'name':


### PR DESCRIPTION
Upgrades are the one package action that knows which version a package moved *from*, and nothing recorded it ([AI-501](https://linear.app/floxdotdev/issue/AI-501)).

## What `cli.package.upgrade` now carries

The event gets its own payload (the shared package payload stays shape-identical for install/uninstall), emitted per upgraded package for the current system:

| Key | Value |
|---|---|
| `package` | The coordinate **as written in the manifest** — catalog pkg path, flake installable, or store path (`ManifestPackageDescriptor::package_identifier`). Same identity class as the install events, stable across upgrades. Previously this event emitted the manifest install id — a renamable label that diverges for aliased installs and even by default for nested paths (`pip` vs `python313Packages.pip`). Falls back to the install id if the descriptor lookup fails. |
| `install_id` | The per-invocation unique key — one coordinate installed under several ids upgrades as several rows, so `package` alone must not be deduped on. |
| `previous_version` / `version` | Before and after; each absent when unknown, with empty strings collapsed to absent. A rebuild without a version change carries the same value in both. |

## Compatibility: Mechanism A

Additive-optional keys; rows buffered by older producers round-trip unchanged (pinned). Install/uninstall wire output is pinned unchanged by their goldens; the envelope and legacy pipeline are untouched. The emit work sits behind `when_client_set`, so opted-out runs build no payloads.

## Notes for reviewers

- **Earlier upgrade rows carried install ids** — the two coincide for the common unaliased single-component case, so the divergent subset is smaller still. Correcting an earlier draft of this note: the v2 pipeline is **not** dormant in production — ~124 `cli.package.upgrade` rows exist (2026-07-16 → 2026-07-31). So this is a mid-stream meaning change to an existing key, not a no-op: rows written before this merge carry the install id in `package`, rows after carry the coordinate, and nothing on the wire distinguishes them apart from event date.
- **Flake caveat**: previous/post pairing against server-side resolution rows is not reconstructable for flakes (no resolution row) — which is why `version` rides the event itself rather than leaning on a cross-system join.
- `cli.package.uninstall` still emits the install id: its emit site has only the manifest modification in hand, and no version data rides it. Tracked follow-up.

## Testing

- Wire: full-fields golden, minimal golden (optional keys omitted, never null), old-row deserialize round-trip; unchanged install/uninstall goldens.
- `ManifestPackageDescriptor::package_identifier` pinned against hardcoded literals for all three variants; `upgrade_payload` unit tests pin the descriptor coordinate against a divergent install id, the empty-version collapse (the catalog fake really locks `version: ""`), and the missing-descriptor fallback.
- End-to-end: a real 2.10.1 → 2.12.3 upgrade via replay fixtures through a mock events hub, asserting the exact full payload. All sibling `Upgrade::handle` tests are in the `global_events_client` serial group.
- 656/656 nextest across flox-manifest / flox-events / flox; clippy and fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

