### PR TITLE
feat(nef): fail the catalog scan loudly on parse and IO errors

### DIFF
--- a/cli/nef-lock-catalog/src/bin/lock.rs
+++ b/cli/nef-lock-catalog/src/bin/lock.rs
@@ -69,10 +69,19 @@ struct Cli {
 async fn main() -> ExitCode {
     let cli = Cli::parse();
 
+    // A `warn` floor so the scanner's warnings are printed, scoped to this
+    // crate so a dependency's are not. `RUST_LOG` replaces it.
+    //
     // `--verbose` raises this crate's log level to `debug` on top of any
     // `RUST_LOG` setting; the file/reference/request diagnostics are emitted at
     // that level. Diagnostics go to stderr so `--out /dev/stdout` stays clean.
-    let mut filter = tracing_subscriber::EnvFilter::from_default_env();
+    let mut filter = tracing_subscriber::EnvFilter::builder()
+        .with_default_directive(
+            "nef_lock_catalog=warn"
+                .parse()
+                .expect("valid default directive"),
+        )
+        .from_env_lossy();
     if cli.verbose {
         filter = filter
             .add_directive("nef_lock_catalog=debug".parse().expect("valid directive"))

--- a/cli/nef-lock-catalog/src/bin/lock.rs
+++ b/cli/nef-lock-catalog/src/bin/lock.rs
@@ -91,9 +91,11 @@ async fn main() -> ExitCode {
     match run(cli).await {
         Ok(()) => ExitCode::SUCCESS,
         // Decorate the rendered message body with `✘ ERROR:` here — the single
-        // place presentation is applied.
+        // place presentation is applied. The alternate form appends the source
+        // chain, which is where a wrapped cause states what actually went
+        // wrong (a scan failure carries the rnix parse error that way).
         Err(err) => {
-            eprintln!("{}", format_error(err));
+            eprintln!("{}", format_error(format!("{err:#}")));
             ExitCode::FAILURE
         },
     }

--- a/cli/nef-lock-catalog/src/lib.rs
+++ b/cli/nef-lock-catalog/src/lib.rs
@@ -27,4 +27,12 @@ pub use lock::build_lock::{BuildLock, render_lock, write_lock};
 pub use lock::flakeref::NixFlakeref;
 pub use lock::lookup::{LockError, lock_references};
 pub use lock::render::render_unresolvable;
-pub use scan::{CatalogRef, ImportSite, ScanError, scan_package, scan_package_with_roots};
+pub use scan::{
+    CatalogRef,
+    ImportSite,
+    InvalidCatalogRef,
+    InvalidCatalogRefKind,
+    ScanError,
+    scan_package,
+    scan_package_with_roots,
+};

--- a/cli/nef-lock-catalog/src/lib.rs
+++ b/cli/nef-lock-catalog/src/lib.rs
@@ -27,4 +27,4 @@ pub use lock::build_lock::{BuildLock, render_lock, write_lock};
 pub use lock::flakeref::NixFlakeref;
 pub use lock::lookup::{LockError, lock_references};
 pub use lock::render::render_unresolvable;
-pub use scan::{CatalogRef, ScanError, scan_package, scan_package_with_roots};
+pub use scan::{CatalogRef, ImportSite, ScanError, scan_package, scan_package_with_roots};

--- a/cli/nef-lock-catalog/src/lib.rs
+++ b/cli/nef-lock-catalog/src/lib.rs
@@ -27,12 +27,4 @@ pub use lock::build_lock::{BuildLock, render_lock, write_lock};
 pub use lock::flakeref::NixFlakeref;
 pub use lock::lookup::{LockError, lock_references};
 pub use lock::render::render_unresolvable;
-pub use scan::{
-    CatalogRef,
-    ImportSite,
-    InvalidCatalogRef,
-    InvalidCatalogRefKind,
-    ScanError,
-    scan_package,
-    scan_package_with_roots,
-};
+pub use scan::{CatalogRef, ImportSite, ScanError, scan_package, scan_package_with_roots};

--- a/cli/nef-lock-catalog/src/lock/lookup.rs
+++ b/cli/nef-lock-catalog/src/lock/lookup.rs
@@ -39,17 +39,6 @@ pub enum LockError {
     #[error("{} catalog reference(s) were unresolvable", .0.len())]
     Unresolvable(Vec<UnresolvableEntry>),
 
-    /// The scan produced a root-level sentinel (`catalogs.*`): the expression
-    /// uses the whole catalog namespace in a way that cannot be analyzed
-    /// statically (e.g. passes `catalogs` to an opaque function or selects a
-    /// catalog dynamically). The wire form of such a reference (`*`) can
-    /// never resolve, so fail before making a request.
-    #[error(
-        "Cannot determine which catalogs the expression uses; it references the whole catalog namespace in a way that cannot be analyzed.\n\
-         Reference packages as 'catalogs.<catalog>.<package>', or forward 'catalogs' only through 'import' arguments."
-    )]
-    RootNamespaceEscape,
-
     /// The catalog lookup request itself failed.
     #[error(transparent)]
     Client(#[from] FloxhubClientError),
@@ -76,10 +65,6 @@ pub async fn lock_references(
     references: BTreeSet<CatalogRef>,
     stability: Stability,
 ) -> Result<BuildLock, LockError> {
-    if references.iter().any(is_root_sentinel) {
-        return Err(LockError::RootNamespaceEscape);
-    }
-
     let request = build_request(references, stability);
     // The exact JSON POSTed to `/build-inputs/lookup`, for `--verbose`. Guarded
     // so the request is only serialized when the level is enabled.
@@ -93,12 +78,6 @@ pub async fn lock_references(
 
     let response = client.build_inputs_lookup(request).await?;
     lock_from_response(response)
-}
-
-/// Whether a scanned reference is a root-level sentinel (`<root>.*`), whose
-/// wire form (`*`) the server can never resolve.
-fn is_root_sentinel(reference: &CatalogRef) -> bool {
-    reference.as_str().split_once('.').map(|(_root, rest)| rest) == Some("*")
 }
 
 /// Convert the reference list into the generated wire request.
@@ -177,29 +156,6 @@ mod tests {
     use serde_json::json;
 
     use super::*;
-
-    #[test]
-    fn root_sentinel_detected_only_at_root_level() {
-        let cases = [
-            // A root-level sentinel would go on the wire as `*`.
-            ("catalogs.*", true),
-            // Catalog and package sentinels expand server-side.
-            ("catalogs.myorg.*", false),
-            ("catalogs.myorg.pkg.*", false),
-            ("catalogs.myorg.pkg", false),
-        ];
-        let got: Vec<(&str, bool)> = cases
-            .iter()
-            .map(|(reference, _)| {
-                (
-                    *reference,
-                    is_root_sentinel(&CatalogRef::new_unchecked(*reference)),
-                )
-            })
-            .collect();
-        let expected: Vec<(&str, bool)> = cases.into_iter().collect();
-        assert_eq!(got, expected);
-    }
 
     #[test]
     fn build_request_maps_references_and_stability() {

--- a/cli/nef-lock-catalog/src/lock/lookup.rs
+++ b/cli/nef-lock-catalog/src/lock/lookup.rs
@@ -190,7 +190,12 @@ mod tests {
         ];
         let got: Vec<(&str, bool)> = cases
             .iter()
-            .map(|(reference, _)| (*reference, is_root_sentinel(&CatalogRef::from(*reference))))
+            .map(|(reference, _)| {
+                (
+                    *reference,
+                    is_root_sentinel(&CatalogRef::new_unchecked(*reference)),
+                )
+            })
             .collect();
         let expected: Vec<(&str, bool)> = cases.into_iter().collect();
         assert_eq!(got, expected);
@@ -199,8 +204,8 @@ mod tests {
     #[test]
     fn build_request_maps_references_and_stability() {
         let references = BTreeSet::from([
-            CatalogRef::from("catalogs.myorg.hello"),
-            CatalogRef::from("catalogs.myorg.world"),
+            CatalogRef::new_unchecked("catalogs.myorg.hello"),
+            CatalogRef::new_unchecked("catalogs.myorg.world"),
         ]);
 
         let wire = build_request(references, "stable".parse().unwrap());

--- a/cli/nef-lock-catalog/src/lock/lookup.rs
+++ b/cli/nef-lock-catalog/src/lock/lookup.rs
@@ -109,13 +109,21 @@ fn build_request(
 /// namespace is catalog-relative (`<catalog>.<package>`). Drop the leading root
 /// segment so the request matches what the server expects.
 fn wire_reference(reference: &CatalogRef) -> ReferencesItem {
-    let reference = reference.as_str();
-    let s = reference
-        .split_once('.')
-        .map(|(_root, rest)| rest.to_string())
-        .unwrap_or_else(|| reference.to_string());
+    // A reference always has a root to drop; that is what makes it one. The
+    // components go out as written rather than through `Display`, whose
+    // quoting is for reading a path back, not for the server's syntax.
+    let relative = reference
+        .path()
+        .components()
+        .iter()
+        .skip(1)
+        .map(|component| component.name().unwrap_or("*"))
+        .collect::<Vec<_>>()
+        .join(".");
     // Catalog paths are well below the 1024-char wire limit.
-    s.parse().expect("catalog reference exceeded 1024 chars")
+    relative
+        .parse()
+        .expect("catalog reference exceeded 1024 chars")
 }
 
 /// Map a lookup response into a [BuildLock], or fail with the unresolvable

--- a/cli/nef-lock-catalog/src/lock/lookup.rs
+++ b/cli/nef-lock-catalog/src/lock/lookup.rs
@@ -113,7 +113,11 @@ fn wire_reference(reference: &CatalogRef) -> ReferencesItem {
     // attribute Nix would not read bare goes out quoted, which the dotted wire
     // format needs to stay unambiguous — it cannot express a name containing a
     // `.` any other way.
-    let relative = reference.path().pop_root().to_string();
+    let relative = reference
+        .path()
+        .pop_root()
+        .expect("a reference names something under its root")
+        .to_string();
     // Catalog paths are well below the 1024-char wire limit.
     relative
         .parse()

--- a/cli/nef-lock-catalog/src/lock/lookup.rs
+++ b/cli/nef-lock-catalog/src/lock/lookup.rs
@@ -109,17 +109,11 @@ fn build_request(
 /// namespace is catalog-relative (`<catalog>.<package>`). Drop the leading root
 /// segment so the request matches what the server expects.
 fn wire_reference(reference: &CatalogRef) -> ReferencesItem {
-    // A reference always has a root to drop; that is what makes it one. The
-    // components go out as written rather than through `Display`, whose
-    // quoting is for reading a path back, not for the server's syntax.
-    let relative = reference
-        .path()
-        .components()
-        .iter()
-        .skip(1)
-        .map(|component| component.name().unwrap_or("*"))
-        .collect::<Vec<_>>()
-        .join(".");
+    // A reference always has a root to drop; that is what makes it one. An
+    // attribute Nix would not read bare goes out quoted, which the dotted wire
+    // format needs to stay unambiguous — it cannot express a name containing a
+    // `.` any other way.
+    let relative = reference.path().pop_root().to_string();
     // Catalog paths are well below the 1024-char wire limit.
     relative
         .parse()

--- a/cli/nef-lock-catalog/src/scan/analyze.rs
+++ b/cli/nef-lock-catalog/src/scan/analyze.rs
@@ -14,23 +14,29 @@ use rowan::ast::AstNode;
 use tracing::{debug, warn};
 
 use super::attr_path::{attr_static_name, ident_name, static_str_content};
-use super::{
-    AttrPath,
-    CatalogRef,
-    Component,
-    ImportSite,
-    InvalidCatalogRef,
-    InvalidCatalogRefKind,
-    ScanError,
-};
+use super::{AttrPath, Component, ImportSite, ScanError};
+
+/// Where a path was first found. Kept alongside the path so that one which
+/// turns out to be unlockable — only decidable once forwarding has rewritten
+/// it into the top-level namespace — is still reported against the file and
+/// line it came from.
+#[derive(Debug, Clone)]
+pub(super) struct RefSource {
+    pub(super) file: PathBuf,
+    pub(super) position: (usize, usize),
+}
 
 /// Catalog references and dependency attr-paths extracted from one file.
 #[derive(Debug)]
 pub(super) struct FileInfo {
-    /// Fully-qualified catalog attr-paths referenced by the file
-    /// (e.g. `catalogs.myorg.toolkit.readVersion`). Tracked as [CatalogRef]
-    /// from the scan result onward; the walker builds them as strings.
-    pub(super) refs: BTreeSet<CatalogRef>,
+    /// Catalog attr-paths referenced by the file, rewritten into the
+    /// namespace of whoever imported it, each with the source it was found at.
+    ///
+    /// Paths rather than [CatalogRef]s: whether one can be locked depends on
+    /// its depth below the top-level root, which a file scanned through a
+    /// forwarded namespace does not know. The graph converts them once the
+    /// rewriting is done.
+    pub(super) refs: BTreeMap<AttrPath, RefSource>,
     /// Attr-paths of the packages this file depends on, resolved by the
     /// package graph's closure expansion. The first component is the
     /// dependency argument; any further components are members selected on it
@@ -50,6 +56,15 @@ struct ScanCtx<'a> {
 }
 
 impl ScanCtx<'_> {
+    /// Where in this file `offset` falls, for reporting a path that turns out
+    /// not to be lockable.
+    fn source_at(&self, offset: usize) -> RefSource {
+        RefSource {
+            file: self.path.to_path_buf(),
+            position: line_col(self.content, offset),
+        }
+    }
+
     /// Emit a `debug` event locating one discovered reference at `offset` (a
     /// byte offset into the file). Surfaced by `lock --verbose`.
     fn report(&self, offset: usize, reference: &str) {
@@ -171,9 +186,9 @@ pub(super) fn analyze_file_at(
     content: &str,
     root_attributes: &HashSet<String>,
     file_dir: Option<&Path>,
-    visited: &mut HashMap<PathBuf, HashSet<BTreeMap<String, String>>>,
+    visited: &mut HashMap<PathBuf, HashSet<BTreeMap<String, AttrPath>>>,
     path: &Path,
-    root_origins: &BTreeMap<String, String>,
+    root_origins: &BTreeMap<String, AttrPath>,
 ) -> Result<FileInfo, ScanError> {
     debug!(file = %path.display(), "reading NEF expression");
 
@@ -233,13 +248,17 @@ pub(super) fn analyze_file_at(
     collect_dependency_selections(root.syntax(), &dependency_arg_names, &mut dependency_args);
 
     let ctx = ScanCtx { path, content };
-    let mut walker = Walker::new(root_attributes, declared_params.as_ref(), ctx);
+    let mut walker = Walker::new(
+        root_attributes,
+        declared_params.as_ref(),
+        ctx.clone(),
+        root_origins,
+    );
     walker.walk_root(&root);
     let WalkResult {
         mut refs,
         pending_imports,
         first_root_use,
-        mut rejected_refs,
     } = walker.finish();
 
     // Imports are IO: the walker only records facts, the drain here reads and
@@ -270,31 +289,23 @@ pub(super) fn analyze_file_at(
                 })?;
             // The child is scanned with its own parameter names as root_attributes;
             // its refs are rewritten back into the parent's namespace.
-            let rewrites: HashMap<String, String> = match pending.arg {
+            let rewrites: BTreeMap<String, AttrPath> = match pending.arg {
                 ImportArg::Set(forwards) => forwards,
-                ImportArg::Root(parent_root) => {
+                ImportArg::Whole(parent) => {
                     match top_ident_param(&imported_content, &target)? {
-                        Some(param) => HashMap::from([(param, parent_root)]),
+                        Some(param) => BTreeMap::from([(param, parent)]),
                         None => {
                             // A pattern parameter destructures the namespace into
                             // names the scanner cannot statically bind, so
-                            // anything under the root may be referenced: it
-                            // escapes whole rather than being dropped.
+                            // anything under it may be referenced: it escapes
+                            // whole rather than being dropped.
                             warn!(
                                 file = %target.display(),
-                                root = %parent_root,
-                                "imported file does not take the namespace as a plain parameter; locking the whole root",
+                                namespace = %parent,
+                                "imported file does not take the namespace as a plain parameter; locking the whole subtree",
                             );
-                            let reason = InvalidCatalogRef {
-                                path: AttrPath::root(&parent_root).append_wildcard(),
-                                kind: InvalidCatalogRefKind::RootWildcard,
-                            };
-                            rejected_refs
-                                .entry(reason.path.clone())
-                                .or_insert(RejectedRef {
-                                    offset: pending.offset,
-                                    reason: reason.to_string(),
-                                });
+                            refs.entry(parent.append_wildcard())
+                                .or_insert_with(|| ctx.source_at(pending.offset));
                             continue;
                         },
                     }
@@ -307,12 +318,9 @@ pub(super) fn analyze_file_at(
             // being stored: two chains whose immediate maps look identical can
             // still stand for different top-level root_attributes, and only an identical
             // composition contributes identical refs.
-            let child_origins: BTreeMap<String, String> = rewrites
+            let child_origins: BTreeMap<String, AttrPath> = rewrites
                 .iter()
-                .map(|(child, parent)| {
-                    let origin = root_origins.get(parent).unwrap_or(parent);
-                    (child.clone(), origin.clone())
-                })
+                .map(|(child, parent)| (child.clone(), rewrite_root(parent, root_origins)))
                 .collect();
             if !visited
                 .entry(target.clone())
@@ -331,24 +339,12 @@ pub(super) fn analyze_file_at(
                 &target,
                 &child_origins,
             )?;
-            // Rewriting only replaces the leading component, so a reference
-            // valid in the child stays valid in the parent; the conversion
-            // routes any surprise through the same reporting as the walk's.
-            for reference in imported.refs {
-                let rewritten = rewrite_root(reference.path(), &rewrites);
-                match CatalogRef::try_from(rewritten) {
-                    Ok(reference) => {
-                        refs.insert(reference);
-                    },
-                    Err(reason) => {
-                        rejected_refs
-                            .entry(reason.path.clone())
-                            .or_insert(RejectedRef {
-                                offset: pending.offset,
-                                reason: reason.to_string(),
-                            });
-                    },
-                }
+            // The child's paths move into this file's namespace, keeping the
+            // source they were found at so a path that cannot be locked is
+            // still reported against the file that wrote it.
+            for (child_path, source) in imported.refs {
+                refs.entry(rewrite_root(&child_path, &rewrites))
+                    .or_insert(source);
             }
         }
     }
@@ -356,12 +352,6 @@ pub(super) fn analyze_file_at(
     // With the refs complete (imports included), reject any that resolve
     // through a root the top-level lambda does not declare — they could never
     // evaluate. Roots are checked in sorted order for a deterministic error.
-    //
-    // Rejected references are searched alongside the kept ones. A file like
-    // `{ mkDerivation }: mkDerivation { passthru = catalogs; }` uses the root
-    // but contributes nothing to `refs`, so searching `refs` alone would not
-    // see `catalogs` used at all and would fall through to the rejection,
-    // which says less than naming the undeclared argument.
     if let Some(declared) = &declared_params {
         let mut undeclared: Vec<&String> = root_attributes
             .iter()
@@ -370,10 +360,8 @@ pub(super) fn analyze_file_at(
         undeclared.sort();
         for root in undeclared {
             let referenced = refs
-                .iter()
-                .map(|reference| reference.path().root_name())
-                .chain(rejected_refs.keys().map(AttrPath::root_name))
-                .any(|name| name == Some(root.as_str()));
+                .keys()
+                .any(|path| path.root_name() == Some(root.as_str()));
             if referenced {
                 return Err(ScanError::UndeclaredRoot {
                     root: root.clone(),
@@ -386,18 +374,6 @@ pub(super) fn analyze_file_at(
         }
     }
 
-    // A namespace that escaped static analysis widened to a reference
-    // [CatalogRef] refuses. Reporting it here, rather than where the lock
-    // request is built, is what gives the failure a file and a position; the
-    // first by name keeps the choice independent of traversal order.
-    if let Some((_, rejected)) = rejected_refs.pop_first() {
-        return Err(ScanError::UnlockableReference {
-            file: path.to_path_buf(),
-            position: Some(line_col(content, rejected.offset)),
-            reason: rejected.reason,
-        });
-    }
-
     Ok(FileInfo {
         refs,
         dependency_args,
@@ -406,10 +382,10 @@ pub(super) fn analyze_file_at(
 
 /// The identity `root_origins` map for an entry file, whose root_attributes are the
 /// top-level root_attributes themselves (see [analyze_file_at]).
-pub(super) fn identity_origins(root_attributes: &HashSet<String>) -> BTreeMap<String, String> {
+pub(super) fn identity_origins(root_attributes: &HashSet<String>) -> BTreeMap<String, AttrPath> {
     root_attributes
         .iter()
-        .map(|root| (root.clone(), root.clone()))
+        .map(|root| (root.clone(), AttrPath::root(root)))
         .collect()
 }
 
@@ -494,14 +470,18 @@ struct PendingImport {
 }
 
 /// The catalog-forwarding shape of an import's argument.
+///
+/// A forward carries a path, not just a root: `{ myorg = catalogs.myorg; }`
+/// hands the child a catalog, and its refs come back under
+/// `catalogs.myorg.…` rather than the child's own parameter name.
 #[derive(Debug)]
 enum ImportArg {
-    /// An attrset argument: child parameter name → parent root it is bound
-    /// to (`{ inherit catalogs; }`, `{ cats = catalogs; }`).
-    Set(HashMap<String, String>),
-    /// The whole argument is a root namespace (`import ./h.nix catalogs`);
-    /// the child's lambda parameter binds this parent root.
-    Root(String),
+    /// An attrset argument: child parameter name → the parent path it is
+    /// bound to (`{ inherit catalogs; }`, `{ cats = catalogs; }`).
+    Set(BTreeMap<String, AttrPath>),
+    /// The whole argument is a catalog path (`import ./h.nix catalogs`); the
+    /// child's lambda parameter binds it.
+    Whole(AttrPath),
 }
 
 /// What consumes an attrset appearing in value position, deciding which of
@@ -514,7 +494,7 @@ enum AttrsetConsumer<'a> {
     /// An `import` application: names forwarded into the imported file (per
     /// [Walker::import_forwards]) are scanned through it; a root-named entry
     /// that does not forward is warned about.
-    Import(&'a HashMap<String, String>),
+    Import(&'a BTreeMap<String, AttrPath>),
     /// A lambda defined in this file: an entry binding a root under a
     /// parameter of the same name was already walked in the body.
     Lambda(&'a HashSet<String>),
@@ -531,31 +511,26 @@ struct Walker<'a> {
     /// hides them (see the declaration check in [analyze_file_at]).
     declared_params: Option<&'a HashSet<String>>,
     ctx: ScanCtx<'a>,
-    refs: BTreeSet<CatalogRef>,
+    /// Each root this file knows mapped to the top-level path it stands for.
+    /// A file scanned through a forwarded namespace writes paths shortened by
+    /// the prefix it was handed, so depth is judged against where a path will
+    /// end up rather than how it reads here.
+    root_origins: &'a BTreeMap<String, AttrPath>,
+    /// Paths reached, each with where it was first found. Not [CatalogRef]s:
+    /// the walk stays infallible, and lockability is decided once the graph
+    /// has every path in the top-level namespace.
+    refs: BTreeMap<AttrPath, RefSource>,
     pending_imports: Vec<PendingImport>,
     /// Byte offset of the first use of each root, for locating an
     /// undeclared-root error after the walk.
     first_root_use: HashMap<String, usize>,
-    /// Paths [CatalogRef] refused, keyed by the path — which the
-    /// undeclared-root check still needs to attribute to a root. Collected
-    /// rather than raised so the walk stays infallible; [analyze_file_at]
-    /// reports the first once the refs are complete.
-    rejected_refs: BTreeMap<AttrPath, RejectedRef>,
-}
-
-/// Where a path [CatalogRef] refused was first emitted, and what the rule that
-/// refused it said. The reason is kept rendered: nothing inspects it.
-struct RejectedRef {
-    offset: usize,
-    reason: String,
 }
 
 /// What [Walker::finish] hands back to the IO drain in [analyze_file_at].
 struct WalkResult {
-    refs: BTreeSet<CatalogRef>,
+    refs: BTreeMap<AttrPath, RefSource>,
     pending_imports: Vec<PendingImport>,
     first_root_use: HashMap<String, usize>,
-    rejected_refs: BTreeMap<AttrPath, RejectedRef>,
 }
 
 impl<'a> Walker<'a> {
@@ -565,16 +540,24 @@ impl<'a> Walker<'a> {
         root_attributes: &'a HashSet<String>,
         declared_params: Option<&'a HashSet<String>>,
         ctx: ScanCtx<'a>,
+        root_origins: &'a BTreeMap<String, AttrPath>,
     ) -> Self {
         Self {
             root_attributes,
             declared_params,
             ctx,
-            refs: BTreeSet::new(),
+            root_origins,
+            refs: BTreeMap::new(),
             pending_imports: Vec::new(),
             first_root_use: HashMap::new(),
-            rejected_refs: BTreeMap::new(),
         }
+    }
+
+    /// Whether a path reaches a package once it is back in the top-level
+    /// namespace, which is the depth that decides both widening and, later,
+    /// lockability.
+    fn reaches_package(&self, path: &AttrPath) -> bool {
+        reaches_package(&rewrite_root(path, self.root_origins))
     }
 
     /// Walk the file's top-level expression, seeding the environment with the
@@ -599,32 +582,18 @@ impl<'a> Walker<'a> {
             refs: self.refs,
             pending_imports: self.pending_imports,
             first_root_use: self.first_root_use,
-            rejected_refs: self.rejected_refs,
         }
     }
 
-    /// Record the reference a resolved path denotes, or — when it is one
-    /// [CatalogRef] refuses — why, so [analyze_file_at] can report it.
+    /// Record the path a use site resolves to, and where it was found.
+    /// Whether it can be locked is decided once forwarding has put it in the
+    /// top-level namespace, so nothing is rejected here.
     fn emit(&mut self, offset: usize, path: AttrPath) {
         self.note_root_use(offset, &path);
-        match CatalogRef::try_from(path) {
-            Ok(reference) => {
-                self.ctx.report(offset, &reference.to_string());
-                self.refs.insert(reference);
-            },
-            Err(reason) => self.note_rejected_ref(offset, reason),
-        }
-    }
-
-    /// Record why [CatalogRef] refused a reference, and where it was first
-    /// emitted.
-    fn note_rejected_ref(&mut self, offset: usize, reason: InvalidCatalogRef) {
-        self.rejected_refs
-            .entry(reason.path.clone())
-            .or_insert(RejectedRef {
-                offset,
-                reason: reason.to_string(),
-            });
+        self.ctx.report(offset, &path.to_string());
+        self.refs
+            .entry(path)
+            .or_insert_with(|| self.ctx.source_at(offset));
     }
 
     /// Record where the root a path is rooted at was first used.
@@ -703,15 +672,15 @@ impl<'a> Walker<'a> {
     /// under it may be accessed.
     fn emit_value_paths(&mut self, offset: usize, paths: BTreeSet<AttrPath>) {
         for path in paths {
-            if reaches_package(&path) {
+            if self.reaches_package(&path) {
                 self.emit(offset, path);
                 continue;
             }
             // A catalog widened to `<root>.<catalog>.*` over-locks but still
-            // resolves, so it is worth a warning. Widening the root itself is
-            // rejected outright by [analyze_file_at] and needs none.
+            // resolves, so it is worth a warning. Widening the root itself
+            // reaches nothing and the graph rejects it, needing none.
             let widened = path.append_wildcard();
-            if reaches_package(&widened) {
+            if self.reaches_package(&widened) {
                 self.ctx.warn_escape(offset, &widened.to_string());
             }
             self.emit(offset, widened);
@@ -722,9 +691,18 @@ impl<'a> Walker<'a> {
     /// positions where shallow paths are consumed rather than escaping.
     fn emit_deep_paths(&mut self, offset: usize, paths: BTreeSet<AttrPath>) {
         for path in paths {
-            if reaches_package(&path) {
+            if self.reaches_package(&path) {
                 self.emit(offset, path);
             }
+        }
+    }
+
+    /// A path that stops short of a package, widened so it names everything
+    /// under itself instead. Already-deep paths are returned unchanged.
+    fn widen_to_package(&self, path: AttrPath) -> AttrPath {
+        match self.reaches_package(&path) {
+            true => path,
+            false => path.append_wildcard(),
         }
     }
 
@@ -1030,7 +1008,7 @@ impl<'a> Walker<'a> {
                 };
                 // A static key can still land on a catalog, which reaches
                 // nothing on its own, so it widens.
-                self.emit(offset_of(apply.syntax()), widen_to_package(path));
+                self.emit(offset_of(apply.syntax()), self.widen_to_package(path));
             }
             self.walk_consumed_source(&target, env);
             if let Some(key) = key {
@@ -1097,8 +1075,8 @@ impl<'a> Walker<'a> {
                     // Forwarding is a use of each parent root: refs surfacing
                     // from the import trace back to this argument.
                     let arg_offset = offset_of(attrset.syntax());
-                    for parent_root in forwards.values() {
-                        self.note_root_use(arg_offset, &AttrPath::root(parent_root));
+                    for parent in forwards.values() {
+                        self.note_root_use(arg_offset, parent);
                     }
                     self.pending_imports.push(PendingImport {
                         path,
@@ -1109,21 +1087,21 @@ impl<'a> Walker<'a> {
                 true
             },
             other => {
-                // `import ./h.nix catalogs` — the whole namespace is the
+                // `import ./h.nix catalogs` — the namespace itself is the
                 // argument, consumed by following the import.
-                if let Some(Binding::Path(root_path)) = resolve_expr_binding(other, env)
-                    && let Some(root) = root_path.as_whole_root()
-                {
-                    let root = root.to_string();
-                    self.note_root_use(offset_of(other.syntax()), &root_path);
-                    self.pending_imports.push(PendingImport {
-                        path,
-                        arg: ImportArg::Root(root),
-                        offset,
-                    });
-                    return true;
+                let Some(Binding::Path(parent)) = resolve_expr_binding(other, env) else {
+                    return false;
+                };
+                if reaches_package(&parent) {
+                    return false;
                 }
-                false
+                self.note_root_use(offset_of(other.syntax()), &parent);
+                self.pending_imports.push(PendingImport {
+                    path,
+                    arg: ImportArg::Whole(parent),
+                    offset,
+                });
+                true
             },
         }
     }
@@ -1202,8 +1180,8 @@ impl<'a> Walker<'a> {
     /// `cats = catalogs;`). A binding that *names* a root but is bound to
     /// something else is not forwarded; [Self::walk_import_arg] warns about
     /// it — the imported file will not be scanned through it.
-    fn import_forwards(&self, arg: &ast::AttrSet, env: &Env) -> HashMap<String, String> {
-        let mut forwards = HashMap::new();
+    fn import_forwards(&self, arg: &ast::AttrSet, env: &Env) -> BTreeMap<String, AttrPath> {
+        let mut forwards = BTreeMap::new();
         for entry in arg.attrpath_values() {
             let Some(attrpath) = entry.attrpath() else {
                 continue;
@@ -1217,9 +1195,9 @@ impl<'a> Walker<'a> {
             };
             let Some(value) = entry.value() else { continue };
             if let Some(Binding::Path(path)) = resolve_expr_binding(&value, env)
-                && let Some(root) = path.as_whole_root()
+                && !reaches_package(&path)
             {
-                forwards.insert(name, root.to_string());
+                forwards.insert(name, path);
             }
         }
         for inherit in arg.inherits() {
@@ -1237,9 +1215,9 @@ impl<'a> Walker<'a> {
                     (true, _) => None,
                 };
                 if let Some(Binding::Path(path)) = binding
-                    && let Some(root) = path.as_whole_root()
+                    && !reaches_package(&path)
                 {
-                    forwards.insert(name, root.to_string());
+                    forwards.insert(name, path);
                 }
             }
         }
@@ -1254,7 +1232,7 @@ impl<'a> Walker<'a> {
                         // A select can land on a catalog, which reaches
                         // nothing on its own, so it widens.
                         for path in paths {
-                            self.emit(offset_of(select.syntax()), widen_to_package(path));
+                            self.emit(offset_of(select.syntax()), self.widen_to_package(path));
                         }
                     },
                     // The select reaches a modeled set (`t.sub`) used as a
@@ -1689,15 +1667,6 @@ fn reaches_package(path: &AttrPath) -> bool {
     }
 }
 
-/// A path that stops short of a package, widened so it names everything under
-/// itself instead. Already-deep paths are returned unchanged.
-fn widen_to_package(path: AttrPath) -> AttrPath {
-    match reaches_package(&path) {
-        true => path,
-        false => path.append_wildcard(),
-    }
-}
-
 /// The binding `inherit (<source>) <name>;` produces for `name`, given the
 /// source's binding: one more component on an attr-path, or a member of a
 /// modeled set.
@@ -1778,14 +1747,14 @@ fn top_ident_param(content: &str, path: &Path) -> Result<Option<String>, ScanErr
 /// Rewrite a child-rooted path back to the parent's namespace using the
 /// child-name → parent-root map of the import that forwarded it. Only the root
 /// changes, so a path valid in the child stays valid in the parent.
-fn rewrite_root(path: &AttrPath, rewrites: &HashMap<String, String>) -> AttrPath {
+fn rewrite_root(path: &AttrPath, rewrites: &BTreeMap<String, AttrPath>) -> AttrPath {
     let Some(parent) = path.root_name().and_then(|root| rewrites.get(root)) else {
         return path.clone();
     };
     path.components()
         .iter()
         .skip(1)
-        .fold(AttrPath::root(parent), |path, component| match component {
+        .fold(parent.clone(), |path, component| match component {
             Component::Attribute(name) => path.append_attribute(name),
             Component::Wildcard => path.append_wildcard(),
         })
@@ -1859,8 +1828,14 @@ mod tests {
         .expect("scan should succeed")
     }
 
-    fn refs(content: &str, root_attributes: &HashSet<String>) -> BTreeSet<CatalogRef> {
-        analyze_file(content, root_attributes).refs
+    /// The paths a file resolves to, rendered. Lockability is the graph's
+    /// call, so these are what the walk found, not what survives conversion.
+    fn refs(content: &str, root_attributes: &HashSet<String>) -> BTreeSet<String> {
+        rendered(analyze_file(content, root_attributes).refs)
+    }
+
+    fn rendered(refs: BTreeMap<AttrPath, RefSource>) -> BTreeSet<String> {
+        refs.into_keys().map(|path| path.to_string()).collect()
     }
 
     fn scan_err(content: &str, root_attributes: &HashSet<String>) -> ScanError {
@@ -1875,12 +1850,12 @@ mod tests {
         .expect_err("scan should fail")
     }
 
-    fn refs_at(path: &str, root_attributes: &HashSet<String>) -> BTreeSet<CatalogRef> {
+    fn refs_at(path: &str, root_attributes: &HashSet<String>) -> BTreeSet<String> {
         let path = Path::new(path);
         let content = fs::read_to_string(path).expect("test fixture missing");
         let dir = path.parent();
         let mut visited = HashMap::new();
-        analyze_file_at(
+        let info = analyze_file_at(
             &content,
             root_attributes,
             dir,
@@ -1888,8 +1863,8 @@ mod tests {
             path,
             &identity_origins(root_attributes),
         )
-        .expect("scan should succeed")
-        .refs
+        .expect("scan should succeed");
+        rendered(info.refs)
     }
 
     fn scan_err_at(path: &str, root_attributes: &HashSet<String>) -> ScanError {
@@ -1908,8 +1883,8 @@ mod tests {
         .expect_err("scan should fail")
     }
 
-    fn set(items: &[&str]) -> BTreeSet<CatalogRef> {
-        items.iter().map(|s| CatalogRef::new_unchecked(s)).collect()
+    fn set(items: &[&str]) -> BTreeSet<String> {
+        items.iter().map(|s| s.to_string()).collect()
     }
 
     #[test]
@@ -2002,8 +1977,8 @@ mod tests {
             include_str!("../../test_data/catalog_refs/multi-attr-inherit.nix"),
             &root_attributes(&["catalogs"]),
         );
-        assert!(!got.contains(&CatalogRef::new_unchecked("catalogs.myorg.python3Packages")));
-        assert!(!got.contains(&CatalogRef::new_unchecked("catalogs.myorg.toolkit")));
+        assert!(!got.contains("catalogs.myorg.python3Packages"));
+        assert!(!got.contains("catalogs.myorg.toolkit"));
     }
 
     #[test]
@@ -2200,7 +2175,7 @@ mod tests {
             include_str!("../../test_data/catalog_refs/with-namespace.nix"),
             &root_attributes(&["catalogs"]),
         );
-        assert!(!got.contains(&CatalogRef::new_unchecked("catalogs.myorg")));
+        assert!(!got.contains("catalogs.myorg"));
     }
 
     #[test]
@@ -2209,10 +2184,7 @@ mod tests {
             "{ catalogs }: let org = catalogs.myorg; in with org; toolkit",
             &root_attributes(&["catalogs"]),
         );
-        assert!(
-            got.contains(&CatalogRef::new_unchecked("catalogs.myorg.*")),
-            "got: {got:?}"
-        );
+        assert!(got.contains("catalogs.myorg.*"), "got: {got:?}");
     }
 
     #[test]
@@ -2335,10 +2307,7 @@ mod tests {
             "{ catalogs, x }: let a = if x then a.sub else catalogs.b.pkg; in a",
             &root_attributes(&["catalogs"]),
         );
-        assert!(
-            got.contains(&CatalogRef::new_unchecked("catalogs.b.pkg")),
-            "got: {got:?}"
-        );
+        assert!(got.contains("catalogs.b.pkg"), "got: {got:?}");
     }
 
     #[test]
@@ -2429,34 +2398,27 @@ mod tests {
     }
 
     #[test]
-    fn escaping_root_namespace_is_an_error() {
-        // Widening a whole catalog over-locks but still resolves; widening the
-        // root itself yields a reference whose wire form is `*`, so the scan
-        // fails instead of emitting one.
+    fn escaping_root_namespace_widens_to_the_root() {
+        // The walk records the widening; that a root wildcard cannot be locked
+        // is the graph's call, once forwarding has settled every path (see
+        // `root_wildcard_fails_the_scan`).
         let cases = [
             // The root escapes into an opaque function.
-            ("{ catalogs, f }: f catalogs", (1, 20)),
+            "{ catalogs, f }: f catalogs",
             // Escape positions other than function arguments.
-            ("{ catalogs }: [ catalogs ]", (1, 17)),
-            ("{ catalogs, f }: f { inherit catalogs; }", (1, 30)),
+            "{ catalogs }: [ catalogs ]",
+            "{ catalogs, f }: f { inherit catalogs; }",
             // Helper-lambda indirection: the lambda parameter is opaque, so
             // the refs inside it are invisible and the root escapes whole.
-            (
-                "{ catalogs }: let f = c: c.myorg.toolkit; in f catalogs",
-                (1, 48),
-            ),
+            "{ catalogs }: let f = c: c.myorg.toolkit; in f catalogs",
             // The @-name carries the root, so passing it whole escapes the
             // root like `f catalogs` does.
-            ("args@{ catalogs, f, ... }: f args", (1, 30)),
+            "args@{ catalogs, f, ... }: f args",
         ];
-        for (content, position) in cases {
-            let err = scan_err(content, &root_attributes(&["catalogs"]));
-            assert_matches!(
-                err,
-                ScanError::UnlockableReference { file, position: got, reason }
-                    if file == Path::new("test.nix")
-                        && got == Some(position)
-                        && reason == "'catalogs.*' references the whole catalog namespace",
+        for content in cases {
+            assert_eq!(
+                refs(content, &root_attributes(&["catalogs"])),
+                set(&["catalogs.*"]),
                 "content: {content}"
             );
         }
@@ -2501,12 +2463,12 @@ mod tests {
         }
         // A lambda that binds the namespace under a different name cannot be
         // matched to the set's root member (and its body is walked with an
-        // opaque parameter), so the root escapes and the scan fails.
-        let err = scan_err(
+        // opaque parameter), so the root escapes.
+        let got = refs(
             "args@{ catalogs, ... }: let mkPkg = { cats }: cats.myorg.inner; in mkPkg args",
             &root_attributes(&["catalogs"]),
         );
-        assert_matches!(err, ScanError::UnlockableReference { .. });
+        assert_eq!(got, set(&["catalogs.*"]));
     }
 
     #[test]
@@ -2755,11 +2717,11 @@ mod tests {
         // The `with` namespace is dynamic at the catalog component, so it
         // widens to the root even though the dynamic component holds a
         // resolvable ref of its own.
-        let err = scan_err(
+        let got = refs(
             "{ catalogs }: with catalogs.${catalogs.a.name}; toolkit",
             &root_attributes(&["catalogs"]),
         );
-        assert_matches!(err, ScanError::UnlockableReference { .. });
+        assert_eq!(got, set(&["catalogs.*", "catalogs.a.name"]));
     }
 
     #[test]
@@ -2801,13 +2763,13 @@ mod tests {
 
     #[test]
     fn dynamic_attr_at_first_component_escapes_the_root() {
-        // A dynamic catalog name could be any catalog, so the reference widens
-        // to the root and cannot be locked.
-        let err = scan_err(
+        // A dynamic catalog name could be any catalog, so the path widens to
+        // the root.
+        let got = refs(
             "{ catalogs, org }: catalogs.${org}.pkg",
             &root_attributes(&["catalogs"]),
         );
-        assert_matches!(err, ScanError::UnlockableReference { .. });
+        assert_eq!(got, set(&["catalogs.*"]));
     }
 
     #[test]
@@ -2916,17 +2878,8 @@ mod tests {
     fn import_arg_namespace_not_forwarded_escapes() {
         let cases: &[(&str, &[&str])] = &[
             // A catalog-level alias as an import argument is not forwarded
-            // (only whole root_attributes are), so the child uses the namespace where
-            // the scanner cannot see it: it escapes.
-            (
-                "{ catalogs }: let org = catalogs.myorg; in import ./x.nix { dep = org; }",
-                &["catalogs.myorg.*"],
-            ),
-            (
-                "{ catalogs }: let org = catalogs.myorg; in import ./x.nix { inherit org; }",
-                &["catalogs.myorg.*"],
-            ),
-            // A modeled set argument escapes through its members.
+            // A modeled set argument is not a path, so it is not forwarded and
+            // escapes through its members.
             (
                 "{ catalogs }: let s = { org = catalogs.myorg; }; in import ./x.nix { arg = s; }",
                 &["catalogs.myorg.*"],
@@ -2980,18 +2933,32 @@ mod tests {
     }
 
     #[test]
+    fn import_narrowed_namespace_is_followed_and_rewritten() {
+        // A catalog forwarded into a helper is scanned through, and the
+        // helper's paths come back under it. `myorg.pkg` is one component in
+        // the helper but package-deep once rewritten, which is why depth is
+        // judged after rewriting rather than per file.
+        let got = refs_at(
+            "test_data/catalog_refs/narrowed-forward/entry.nix",
+            &root_attributes(&["catalogs"]),
+        );
+        assert_eq!(
+            got,
+            set(&["catalogs.myorg.pkg", "catalogs.myorg.toolkit.readVersion",])
+        );
+    }
+
+    #[test]
     fn import_whole_root_to_pattern_param_escapes() {
         // The helper destructures the namespace with a pattern parameter; its
         // entries are namespace members, not root_attributes, so they cannot
-        // be bound statically. The whole root escapes rather than being
-        // dropped, which the scan then rejects, pointing at the import.
-        let path = "test_data/catalog_refs/import-entry-pattern.nix";
-        let err = scan_err_at(path, &root_attributes(&["catalogs"]));
-        assert_matches!(
-            err,
-            ScanError::UnlockableReference { file, position, .. }
-                if file == Path::new(path) && position == Some((5, 1))
+        // be bound statically. The whole namespace escapes rather than being
+        // dropped.
+        let got = refs_at(
+            "test_data/catalog_refs/import-entry-pattern.nix",
+            &root_attributes(&["catalogs"]),
         );
+        assert_eq!(got, set(&["catalogs.*"]));
     }
 
     #[test]
@@ -3013,16 +2980,15 @@ mod tests {
     }
 
     #[test]
-    fn import_dynamic_path_forwarding_root_is_an_error() {
+    fn import_dynamic_path_forwarding_root_widens() {
         // The import target is not statically known, so the forwarded
-        // namespace escapes analysis and the scan fails rather than locking a
-        // reference that could never resolve (a warning names the dynamic
+        // namespace escapes analysis and widens (a warning names the dynamic
         // path).
-        let err = scan_err(
+        let got = refs(
             "{ catalogs, p }: import p { inherit catalogs; }",
             &root_attributes(&["catalogs"]),
         );
-        assert_matches!(err, ScanError::UnlockableReference { .. });
+        assert_eq!(got, set(&["catalogs.*"]));
     }
 
     #[test]

--- a/cli/nef-lock-catalog/src/scan/analyze.rs
+++ b/cli/nef-lock-catalog/src/scan/analyze.rs
@@ -343,7 +343,10 @@ pub(super) fn analyze_file_at(
     }
 
     Ok(FileInfo {
-        refs: refs.into_iter().map(CatalogRef).collect(),
+        // Unchecked for now: the walker can still emit a root wildcard, and
+        // rejecting one here needs the scan error that reports where it came
+        // from.
+        refs: refs.into_iter().map(CatalogRef::new_unchecked).collect(),
         dependency_args,
     })
 }
@@ -1848,7 +1851,10 @@ mod tests {
     }
 
     fn set(items: &[&str]) -> BTreeSet<CatalogRef> {
-        items.iter().map(|s| CatalogRef::from(*s)).collect()
+        items
+            .iter()
+            .map(|s| CatalogRef::new_unchecked(*s))
+            .collect()
     }
 
     #[test]
@@ -1941,8 +1947,8 @@ mod tests {
             include_str!("../../test_data/catalog_refs/multi-attr-inherit.nix"),
             &root_attributes(&["catalogs"]),
         );
-        assert!(!got.contains(&CatalogRef::from("catalogs.myorg.python3Packages")));
-        assert!(!got.contains(&CatalogRef::from("catalogs.myorg.toolkit")));
+        assert!(!got.contains(&CatalogRef::new_unchecked("catalogs.myorg.python3Packages")));
+        assert!(!got.contains(&CatalogRef::new_unchecked("catalogs.myorg.toolkit")));
     }
 
     #[test]
@@ -2139,7 +2145,7 @@ mod tests {
             include_str!("../../test_data/catalog_refs/with-namespace.nix"),
             &root_attributes(&["catalogs"]),
         );
-        assert!(!got.contains(&CatalogRef::from("catalogs.myorg")));
+        assert!(!got.contains(&CatalogRef::new_unchecked("catalogs.myorg")));
     }
 
     #[test]
@@ -2149,7 +2155,7 @@ mod tests {
             &root_attributes(&["catalogs"]),
         );
         assert!(
-            got.contains(&CatalogRef::from("catalogs.myorg.*")),
+            got.contains(&CatalogRef::new_unchecked("catalogs.myorg.*")),
             "got: {got:?}"
         );
     }
@@ -2275,7 +2281,7 @@ mod tests {
             &root_attributes(&["catalogs"]),
         );
         assert!(
-            got.contains(&CatalogRef::from("catalogs.b.pkg")),
+            got.contains(&CatalogRef::new_unchecked("catalogs.b.pkg")),
             "got: {got:?}"
         );
     }

--- a/cli/nef-lock-catalog/src/scan/analyze.rs
+++ b/cli/nef-lock-catalog/src/scan/analyze.rs
@@ -14,7 +14,7 @@ use rowan::ast::AstNode;
 use tracing::{debug, warn};
 
 use super::attr_path::{attr_static_name, ident_name, static_str_content};
-use super::{AttrPath, Component, ImportSite, ScanError};
+use super::{AttrPath, ImportSite, ScanError};
 
 /// Where a path was first found. Kept alongside the path so that one which
 /// turns out to be unlockable — only decidable once forwarding has rewritten
@@ -954,7 +954,7 @@ impl<'a> Walker<'a> {
                 params.contains(name)
                     && self.root_attributes.contains(name)
                     && matches!(binding, Some(Binding::Path(path))
-                        if path.components() == [Component::Attribute(name.to_string())])
+                        if path.len() == 1 && path.root_name() == Some(name))
             },
         }
     }
@@ -1661,10 +1661,9 @@ fn resolve_select_paths(select: &ast::Select, env: &Env) -> Option<BTreeSet<Attr
 /// shallower is not lockable, so the walker widens it (see
 /// [Walker::emit_value_paths]) and [CatalogRef] refuses what is left.
 fn reaches_package(path: &AttrPath) -> bool {
-    match path.is_wildcard() {
-        true => path.base().len() >= 2,
-        false => path.len() >= 3,
-    }
+    // A wildcard is always last and stands for whatever it replaced, so it
+    // counts as the component reaching into the catalog like any other.
+    path.len() >= 3
 }
 
 /// The binding `inherit (<source>) <name>;` produces for `name`, given the
@@ -1751,13 +1750,7 @@ fn rewrite_root(path: &AttrPath, rewrites: &BTreeMap<String, AttrPath>) -> AttrP
     let Some(parent) = path.root_name().and_then(|root| rewrites.get(root)) else {
         return path.clone();
     };
-    path.components()
-        .iter()
-        .skip(1)
-        .fold(parent.clone(), |path, component| match component {
-            Component::Attribute(name) => path.append_attribute(name),
-            Component::Wildcard => path.append_wildcard(),
-        })
+    parent.clone().concat(path.pop_root())
 }
 
 /// Extract a statically-known path or string literal as a string, or `None`

--- a/cli/nef-lock-catalog/src/scan/analyze.rs
+++ b/cli/nef-lock-catalog/src/scan/analyze.rs
@@ -8,6 +8,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use flox_core::canonical_path::CanonicalPath;
 use rnix::ast;
 use rnix::ast::HasEntry;
 use rowan::ast::AstNode;
@@ -165,19 +166,21 @@ pub(super) fn line_col(content: &str, offset: usize) -> (usize, usize) {
 /// When `file_dir` is `Some`, `import` calls forwarding a root are followed into
 /// the imported file; `visited` maps each drained target file to the top-level
 /// forwardings already scanned for it (see the drain below). `path` is the
-/// file's location, recorded in scan errors and used for verbose reference
-/// reporting. `root_origins` maps each root to the top-level root it stands
-/// for — the identity map at the entry file, and the composition of the
-/// forwarding chain in imported files. `import_stack` holds the files this one
-/// was reached through, canonicalized, so the drain can recognize a back-edge.
+/// file's canonical location, recorded in scan errors and used for verbose
+/// reference reporting; the drain resolves import targets the same way, so one
+/// file is named one way however it was reached. `root_origins` maps each root
+/// to the top-level root it stands for — the identity map at the entry file,
+/// and the composition of the forwarding chain in imported files.
+/// `import_stack` holds the files this one was reached through, so the drain
+/// can recognize a back-edge.
 pub(super) fn analyze_file_at(
     content: &str,
     root_attributes: &HashSet<String>,
     file_dir: Option<&Path>,
     visited: &mut HashMap<PathBuf, HashSet<BTreeMap<String, AttrPath>>>,
-    path: &Path,
+    path: &CanonicalPath,
     root_origins: &BTreeMap<String, AttrPath>,
-    import_stack: &[PathBuf],
+    import_stack: &[CanonicalPath],
 ) -> Result<FileInfo, ScanError> {
     debug!(file = %path.display(), "reading NEF expression");
 
@@ -253,29 +256,29 @@ pub(super) fn analyze_file_at(
     // Imports are IO: the walker only records facts, the drain here reads and
     // recurses. Relative paths resolve against the importing file's directory.
     if let Some(dir) = file_dir {
-        // Targets are canonicalized, so the stack this file extends must be
-        // too for a back-edge to be recognized. This file's content has
-        // already been read, so unlike an import target it cannot be missing:
-        // a failure here is a real IO fault and is reported rather than
-        // guessed around.
-        let canonical_path =
-            fs::canonicalize(path).map_err(|source| ScanError::UnreadableFile {
-                file: path.to_path_buf(),
-                source,
-                imported_from: None,
-            })?;
         for pending in pending_imports {
-            let target = dir.join(&pending.path);
-            // The fallback for an uncanonicalizable (missing) target still
-            // normalizes `.` components so errors show a clean path.
-            let target =
-                fs::canonicalize(&target).unwrap_or_else(|_| target.components().collect());
+            // Normalized so that a target which does not resolve still names a
+            // clean path in the error below.
+            let raw_target: PathBuf = dir.join(&pending.path).components().collect();
             // `import ./dir` means `./dir/default.nix`.
-            let target = if target.is_dir() {
-                target.join("default.nix")
+            let raw_target = if raw_target.is_dir() {
+                raw_target.join("default.nix")
             } else {
-                target
+                raw_target
             };
+            let import_site = || ImportSite {
+                file: path.to_path_buf(),
+                position: line_col(content, pending.offset),
+            };
+            // The refs the imported file would contribute cannot be
+            // discovered, so fail rather than silently under-lock — whether
+            // the target resolves to nothing or cannot be read once it does.
+            let target =
+                CanonicalPath::new(&raw_target).map_err(|err| ScanError::UnreadableFile {
+                    file: err.path,
+                    source: err.err,
+                    imported_from: Some(import_site()),
+                })?;
             // A back-edge to a file already being analyzed would re-enter it
             // under the namespace this lap forwards, which is one component
             // deeper than the last. Following that explores instantiations no
@@ -285,16 +288,11 @@ pub(super) fn analyze_file_at(
             if import_stack.contains(&target) {
                 continue;
             }
-            // The refs the imported file would contribute cannot be
-            // discovered, so fail rather than silently under-lock.
             let imported_content =
                 fs::read_to_string(&target).map_err(|source| ScanError::UnreadableFile {
-                    file: target.clone(),
+                    file: target.to_path_buf(),
                     source,
-                    imported_from: Some(ImportSite {
-                        file: path.to_path_buf(),
-                        position: line_col(content, pending.offset),
-                    }),
+                    imported_from: Some(import_site()),
                 })?;
             // The child is scanned with its own parameter names as root_attributes;
             // its refs are rewritten back into the parent's namespace.
@@ -332,7 +330,7 @@ pub(super) fn analyze_file_at(
                 .map(|(child, parent)| (child.clone(), rewrite_root(parent, root_origins)))
                 .collect();
             if !visited
-                .entry(target.clone())
+                .entry(target.to_path_buf())
                 .or_default()
                 .insert(child_origins.clone())
             {
@@ -340,11 +338,8 @@ pub(super) fn analyze_file_at(
             }
             let child_root_attributes: HashSet<String> = rewrites.keys().cloned().collect();
             let import_dir = target.parent().map(Path::to_path_buf);
-            let child_stack: Vec<PathBuf> = import_stack
-                .iter()
-                .cloned()
-                .chain([canonical_path.clone()])
-                .collect();
+            let child_stack: Vec<CanonicalPath> =
+                import_stack.iter().cloned().chain([path.clone()]).collect();
             let imported = analyze_file_at(
                 &imported_content,
                 &child_root_attributes,
@@ -1833,7 +1828,7 @@ mod tests {
             root_attributes,
             None,
             &mut HashMap::new(),
-            Path::new("test.nix"),
+            &CanonicalPath::new_unchecked("test.nix"),
             &identity_origins(root_attributes),
             &[],
         )
@@ -1856,7 +1851,7 @@ mod tests {
             root_attributes,
             None,
             &mut HashMap::new(),
-            Path::new("test.nix"),
+            &CanonicalPath::new_unchecked("test.nix"),
             &identity_origins(root_attributes),
             &[],
         )
@@ -1864,8 +1859,8 @@ mod tests {
     }
 
     fn refs_at(path: &str, root_attributes: &HashSet<String>) -> BTreeSet<String> {
-        let path = Path::new(path);
-        let content = fs::read_to_string(path).expect("test fixture missing");
+        let path = CanonicalPath::new(path).expect("test fixture missing");
+        let content = fs::read_to_string(&path).expect("test fixture missing");
         let dir = path.parent();
         let mut visited = HashMap::new();
         let info = analyze_file_at(
@@ -1873,7 +1868,7 @@ mod tests {
             root_attributes,
             dir,
             &mut visited,
-            path,
+            &path,
             &identity_origins(root_attributes),
             &[],
         )
@@ -1882,8 +1877,8 @@ mod tests {
     }
 
     fn scan_err_at(path: &str, root_attributes: &HashSet<String>) -> ScanError {
-        let path = Path::new(path);
-        let content = fs::read_to_string(path).expect("test fixture missing");
+        let path = CanonicalPath::new(path).expect("test fixture missing");
+        let content = fs::read_to_string(&path).expect("test fixture missing");
         let dir = path.parent();
         let mut visited = HashMap::new();
         analyze_file_at(
@@ -1891,7 +1886,7 @@ mod tests {
             root_attributes,
             dir,
             &mut visited,
-            path,
+            &path,
             &identity_origins(root_attributes),
             &[],
         )
@@ -3084,6 +3079,10 @@ mod tests {
                 (5, 1),
             ),
         ];
+        // The scan names files canonically. The missing target has no
+        // canonical form of its own, so it is named under the canonical
+        // directory the import resolved against.
+        let dir = fs::canonicalize("test_data/catalog_refs").unwrap();
         for (path, position) in cases {
             let err = scan_err_at(path, &root_attributes(&["catalogs"]));
             assert_matches!(
@@ -3092,10 +3091,10 @@ mod tests {
                     file,
                     source,
                     imported_from: Some(site),
-                } if file == Path::new("test_data/catalog_refs/no-such-helper.nix")
+                } if file == dir.join("no-such-helper.nix")
                     && source.kind() == std::io::ErrorKind::NotFound
                     && site == ImportSite {
-                        file: PathBuf::from(path),
+                        file: fs::canonicalize(path).unwrap(),
                         position,
                     },
                 "fixture: {path}"
@@ -3112,9 +3111,12 @@ mod tests {
         let err = scan_err_at(path, &root_attributes(&["catalogs"]));
         // Asserted through the rendered message: it names the file and the
         // position, and the parse error's exact shape is rnix's to change.
+        // The scan names files canonically; `scan_package` is what re-expresses
+        // them against the package-set root.
+        let canonical = fs::canonicalize(path).unwrap();
         assert_eq!(
             err.to_string(),
-            format!("Invalid Nix syntax at {path}:5:11")
+            format!("Invalid Nix syntax at {}:5:11", canonical.display())
         );
     }
 
@@ -3266,14 +3268,15 @@ mod tests {
 
     #[test]
     fn undeclared_root_forwarded_to_import_errors_at_forward_site() {
-        let path = Path::new("test_data/catalog_refs/undeclared-forward/entry.nix");
-        let content = fs::read_to_string(path).expect("test fixture missing");
+        let path = CanonicalPath::new("test_data/catalog_refs/undeclared-forward/entry.nix")
+            .expect("test fixture missing");
+        let content = fs::read_to_string(&path).expect("test fixture missing");
         let err = analyze_file_at(
             &content,
             &root_attributes(&["catalogs"]),
             path.parent(),
             &mut HashMap::new(),
-            path,
+            &path,
             &identity_origins(&root_attributes(&["catalogs"])),
             &[],
         )
@@ -3284,7 +3287,7 @@ mod tests {
                 root,
                 file,
                 position,
-            } if root == "catalogs" && file == path && position == Some((6, 35))
+            } if root == "catalogs" && file == *path && position == Some((6, 35))
         );
     }
 }

--- a/cli/nef-lock-catalog/src/scan/analyze.rs
+++ b/cli/nef-lock-catalog/src/scan/analyze.rs
@@ -13,7 +13,7 @@ use rnix::ast::HasEntry;
 use rowan::ast::AstNode;
 use tracing::{debug, warn};
 
-use super::{CatalogRef, ScanError};
+use super::{CatalogRef, ImportSite, ScanError};
 
 /// Catalog references and dependency attr-paths extracted from one file.
 #[derive(Debug)]
@@ -243,15 +243,17 @@ pub(super) fn analyze_file_at(
             } else {
                 target
             };
-            let Ok(imported_content) = fs::read_to_string(&target) else {
-                // The refs the imported file would contribute cannot be
-                // discovered, so fail rather than silently under-lock.
-                return Err(ScanError::UnreadableImport {
-                    target,
-                    file: path.to_path_buf(),
-                    position: line_col(content, pending.offset),
-                });
-            };
+            // The refs the imported file would contribute cannot be
+            // discovered, so fail rather than silently under-lock.
+            let imported_content =
+                fs::read_to_string(&target).map_err(|source| ScanError::UnreadableFile {
+                    file: target.clone(),
+                    source,
+                    imported_from: Some(ImportSite {
+                        file: path.to_path_buf(),
+                        position: line_col(content, pending.offset),
+                    }),
+                })?;
             // The child is scanned with its own parameter names as root_attributes;
             // its refs are rewritten back into the parent's namespace.
             let rewrites: HashMap<String, String> = match pending.arg {
@@ -1776,6 +1778,8 @@ fn attr_static_name(attr: &ast::Attr) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
+
     use super::*;
 
     fn root_attributes(names: &[&str]) -> HashSet<String> {
@@ -2984,13 +2988,18 @@ mod tests {
         ];
         for (path, position) in cases {
             let err = scan_err_at(path, &root_attributes(&["catalogs"]));
-            assert_eq!(
+            assert_matches!(
                 err,
-                ScanError::UnreadableImport {
-                    target: PathBuf::from("test_data/catalog_refs/no-such-helper.nix"),
-                    file: PathBuf::from(path),
-                    position,
-                },
+                ScanError::UnreadableFile {
+                    file,
+                    source,
+                    imported_from: Some(site),
+                } if file == Path::new("test_data/catalog_refs/no-such-helper.nix")
+                    && source.kind() == std::io::ErrorKind::NotFound
+                    && site == ImportSite {
+                        file: PathBuf::from(path),
+                        position,
+                    },
                 "fixture: {path}"
             );
         }
@@ -3087,13 +3096,16 @@ mod tests {
             ),
         ];
         for (label, content, position) in cases {
-            assert_eq!(
-                scan_err(content, &root_attributes(&["catalogs"])),
+            let err = scan_err(content, &root_attributes(&["catalogs"]));
+            assert_matches!(
+                err,
                 ScanError::UndeclaredRoot {
-                    root: "catalogs".to_string(),
-                    file: PathBuf::from("test.nix"),
-                    position: Some(position),
-                },
+                    root,
+                    file,
+                    position: got,
+                } if root == "catalogs"
+                    && file == Path::new("test.nix")
+                    && got == Some(position),
                 "{label}",
             );
         }
@@ -3167,10 +3179,13 @@ mod tests {
             &identity_origins(&root_attributes(&["catalogs"])),
         )
         .expect_err("scan should fail");
-        assert_eq!(err, ScanError::UndeclaredRoot {
-            root: "catalogs".to_string(),
-            file: path.to_path_buf(),
-            position: Some((6, 35)),
-        });
+        assert_matches!(
+            err,
+            ScanError::UndeclaredRoot {
+                root,
+                file,
+                position,
+            } if root == "catalogs" && file == path && position == Some((6, 35))
+        );
     }
 }

--- a/cli/nef-lock-catalog/src/scan/analyze.rs
+++ b/cli/nef-lock-catalog/src/scan/analyze.rs
@@ -96,19 +96,6 @@ impl ScanCtx<'_> {
             "import argument is not the catalog namespace; the imported file is not scanned through it",
         );
     }
-
-    /// Warn that a catalog namespace escapes static analysis at `offset`,
-    /// widening to `reference`.
-    fn warn_escape(&self, offset: usize, reference: &str) {
-        let (line, column) = line_col(self.content, offset);
-        warn!(
-            reference,
-            file = %self.path.display(),
-            line,
-            column,
-            "catalog namespace escapes static analysis; locking the whole subtree",
-        );
-    }
 }
 
 /// Parse a Nix file, rejecting any syntax error.
@@ -676,14 +663,10 @@ impl<'a> Walker<'a> {
                 self.emit(offset, path);
                 continue;
             }
-            // A catalog widened to `<root>.<catalog>.*` over-locks but still
-            // resolves, so it is worth a warning. Widening the root itself
-            // reaches nothing and the graph rejects it, needing none.
-            let widened = path.append_wildcard();
-            if self.reaches_package(&widened) {
-                self.ctx.warn_escape(offset, &widened.to_string());
-            }
-            self.emit(offset, widened);
+            // Whether widening over-locks or reaches nothing at all is a
+            // question about the finished reference, which the graph answers
+            // once every path is back in the top-level namespace.
+            self.emit(offset, path.append_wildcard());
         }
     }
 

--- a/cli/nef-lock-catalog/src/scan/analyze.rs
+++ b/cli/nef-lock-catalog/src/scan/analyze.rs
@@ -1747,10 +1747,10 @@ fn top_ident_param(content: &str, path: &Path) -> Result<Option<String>, ScanErr
 /// child-name → parent-root map of the import that forwarded it. Only the root
 /// changes, so a path valid in the child stays valid in the parent.
 fn rewrite_root(path: &AttrPath, rewrites: &BTreeMap<String, AttrPath>) -> AttrPath {
-    let Some(parent) = path.root_name().and_then(|root| rewrites.get(root)) else {
-        return path.clone();
-    };
-    parent.clone().concat(path.pop_root())
+    match path.root_name().and_then(|root| rewrites.get(root)) {
+        Some(parent) => path.replace_root(parent),
+        None => path.clone(),
+    }
 }
 
 /// Extract a statically-known path or string literal as a string, or `None`

--- a/cli/nef-lock-catalog/src/scan/analyze.rs
+++ b/cli/nef-lock-catalog/src/scan/analyze.rs
@@ -13,7 +13,16 @@ use rnix::ast::HasEntry;
 use rowan::ast::AstNode;
 use tracing::{debug, warn};
 
-use super::{CatalogRef, ImportSite, InvalidCatalogRef, InvalidCatalogRefKind, ScanError};
+use super::attr_path::{attr_static_name, ident_name, static_str_content};
+use super::{
+    AttrPath,
+    CatalogRef,
+    Component,
+    ImportSite,
+    InvalidCatalogRef,
+    InvalidCatalogRefKind,
+    ScanError,
+};
 
 /// Catalog references and dependency attr-paths extracted from one file.
 #[derive(Debug)]
@@ -277,11 +286,11 @@ pub(super) fn analyze_file_at(
                                 "imported file does not take the namespace as a plain parameter; locking the whole root",
                             );
                             let reason = InvalidCatalogRef {
-                                reference: format!("{parent_root}.*"),
+                                path: AttrPath::root(&parent_root).append_wildcard(),
                                 kind: InvalidCatalogRefKind::RootWildcard,
                             };
                             rejected_refs
-                                .entry(reason.reference.clone())
+                                .entry(reason.path.clone())
                                 .or_insert(RejectedRef {
                                     offset: pending.offset,
                                     reason: reason.to_string(),
@@ -323,17 +332,17 @@ pub(super) fn analyze_file_at(
                 &child_origins,
             )?;
             // Rewriting only replaces the leading component, so a reference
-            // valid in the child stays valid in the parent; the parse routes
-            // any surprise through the same reporting as the walk's own.
+            // valid in the child stays valid in the parent; the conversion
+            // routes any surprise through the same reporting as the walk's.
             for reference in imported.refs {
-                let rewritten = rewrite_root(reference.into(), &rewrites);
-                match rewritten.parse() {
+                let rewritten = rewrite_root(reference.path(), &rewrites);
+                match CatalogRef::try_from(rewritten) {
                     Ok(reference) => {
                         refs.insert(reference);
                     },
                     Err(reason) => {
                         rejected_refs
-                            .entry(reason.reference.clone())
+                            .entry(reason.path.clone())
                             .or_insert(RejectedRef {
                                 offset: pending.offset,
                                 reason: reason.to_string(),
@@ -362,9 +371,9 @@ pub(super) fn analyze_file_at(
         for root in undeclared {
             let referenced = refs
                 .iter()
-                .map(CatalogRef::as_str)
-                .chain(rejected_refs.keys().map(String::as_str))
-                .any(|reference| reference_root(reference) == root);
+                .map(|reference| reference.path().root_name())
+                .chain(rejected_refs.keys().map(AttrPath::root_name))
+                .any(|name| name == Some(root.as_str()));
             if referenced {
                 return Err(ScanError::UndeclaredRoot {
                     root: root.clone(),
@@ -405,10 +414,6 @@ pub(super) fn identity_origins(root_attributes: &HashSet<String>) -> BTreeMap<St
 }
 
 /// The root component of a dotted reference (`catalogs.a.b` → `catalogs`).
-fn reference_root(reference: &str) -> &str {
-    reference.split('.').next().unwrap_or(reference)
-}
-
 /// Collect the static attr-paths selected on dependency arguments.
 ///
 /// For every `select` whose base identifier is a dependency argument in
@@ -448,13 +453,13 @@ fn collect_dependency_selections(
 #[derive(Clone, Debug, PartialEq)]
 enum Binding {
     /// The name resolves to a catalog attr-path: a root itself
-    /// (`catalogs` = `Path(["catalogs"])`) or an alias of one. A path may end
-    /// in `"*"` when a dynamic component collapsed it.
-    Path(Vec<String>),
+    /// (`catalogs` = `Path(AttrPath::root("catalogs"))`) or an alias of one. A
+    /// path ends in a wildcard when a dynamic component collapsed it.
+    Path(AttrPath),
     /// The name resolves to one of several attr-paths (a conditional alias);
     /// every path is locked so the expression works whichever branch is
     /// taken.
-    Paths(BTreeSet<Vec<String>>),
+    Paths(BTreeSet<AttrPath>),
     /// The name is bound to an attrset literal; selecting a member continues
     /// resolution with that member's binding. Members the scanner cannot
     /// model are absent.
@@ -531,15 +536,15 @@ struct Walker<'a> {
     /// Byte offset of the first use of each root, for locating an
     /// undeclared-root error after the walk.
     first_root_use: HashMap<String, usize>,
-    /// References [CatalogRef] refused, keyed by the reference — which the
+    /// Paths [CatalogRef] refused, keyed by the path — which the
     /// undeclared-root check still needs to attribute to a root. Collected
     /// rather than raised so the walk stays infallible; [analyze_file_at]
     /// reports the first once the refs are complete.
-    rejected_refs: BTreeMap<String, RejectedRef>,
+    rejected_refs: BTreeMap<AttrPath, RejectedRef>,
 }
 
-/// Where a reference [CatalogRef] refused was first emitted, and what the rule
-/// that refused it said. The reason is kept rendered: nothing inspects it.
+/// Where a path [CatalogRef] refused was first emitted, and what the rule that
+/// refused it said. The reason is kept rendered: nothing inspects it.
 struct RejectedRef {
     offset: usize,
     reason: String,
@@ -550,7 +555,7 @@ struct WalkResult {
     refs: BTreeSet<CatalogRef>,
     pending_imports: Vec<PendingImport>,
     first_root_use: HashMap<String, usize>,
-    rejected_refs: BTreeMap<String, RejectedRef>,
+    rejected_refs: BTreeMap<AttrPath, RejectedRef>,
 }
 
 impl<'a> Walker<'a> {
@@ -580,7 +585,7 @@ impl<'a> Walker<'a> {
         let env: Env = self
             .root_attributes
             .iter()
-            .map(|root| (root.clone(), Binding::Path(vec![root.clone()])))
+            .map(|root| (root.clone(), Binding::Path(AttrPath::root(root))))
             .collect();
         if let Some(expr) = root.expr() {
             self.walk(expr.syntax(), &env);
@@ -598,13 +603,13 @@ impl<'a> Walker<'a> {
         }
     }
 
-    /// Record a discovered reference, or — when it is one [CatalogRef] refuses
-    /// — where it was emitted, so [analyze_file_at] can report it.
-    fn emit(&mut self, offset: usize, reference: String) {
-        self.ctx.report(offset, &reference);
-        self.note_root_use(offset, &reference);
-        match reference.parse() {
+    /// Record the reference a resolved path denotes, or — when it is one
+    /// [CatalogRef] refuses — why, so [analyze_file_at] can report it.
+    fn emit(&mut self, offset: usize, path: AttrPath) {
+        self.note_root_use(offset, &path);
+        match CatalogRef::try_from(path) {
             Ok(reference) => {
+                self.ctx.report(offset, &reference.to_string());
                 self.refs.insert(reference);
             },
             Err(reason) => self.note_rejected_ref(offset, reason),
@@ -615,17 +620,18 @@ impl<'a> Walker<'a> {
     /// emitted.
     fn note_rejected_ref(&mut self, offset: usize, reason: InvalidCatalogRef) {
         self.rejected_refs
-            .entry(reason.reference.clone())
+            .entry(reason.path.clone())
             .or_insert(RejectedRef {
                 offset,
                 reason: reason.to_string(),
             });
     }
 
-    /// Record where a root was first used (`reference` may be the bare root
-    /// name or a dotted path under it).
-    fn note_root_use(&mut self, offset: usize, reference: &str) {
-        let root = reference_root(reference);
+    /// Record where the root a path is rooted at was first used.
+    fn note_root_use(&mut self, offset: usize, path: &AttrPath) {
+        let Some(root) = path.root_name() else {
+            return;
+        };
         if !self.first_root_use.contains_key(root) {
             self.first_root_use.insert(root.to_string(), offset);
         }
@@ -695,30 +701,29 @@ impl<'a> Walker<'a> {
     /// inherits). A package-deep path is an exact ref; a whole catalog or the
     /// root escaping into unknown code widens to a sentinel, since anything
     /// under it may be accessed.
-    fn emit_value_paths(&mut self, offset: usize, paths: BTreeSet<Vec<String>>) {
+    fn emit_value_paths(&mut self, offset: usize, paths: BTreeSet<AttrPath>) {
         for path in paths {
-            if path.len() >= 3 || path.last().map(String::as_str) == Some("*") {
-                self.emit(offset, join_path(&path));
+            if reaches_package(&path) {
+                self.emit(offset, path);
                 continue;
             }
             // A catalog widened to `<root>.<catalog>.*` over-locks but still
             // resolves, so it is worth a warning. Widening the root itself is
             // rejected outright by [analyze_file_at] and needs none.
-            let escapes_catalog = path.len() >= 2;
-            let reference = join_path(&append_star(path));
-            if escapes_catalog {
-                self.ctx.warn_escape(offset, &reference);
+            let widened = path.append_wildcard();
+            if reaches_package(&widened) {
+                self.ctx.warn_escape(offset, &widened.to_string());
             }
-            self.emit(offset, reference);
+            self.emit(offset, widened);
         }
     }
 
     /// [Self::emit_value_paths] restricted to package-deep paths, for
     /// positions where shallow paths are consumed rather than escaping.
-    fn emit_deep_paths(&mut self, offset: usize, paths: BTreeSet<Vec<String>>) {
+    fn emit_deep_paths(&mut self, offset: usize, paths: BTreeSet<AttrPath>) {
         for path in paths {
-            if path.len() >= 3 || path.last().map(String::as_str) == Some("*") {
-                self.emit(offset, join_path(&path));
+            if reaches_package(&path) {
+                self.emit(offset, path);
             }
         }
     }
@@ -789,7 +794,7 @@ impl<'a> Walker<'a> {
             .declared_params
             .is_none_or(|declared| declared.contains(name));
         if receivable && self.root_attributes.contains(name) {
-            Binding::Path(vec![name.to_string()])
+            Binding::Path(AttrPath::root(name))
         } else {
             Binding::Opaque
         }
@@ -834,9 +839,8 @@ impl<'a> Walker<'a> {
     /// `inherit (<source>) a b c;` in a binding scope (`let`, `rec { }`,
     /// consumed set literal) — each name only becomes an alias (use sites
     /// drive the refs, like an alias binding's RHS: only package-deep
-    /// members are refs of their own). A name the catalog cannot contain
-    /// (dotted quoted attr) collapses to a sentinel at the source. A
-    /// from-less `inherit x;` only rebinds the outer name.
+    /// members are refs of their own). A dynamic name collapses to a sentinel
+    /// at the source. A from-less `inherit x;` only rebinds the outer name.
     fn walk_binding_inherit(&mut self, inherit: &ast::Inherit, env: &Env) {
         let Some(from_expr) = inherit.from().and_then(|from| from.expr()) else {
             return;
@@ -850,11 +854,12 @@ impl<'a> Walker<'a> {
             Some(bases) => {
                 for attr in inherit.attrs() {
                     let name = attr_static_name(&attr);
-                    let paths: BTreeSet<Vec<String>> = bases
+                    let paths: BTreeSet<AttrPath> = bases
                         .iter()
+                        .cloned()
                         .map(|base| match &name {
-                            Some(name) => append_component(base.clone(), name.clone()),
-                            None => append_star(base.clone()),
+                            Some(name) => base.append_attribute(name),
+                            None => base.append_wildcard(),
                         })
                         .collect();
                     self.emit_deep_paths(offset_of(attr.syntax()), paths);
@@ -930,12 +935,12 @@ impl<'a> Walker<'a> {
         for attr in inherit.attrs() {
             let offset = offset_of(attr.syntax());
             let Some(name) = attr_static_name(&attr) else {
-                // A name the catalog cannot contain (dotted quoted attr)
-                // collapses to a sentinel at the source.
+                // A dynamic name is unknown until evaluated, so the source
+                // collapses to a sentinel.
                 if let Some(source) = &from_binding {
-                    let paths: BTreeSet<Vec<String>> = escaping_paths_of(source)
+                    let paths: BTreeSet<AttrPath> = escaping_paths_of(source)
                         .into_iter()
-                        .map(append_star)
+                        .map(AttrPath::append_wildcard)
                         .collect();
                     self.emit_value_paths(offset, paths);
                 }
@@ -970,7 +975,8 @@ impl<'a> Walker<'a> {
             AttrsetConsumer::Lambda(params) => {
                 params.contains(name)
                     && self.root_attributes.contains(name)
-                    && matches!(binding, Some(Binding::Path(path)) if path.len() == 1 && path[0] == name)
+                    && matches!(binding, Some(Binding::Path(path))
+                        if path.components() == [Component::Attribute(name.to_string())])
             },
         }
     }
@@ -992,8 +998,10 @@ impl<'a> Walker<'a> {
         if let Some(ns) = with_expr.namespace()
             && let Some(paths) = resolve_expr_paths(&ns, env)
         {
+            // `with` puts every name under the namespace in scope without
+            // naming any, so the whole subtree is reachable.
             for path in paths {
-                self.emit(offset_of(with_expr.syntax()), join_path(&append_star(path)));
+                self.emit(offset_of(with_expr.syntax()), path.append_wildcard());
             }
             self.walk_consumed_source(&ns, env);
             if let Some(body) = with_expr.body() {
@@ -1017,13 +1025,12 @@ impl<'a> Walker<'a> {
             let key = inner.argument();
             for target_path in target_paths {
                 let path = match key.as_ref().and_then(static_str) {
-                    Some(key) => append_component(target_path, key),
-                    None => append_star(target_path),
+                    Some(key) => target_path.append_attribute(key),
+                    None => target_path.append_wildcard(),
                 };
-                self.emit(
-                    offset_of(apply.syntax()),
-                    join_path(&widen_if_catalog_level(path)),
-                );
+                // A static key can still land on a catalog, which reaches
+                // nothing on its own, so it widens.
+                self.emit(offset_of(apply.syntax()), widen_to_package(path));
             }
             self.walk_consumed_source(&target, env);
             if let Some(key) = key {
@@ -1091,7 +1098,7 @@ impl<'a> Walker<'a> {
                     // from the import trace back to this argument.
                     let arg_offset = offset_of(attrset.syntax());
                     for parent_root in forwards.values() {
-                        self.note_root_use(arg_offset, parent_root);
+                        self.note_root_use(arg_offset, &AttrPath::root(parent_root));
                     }
                     self.pending_imports.push(PendingImport {
                         path,
@@ -1105,12 +1112,13 @@ impl<'a> Walker<'a> {
                 // `import ./h.nix catalogs` — the whole namespace is the
                 // argument, consumed by following the import.
                 if let Some(Binding::Path(root_path)) = resolve_expr_binding(other, env)
-                    && let [root] = root_path.as_slice()
+                    && let Some(root) = root_path.as_whole_root()
                 {
-                    self.note_root_use(offset_of(other.syntax()), root);
+                    let root = root.to_string();
+                    self.note_root_use(offset_of(other.syntax()), &root_path);
                     self.pending_imports.push(PendingImport {
                         path,
-                        arg: ImportArg::Root(root.clone()),
+                        arg: ImportArg::Root(root),
                         offset,
                     });
                     return true;
@@ -1138,7 +1146,7 @@ impl<'a> Walker<'a> {
                     // lambda binds under the same root name were walked in
                     // the body; only the rest escapes.
                     if let Some(Binding::Set(members)) = env.get(&name) {
-                        let uncovered: BTreeSet<Vec<String>> = members
+                        let uncovered: BTreeSet<AttrPath> = members
                             .iter()
                             .filter(|(member, binding)| {
                                 !self.consumed_by(&consumer, member, Some(binding))
@@ -1209,9 +1217,9 @@ impl<'a> Walker<'a> {
             };
             let Some(value) = entry.value() else { continue };
             if let Some(Binding::Path(path)) = resolve_expr_binding(&value, env)
-                && let [root] = path.as_slice()
+                && let Some(root) = path.as_whole_root()
             {
-                forwards.insert(name, root.clone());
+                forwards.insert(name, root.to_string());
             }
         }
         for inherit in arg.inherits() {
@@ -1229,9 +1237,9 @@ impl<'a> Walker<'a> {
                     (true, _) => None,
                 };
                 if let Some(Binding::Path(path)) = binding
-                    && let [root] = path.as_slice()
+                    && let Some(root) = path.as_whole_root()
                 {
-                    forwards.insert(name, root.clone());
+                    forwards.insert(name, root.to_string());
                 }
             }
         }
@@ -1243,11 +1251,10 @@ impl<'a> Walker<'a> {
             Some(binding) => {
                 match paths_of(binding.clone()) {
                     Some(paths) => {
+                        // A select can land on a catalog, which reaches
+                        // nothing on its own, so it widens.
                         for path in paths {
-                            self.emit(
-                                offset_of(select.syntax()),
-                                join_path(&widen_if_catalog_level(path)),
-                            );
+                            self.emit(offset_of(select.syntax()), widen_to_package(path));
                         }
                     },
                     // The select reaches a modeled set (`t.sub`) used as a
@@ -1278,9 +1285,9 @@ impl<'a> Walker<'a> {
                         .any(|attr| attr_static_name(&attr).is_none())
                 });
                 if dynamic {
-                    let paths: BTreeSet<Vec<String>> = escaping_paths_of(&binding)
+                    let paths: BTreeSet<AttrPath> = escaping_paths_of(&binding)
                         .into_iter()
-                        .map(append_star)
+                        .map(AttrPath::append_wildcard)
                         .collect();
                     if !paths.is_empty() {
                         self.emit_value_paths(offset_of(select.syntax()), paths);
@@ -1336,7 +1343,7 @@ impl<'a> Walker<'a> {
                     Some(paths) => {
                         for path in paths {
                             if path.len() >= 3 {
-                                self.emit(offset_of(select.syntax()), join_path(&path));
+                                self.emit(offset_of(select.syntax()), path);
                             }
                         }
                         if let Some(base) = select.expr() {
@@ -1576,20 +1583,22 @@ fn resolve_expr_binding(expr: &ast::Expr, env: &Env) -> Option<Binding> {
             let mut current = resolve_expr_binding(&select.expr()?, env)?;
             for attr in select.attrpath()?.attrs() {
                 current = match (current, attr_static_name(&attr)) {
-                    (Binding::Path(path), Some(name)) => {
-                        Binding::Path(append_component(path, name))
-                    },
+                    (Binding::Path(path), Some(name)) => Binding::Path(path.append_attribute(name)),
                     // A dynamic component collapses the path and consumes
                     // whatever follows.
-                    (Binding::Path(path), None) => return Some(Binding::Path(append_star(path))),
+                    (Binding::Path(path), None) => {
+                        return Some(Binding::Path(path.append_wildcard()));
+                    },
                     (Binding::Paths(paths), Some(name)) => Binding::Paths(
                         paths
                             .into_iter()
-                            .map(|path| append_component(path, name.clone()))
+                            .map(|path| path.append_attribute(&name))
                             .collect(),
                     ),
                     (Binding::Paths(paths), None) => {
-                        return Some(Binding::Paths(paths.into_iter().map(append_star).collect()));
+                        return Some(Binding::Paths(
+                            paths.into_iter().map(AttrPath::append_wildcard).collect(),
+                        ));
                     },
                     (Binding::Set(members), Some(name)) => members.get(&name)?.clone(),
                     (Binding::Set(_), None) => return None,
@@ -1616,7 +1625,7 @@ fn resolve_expr_binding(expr: &ast::Expr, env: &Env) -> Option<Binding> {
         // A conditional resolves to whichever branches the scanner can model;
         // all of them must be locked.
         ast::Expr::IfElse(if_else) => {
-            let mut paths: BTreeSet<Vec<String>> = BTreeSet::new();
+            let mut paths: BTreeSet<AttrPath> = BTreeSet::new();
             for branch in [if_else.body(), if_else.else_body()].into_iter().flatten() {
                 match resolve_expr_binding(&branch, env) {
                     Some(Binding::Path(path)) => {
@@ -1635,7 +1644,7 @@ fn resolve_expr_binding(expr: &ast::Expr, env: &Env) -> Option<Binding> {
 
 /// The attr-paths a binding denotes: one for an alias, several for a
 /// conditional alias, none for sets and opaque bindings.
-fn paths_of(binding: Binding) -> Option<BTreeSet<Vec<String>>> {
+fn paths_of(binding: Binding) -> Option<BTreeSet<AttrPath>> {
     match binding {
         Binding::Path(path) => Some(BTreeSet::from([path])),
         Binding::Paths(paths) => Some(paths),
@@ -1647,7 +1656,7 @@ fn paths_of(binding: Binding) -> Option<BTreeSet<Vec<String>>> {
 /// code the scanner cannot follow: an alias's own paths, or every path
 /// reachable through the members of a modeled set (recursively). Bindings
 /// that carry no catalog paths contribute nothing.
-fn escaping_paths_of(binding: &Binding) -> BTreeSet<Vec<String>> {
+fn escaping_paths_of(binding: &Binding) -> BTreeSet<AttrPath> {
     match binding {
         Binding::Path(path) => BTreeSet::from([path.clone()]),
         Binding::Paths(paths) => paths.clone(),
@@ -1657,29 +1666,36 @@ fn escaping_paths_of(binding: &Binding) -> BTreeSet<Vec<String>> {
 }
 
 /// Resolve an expression to the set of attr-paths it may denote.
-fn resolve_expr_paths(expr: &ast::Expr, env: &Env) -> Option<BTreeSet<Vec<String>>> {
+fn resolve_expr_paths(expr: &ast::Expr, env: &Env) -> Option<BTreeSet<AttrPath>> {
     paths_of(resolve_expr_binding(expr, env)?)
 }
 
 /// [resolve_expr_paths] for a select node.
-fn resolve_select_paths(select: &ast::Select, env: &Env) -> Option<BTreeSet<Vec<String>>> {
+fn resolve_select_paths(select: &ast::Select, env: &Env) -> Option<BTreeSet<AttrPath>> {
     paths_of(resolve_expr_binding(
         &ast::Expr::Select(select.clone()),
         env,
     )?)
 }
 
-/// Append one component; a path already collapsed to `*` absorbs it.
-fn append_component(mut path: Vec<String>, name: String) -> Vec<String> {
-    if path.last().map(String::as_str) != Some("*") {
-        path.push(name);
+/// Whether a path reaches into a catalog: a root, the catalog, and something
+/// within it — where a wildcard stands in for that last part. Anything
+/// shallower is not lockable, so the walker widens it (see
+/// [Walker::emit_value_paths]) and [CatalogRef] refuses what is left.
+fn reaches_package(path: &AttrPath) -> bool {
+    match path.is_wildcard() {
+        true => path.base().len() >= 2,
+        false => path.len() >= 3,
     }
-    path
 }
 
-/// Collapse the path's tail to a `*` sentinel (idempotent).
-fn append_star(path: Vec<String>) -> Vec<String> {
-    append_component(path, "*".to_string())
+/// A path that stops short of a package, widened so it names everything under
+/// itself instead. Already-deep paths are returned unchanged.
+fn widen_to_package(path: AttrPath) -> AttrPath {
+    match reaches_package(&path) {
+        true => path,
+        false => path.append_wildcard(),
+    }
 }
 
 /// The binding `inherit (<source>) <name>;` produces for `name`, given the
@@ -1687,39 +1703,17 @@ fn append_star(path: Vec<String>) -> Vec<String> {
 /// modeled set.
 fn member_binding(source: &Binding, name: &str) -> Option<Binding> {
     match source {
-        Binding::Path(base) => Some(Binding::Path(append_component(
-            base.clone(),
-            name.to_string(),
-        ))),
+        Binding::Path(base) => Some(Binding::Path(base.clone().append_attribute(name))),
         Binding::Paths(bases) => Some(Binding::Paths(
             bases
                 .iter()
                 .cloned()
-                .map(|base| append_component(base, name.to_string()))
+                .map(|base| base.append_attribute(name))
                 .collect(),
         )),
         Binding::Set(members) => members.get(name).cloned(),
         _ => None,
     }
-}
-
-/// Widen a path that names a whole catalog or the root itself (fewer than two
-/// components past the root) to a `.*` sentinel: the server's resolution floor
-/// is catalog + one component, so such an exact ref can never resolve.
-fn widen_if_catalog_level(path: Vec<String>) -> Vec<String> {
-    if path.len() < 3 {
-        append_star(path)
-    } else {
-        path
-    }
-}
-
-fn join_path(path: &[String]) -> String {
-    path.join(".")
-}
-
-fn ident_name(ident: &ast::Ident) -> Option<String> {
-    Some(ident.ident_token()?.text().to_string())
 }
 
 /// The inner application of a two-argument call `f a b`, i.e. `f a`.
@@ -1781,16 +1775,20 @@ fn top_ident_param(content: &str, path: &Path) -> Result<Option<String>, ScanErr
     Ok(param.ident().as_ref().and_then(ident_name))
 }
 
-/// Rewrite a child-rooted reference back to the parent's namespace using the
-/// child-name → parent-root map of the import that forwarded it.
-fn rewrite_root(reference: String, rewrites: &HashMap<String, String>) -> String {
-    match reference.split_once('.') {
-        Some((root, rest)) => match rewrites.get(root) {
-            Some(parent) => format!("{parent}.{rest}"),
-            None => reference,
-        },
-        None => reference,
-    }
+/// Rewrite a child-rooted path back to the parent's namespace using the
+/// child-name → parent-root map of the import that forwarded it. Only the root
+/// changes, so a path valid in the child stays valid in the parent.
+fn rewrite_root(path: &AttrPath, rewrites: &HashMap<String, String>) -> AttrPath {
+    let Some(parent) = path.root_name().and_then(|root| rewrites.get(root)) else {
+        return path.clone();
+    };
+    path.components()
+        .iter()
+        .skip(1)
+        .fold(AttrPath::root(parent), |path, component| match component {
+            Component::Attribute(name) => path.append_attribute(name),
+            Component::Wildcard => path.append_wildcard(),
+        })
 }
 
 /// Extract a statically-known path or string literal as a string, or `None`
@@ -1837,38 +1835,6 @@ fn is_get_attr_fn(expr: &ast::Expr) -> bool {
 fn static_str(expr: &ast::Expr) -> Option<String> {
     let ast::Expr::Str(s) = expr else { return None };
     static_str_content(s)
-}
-
-/// Extract a string node's contents when it has no interpolation, or `None`.
-fn static_str_content(s: &ast::Str) -> Option<String> {
-    if s.syntax().children().next().is_some() {
-        return None;
-    }
-    s.syntax().children_with_tokens().find_map(|n| {
-        if let rowan::NodeOrToken::Token(t) = n
-            && t.kind() == rnix::SyntaxKind::TOKEN_STRING_CONTENT
-        {
-            return Some(t.text().to_string());
-        }
-        None
-    })
-}
-
-/// Resolve an attribute to its statically-known component name: a plain
-/// identifier, or a non-interpolated string literal that is a valid catalog
-/// component name. Returns `None` for dynamic attrs and for quoted names the
-/// catalog cannot contain (`.`, `"`, `\` are rejected by the server's name
-/// validators), which callers collapse to a `*` sentinel.
-fn attr_static_name(attr: &ast::Attr) -> Option<String> {
-    match attr {
-        ast::Attr::Ident(id) => Some(id.ident_token()?.text().to_string()),
-        ast::Attr::Str(s) => {
-            let name = static_str_content(s)?;
-            let valid = !name.is_empty() && !name.contains(['.', '"', '\\']);
-            valid.then_some(name)
-        },
-        ast::Attr::Dynamic(_) => None,
-    }
 }
 
 #[cfg(test)]
@@ -1943,10 +1909,7 @@ mod tests {
     }
 
     fn set(items: &[&str]) -> BTreeSet<CatalogRef> {
-        items
-            .iter()
-            .map(|s| CatalogRef::new_unchecked(*s))
-            .collect()
+        items.iter().map(|s| CatalogRef::new_unchecked(s)).collect()
     }
 
     #[test]
@@ -2653,11 +2616,11 @@ mod tests {
             // An unused inherit binding is never evaluated and locks
             // nothing, like an unused alias binding.
             ("{ catalogs }: let inherit (catalogs) myorg; in null", &[]),
-            // A quoted name the catalog cannot contain still collapses to a
-            // sentinel at the source.
+            // A quoted name is a component like any other; whether the
+            // catalog holds one is not the scanner's call.
             (
                 "{ catalogs }: let inherit (catalogs.myorg) \"a.b\"; in null",
-                &["catalogs.myorg.*"],
+                &["catalogs.myorg.\"a.b\""],
             ),
         ];
         for (content, expected) in cases {
@@ -2802,15 +2765,15 @@ mod tests {
     #[test]
     fn quoted_attrs_static_when_valid_names() {
         let cases: &[(&str, &[&str])] = &[
-            // A non-interpolated string attr that is a valid catalog component
-            // name is an ordinary static component.
+            // A non-interpolated string attr is an ordinary static component,
+            // rendered bare when Nix would read it as an identifier.
             (r#"{ catalogs }: catalogs.myorg."with-dash".x"#, &[
                 "catalogs.myorg.with-dash.x",
             ]),
-            // A quoted attr containing `.` cannot exist as a catalog component
-            // (server rejects dotted names), so it collapses to a sentinel.
+            // A quoted attr containing `.` is one component, not two: it is
+            // recorded as written and rendered back quoted.
             (r#"{ catalogs }: catalogs.myorg."foo.bar""#, &[
-                "catalogs.myorg.*",
+                r#"catalogs.myorg."foo.bar""#,
             ]),
             // Quoted inherit names are components too, not silently dropped.
             (

--- a/cli/nef-lock-catalog/src/scan/analyze.rs
+++ b/cli/nef-lock-catalog/src/scan/analyze.rs
@@ -168,7 +168,8 @@ pub(super) fn line_col(content: &str, offset: usize) -> (usize, usize) {
 /// file's location, recorded in scan errors and used for verbose reference
 /// reporting. `root_origins` maps each root to the top-level root it stands
 /// for — the identity map at the entry file, and the composition of the
-/// forwarding chain in imported files.
+/// forwarding chain in imported files. `import_stack` holds the files this one
+/// was reached through, canonicalized, so the drain can recognize a back-edge.
 pub(super) fn analyze_file_at(
     content: &str,
     root_attributes: &HashSet<String>,
@@ -176,6 +177,7 @@ pub(super) fn analyze_file_at(
     visited: &mut HashMap<PathBuf, HashSet<BTreeMap<String, AttrPath>>>,
     path: &Path,
     root_origins: &BTreeMap<String, AttrPath>,
+    import_stack: &[PathBuf],
 ) -> Result<FileInfo, ScanError> {
     debug!(file = %path.display(), "reading NEF expression");
 
@@ -251,6 +253,17 @@ pub(super) fn analyze_file_at(
     // Imports are IO: the walker only records facts, the drain here reads and
     // recurses. Relative paths resolve against the importing file's directory.
     if let Some(dir) = file_dir {
+        // Targets are canonicalized, so the stack this file extends must be
+        // too for a back-edge to be recognized. This file's content has
+        // already been read, so unlike an import target it cannot be missing:
+        // a failure here is a real IO fault and is reported rather than
+        // guessed around.
+        let canonical_path =
+            fs::canonicalize(path).map_err(|source| ScanError::UnreadableFile {
+                file: path.to_path_buf(),
+                source,
+                imported_from: None,
+            })?;
         for pending in pending_imports {
             let target = dir.join(&pending.path);
             // The fallback for an uncanonicalizable (missing) target still
@@ -263,6 +276,15 @@ pub(super) fn analyze_file_at(
             } else {
                 target
             };
+            // A back-edge to a file already being analyzed would re-enter it
+            // under the namespace this lap forwards, which is one component
+            // deeper than the last. Following that explores instantiations no
+            // evaluation reaches — the cycle is only ever entered once — and
+            // the paths written there read as packages that do not exist. The
+            // file's own refs were collected when it was first entered.
+            if import_stack.contains(&target) {
+                continue;
+            }
             // The refs the imported file would contribute cannot be
             // discovered, so fail rather than silently under-lock.
             let imported_content =
@@ -318,6 +340,11 @@ pub(super) fn analyze_file_at(
             }
             let child_root_attributes: HashSet<String> = rewrites.keys().cloned().collect();
             let import_dir = target.parent().map(Path::to_path_buf);
+            let child_stack: Vec<PathBuf> = import_stack
+                .iter()
+                .cloned()
+                .chain([canonical_path.clone()])
+                .collect();
             let imported = analyze_file_at(
                 &imported_content,
                 &child_root_attributes,
@@ -325,6 +352,7 @@ pub(super) fn analyze_file_at(
                 visited,
                 &target,
                 &child_origins,
+                &child_stack,
             )?;
             // The child's paths move into this file's namespace, keeping the
             // source they were found at so a path that cannot be locked is
@@ -1075,7 +1103,7 @@ impl<'a> Walker<'a> {
                 let Some(Binding::Path(parent)) = resolve_expr_binding(other, env) else {
                     return false;
                 };
-                if reaches_package(&parent) {
+                if self.reaches_package(&parent) {
                     return false;
                 }
                 self.note_root_use(offset_of(other.syntax()), &parent);
@@ -1144,20 +1172,24 @@ impl<'a> Walker<'a> {
                     entry
                         .value()
                         .and_then(|value| resolve_expr_binding(&value, env))
-                        .is_some_and(|binding| is_forwardable(&binding))
+                        .is_some_and(|binding| self.is_forwardable(&binding))
                 }) || attrset.inherits().any(|inherit| {
                     inherit.from().is_none()
                         && inherit.attrs().any(|attr| {
                             attr_static_name(&attr)
                                 .and_then(|name| env.get(&name))
-                                .is_some_and(is_forwardable)
+                                .is_some_and(|binding| self.is_forwardable(binding))
                         })
                 })
             },
-            other => {
-                resolve_expr_binding(other, env).is_some_and(|binding| is_forwardable(&binding))
-            },
+            other => resolve_expr_binding(other, env)
+                .is_some_and(|binding| self.is_forwardable(&binding)),
         }
+    }
+
+    /// Whether a binding forwards a namespace rather than a package.
+    fn is_forwardable(&self, binding: &Binding) -> bool {
+        matches!(binding, Binding::Path(path) if !self.reaches_package(path))
     }
 
     /// Resolve which names an import's argument attrset forwards a whole
@@ -1180,7 +1212,7 @@ impl<'a> Walker<'a> {
             };
             let Some(value) = entry.value() else { continue };
             if let Some(Binding::Path(path)) = resolve_expr_binding(&value, env)
-                && !reaches_package(&path)
+                && !self.reaches_package(&path)
             {
                 forwards.insert(name, path);
             }
@@ -1200,7 +1232,7 @@ impl<'a> Walker<'a> {
                     (true, _) => None,
                 };
                 if let Some(Binding::Path(path)) = binding
-                    && !reaches_package(&path)
+                    && !self.reaches_package(&path)
                 {
                     forwards.insert(name, path);
                 }
@@ -1645,6 +1677,12 @@ fn resolve_select_paths(select: &ast::Select, env: &Env) -> Option<BTreeSet<Attr
 /// within it — where a wildcard stands in for that last part. Anything
 /// shallower is not lockable, so the walker widens it (see
 /// [Walker::emit_value_paths]) and [CatalogRef] refuses what is left.
+///
+/// This measures the path as written, so it only answers for the top-level
+/// namespace. Callers inside the walker want [Walker::reaches_package], which
+/// re-roots first: a file reached through a forward writes its paths in the
+/// namespace it was handed, and judging those raw reads a narrowed forward as
+/// shallow forever, which is what lets an import cycle recurse without end.
 fn reaches_package(path: &AttrPath) -> bool {
     // A wildcard is always last and stands for whatever it replaced, so it
     // counts as the component reaching into the catalog like any other.
@@ -1689,11 +1727,6 @@ fn extract_import(apply: &ast::Apply) -> Option<(Option<String>, ast::Expr)> {
     }
     let path = static_path_str(&inner.argument()?);
     Some((path, apply.argument()?))
-}
-
-/// Whether a binding is a whole catalog root.
-fn is_forwardable(binding: &Binding) -> bool {
-    matches!(binding, Binding::Path(path) if !reaches_package(path))
 }
 
 /// The file's package function: the top-level lambda, looked for through
@@ -1802,6 +1835,7 @@ mod tests {
             &mut HashMap::new(),
             Path::new("test.nix"),
             &identity_origins(root_attributes),
+            &[],
         )
         .expect("scan should succeed")
     }
@@ -1824,6 +1858,7 @@ mod tests {
             &mut HashMap::new(),
             Path::new("test.nix"),
             &identity_origins(root_attributes),
+            &[],
         )
         .expect_err("scan should fail")
     }
@@ -1840,6 +1875,7 @@ mod tests {
             &mut visited,
             path,
             &identity_origins(root_attributes),
+            &[],
         )
         .expect("scan should succeed");
         rendered(info.refs)
@@ -1857,6 +1893,7 @@ mod tests {
             &mut visited,
             path,
             &identity_origins(root_attributes),
+            &[],
         )
         .expect_err("scan should fail")
     }
@@ -3009,6 +3046,32 @@ mod tests {
     }
 
     #[test]
+    fn package_deep_forward_is_not_followed() {
+        // The argument is two components in the file that writes it, so judged
+        // as written it looks like a namespace to forward. Re-rooted it is
+        // already a package, and a package passed into an import is a value,
+        // not a namespace the imported file writes paths under.
+        let got = refs_at(
+            "test_data/catalog_refs/narrowed-forward-deep/entry.nix",
+            &root_attributes(&["catalogs"]),
+        );
+        assert_eq!(got, set(&["catalogs.myorg.pkg"]));
+    }
+
+    #[test]
+    fn narrowed_forward_cycle_terminates() {
+        // A cycle whose forward narrows on every lap: the local path stays the
+        // same length while the namespace it lands in grows, so the drain's
+        // visited key never repeats. Only re-rooting before judging depth ends
+        // it.
+        let got = refs_at(
+            "test_data/catalog_refs/narrowed-forward-cycle/entry.nix",
+            &root_attributes(&["catalogs"]),
+        );
+        assert_eq!(got, set(&["catalogs.myorg.pkg"]));
+    }
+
+    #[test]
     fn import_unreadable_target_fails_scan() {
         // The import target cannot be read, so the refs it would contribute
         // through the forwarded namespaces cannot be discovered; the scan
@@ -3212,6 +3275,7 @@ mod tests {
             &mut HashMap::new(),
             path,
             &identity_origins(&root_attributes(&["catalogs"])),
+            &[],
         )
         .expect_err("scan should fail");
         assert_matches!(

--- a/cli/nef-lock-catalog/src/scan/analyze.rs
+++ b/cli/nef-lock-catalog/src/scan/analyze.rs
@@ -87,6 +87,48 @@ impl ScanCtx<'_> {
     }
 }
 
+/// Parse a Nix file, rejecting any syntax error.
+///
+/// rnix is error-tolerant: `Parse::tree` yields a partial tree for a malformed
+/// file, so an unchecked parse silently drops the references in the broken
+/// region. The error is carried as the scan error's source, so its own
+/// rendering describes what the parser rejected. It locates itself by byte
+/// offset, so the position is resolved here, where the content is in hand.
+///
+/// A malformed file can produce several errors, and only the first is reported,
+/// for simplicity.
+/// The main objective is to report that the file failed to parse,
+/// other tools are in a better place to report details.
+fn parse_nix(content: &str, path: &Path) -> Result<rnix::Root, ScanError> {
+    let parse = rnix::Root::parse(content);
+    let Some(error) = parse.errors().first() else {
+        return Ok(parse.tree());
+    };
+    Err(ScanError::UnparsableFile {
+        file: path.to_path_buf(),
+        position: parse_error_offset(error).map(|offset| line_col(content, offset)),
+        error: error.clone(),
+    })
+}
+
+/// The byte offset a parse error points at. `None` for the variants that carry
+/// no source range (end-of-file and recursion-limit errors).
+fn parse_error_offset(error: &rnix::ParseError) -> Option<usize> {
+    use rnix::ParseError;
+
+    let range = match error {
+        ParseError::Unexpected(range)
+        | ParseError::UnexpectedExtra(range)
+        | ParseError::UnexpectedDoubleBind(range)
+        | ParseError::UnexpectedWanted(_, range, _)
+        | ParseError::DuplicatedArgs(range, _) => range,
+        // `ParseError` is `#[non_exhaustive]`, so a catch-all is required; a
+        // variant added upstream degrades to a file-level location.
+        _ => return None,
+    };
+    Some(usize::from(range.start()))
+}
+
 /// Resolve a byte `offset` into `content` to a 1-based `(line, column)`.
 pub(super) fn line_col(content: &str, offset: usize) -> (usize, usize) {
     let mut line = 1;
@@ -126,8 +168,7 @@ pub(super) fn analyze_file_at(
 ) -> Result<FileInfo, ScanError> {
     debug!(file = %path.display(), "reading NEF expression");
 
-    let parse = rnix::Root::parse(content);
-    let root = parse.tree();
+    let root = parse_nix(content, path)?;
 
     // Dependency arguments come from the eventual package function: wrappers
     // around it (`let … in`, `with …;`, parentheses) do not change which
@@ -215,21 +256,23 @@ pub(super) fn analyze_file_at(
             // its refs are rewritten back into the parent's namespace.
             let rewrites: HashMap<String, String> = match pending.arg {
                 ImportArg::Set(forwards) => forwards,
-                ImportArg::Root(parent_root) => match top_ident_param(&imported_content) {
-                    Some(param) => HashMap::from([(param, parent_root)]),
-                    None => {
-                        // A pattern parameter destructures the namespace into
-                        // names the scanner cannot statically bind, so
-                        // anything under the root may be referenced: it
-                        // escapes whole rather than being dropped.
-                        warn!(
-                            file = %target.display(),
-                            root = %parent_root,
-                            "imported file does not take the namespace as a plain parameter; locking the whole root",
-                        );
-                        refs.insert(format!("{parent_root}.*"));
-                        continue;
-                    },
+                ImportArg::Root(parent_root) => {
+                    match top_ident_param(&imported_content, &target)? {
+                        Some(param) => HashMap::from([(param, parent_root)]),
+                        None => {
+                            // A pattern parameter destructures the namespace into
+                            // names the scanner cannot statically bind, so
+                            // anything under the root may be referenced: it
+                            // escapes whole rather than being dropped.
+                            warn!(
+                                file = %target.display(),
+                                root = %parent_root,
+                                "imported file does not take the namespace as a plain parameter; locking the whole root",
+                            );
+                            refs.insert(format!("{parent_root}.*"));
+                            continue;
+                        },
+                    }
                 },
             };
             // The same file imported under a different forwarding contributes
@@ -1626,15 +1669,19 @@ fn top_level_lambda(root: &rnix::Root) -> Option<ast::Lambda> {
 }
 
 /// The name of a file's top-level plain lambda parameter (`cats: …`), if any.
-fn top_ident_param(content: &str) -> Option<String> {
-    let root = rnix::Root::parse(content).tree();
+///
+/// Parses the imported file before the recursion does, so a syntax error there
+/// surfaces as such instead of looking like a pattern parameter and widening the
+/// whole root to a sentinel.
+fn top_ident_param(content: &str, path: &Path) -> Result<Option<String>, ScanError> {
+    let root = parse_nix(content, path)?;
     let Some(ast::Expr::Lambda(lambda)) = root.expr() else {
-        return None;
+        return Ok(None);
     };
     let Some(ast::Param::IdentParam(param)) = lambda.param() else {
-        return None;
+        return Ok(None);
     };
-    param.ident().as_ref().and_then(ident_name)
+    Ok(param.ident().as_ref().and_then(ident_name))
 }
 
 /// Rewrite a child-rooted reference back to the parent's namespace using the
@@ -2944,6 +2991,45 @@ mod tests {
                     file: PathBuf::from(path),
                     position,
                 },
+                "fixture: {path}"
+            );
+        }
+    }
+
+    #[test]
+    fn unparsable_file_fails_scan() {
+        // rnix recovers from the malformed binding and yields a partial tree,
+        // which would drop the refs in the broken region; the scan fails
+        // instead, pointing at the syntax error.
+        let path = "test_data/catalog_refs/invalid-syntax.nix";
+        let err = scan_err_at(path, &root_attributes(&["catalogs"]));
+        // Asserted through the rendered message: it names the file and the
+        // position, and the parse error's exact shape is rnix's to change.
+        assert_eq!(
+            err.to_string(),
+            format!("Invalid Nix syntax at {path}:5:11")
+        );
+    }
+
+    #[test]
+    fn unparsable_import_target_fails_scan_naming_the_import() {
+        // A syntax error in an imported file is reported against that file,
+        // not the entry that forwards into it. The two forwarding shapes are
+        // detected in different places: the attrset form parses the target in
+        // the recursion, the whole-root form earlier, in `top_ident_param`.
+        // Without the latter's check the unparsed target reads as a pattern
+        // parameter and widens the root to `catalogs.*` instead of failing.
+        let target =
+            fs::canonicalize("test_data/catalog_refs/parse-error-import/broken.nix").unwrap();
+        let cases = [
+            "test_data/catalog_refs/parse-error-import/entry.nix",
+            "test_data/catalog_refs/parse-error-import/whole-root.nix",
+        ];
+        for path in cases {
+            let err = scan_err_at(path, &root_attributes(&["catalogs"]));
+            assert_eq!(
+                err.to_string(),
+                format!("Invalid Nix syntax at {}:4:12", target.display()),
                 "fixture: {path}"
             );
         }

--- a/cli/nef-lock-catalog/src/scan/analyze.rs
+++ b/cli/nef-lock-catalog/src/scan/analyze.rs
@@ -1025,7 +1025,7 @@ impl<'a> Walker<'a> {
             // A dynamic import path cannot be followed; when the argument
             // would forward a namespace, say so rather than failing silently
             // (the argument then escapes analysis as a value below).
-            Some((None, arg)) if self.forwards_any_root(&arg, env) => {
+            Some((None, arg)) if self.forwards_any_namespace(&arg, env) => {
                 self.ctx.warn_dynamic_import(offset_of(apply.syntax()));
             },
             Some((None, _)) | None => {},
@@ -1151,26 +1151,28 @@ impl<'a> Walker<'a> {
         }
     }
 
-    /// Whether an import argument would forward a whole root namespace.
-    fn forwards_any_root(&self, arg: &ast::Expr, env: &Env) -> bool {
+    /// Whether an import argument would forward a namespace, were the import
+    /// followable. Asks the same question as [Self::import_forwards], so the
+    /// warning fires exactly where following would have scanned through.
+    fn forwards_any_namespace(&self, arg: &ast::Expr, env: &Env) -> bool {
         match arg {
             ast::Expr::AttrSet(attrset) => {
                 attrset.attrpath_values().any(|entry| {
                     entry
                         .value()
                         .and_then(|value| resolve_expr_binding(&value, env))
-                        .is_some_and(|binding| is_root_binding(&binding))
+                        .is_some_and(|binding| is_forwardable(&binding))
                 }) || attrset.inherits().any(|inherit| {
                     inherit.from().is_none()
                         && inherit.attrs().any(|attr| {
                             attr_static_name(&attr)
                                 .and_then(|name| env.get(&name))
-                                .is_some_and(is_root_binding)
+                                .is_some_and(is_forwardable)
                         })
                 })
             },
             other => {
-                resolve_expr_binding(other, env).is_some_and(|binding| is_root_binding(&binding))
+                resolve_expr_binding(other, env).is_some_and(|binding| is_forwardable(&binding))
             },
         }
     }
@@ -1707,8 +1709,8 @@ fn extract_import(apply: &ast::Apply) -> Option<(Option<String>, ast::Expr)> {
 }
 
 /// Whether a binding is a whole catalog root.
-fn is_root_binding(binding: &Binding) -> bool {
-    matches!(binding, Binding::Path(path) if path.len() == 1)
+fn is_forwardable(binding: &Binding) -> bool {
+    matches!(binding, Binding::Path(path) if !reaches_package(path))
 }
 
 /// The file's package function: the top-level lambda, looked for through

--- a/cli/nef-lock-catalog/src/scan/analyze.rs
+++ b/cli/nef-lock-catalog/src/scan/analyze.rs
@@ -13,7 +13,7 @@ use rnix::ast::HasEntry;
 use rowan::ast::AstNode;
 use tracing::{debug, warn};
 
-use super::{CatalogRef, ImportSite, ScanError};
+use super::{CatalogRef, ImportSite, InvalidCatalogRef, InvalidCatalogRefKind, ScanError};
 
 /// Catalog references and dependency attr-paths extracted from one file.
 #[derive(Debug)]
@@ -226,7 +226,12 @@ pub(super) fn analyze_file_at(
     let ctx = ScanCtx { path, content };
     let mut walker = Walker::new(root_attributes, declared_params.as_ref(), ctx);
     walker.walk_root(&root);
-    let (mut refs, pending_imports, first_root_use) = walker.finish();
+    let WalkResult {
+        mut refs,
+        pending_imports,
+        first_root_use,
+        mut rejected_refs,
+    } = walker.finish();
 
     // Imports are IO: the walker only records facts, the drain here reads and
     // recurses. Relative paths resolve against the importing file's directory.
@@ -271,7 +276,16 @@ pub(super) fn analyze_file_at(
                                 root = %parent_root,
                                 "imported file does not take the namespace as a plain parameter; locking the whole root",
                             );
-                            refs.insert(format!("{parent_root}.*"));
+                            let reason = InvalidCatalogRef {
+                                reference: format!("{parent_root}.*"),
+                                kind: InvalidCatalogRefKind::RootWildcard,
+                            };
+                            rejected_refs
+                                .entry(reason.reference.clone())
+                                .or_insert(RejectedRef {
+                                    offset: pending.offset,
+                                    reason: reason.to_string(),
+                                });
                             continue;
                         },
                     }
@@ -308,18 +322,37 @@ pub(super) fn analyze_file_at(
                 &target,
                 &child_origins,
             )?;
-            refs.extend(
-                imported
-                    .refs
-                    .into_iter()
-                    .map(|reference| rewrite_root(reference.into(), &rewrites)),
-            );
+            // Rewriting only replaces the leading component, so a reference
+            // valid in the child stays valid in the parent; the parse routes
+            // any surprise through the same reporting as the walk's own.
+            for reference in imported.refs {
+                let rewritten = rewrite_root(reference.into(), &rewrites);
+                match rewritten.parse() {
+                    Ok(reference) => {
+                        refs.insert(reference);
+                    },
+                    Err(reason) => {
+                        rejected_refs
+                            .entry(reason.reference.clone())
+                            .or_insert(RejectedRef {
+                                offset: pending.offset,
+                                reason: reason.to_string(),
+                            });
+                    },
+                }
+            }
         }
     }
 
     // With the refs complete (imports included), reject any that resolve
     // through a root the top-level lambda does not declare — they could never
     // evaluate. Roots are checked in sorted order for a deterministic error.
+    //
+    // Rejected references are searched alongside the kept ones. A file like
+    // `{ mkDerivation }: mkDerivation { passthru = catalogs; }` uses the root
+    // but contributes nothing to `refs`, so searching `refs` alone would not
+    // see `catalogs` used at all and would fall through to the rejection,
+    // which says less than naming the undeclared argument.
     if let Some(declared) = &declared_params {
         let mut undeclared: Vec<&String> = root_attributes
             .iter()
@@ -327,10 +360,12 @@ pub(super) fn analyze_file_at(
             .collect();
         undeclared.sort();
         for root in undeclared {
-            if refs
+            let referenced = refs
                 .iter()
-                .any(|reference| reference_root(reference) == root)
-            {
+                .map(CatalogRef::as_str)
+                .chain(rejected_refs.keys().map(String::as_str))
+                .any(|reference| reference_root(reference) == root);
+            if referenced {
                 return Err(ScanError::UndeclaredRoot {
                     root: root.clone(),
                     file: path.to_path_buf(),
@@ -342,11 +377,20 @@ pub(super) fn analyze_file_at(
         }
     }
 
+    // A namespace that escaped static analysis widened to a reference
+    // [CatalogRef] refuses. Reporting it here, rather than where the lock
+    // request is built, is what gives the failure a file and a position; the
+    // first by name keeps the choice independent of traversal order.
+    if let Some((_, rejected)) = rejected_refs.pop_first() {
+        return Err(ScanError::UnlockableReference {
+            file: path.to_path_buf(),
+            position: Some(line_col(content, rejected.offset)),
+            reason: rejected.reason,
+        });
+    }
+
     Ok(FileInfo {
-        // Unchecked for now: the walker can still emit a root wildcard, and
-        // rejecting one here needs the scan error that reports where it came
-        // from.
-        refs: refs.into_iter().map(CatalogRef::new_unchecked).collect(),
+        refs,
         dependency_args,
     })
 }
@@ -482,11 +526,31 @@ struct Walker<'a> {
     /// hides them (see the declaration check in [analyze_file_at]).
     declared_params: Option<&'a HashSet<String>>,
     ctx: ScanCtx<'a>,
-    refs: BTreeSet<String>,
+    refs: BTreeSet<CatalogRef>,
     pending_imports: Vec<PendingImport>,
     /// Byte offset of the first use of each root, for locating an
     /// undeclared-root error after the walk.
     first_root_use: HashMap<String, usize>,
+    /// References [CatalogRef] refused, keyed by the reference — which the
+    /// undeclared-root check still needs to attribute to a root. Collected
+    /// rather than raised so the walk stays infallible; [analyze_file_at]
+    /// reports the first once the refs are complete.
+    rejected_refs: BTreeMap<String, RejectedRef>,
+}
+
+/// Where a reference [CatalogRef] refused was first emitted, and what the rule
+/// that refused it said. The reason is kept rendered: nothing inspects it.
+struct RejectedRef {
+    offset: usize,
+    reason: String,
+}
+
+/// What [Walker::finish] hands back to the IO drain in [analyze_file_at].
+struct WalkResult {
+    refs: BTreeSet<CatalogRef>,
+    pending_imports: Vec<PendingImport>,
+    first_root_use: HashMap<String, usize>,
+    rejected_refs: BTreeMap<String, RejectedRef>,
 }
 
 impl<'a> Walker<'a> {
@@ -504,6 +568,7 @@ impl<'a> Walker<'a> {
             refs: BTreeSet::new(),
             pending_imports: Vec::new(),
             first_root_use: HashMap::new(),
+            rejected_refs: BTreeMap::new(),
         }
     }
 
@@ -522,17 +587,39 @@ impl<'a> Walker<'a> {
         }
     }
 
-    /// Consume the walker, returning its collected facts as
-    /// `(refs, pending imports, first-use offsets)` for the IO drain in
+    /// Consume the walker, returning its collected facts for the IO drain in
     /// [analyze_file_at].
-    fn finish(self) -> (BTreeSet<String>, Vec<PendingImport>, HashMap<String, usize>) {
-        (self.refs, self.pending_imports, self.first_root_use)
+    fn finish(self) -> WalkResult {
+        WalkResult {
+            refs: self.refs,
+            pending_imports: self.pending_imports,
+            first_root_use: self.first_root_use,
+            rejected_refs: self.rejected_refs,
+        }
     }
 
+    /// Record a discovered reference, or — when it is one [CatalogRef] refuses
+    /// — where it was emitted, so [analyze_file_at] can report it.
     fn emit(&mut self, offset: usize, reference: String) {
         self.ctx.report(offset, &reference);
         self.note_root_use(offset, &reference);
-        self.refs.insert(reference);
+        match reference.parse() {
+            Ok(reference) => {
+                self.refs.insert(reference);
+            },
+            Err(reason) => self.note_rejected_ref(offset, reason),
+        }
+    }
+
+    /// Record why [CatalogRef] refused a reference, and where it was first
+    /// emitted.
+    fn note_rejected_ref(&mut self, offset: usize, reason: InvalidCatalogRef) {
+        self.rejected_refs
+            .entry(reason.reference.clone())
+            .or_insert(RejectedRef {
+                offset,
+                reason: reason.to_string(),
+            });
     }
 
     /// Record where a root was first used (`reference` may be the bare root
@@ -606,18 +693,23 @@ impl<'a> Walker<'a> {
 
     /// Emit refs for paths used as plain values (bare idents, from-less
     /// inherits). A package-deep path is an exact ref; a whole catalog or the
-    /// root escaping into unknown code widens to a sentinel with a warning,
-    /// since anything under it may be accessed.
+    /// root escaping into unknown code widens to a sentinel, since anything
+    /// under it may be accessed.
     fn emit_value_paths(&mut self, offset: usize, paths: BTreeSet<Vec<String>>) {
         for path in paths {
             if path.len() >= 3 || path.last().map(String::as_str) == Some("*") {
                 self.emit(offset, join_path(&path));
-            } else {
-                let reference = join_path(&append_star(path));
-                self.ctx.warn_escape(offset, &reference);
-                self.note_root_use(offset, &reference);
-                self.refs.insert(reference);
+                continue;
             }
+            // A catalog widened to `<root>.<catalog>.*` over-locks but still
+            // resolves, so it is worth a warning. Widening the root itself is
+            // rejected outright by [analyze_file_at] and needs none.
+            let escapes_catalog = path.len() >= 2;
+            let reference = join_path(&append_star(path));
+            if escapes_catalog {
+                self.ctx.warn_escape(offset, &reference);
+            }
+            self.emit(offset, reference);
         }
     }
 
@@ -2319,24 +2411,12 @@ mod tests {
     }
 
     #[test]
-    fn escaping_namespaces_emit_sentinels() {
+    fn escaping_catalogs_emit_sentinels() {
         let cases: &[(&str, &[&str])] = &[
-            // The whole root escapes into an opaque function: anything under
-            // it may be accessed.
-            ("{ catalogs, f }: f catalogs", &["catalogs.*"]),
             // A whole catalog escapes through an alias.
             ("{ catalogs, f }: let org = catalogs.myorg; in f org", &[
                 "catalogs.myorg.*",
             ]),
-            // Escape positions other than function arguments.
-            ("{ catalogs }: [ catalogs ]", &["catalogs.*"]),
-            ("{ catalogs, f }: f { inherit catalogs; }", &["catalogs.*"]),
-            // Helper-lambda indirection: the lambda parameter is opaque, so
-            // the refs inside it are invisible; the escaping root covers them.
-            (
-                "{ catalogs }: let f = c: c.myorg.toolkit; in f catalogs",
-                &["catalogs.*"],
-            ),
             // A modeled set escapes through every path reachable from its
             // members.
             (
@@ -2359,9 +2439,6 @@ mod tests {
             ("{ catalogs }: rec { org = catalogs.myorg; }", &[
                 "catalogs.myorg.*",
             ]),
-            // The @-name carries the root, so passing it whole escapes the
-            // root like `f catalogs` does.
-            ("args@{ catalogs, f, ... }: f args", &["catalogs.*"]),
             // A select reaching a nested modeled set escapes its members.
             (
                 "{ catalogs, f }: let t = { sub = { org = catalogs.myorg; }; }; in f t.sub",
@@ -2383,6 +2460,40 @@ mod tests {
             assert_eq!(
                 refs(content, &root_attributes(&["catalogs"])),
                 set(expected),
+                "content: {content}"
+            );
+        }
+    }
+
+    #[test]
+    fn escaping_root_namespace_is_an_error() {
+        // Widening a whole catalog over-locks but still resolves; widening the
+        // root itself yields a reference whose wire form is `*`, so the scan
+        // fails instead of emitting one.
+        let cases = [
+            // The root escapes into an opaque function.
+            ("{ catalogs, f }: f catalogs", (1, 20)),
+            // Escape positions other than function arguments.
+            ("{ catalogs }: [ catalogs ]", (1, 17)),
+            ("{ catalogs, f }: f { inherit catalogs; }", (1, 30)),
+            // Helper-lambda indirection: the lambda parameter is opaque, so
+            // the refs inside it are invisible and the root escapes whole.
+            (
+                "{ catalogs }: let f = c: c.myorg.toolkit; in f catalogs",
+                (1, 48),
+            ),
+            // The @-name carries the root, so passing it whole escapes the
+            // root like `f catalogs` does.
+            ("args@{ catalogs, f, ... }: f args", (1, 30)),
+        ];
+        for (content, position) in cases {
+            let err = scan_err(content, &root_attributes(&["catalogs"]));
+            assert_matches!(
+                err,
+                ScanError::UnlockableReference { file, position: got, reason }
+                    if file == Path::new("test.nix")
+                        && got == Some(position)
+                        && reason == "'catalogs.*' references the whole catalog namespace",
                 "content: {content}"
             );
         }
@@ -2417,13 +2528,6 @@ mod tests {
                 "args@{ catalogs, ... }: let mkPkg = { catalogs }: catalogs.myorg.inner; in mkPkg args",
                 &["catalogs.myorg.inner"],
             ),
-            // A lambda that binds the namespace under a different name
-            // cannot be matched to the set's root member (and its body is
-            // walked with an opaque parameter): the root escapes.
-            (
-                "args@{ catalogs, ... }: let mkPkg = { cats }: cats.myorg.inner; in mkPkg args",
-                &["catalogs.*"],
-            ),
         ];
         for (content, expected) in cases {
             assert_eq!(
@@ -2432,6 +2536,14 @@ mod tests {
                 "content: {content}"
             );
         }
+        // A lambda that binds the namespace under a different name cannot be
+        // matched to the set's root member (and its body is walked with an
+        // opaque parameter), so the root escapes and the scan fails.
+        let err = scan_err(
+            "args@{ catalogs, ... }: let mkPkg = { cats }: cats.myorg.inner; in mkPkg args",
+            &root_attributes(&["catalogs"]),
+        );
+        assert_matches!(err, ScanError::UnlockableReference { .. });
     }
 
     #[test]
@@ -2666,10 +2778,6 @@ mod tests {
                 &["catalogs.a.name", "catalogs.myorg.*"],
             ),
             (
-                "{ catalogs }: with catalogs.${catalogs.a.name}; toolkit",
-                &["catalogs.*", "catalogs.a.name"],
-            ),
-            (
                 "{ catalogs }: builtins.getAttr \"k\" catalogs.myorg.${catalogs.a.name}",
                 &["catalogs.a.name", "catalogs.myorg.*"],
             ),
@@ -2681,6 +2789,14 @@ mod tests {
                 "content: {content}"
             );
         }
+        // The `with` namespace is dynamic at the catalog component, so it
+        // widens to the root even though the dynamic component holds a
+        // resolvable ref of its own.
+        let err = scan_err(
+            "{ catalogs }: with catalogs.${catalogs.a.name}; toolkit",
+            &root_attributes(&["catalogs"]),
+        );
+        assert_matches!(err, ScanError::UnlockableReference { .. });
     }
 
     #[test]
@@ -2721,12 +2837,14 @@ mod tests {
     }
 
     #[test]
-    fn dynamic_attr_at_first_component_emits_root_sentinel() {
-        let got = refs(
+    fn dynamic_attr_at_first_component_escapes_the_root() {
+        // A dynamic catalog name could be any catalog, so the reference widens
+        // to the root and cannot be locked.
+        let err = scan_err(
             "{ catalogs, org }: catalogs.${org}.pkg",
             &root_attributes(&["catalogs"]),
         );
-        assert_eq!(got, set(&["catalogs.*"]));
+        assert_matches!(err, ScanError::UnlockableReference { .. });
     }
 
     #[test]
@@ -2900,15 +3018,17 @@ mod tests {
 
     #[test]
     fn import_whole_root_to_pattern_param_escapes() {
-        // The helper destructures the namespace with a pattern parameter;
-        // its entries are namespace members, not root_attributes, so they cannot be
-        // bound statically and the whole root escapes rather than being
-        // dropped.
-        let got = refs_at(
-            "test_data/catalog_refs/import-entry-pattern.nix",
-            &root_attributes(&["catalogs"]),
+        // The helper destructures the namespace with a pattern parameter; its
+        // entries are namespace members, not root_attributes, so they cannot
+        // be bound statically. The whole root escapes rather than being
+        // dropped, which the scan then rejects, pointing at the import.
+        let path = "test_data/catalog_refs/import-entry-pattern.nix";
+        let err = scan_err_at(path, &root_attributes(&["catalogs"]));
+        assert_matches!(
+            err,
+            ScanError::UnlockableReference { file, position, .. }
+                if file == Path::new(path) && position == Some((5, 1))
         );
-        assert_eq!(got, set(&["catalogs.*"]));
     }
 
     #[test]
@@ -2930,14 +3050,16 @@ mod tests {
     }
 
     #[test]
-    fn import_dynamic_path_forwarding_root_is_conservative() {
-        // The import target cannot be read, so the forwarded namespace
-        // escapes analysis (a warning points at the dynamic path).
-        let got = refs(
+    fn import_dynamic_path_forwarding_root_is_an_error() {
+        // The import target is not statically known, so the forwarded
+        // namespace escapes analysis and the scan fails rather than locking a
+        // reference that could never resolve (a warning names the dynamic
+        // path).
+        let err = scan_err(
             "{ catalogs, p }: import p { inherit catalogs; }",
             &root_attributes(&["catalogs"]),
         );
-        assert_eq!(got, set(&["catalogs.*"]));
+        assert_matches!(err, ScanError::UnlockableReference { .. });
     }
 
     #[test]

--- a/cli/nef-lock-catalog/src/scan/attr_path.rs
+++ b/cli/nef-lock-catalog/src/scan/attr_path.rs
@@ -88,18 +88,28 @@ impl AttrPath {
     }
 
     /// The path with its root dropped, for reading it against a namespace
-    /// other than the one it was rooted at.
-    pub(crate) fn pop_root(&self) -> Self {
-        Self(self.0.iter().skip(1).cloned().collect())
+    /// other than the one it was rooted at. `None` for a path that is only a
+    /// root, which leaves nothing — every other way of building a path yields
+    /// at least one component, so this is what keeps an empty one
+    /// unrepresentable.
+    ///
+    /// A remaining lone wildcard is kept: `myorg.*` popped to `*` still says
+    /// the namespace it is re-rooted onto was reached but not resolved
+    /// through.
+    pub(crate) fn pop_root(&self) -> Option<Self> {
+        (self.len() >= 2).then(|| Self(self.0.iter().skip(1).cloned().collect()))
     }
 
-    /// This path continued by `tail`, the inverse of [Self::pop_root] for a
-    /// path being re-rooted. Appending obeys the same absorbing rule as
-    /// [Self::append_attribute]: nothing follows a wildcard.
-    pub(crate) fn concat(self, tail: Self) -> Self {
-        tail.0
-            .into_iter()
-            .fold(self, |path, component| match component {
+    /// This path with `parent` in place of its root, which is how a path
+    /// forwarded into an import moves back into the namespace that forwarded
+    /// it. A path that is only a root becomes `parent` itself, and a trailing
+    /// wildcard survives, so `myorg.*` re-rooted onto `catalogs.myorg` is
+    /// `catalogs.myorg.*`.
+    pub(crate) fn replace_root(&self, parent: &Self) -> Self {
+        self.0
+            .iter()
+            .skip(1)
+            .fold(parent.clone(), |path, component| match component {
                 Component::Attribute(name) => path.append_attribute(name),
                 Component::Wildcard => path.append_wildcard(),
             })
@@ -233,23 +243,44 @@ mod tests {
     }
 
     #[test]
-    fn pop_root_and_concat_re_root_a_path() {
-        // How a forwarded path moves between namespaces: the child's root is
-        // dropped and the parent's prefix takes its place.
-        let child = AttrPath::root("myorg")
-            .append_attribute("toolkit")
-            .append_wildcard();
+    fn replace_root_re_roots_a_forwarded_path() {
+        // How a forwarded path moves between namespaces, including the two
+        // ends: a trailing wildcard survives, and a path that is only a root
+        // becomes the parent itself.
         let parent = AttrPath::root("catalogs").append_attribute("myorg");
-        assert_eq!(
-            parent.concat(child.pop_root()).to_string(),
-            "catalogs.myorg.toolkit.*"
-        );
+        let cases = [
+            (
+                AttrPath::root("myorg")
+                    .append_attribute("toolkit")
+                    .append_wildcard(),
+                "catalogs.myorg.toolkit.*",
+            ),
+            (
+                AttrPath::root("myorg").append_wildcard(),
+                "catalogs.myorg.*",
+            ),
+            (AttrPath::root("myorg"), "catalogs.myorg"),
+        ];
+        for (child, expected) in cases {
+            assert_eq!(child.replace_root(&parent).to_string(), expected);
+        }
     }
 
     #[test]
-    fn concat_onto_a_wildcard_absorbs() {
+    fn pop_root_refuses_to_leave_nothing() {
+        // The only way to reach an empty path, and so the only place that has
+        // to refuse: every other constructor yields at least one component.
+        let widened = AttrPath::root("myorg").append_wildcard();
+        assert_eq!(
+            widened.pop_root().map(|path| path.to_string()),
+            Some("*".to_string())
+        );
+        assert_eq!(AttrPath::root("myorg").pop_root(), None);
+    }
+
+    #[test]
+    fn appending_past_a_wildcard_is_a_no_op() {
         let widened = AttrPath::root("catalogs").append_wildcard();
-        let tail = AttrPath::root("myorg").append_attribute("pkg");
-        assert_eq!(widened.concat(tail).to_string(), "catalogs.*");
+        assert_eq!(widened.append_attribute("myorg").to_string(), "catalogs.*");
     }
 }

--- a/cli/nef-lock-catalog/src/scan/attr_path.rs
+++ b/cli/nef-lock-catalog/src/scan/attr_path.rs
@@ -53,17 +53,17 @@ fn is_bare_identifier(name: &str) -> bool {
 /// about what follows a component that could not be resolved, so appending
 /// past one is a no-op rather than an error.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct AttrPath(Vec<Component>);
+pub(crate) struct AttrPath(Vec<Component>);
 
 impl AttrPath {
     /// A path naming a single attribute, the catalog root the walker seeds its
     /// environment with.
-    pub fn root(name: impl Into<String>) -> Self {
+    pub(crate) fn root(name: impl Into<String>) -> Self {
         Self(vec![Component::Attribute(name.into())])
     }
 
     /// The path with `name` selected on it.
-    pub fn append_attribute(mut self, name: impl Into<String>) -> Self {
+    pub(crate) fn append_attribute(mut self, name: impl Into<String>) -> Self {
         if !self.is_wildcard() {
             self.0.push(Component::Attribute(name.into()));
         }
@@ -71,32 +71,32 @@ impl AttrPath {
     }
 
     /// The path with resolution stopped at its current depth.
-    pub fn append_wildcard(mut self) -> Self {
+    pub(crate) fn append_wildcard(mut self) -> Self {
         if !self.is_wildcard() {
             self.0.push(Component::Wildcard);
         }
         self
     }
 
-    pub fn len(&self) -> usize {
+    pub(crate) fn len(&self) -> usize {
         self.0.len()
     }
 
     /// Whether resolution stopped short of naming the path's last component.
-    pub fn is_wildcard(&self) -> bool {
+    pub(crate) fn is_wildcard(&self) -> bool {
         self.0.last() == Some(&Component::Wildcard)
     }
 
     /// The path with its root dropped, for reading it against a namespace
     /// other than the one it was rooted at.
-    pub fn pop_root(&self) -> Self {
+    pub(crate) fn pop_root(&self) -> Self {
         Self(self.0.iter().skip(1).cloned().collect())
     }
 
     /// This path continued by `tail`, the inverse of [Self::pop_root] for a
     /// path being re-rooted. Appending obeys the same absorbing rule as
     /// [Self::append_attribute]: nothing follows a wildcard.
-    pub fn concat(self, tail: Self) -> Self {
+    pub(crate) fn concat(self, tail: Self) -> Self {
         tail.0
             .into_iter()
             .fold(self, |path, component| match component {
@@ -106,7 +106,7 @@ impl AttrPath {
     }
 
     /// The attribute the path is rooted at, whatever its depth.
-    pub fn root_name(&self) -> Option<&str> {
+    pub(crate) fn root_name(&self) -> Option<&str> {
         match self.0.first() {
             Some(Component::Attribute(name)) => Some(name),
             _ => None,

--- a/cli/nef-lock-catalog/src/scan/attr_path.rs
+++ b/cli/nef-lock-catalog/src/scan/attr_path.rs
@@ -1,0 +1,259 @@
+//! Attribute paths as the walker resolves them.
+//!
+//! The scanner resolves expressions to attribute paths (`catalogs.myorg.pkg`),
+//! stopping where a component cannot be known statically. Modelling that stop
+//! as a [Component] rather than a `"*"` string keeps the sentinel out of the
+//! path's own vocabulary: `*` is the wire form's spelling, applied once when a
+//! path is rendered.
+
+use std::fmt::{self, Display};
+use std::str::FromStr;
+
+use rnix::ast;
+use rowan::ast::AstNode;
+
+/// One component of an [AttrPath].
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Component {
+    /// A statically known attribute name.
+    Attribute(String),
+    /// Resolution stopped here, so anything under this point may be reached.
+    Wildcard,
+}
+
+impl Component {
+    /// The attribute name, as written between the quotes when it had any.
+    pub fn name(&self) -> Option<&str> {
+        match self {
+            Self::Attribute(name) => Some(name),
+            Self::Wildcard => None,
+        }
+    }
+}
+
+/// A name is rendered bare when Nix would accept it as one, and quoted
+/// otherwise so the rendering can be read back. rnix leaves string content
+/// escaped, so a name is re-quoted exactly as it was written and needs no
+/// escaping of its own.
+impl Display for Component {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Attribute(name) if is_bare_identifier(name) => name.fmt(f),
+            Self::Attribute(name) => write!(f, "\"{name}\""),
+            Self::Wildcard => "*".fmt(f),
+        }
+    }
+}
+
+/// Whether Nix would read `name` as an identifier rather than a quoted
+/// attribute: a letter or `_` followed by letters, digits, `_`, `-` or `'`.
+fn is_bare_identifier(name: &str) -> bool {
+    let mut chars = name.chars();
+    chars
+        .next()
+        .is_some_and(|first| first.is_ascii_alphabetic() || first == '_')
+        && chars.all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '\''))
+}
+
+/// An attribute path the walker resolved, rooted at a catalog namespace
+/// parameter (`catalogs.myorg.pkg`).
+///
+/// A [Component::Wildcard] is always last and absorbing: nothing is known
+/// about what follows a component that could not be resolved, so appending
+/// past one is a no-op rather than an error.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct AttrPath(Vec<Component>);
+
+impl AttrPath {
+    /// A path naming a single attribute, the catalog root the walker seeds its
+    /// environment with.
+    pub fn root(name: impl Into<String>) -> Self {
+        Self(vec![Component::Attribute(name.into())])
+    }
+
+    /// The path with `name` selected on it.
+    pub fn append_attribute(mut self, name: impl Into<String>) -> Self {
+        if !self.is_wildcard() {
+            self.0.push(Component::Attribute(name.into()));
+        }
+        self
+    }
+
+    /// The path with resolution stopped at its current depth.
+    pub fn append_wildcard(mut self) -> Self {
+        if !self.is_wildcard() {
+            self.0.push(Component::Wildcard);
+        }
+        self
+    }
+
+    pub fn components(&self) -> &[Component] {
+        &self.0
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Whether resolution stopped short of naming the path's last component.
+    pub fn is_wildcard(&self) -> bool {
+        self.0.last() == Some(&Component::Wildcard)
+    }
+
+    /// The components before a trailing [Component::Wildcard], or the whole
+    /// path when there is none.
+    pub fn base(&self) -> &[Component] {
+        match self.is_wildcard() {
+            true => &self.0[..self.0.len() - 1],
+            false => &self.0,
+        }
+    }
+
+    /// The root this path names when it names a root and nothing under it.
+    ///
+    /// Distinct from [Self::root_name], which answers what a path is rooted
+    /// at however deep it goes. Forwarding a namespace into an import is only
+    /// a forward when the argument *is* the namespace: passing `catalogs.myorg`
+    /// forwards nothing, and reading its root as `catalogs` would follow the
+    /// import as though the whole namespace had been handed over.
+    pub fn as_whole_root(&self) -> Option<&str> {
+        match self.0.as_slice() {
+            [Component::Attribute(name)] => Some(name),
+            _ => None,
+        }
+    }
+
+    /// The attribute the path is rooted at, whatever its depth.
+    pub fn root_name(&self) -> Option<&str> {
+        match self.0.first() {
+            Some(Component::Attribute(name)) => Some(name),
+            _ => None,
+        }
+    }
+}
+
+/// A string that is not an attribute path.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("'{0}' is not an attribute path")]
+pub struct InvalidAttrPath(pub String);
+
+/// The inverse of [Display].
+///
+/// A trailing wildcard is split off first: `*` lexes as multiplication, so
+/// `catalogs.myorg.*` is not Nix and only the rest can be parsed as one. The
+/// rest goes through rnix, so this accepts exactly what the walker records
+/// from source — the same [attr_static_name] — and refuses only a dynamic
+/// attribute.
+impl FromStr for AttrPath {
+    type Err = InvalidAttrPath;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let invalid = || InvalidAttrPath(value.to_string());
+        let (base, wildcard) = match value.strip_suffix(".*") {
+            Some(base) => (base, true),
+            None => (value, false),
+        };
+
+        let parse = rnix::Root::parse(base);
+        let components = parse
+            .errors()
+            .is_empty()
+            .then(|| parse.tree().expr())
+            .flatten()
+            .and_then(|expr| components_of(&expr))
+            .ok_or_else(invalid)?;
+
+        let path = Self(components);
+        Ok(match wildcard {
+            true => path.append_wildcard(),
+            false => path,
+        })
+    }
+}
+
+/// The components of a select chain (`catalogs.myorg.pkg`) or a bare name.
+/// Any other expression yields `None`.
+fn components_of(expr: &ast::Expr) -> Option<Vec<Component>> {
+    match expr {
+        ast::Expr::Ident(ident) => Some(vec![Component::Attribute(ident_name(ident)?)]),
+        ast::Expr::Select(select) => {
+            let mut components = components_of(&select.expr()?)?;
+            for attr in select.attrpath()?.attrs() {
+                components.push(Component::Attribute(attr_static_name(&attr)?));
+            }
+            Some(components)
+        },
+        _ => None,
+    }
+}
+
+/// The name an identifier carries.
+pub(super) fn ident_name(ident: &ast::Ident) -> Option<String> {
+    Some(ident.ident_token()?.text().to_string())
+}
+
+/// The name an attribute is written with, quoted or not, taken as written.
+/// Whether the catalog can hold such a name is the catalog's question, not
+/// this one's — [Display] quotes whatever needs it, so any name survives being
+/// written out and read back.
+///
+/// `None` only for a dynamic attribute, which names nothing until evaluated;
+/// the walker collapses those to a [Component::Wildcard].
+pub(super) fn attr_static_name(attr: &ast::Attr) -> Option<String> {
+    match attr {
+        ast::Attr::Ident(id) => Some(id.ident_token()?.text().to_string()),
+        ast::Attr::Str(s) => static_str_content(s),
+        ast::Attr::Dynamic(_) => None,
+    }
+}
+
+/// Extract a string node's contents when it has no interpolation, or `None`.
+pub(super) fn static_str_content(s: &ast::Str) -> Option<String> {
+    if s.syntax().children().next().is_some() {
+        return None;
+    }
+    s.syntax().children_with_tokens().find_map(|n| {
+        if let rowan::NodeOrToken::Token(t) = n
+            && t.kind() == rnix::SyntaxKind::TOKEN_STRING_CONTENT
+        {
+            return Some(t.text().to_string());
+        }
+        None
+    })
+}
+
+impl Display for AttrPath {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for (index, component) in self.0.iter().enumerate() {
+            if index > 0 {
+                ".".fmt(f)?;
+            }
+            component.fmt(f)?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wildcard_absorbs_further_components() {
+        // Nothing is known past a component that could not be resolved, so a
+        // selection on it names no more than the wildcard already does.
+        let path = AttrPath::root("catalogs")
+            .append_attribute("myorg")
+            .append_wildcard()
+            .append_attribute("pkg")
+            .append_wildcard();
+        assert_eq!(path.to_string(), "catalogs.myorg.*");
+    }
+
+    #[test]
+    fn base_drops_only_a_trailing_wildcard() {
+        let concrete = AttrPath::root("catalogs").append_attribute("myorg");
+        let wildcard = concrete.clone().append_wildcard();
+        assert_eq!((concrete.base().len(), wildcard.base().len()), (2, 2));
+    }
+}

--- a/cli/nef-lock-catalog/src/scan/attr_path.rs
+++ b/cli/nef-lock-catalog/src/scan/attr_path.rs
@@ -12,23 +12,14 @@ use std::str::FromStr;
 use rnix::ast;
 use rowan::ast::AstNode;
 
-/// One component of an [AttrPath].
+/// One component of an [AttrPath]. Internal to the path: callers ask about
+/// depth and re-root paths rather than taking them apart.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum Component {
+pub(super) enum Component {
     /// A statically known attribute name.
     Attribute(String),
     /// Resolution stopped here, so anything under this point may be reached.
     Wildcard,
-}
-
-impl Component {
-    /// The attribute name, as written between the quotes when it had any.
-    pub fn name(&self) -> Option<&str> {
-        match self {
-            Self::Attribute(name) => Some(name),
-            Self::Wildcard => None,
-        }
-    }
 }
 
 /// A name is rendered bare when Nix would accept it as one, and quoted
@@ -87,10 +78,6 @@ impl AttrPath {
         self
     }
 
-    pub fn components(&self) -> &[Component] {
-        &self.0
-    }
-
     pub fn len(&self) -> usize {
         self.0.len()
     }
@@ -100,13 +87,22 @@ impl AttrPath {
         self.0.last() == Some(&Component::Wildcard)
     }
 
-    /// The components before a trailing [Component::Wildcard], or the whole
-    /// path when there is none.
-    pub fn base(&self) -> &[Component] {
-        match self.is_wildcard() {
-            true => &self.0[..self.0.len() - 1],
-            false => &self.0,
-        }
+    /// The path with its root dropped, for reading it against a namespace
+    /// other than the one it was rooted at.
+    pub fn pop_root(&self) -> Self {
+        Self(self.0.iter().skip(1).cloned().collect())
+    }
+
+    /// This path continued by `tail`, the inverse of [Self::pop_root] for a
+    /// path being re-rooted. Appending obeys the same absorbing rule as
+    /// [Self::append_attribute]: nothing follows a wildcard.
+    pub fn concat(self, tail: Self) -> Self {
+        tail.0
+            .into_iter()
+            .fold(self, |path, component| match component {
+                Component::Attribute(name) => path.append_attribute(name),
+                Component::Wildcard => path.append_wildcard(),
+            })
     }
 
     /// The attribute the path is rooted at, whatever its depth.
@@ -237,9 +233,23 @@ mod tests {
     }
 
     #[test]
-    fn base_drops_only_a_trailing_wildcard() {
-        let concrete = AttrPath::root("catalogs").append_attribute("myorg");
-        let wildcard = concrete.clone().append_wildcard();
-        assert_eq!((concrete.base().len(), wildcard.base().len()), (2, 2));
+    fn pop_root_and_concat_re_root_a_path() {
+        // How a forwarded path moves between namespaces: the child's root is
+        // dropped and the parent's prefix takes its place.
+        let child = AttrPath::root("myorg")
+            .append_attribute("toolkit")
+            .append_wildcard();
+        let parent = AttrPath::root("catalogs").append_attribute("myorg");
+        assert_eq!(
+            parent.concat(child.pop_root()).to_string(),
+            "catalogs.myorg.toolkit.*"
+        );
+    }
+
+    #[test]
+    fn concat_onto_a_wildcard_absorbs() {
+        let widened = AttrPath::root("catalogs").append_wildcard();
+        let tail = AttrPath::root("myorg").append_attribute("pkg");
+        assert_eq!(widened.concat(tail).to_string(), "catalogs.*");
     }
 }

--- a/cli/nef-lock-catalog/src/scan/attr_path.rs
+++ b/cli/nef-lock-catalog/src/scan/attr_path.rs
@@ -109,20 +109,6 @@ impl AttrPath {
         }
     }
 
-    /// The root this path names when it names a root and nothing under it.
-    ///
-    /// Distinct from [Self::root_name], which answers what a path is rooted
-    /// at however deep it goes. Forwarding a namespace into an import is only
-    /// a forward when the argument *is* the namespace: passing `catalogs.myorg`
-    /// forwards nothing, and reading its root as `catalogs` would follow the
-    /// import as though the whole namespace had been handed over.
-    pub fn as_whole_root(&self) -> Option<&str> {
-        match self.0.as_slice() {
-            [Component::Attribute(name)] => Some(name),
-            _ => None,
-        }
-    }
-
     /// The attribute the path is rooted at, whatever its depth.
     pub fn root_name(&self) -> Option<&str> {
         match self.0.first() {

--- a/cli/nef-lock-catalog/src/scan/error.rs
+++ b/cli/nef-lock-catalog/src/scan/error.rs
@@ -85,6 +85,71 @@ pub enum ScanError {
     },
 }
 
+impl ScanError {
+    /// Re-express every file this error names relative to `base_dir`.
+    ///
+    /// The scan joins `base_dir` onto the path it is given before reading
+    /// anything, and follows imports through canonicalized absolute paths, so
+    /// by the time a failure is built its paths are absolute. Under `flox
+    /// build` that root is the source copy in the store, which is not a
+    /// location the user can open. The package-set root is the frame they
+    /// wrote the path in, and the builder runs the lock from the project
+    /// directory, so a path relative to it also resolves from their shell.
+    ///
+    /// A path outside `base_dir` is left absolute: it is still the only
+    /// honest way to name it.
+    pub(super) fn relative_to(self, base_dir: &Path) -> Self {
+        match self {
+            Self::UnparsableFile {
+                file,
+                position,
+                error,
+            } => Self::UnparsableFile {
+                file: relative_to(file, base_dir),
+                position,
+                error,
+            },
+            Self::UnlockableReference {
+                file,
+                position,
+                reason,
+            } => Self::UnlockableReference {
+                file: relative_to(file, base_dir),
+                position,
+                reason,
+            },
+            Self::UndeclaredRoot {
+                root,
+                file,
+                position,
+            } => Self::UndeclaredRoot {
+                root,
+                file: relative_to(file, base_dir),
+                position,
+            },
+            Self::UnreadableFile {
+                file,
+                source,
+                imported_from,
+            } => Self::UnreadableFile {
+                file: relative_to(file, base_dir),
+                source,
+                imported_from: imported_from.map(|site| ImportSite {
+                    file: relative_to(site.file, base_dir),
+                    position: site.position,
+                }),
+            },
+        }
+    }
+}
+
+/// `path` expressed relative to `base_dir`, or unchanged when it lies outside.
+pub(super) fn relative_to(path: PathBuf, base_dir: &Path) -> PathBuf {
+    path.strip_prefix(base_dir)
+        .map(Path::to_path_buf)
+        .unwrap_or(path)
+}
+
 /// Render a source location as a message suffix; the position is best-effort
 /// (forwarded-only uses may lack one).
 fn location_suffix(file: &Path, position: Option<(usize, usize)>) -> String {

--- a/cli/nef-lock-catalog/src/scan/error.rs
+++ b/cli/nef-lock-catalog/src/scan/error.rs
@@ -36,6 +36,24 @@ pub enum ScanError {
         error: rnix::ParseError,
     },
 
+    /// The scan discovered a reference [CatalogRef] refuses, so no lock could
+    /// be produced from it. Today that means a namespace escaping static
+    /// analysis as a whole — passing `catalogs` to an opaque function,
+    /// selecting a catalog dynamically, forwarding it through an import that
+    /// cannot be followed — which widens to a root wildcard.
+    ///
+    /// `reason` is whatever the rule that rejected it said, rendered into the
+    /// message rather than exposed as the error's source: nothing inspects it,
+    /// and keeping it opaque means a new rule needs no change here.
+    #[error("{}", unlockable_reference_message(file, *position, reason))]
+    UnlockableReference {
+        file: PathBuf,
+        /// 1-based `(line, column)` where the reference was emitted, when
+        /// recorded.
+        position: Option<(usize, usize)>,
+        reason: String,
+    },
+
     /// A catalog root is referenced by a file whose top-level lambda does not
     /// declare it as a parameter. NEF supplies only declared arguments
     /// (callPackage semantics), so every reference through the root is
@@ -81,6 +99,18 @@ fn location_suffix(file: &Path, position: Option<(usize, usize)>) -> String {
 /// chain is printed.
 fn unparsable_file_message(file: &Path, position: Option<(usize, usize)>) -> String {
     format!("Invalid Nix syntax{}", location_suffix(file, position))
+}
+
+/// Render [ScanError::UnlockableReference] for the user.
+fn unlockable_reference_message(
+    file: &Path,
+    position: Option<(usize, usize)>,
+    reason: &str,
+) -> String {
+    let location = location_suffix(file, position);
+    formatdoc! {"
+        Cannot lock a catalog reference{location}: {reason}.
+        Reference packages as 'catalogs.<CATALOG>.<PACKAGE>'."}
 }
 
 /// Render [ScanError::UndeclaredRoot] for the user.
@@ -176,6 +206,18 @@ mod tests {
             chained(&err),
             "'pkgs/foo.nix' cannot be read: permission denied"
         );
+    }
+
+    #[test]
+    fn unlockable_reference_message_states_the_reason_and_the_location() {
+        let err = ScanError::UnlockableReference {
+            file: PathBuf::from("pkgs/foo.nix"),
+            position: Some((7, 14)),
+            reason: "'catalogs.*' references the whole catalog namespace".to_string(),
+        };
+        assert_eq!(err.to_string(), indoc::indoc! {"
+                Cannot lock a catalog reference at pkgs/foo.nix:7:14: 'catalogs.*' references the whole catalog namespace.
+                Reference packages as 'catalogs.<CATALOG>.<PACKAGE>'."});
     }
 
     #[test]

--- a/cli/nef-lock-catalog/src/scan/error.rs
+++ b/cli/nef-lock-catalog/src/scan/error.rs
@@ -3,8 +3,28 @@ use std::path::{Path, PathBuf};
 use indoc::formatdoc;
 
 /// A scan failure that must stop locking.
-#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+///
+/// `Eq` is absent because [rnix::ParseError] does not implement it.
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
 pub enum ScanError {
+    /// A file the scan must read is not valid Nix. rnix is error-tolerant and
+    /// yields a partial tree for a malformed file, so the references in the
+    /// broken region would be dropped without a signal.
+    ///
+    /// The parse error is the source rather than part of the message: it
+    /// already describes what the parser rejected, and rewriting that would
+    /// duplicate rnix's own reporting.
+    #[error("{}", unparsable_file_message(file, *position))]
+    UnparsableFile {
+        file: PathBuf,
+        /// 1-based `(line, column)` of the parse error, when it carries a
+        /// source range. Resolved at construction: the error locates itself by
+        /// byte offset, and only the file's content turns that into a position.
+        position: Option<(usize, usize)>,
+        #[source]
+        error: rnix::ParseError,
+    },
+
     /// A catalog root is referenced by a file whose top-level lambda does not
     /// declare it as a parameter. NEF supplies only declared arguments
     /// (callPackage semantics), so every reference through the root is
@@ -39,6 +59,13 @@ fn location_suffix(file: &Path, position: Option<(usize, usize)>) -> String {
     }
 }
 
+/// Render [ScanError::UnparsableFile] for the user. Kept to a single line with
+/// no full stop so the parse error reads as its continuation when the source
+/// chain is printed.
+fn unparsable_file_message(file: &Path, position: Option<(usize, usize)>) -> String {
+    format!("Invalid Nix syntax{}", location_suffix(file, position))
+}
+
 /// Render [ScanError::UndeclaredRoot] for the user.
 fn undeclared_root_message(root: &str, file: &Path, position: Option<(usize, usize)>) -> String {
     let location = location_suffix(file, position);
@@ -59,6 +86,46 @@ fn unreadable_import_message(target: &Path, file: &Path, position: (usize, usize
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// What `lock` prints: the message plus the source chain, which is where
+    /// the parse error itself surfaces.
+    fn chained(err: &ScanError) -> String {
+        let mut rendered = err.to_string();
+        let mut source = std::error::Error::source(err);
+        while let Some(err) = source {
+            rendered.push_str(&format!(": {err}"));
+            source = err.source();
+        }
+        rendered
+    }
+
+    #[test]
+    fn unparsable_file_error_message_points_at_the_syntax_error() {
+        let err = ScanError::UnparsableFile {
+            file: PathBuf::from("pkgs/foo.nix"),
+            position: Some((4, 12)),
+            error: rnix::ParseError::UnexpectedEOF,
+        };
+        assert_eq!(
+            chained(&err),
+            "Invalid Nix syntax at pkgs/foo.nix:4:12: unexpected end of file"
+        );
+    }
+
+    #[test]
+    fn unparsable_file_error_message_without_a_position_names_the_file() {
+        // An end-of-file error carries no source range, so there is no position
+        // to report.
+        let err = ScanError::UnparsableFile {
+            file: PathBuf::from("pkgs/foo.nix"),
+            position: None,
+            error: rnix::ParseError::UnexpectedEOF,
+        };
+        assert_eq!(
+            chained(&err),
+            "Invalid Nix syntax in pkgs/foo.nix: unexpected end of file"
+        );
+    }
 
     #[test]
     fn unreadable_import_error_message_points_at_the_import() {

--- a/cli/nef-lock-catalog/src/scan/error.rs
+++ b/cli/nef-lock-catalog/src/scan/error.rs
@@ -2,10 +2,21 @@ use std::path::{Path, PathBuf};
 
 use indoc::formatdoc;
 
+/// Where a file was named, when the scan did not read it directly.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImportSite {
+    /// The importing file.
+    pub file: PathBuf,
+    /// 1-based `(line, column)` of the import application.
+    pub position: (usize, usize),
+}
+
 /// A scan failure that must stop locking.
 ///
-/// `Eq` is absent because [rnix::ParseError] does not implement it.
-#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+/// Only `Debug` is derived: the wrapped [rnix::ParseError] rules out `Eq`, and
+/// [std::io::Error] rules out `Clone` and `PartialEq` too. Tests assert on the
+/// rendered message instead.
+#[derive(Debug, thiserror::Error)]
 pub enum ScanError {
     /// A file the scan must read is not valid Nix. rnix is error-tolerant and
     /// yields a partial tree for a malformed file, so the references in the
@@ -37,16 +48,22 @@ pub enum ScanError {
         position: Option<(usize, usize)>,
     },
 
-    /// An import that forwards catalog namespaces names a target file that
-    /// cannot be read. The refs the imported file would contribute through
-    /// the forwarded namespaces cannot be discovered, so the scan fails
-    /// rather than silently under-locking.
-    #[error("{}", unreadable_import_message(target, file, *position))]
-    UnreadableImport {
-        target: PathBuf,
+    /// A file the scan must read cannot be read. Whether it is the entry
+    /// expression, a dependency argument resolved by file convention, or the
+    /// target of an import that forwards a catalog namespace, the references
+    /// it would contribute cannot be discovered, so the scan fails rather
+    /// than silently under-locking.
+    ///
+    /// The IO error is the source rather than part of the message, so what
+    /// went wrong (missing, unreadable) is stated once, by the OS.
+    #[error("{}", unreadable_file_message(file, imported_from.as_ref()))]
+    UnreadableFile {
         file: PathBuf,
-        /// 1-based `(line, column)` of the import application.
-        position: (usize, usize),
+        #[source]
+        source: std::io::Error,
+        /// `Some` when the file was reached by an `import`; `None` when the
+        /// scan resolved it directly (entry file or dependency argument).
+        imported_from: Option<ImportSite>,
     },
 }
 
@@ -74,13 +91,18 @@ fn undeclared_root_message(root: &str, file: &Path, position: Option<(usize, usi
         Add '{root}' to the function arguments, e.g. '{{ {root}, ... }}:'."}
 }
 
-/// Render [ScanError::UnreadableImport] for the user.
-fn unreadable_import_message(target: &Path, file: &Path, position: (usize, usize)) -> String {
-    let target = target.display();
-    let location = location_suffix(file, Some(position));
-    formatdoc! {"
-        '{target}' is imported{location} but cannot be read.
-        Check that the imported file exists and is readable."}
+/// Render [ScanError::UnreadableFile] for the user. Kept to a single line with
+/// no full stop so the IO error reads as its continuation when the source chain
+/// is printed.
+fn unreadable_file_message(file: &Path, imported_from: Option<&ImportSite>) -> String {
+    let file = file.display();
+    match imported_from {
+        Some(site) => {
+            let location = location_suffix(&site.file, Some(site.position));
+            format!("'{file}' is imported{location} but cannot be read")
+        },
+        None => format!("'{file}' cannot be read"),
+    }
 }
 
 #[cfg(test)]
@@ -128,15 +150,32 @@ mod tests {
     }
 
     #[test]
-    fn unreadable_import_error_message_points_at_the_import() {
-        let err = ScanError::UnreadableImport {
-            target: PathBuf::from("pkgs/helper.nix"),
-            file: PathBuf::from("pkgs/foo.nix"),
-            position: (4, 1),
+    fn unreadable_file_error_message_points_at_the_import() {
+        let err = ScanError::UnreadableFile {
+            file: PathBuf::from("pkgs/helper.nix"),
+            source: std::io::Error::from(std::io::ErrorKind::NotFound),
+            imported_from: Some(ImportSite {
+                file: PathBuf::from("pkgs/foo.nix"),
+                position: (4, 1),
+            }),
         };
-        assert_eq!(err.to_string(), indoc::indoc! {"
-                'pkgs/helper.nix' is imported at pkgs/foo.nix:4:1 but cannot be read.
-                Check that the imported file exists and is readable."});
+        assert_eq!(
+            chained(&err),
+            "'pkgs/helper.nix' is imported at pkgs/foo.nix:4:1 but cannot be read: entity not found"
+        );
+    }
+
+    #[test]
+    fn unreadable_file_error_message_names_a_directly_resolved_file() {
+        let err = ScanError::UnreadableFile {
+            file: PathBuf::from("pkgs/foo.nix"),
+            source: std::io::Error::from(std::io::ErrorKind::PermissionDenied),
+            imported_from: None,
+        };
+        assert_eq!(
+            chained(&err),
+            "'pkgs/foo.nix' cannot be read: permission denied"
+        );
     }
 
     #[test]

--- a/cli/nef-lock-catalog/src/scan/graph.rs
+++ b/cli/nef-lock-catalog/src/scan/graph.rs
@@ -33,14 +33,13 @@ impl PackageGraph {
     }
 
     /// Add an entry package by its path relative to `base_dir`, reading and
-    /// analyzing it. Imports resolve against the entry's own directory. An
-    /// unreadable entry is a no-op. Callable more than once.
+    /// analyzing it. Imports resolve against the entry's own directory.
+    /// Callable more than once.
     pub(super) fn add_root(&mut self, rel_file: impl AsRef<Path>) -> Result<(), ScanError> {
         let path = self.base_dir.join(rel_file.as_ref());
         let key = package_key(rel_file.as_ref());
-        if let Some(scan) = read_and_analyze(&path, &self.root_attributes)? {
-            self.scans.insert(key, scan);
-        }
+        let scan = read_and_analyze(&path, &self.root_attributes)?;
+        self.scans.insert(key, scan);
         Ok(())
     }
 
@@ -127,6 +126,10 @@ fn package_key(rel_file: &Path) -> String {
 /// directory); a `<comp>/default.nix` is a package directory; a directory with
 /// no `default.nix` is an attribute set that is descended into. Components past
 /// the package file are attributes within it and are ignored.
+///
+/// `Ok(None)` means the argument names nothing on disk, which is how an
+/// argument NEF satisfies from nixpkgs looks. A file that does resolve but
+/// cannot be read is an error instead: it is a package of this set.
 fn try_resolve_dependency_argument(
     dir: &Path,
     components: &[String],
@@ -136,12 +139,12 @@ fn try_resolve_dependency_argument(
     for comp in components {
         let file = cur.join(format!("{comp}.nix"));
         if file.is_file() {
-            return read_and_analyze(&file, root_attributes);
+            return read_and_analyze(&file, root_attributes).map(Some);
         }
         let sub = cur.join(comp);
         let default = sub.join("default.nix");
         if default.is_file() {
-            return read_and_analyze(&default, root_attributes);
+            return read_and_analyze(&default, root_attributes).map(Some);
         }
         if sub.is_dir() {
             cur = sub;
@@ -157,16 +160,16 @@ fn try_resolve_dependency_argument(
 /// Relative imports in the file resolve against its own directory, so the
 /// file's parent is passed as the import base. Shared by [PackageGraph::add_root]
 /// (entry packages) and [try_resolve_dependency_argument] (dependencies).
-fn read_and_analyze(
-    path: &Path,
-    root_attributes: &HashSet<String>,
-) -> Result<Option<FileInfo>, ScanError> {
-    // TODO(ECO-133): an unreadable file silently resolves to `None`, which
-    // drops the package and its refs from the closure. This should probably be
-    // a hard error rather than a silent skip.
-    let Ok(content) = fs::read_to_string(path) else {
-        return Ok(None);
-    };
+///
+/// Error, if the file at `path` cannot be read.
+/// Skipping the analysis here would otherwise lead to incomplete closures,
+/// and likely evaluation errors.
+fn read_and_analyze(path: &Path, root_attributes: &HashSet<String>) -> Result<FileInfo, ScanError> {
+    let content = fs::read_to_string(path).map_err(|source| ScanError::UnreadableFile {
+        file: path.to_path_buf(),
+        source,
+        imported_from: None,
+    })?;
     analyze_file_at(
         &content,
         root_attributes,
@@ -175,5 +178,4 @@ fn read_and_analyze(
         path,
         &identity_origins(root_attributes),
     )
-    .map(Some)
 }

--- a/cli/nef-lock-catalog/src/scan/graph.rs
+++ b/cli/nef-lock-catalog/src/scan/graph.rs
@@ -2,6 +2,8 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use tracing::warn;
+
 use super::analyze::{FileInfo, RefSource, analyze_file_at, identity_origins};
 use super::{AttrPath, CatalogRef, ScanError};
 
@@ -93,6 +95,11 @@ impl PackageGraph {
     /// rewritten out of the namespace it was written in. Paths are visited in
     /// order and the first that cannot be locked is reported against the
     /// source it was found at.
+    ///
+    /// A reference that survives but ends in a wildcard is an over-lock: the
+    /// scanner could not resolve that far and locked the subtree instead. That
+    /// too is a property of the finished reference, so it is warned about
+    /// here rather than where the widening happened.
     pub(super) fn references(&self) -> Result<BTreeSet<CatalogRef>, ScanError> {
         let mut paths: BTreeMap<&AttrPath, &RefSource> = BTreeMap::new();
         for scan in self.scans.values() {
@@ -103,13 +110,23 @@ impl PackageGraph {
         paths
             .into_iter()
             .map(|(path, source)| {
-                CatalogRef::try_from(path.clone()).map_err(|reason| {
+                let reference = CatalogRef::try_from(path.clone()).map_err(|reason| {
                     ScanError::UnlockableReference {
                         file: source.file.clone(),
                         position: Some(source.position),
                         reason: reason.to_string(),
                     }
-                })
+                })?;
+                if reference.path().is_wildcard() {
+                    warn!(
+                        reference = %reference,
+                        file = %source.file.display(),
+                        line = source.position.0,
+                        column = source.position.1,
+                        "catalog namespace escapes static analysis; locking the whole subtree",
+                    );
+                }
+                Ok(reference)
             })
             .collect()
     }

--- a/cli/nef-lock-catalog/src/scan/graph.rs
+++ b/cli/nef-lock-catalog/src/scan/graph.rs
@@ -1,10 +1,12 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
+use flox_core::canonical_path::CanonicalPath;
 use tracing::warn;
 
 use super::analyze::{FileInfo, RefSource, analyze_file_at, identity_origins};
+use super::error::relative_to;
 use super::{AttrPath, CatalogRef, ScanError};
 
 /// The NEF package files analyzed during closure resolution, keyed by package
@@ -17,7 +19,7 @@ use super::{AttrPath, CatalogRef, ScanError};
 /// resolves each reachable dependency argument once and caches it in `scans`,
 /// so a package shared by several dependents is analyzed a single time.
 pub(super) struct PackageGraph {
-    base_dir: PathBuf,
+    base_dir: CanonicalPath,
     /// Catalog root parameter names every package is scanned against.
     root_attributes: HashSet<String>,
     scans: HashMap<String, FileInfo>,
@@ -26,9 +28,9 @@ pub(super) struct PackageGraph {
 impl PackageGraph {
     /// An empty graph resolving packages under `base_dir` and scanning each
     /// against `root_attributes` (the catalog root parameter names).
-    pub(super) fn new(base_dir: impl AsRef<Path>, root_attributes: HashSet<String>) -> Self {
+    pub(super) fn new(base_dir: CanonicalPath, root_attributes: HashSet<String>) -> Self {
         Self {
-            base_dir: base_dir.as_ref().to_path_buf(),
+            base_dir,
             root_attributes,
             scans: HashMap::new(),
         }
@@ -120,7 +122,7 @@ impl PackageGraph {
                 if reference.path().is_wildcard() {
                     warn!(
                         reference = %reference,
-                        file = %source.file.display(),
+                        file = %relative_to(source.file.clone(), &self.base_dir).display(),
                         line = source.position.0,
                         column = source.position.1,
                         "catalog namespace escapes static analysis; locking the whole subtree",
@@ -203,7 +205,16 @@ fn try_resolve_dependency_argument(
 /// Skipping the analysis here would otherwise lead to incomplete closures,
 /// and likely evaluation errors.
 fn read_and_analyze(path: &Path, root_attributes: &HashSet<String>) -> Result<FileInfo, ScanError> {
-    let content = fs::read_to_string(path).map_err(|source| ScanError::UnreadableFile {
+    // Files enter the scan here, and the analysis names them canonically from
+    // this point on: import targets are resolved that way, so an entry reached
+    // again through an import has to arrive under the same name to be
+    // recognized as the same file.
+    let path = CanonicalPath::new(path).map_err(|err| ScanError::UnreadableFile {
+        file: err.path,
+        source: err.err,
+        imported_from: None,
+    })?;
+    let content = fs::read_to_string(&path).map_err(|source| ScanError::UnreadableFile {
         file: path.to_path_buf(),
         source,
         imported_from: None,
@@ -213,7 +224,7 @@ fn read_and_analyze(path: &Path, root_attributes: &HashSet<String>) -> Result<Fi
         root_attributes,
         path.parent(),
         &mut HashMap::new(),
-        path,
+        &path,
         &identity_origins(root_attributes),
         &[],
     )

--- a/cli/nef-lock-catalog/src/scan/graph.rs
+++ b/cli/nef-lock-catalog/src/scan/graph.rs
@@ -215,5 +215,6 @@ fn read_and_analyze(path: &Path, root_attributes: &HashSet<String>) -> Result<Fi
         &mut HashMap::new(),
         path,
         &identity_origins(root_attributes),
+        &[],
     )
 }

--- a/cli/nef-lock-catalog/src/scan/graph.rs
+++ b/cli/nef-lock-catalog/src/scan/graph.rs
@@ -1,9 +1,9 @@
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use super::analyze::{FileInfo, analyze_file_at, identity_origins};
-use super::{CatalogRef, ScanError};
+use super::analyze::{FileInfo, RefSource, analyze_file_at, identity_origins};
+use super::{AttrPath, CatalogRef, ScanError};
 
 /// The NEF package files analyzed during closure resolution, keyed by package
 /// key.
@@ -86,10 +86,31 @@ impl PackageGraph {
     /// once [Self::expand_closure] has run: the graph then holds exactly the
     /// reachable packages, since only reachable arguments are ever resolved
     /// into it.
-    pub(super) fn references(&self) -> BTreeSet<CatalogRef> {
-        self.scans
-            .values()
-            .flat_map(|scan| scan.refs.iter().cloned())
+    ///
+    /// This is where paths become references. Whether one can be locked turns
+    /// on its depth below the top-level root, which a file scanned through a
+    /// forwarded namespace cannot know — only here has every path been
+    /// rewritten out of the namespace it was written in. Paths are visited in
+    /// order and the first that cannot be locked is reported against the
+    /// source it was found at.
+    pub(super) fn references(&self) -> Result<BTreeSet<CatalogRef>, ScanError> {
+        let mut paths: BTreeMap<&AttrPath, &RefSource> = BTreeMap::new();
+        for scan in self.scans.values() {
+            for (path, source) in &scan.refs {
+                paths.entry(path).or_insert(source);
+            }
+        }
+        paths
+            .into_iter()
+            .map(|(path, source)| {
+                CatalogRef::try_from(path.clone()).map_err(|reason| {
+                    ScanError::UnlockableReference {
+                        file: source.file.clone(),
+                        position: Some(source.position),
+                        reason: reason.to_string(),
+                    }
+                })
+            })
             .collect()
     }
 }

--- a/cli/nef-lock-catalog/src/scan/mod.rs
+++ b/cli/nef-lock-catalog/src/scan/mod.rs
@@ -7,93 +7,117 @@ use serde::{Deserialize, Serialize};
 use tracing::{debug, instrument};
 
 mod analyze;
+mod attr_path;
 mod error;
 mod graph;
 
+pub use attr_path::{AttrPath, Component, InvalidAttrPath};
 pub use error::{ImportSite, ScanError};
 use graph::PackageGraph;
 
 /// A single catalog attribute-path reference discovered by the scanner,
-/// e.g. `catalogs.myorg.toolkit.readVersion`. A dynamic component collapses
-/// the tail to a `*` sentinel (e.g. `catalogs.myorg.*`).
+/// e.g. `catalogs.myorg.toolkit.readVersion`. Where the walker could not
+/// resolve a path further it names everything under it instead, rendered with
+/// a `*` sentinel (e.g. `catalogs.myorg.*`).
 ///
-/// Distinct from a bare `String` so downstream lookup grouping consumes a
-/// typed reference rather than an arbitrary string, and validated so that
-/// consumers need not re-check the shapes that could never resolve — see
-/// [CatalogRef::from_str].
+/// Distinct from an [AttrPath] because not every path the walker resolves can
+/// be locked: the conversion rejects the shapes that could never resolve, so
+/// consumers need not re-check them.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-#[serde(try_from = "String")]
-pub struct CatalogRef(String);
+#[serde(into = "String", try_from = "String")]
+pub struct CatalogRef(AttrPath);
 
-/// A string that cannot be a [CatalogRef].
+/// An [AttrPath] that cannot be a [CatalogRef].
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
-#[error("'{reference}' {kind}")]
+#[error("'{path}' {kind}")]
 pub struct InvalidCatalogRef {
-    pub reference: String,
+    pub path: AttrPath,
     pub kind: InvalidCatalogRefKind,
 }
 
-/// Why a string cannot be a [CatalogRef]. Both shapes name nothing the server
+/// Why a path cannot be a [CatalogRef]. None of these name anything the server
 /// can resolve, for different reasons.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum InvalidCatalogRefKind {
-    /// The wire form drops the leading root segment, leaving `*`.
+    /// The wire form drops the leading root component, leaving `*`.
     #[error("references the whole catalog namespace")]
     RootWildcard,
-    /// There is no root segment to drop, so the wire form is the reference
+    /// There is no root component to drop, so the wire form is the reference
     /// itself — a name in the scanner's namespace, not the server's.
     #[error("is not rooted at a catalog namespace")]
     Rootless,
+    /// The server resolves no shallower than a catalog plus one component, so
+    /// naming a catalog alone reaches nothing.
+    #[error("names a catalog rather than a package in one")]
+    CatalogLevel,
 }
 
 impl CatalogRef {
-    /// The reference as a dotted attr-path string.
-    pub fn as_str(&self) -> &str {
+    /// The path this reference locks.
+    pub fn path(&self) -> &AttrPath {
         &self.0
     }
 
     /// Build a reference without checking the invariant, so tests can state
     /// their expectations as literals.
     #[cfg(test)]
-    pub(crate) fn new_unchecked(value: impl Into<String>) -> Self {
-        Self(value.into())
+    pub(crate) fn new_unchecked(value: &str) -> Self {
+        Self(value.parse().expect("attr paths always parse"))
     }
 }
 
-/// A reference is rooted and never a bare root wildcard.
-///
-/// The wire form drops the leading root segment, so `catalogs.*` would go out
-/// as `*` and a rootless reference as itself; neither names anything the
-/// server can resolve, and either would fail the whole lock. Rejecting them
-/// here means no consumer has to.
+/// A string that cannot be a [CatalogRef], either because it is not an
+/// attribute path or because it is one that cannot be locked.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ParseCatalogRefError {
+    #[error(transparent)]
+    Path(#[from] InvalidAttrPath),
+    #[error(transparent)]
+    Reference(#[from] InvalidCatalogRef),
+}
+
+/// Parsing reads the text back into an [AttrPath] and applies the same rules
+/// as any other construction, so a reference read from a lock file is held to
+/// them too.
 impl FromStr for CatalogRef {
-    type Err = InvalidCatalogRef;
+    type Err = ParseCatalogRefError;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        let kind = match value.split_once('.') {
-            None => InvalidCatalogRefKind::Rootless,
-            Some((_, "*")) => InvalidCatalogRefKind::RootWildcard,
-            Some(_) => return Ok(Self(value.to_string())),
-        };
-        Err(InvalidCatalogRef {
-            reference: value.to_string(),
-            kind,
-        })
+        let path: AttrPath = value.parse()?;
+        Ok(path.try_into()?)
     }
 }
 
 /// Deserialization goes through [FromStr] (see `#[serde(try_from)]`).
 impl TryFrom<String> for CatalogRef {
-    type Error = InvalidCatalogRef;
+    type Error = ParseCatalogRefError;
 
     fn try_from(value: String) -> Result<Self, Self::Error> {
         value.parse()
     }
 }
 
+/// A reference reaches a package: a root, the catalog it names, and something
+/// within it — or a wildcard standing in for that last part.
+impl TryFrom<AttrPath> for CatalogRef {
+    type Error = InvalidCatalogRef;
+
+    fn try_from(path: AttrPath) -> Result<Self, Self::Error> {
+        let kind = match (path.base().len(), path.is_wildcard()) {
+            // A wildcard stands for whatever it replaced, so a base naming a
+            // root and a catalog already reaches into one.
+            (2.., true) | (3.., false) => return Ok(Self(path)),
+            (_, true) => InvalidCatalogRefKind::RootWildcard,
+            (2, false) => InvalidCatalogRefKind::CatalogLevel,
+            (_, false) => InvalidCatalogRefKind::Rootless,
+        };
+        Err(InvalidCatalogRef { path, kind })
+    }
+}
+
 impl From<CatalogRef> for String {
     fn from(value: CatalogRef) -> Self {
-        value.0
+        value.0.to_string()
     }
 }
 
@@ -168,38 +192,73 @@ mod tests {
     use super::*;
 
     fn set(items: &[&str]) -> BTreeSet<CatalogRef> {
-        items
-            .iter()
-            .map(|s| CatalogRef::new_unchecked(*s))
-            .collect()
+        items.iter().map(|s| CatalogRef::new_unchecked(s)).collect()
     }
 
     #[test]
     fn catalog_ref_rejects_references_that_cannot_resolve() {
-        use InvalidCatalogRefKind::{RootWildcard, Rootless};
+        use InvalidCatalogRefKind::{CatalogLevel, RootWildcard, Rootless};
 
         let cases = [
-            // Rooted references, whatever the depth or sentinel. Catalog and
-            // package sentinels expand server-side.
+            // References that reach into a catalog, whatever the depth.
+            // Catalog and package sentinels expand server-side.
             ("catalogs.myorg.pkg.readVersion", None),
             ("catalogs.myorg.pkg", None),
             ("catalogs.myorg.pkg.*", None),
             ("catalogs.myorg.*", None),
-            // Neither names anything resolvable, for different reasons: the
-            // wire form of the first is `*`, of the second the name itself.
+            // None of these name anything resolvable: the wire form of the
+            // first is `*`, of the second the name itself, and the third stops
+            // at a catalog rather than reaching into one.
             ("catalogs.*", Some(RootWildcard)),
             ("catalogs", Some(Rootless)),
+            ("catalogs.myorg", Some(CatalogLevel)),
         ];
         let got: Vec<(&str, Option<InvalidCatalogRefKind>)> = cases
             .iter()
             .map(|(reference, _)| {
-                (
-                    *reference,
-                    reference.parse::<CatalogRef>().err().map(|err| err.kind),
-                )
+                let kind = match reference.parse::<CatalogRef>() {
+                    Ok(_) => None,
+                    Err(ParseCatalogRefError::Reference(err)) => Some(err.kind),
+                    Err(err) => panic!("{reference}: expected a rejected path, got {err}"),
+                };
+                (*reference, kind)
             })
             .collect();
         assert_eq!(got, cases.to_vec());
+    }
+
+    #[test]
+    fn catalog_ref_rejects_text_that_is_not_an_attribute_path() {
+        // Parsing goes through rnix, so what is not Nix is not a path. A
+        // dynamic attribute is the one Nix-legal shape refused: it names
+        // nothing until evaluated.
+        let cases = ["catalogs myorg", "catalogs.${org}.pkg", ""];
+        for reference in cases {
+            assert_matches!(
+                reference.parse::<CatalogRef>(),
+                Err(ParseCatalogRefError::Path(_)),
+                "reference: {reference}"
+            );
+        }
+    }
+
+    #[test]
+    fn catalog_ref_round_trips_quoted_names() {
+        // A name the catalog could not hold is still a path Nix accepts, so
+        // parsing keeps it and rendering quotes it back. The walker widens
+        // rather than emitting one, but a reference read from text must
+        // survive being written out again.
+        for reference in [
+            "catalogs.myorg.pkg",
+            "catalogs.myorg.*",
+            "catalogs.\"foo.bar\".pkg",
+            "catalogs.myorg.\"with space\"",
+        ] {
+            let parsed = reference
+                .parse::<CatalogRef>()
+                .unwrap_or_else(|err| panic!("{reference}: {err}"));
+            assert_eq!(parsed.to_string(), reference);
+        }
     }
 
     #[test]
@@ -208,7 +267,7 @@ mod tests {
         // lock file could reintroduce a reference the type rules out.
         assert_matches!(
             serde_json::from_str::<CatalogRef>("\"catalogs.myorg.pkg\""),
-            Ok(reference) if reference.as_str() == "catalogs.myorg.pkg"
+            Ok(reference) if reference.to_string() == "catalogs.myorg.pkg"
         );
         assert_matches!(serde_json::from_str::<CatalogRef>("\"catalogs.*\""), Err(_));
     }
@@ -371,10 +430,12 @@ mod tests {
     /// anything shallower can never resolve (the server's floor is catalog +
     /// one component) and would fail the whole lock.
     #[test]
-    fn all_fixture_refs_are_lockable_shapes() {
+    fn every_fixture_scans_to_a_result() {
+        // The shapes this used to check for are now unrepresentable, so what
+        // is left is a sweep: every top-level fixture either scans or fails
+        // deliberately, and between them they do produce references.
         let dir = Path::new("test_data/catalog_refs");
         let mut scanned = 0;
-        let mut violations: Vec<String> = Vec::new();
         for entry in fs::read_dir(dir).expect("fixture dir") {
             let path = entry.expect("fixture entry").path();
             if path.extension().and_then(|ext| ext.to_str()) != Some("nix") {
@@ -382,20 +443,12 @@ mod tests {
             }
             let rel = path.file_name().expect("fixture file name");
             // Some fixtures pin scan *errors* (unreadable imports,
-            // undeclared root_attributes); they emit no refs to check.
+            // undeclared root_attributes); they emit no refs to count.
             let Ok(references) = scan_package(dir, Path::new(rel)) else {
                 continue;
             };
-            for reference in references {
-                scanned += 1;
-                let reference = reference.as_str();
-                let post_root = reference.split('.').count() - 1;
-                if !reference.ends_with(".*") && post_root < 2 {
-                    violations.push(reference.to_string());
-                }
-            }
+            scanned += references.len();
         }
-        assert_eq!(violations, Vec::<String>::new());
         assert!(scanned > 0, "no fixture refs scanned");
     }
 }

--- a/cli/nef-lock-catalog/src/scan/mod.rs
+++ b/cli/nef-lock-catalog/src/scan/mod.rs
@@ -27,8 +27,24 @@ pub struct CatalogRef(String);
 
 /// A string that cannot be a [CatalogRef].
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
-#[error("'{0}' references the whole catalog namespace")]
-pub struct RootWildcard(pub String);
+#[error("'{reference}' {kind}")]
+pub struct InvalidCatalogRef {
+    pub reference: String,
+    pub kind: InvalidCatalogRefKind,
+}
+
+/// Why a string cannot be a [CatalogRef]. Both shapes name nothing the server
+/// can resolve, for different reasons.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum InvalidCatalogRefKind {
+    /// The wire form drops the leading root segment, leaving `*`.
+    #[error("references the whole catalog namespace")]
+    RootWildcard,
+    /// There is no root segment to drop, so the wire form is the reference
+    /// itself — a name in the scanner's namespace, not the server's.
+    #[error("is not rooted at a catalog namespace")]
+    Rootless,
+}
 
 impl CatalogRef {
     /// The reference as a dotted attr-path string.
@@ -36,9 +52,9 @@ impl CatalogRef {
         &self.0
     }
 
-    /// Build a reference without checking the invariant, for tests and for the
-    /// scanner's own construction, which reports a violation with the source
-    /// location it alone has.
+    /// Build a reference without checking the invariant, so tests can state
+    /// their expectations as literals.
+    #[cfg(test)]
     pub(crate) fn new_unchecked(value: impl Into<String>) -> Self {
         Self(value.into())
     }
@@ -51,19 +67,24 @@ impl CatalogRef {
 /// server can resolve, and either would fail the whole lock. Rejecting them
 /// here means no consumer has to.
 impl FromStr for CatalogRef {
-    type Err = RootWildcard;
+    type Err = InvalidCatalogRef;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value.split_once('.') {
-            None | Some((_, "*")) => Err(RootWildcard(value.to_string())),
-            Some(_) => Ok(Self(value.to_string())),
-        }
+        let kind = match value.split_once('.') {
+            None => InvalidCatalogRefKind::Rootless,
+            Some((_, "*")) => InvalidCatalogRefKind::RootWildcard,
+            Some(_) => return Ok(Self(value.to_string())),
+        };
+        Err(InvalidCatalogRef {
+            reference: value.to_string(),
+            kind,
+        })
     }
 }
 
 /// Deserialization goes through [FromStr] (see `#[serde(try_from)]`).
 impl TryFrom<String> for CatalogRef {
-    type Error = RootWildcard;
+    type Error = InvalidCatalogRef;
 
     fn try_from(value: String) -> Result<Self, Self::Error> {
         value.parse()
@@ -155,19 +176,28 @@ mod tests {
 
     #[test]
     fn catalog_ref_rejects_references_that_cannot_resolve() {
+        use InvalidCatalogRefKind::{RootWildcard, Rootless};
+
         let cases = [
-            // Rooted references, whatever the depth or sentinel.
-            ("catalogs.myorg.pkg.readVersion", true),
-            ("catalogs.myorg.pkg", true),
-            ("catalogs.myorg.*", true),
-            // A root wildcard goes on the wire as `*`, a rootless reference as
-            // itself; neither names anything resolvable.
-            ("catalogs.*", false),
-            ("catalogs", false),
+            // Rooted references, whatever the depth or sentinel. Catalog and
+            // package sentinels expand server-side.
+            ("catalogs.myorg.pkg.readVersion", None),
+            ("catalogs.myorg.pkg", None),
+            ("catalogs.myorg.pkg.*", None),
+            ("catalogs.myorg.*", None),
+            // Neither names anything resolvable, for different reasons: the
+            // wire form of the first is `*`, of the second the name itself.
+            ("catalogs.*", Some(RootWildcard)),
+            ("catalogs", Some(Rootless)),
         ];
-        let got: Vec<(&str, bool)> = cases
+        let got: Vec<(&str, Option<InvalidCatalogRefKind>)> = cases
             .iter()
-            .map(|(reference, _)| (*reference, reference.parse::<CatalogRef>().is_ok()))
+            .map(|(reference, _)| {
+                (
+                    *reference,
+                    reference.parse::<CatalogRef>().err().map(|err| err.kind),
+                )
+            })
             .collect();
         assert_eq!(got, cases.to_vec());
     }

--- a/cli/nef-lock-catalog/src/scan/mod.rs
+++ b/cli/nef-lock-catalog/src/scan/mod.rs
@@ -42,13 +42,12 @@ pub struct InvalidCatalogRef {
 /// can resolve, for different reasons.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub(crate) enum InvalidCatalogRefKind {
-    /// The wire form drops the leading root component, leaving `*`.
+    /// The path names the namespace and nothing under it, whether it says so
+    /// with a wildcard (`catalogs.*`) or by naming the root alone
+    /// (`catalogs`). The wire form drops the root, leaving `*` or nothing.
     #[error("references the whole catalog namespace")]
     RootWildcard,
-    /// There is no root component to drop, so the wire form is the reference
-    /// itself — a name in the scanner's namespace, not the server's.
-    #[error("is not rooted at a catalog namespace")]
-    Rootless,
+
     /// The server resolves no shallower than a catalog plus one component, so
     /// naming a catalog alone reaches nothing.
     #[error("names a catalog rather than a package in one")]
@@ -109,11 +108,12 @@ impl TryFrom<AttrPath> for CatalogRef {
     fn try_from(path: AttrPath) -> Result<Self, Self::Error> {
         // A wildcard is always last and stands for whatever it replaced, so
         // depth alone decides: root, catalog, and something within it.
+        // Anything shallower than a catalog names the namespace itself,
+        // however it is written.
         let kind = match (path.len(), path.is_wildcard()) {
             (3.., _) => return Ok(Self(path)),
-            (_, true) => InvalidCatalogRefKind::RootWildcard,
             (2, false) => InvalidCatalogRefKind::CatalogLevel,
-            (_, false) => InvalidCatalogRefKind::Rootless,
+            _ => InvalidCatalogRefKind::RootWildcard,
         };
         Err(InvalidCatalogRef { path, kind })
     }
@@ -201,7 +201,7 @@ mod tests {
 
     #[test]
     fn catalog_ref_rejects_references_that_cannot_resolve() {
-        use InvalidCatalogRefKind::{CatalogLevel, RootWildcard, Rootless};
+        use InvalidCatalogRefKind::{CatalogLevel, RootWildcard};
 
         let cases = [
             // References that reach into a catalog, whatever the depth.
@@ -210,11 +210,10 @@ mod tests {
             ("catalogs.myorg.pkg", None),
             ("catalogs.myorg.pkg.*", None),
             ("catalogs.myorg.*", None),
-            // None of these name anything resolvable: the wire form of the
-            // first is `*`, of the second the name itself, and the third stops
-            // at a catalog rather than reaching into one.
+            // Naming the namespace and naming it with a wildcard are the same
+            // reference; stopping at a catalog reaches nothing either.
             ("catalogs.*", Some(RootWildcard)),
-            ("catalogs", Some(Rootless)),
+            ("catalogs", Some(RootWildcard)),
             ("catalogs.myorg", Some(CatalogLevel)),
         ];
         let got: Vec<(&str, Option<InvalidCatalogRefKind>)> = cases

--- a/cli/nef-lock-catalog/src/scan/mod.rs
+++ b/cli/nef-lock-catalog/src/scan/mod.rs
@@ -11,7 +11,8 @@ mod attr_path;
 mod error;
 mod graph;
 
-pub use attr_path::{AttrPath, InvalidAttrPath};
+pub(crate) use attr_path::AttrPath;
+pub use attr_path::InvalidAttrPath;
 pub use error::{ImportSite, ScanError};
 use graph::PackageGraph;
 
@@ -31,14 +32,16 @@ pub struct CatalogRef(AttrPath);
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 #[error("'{path}' {kind}")]
 pub struct InvalidCatalogRef {
-    pub path: AttrPath,
-    pub kind: InvalidCatalogRefKind,
+    /// The offending path. Crate-internal like [AttrPath] itself: outside the
+    /// crate a reference is text, and the message says which rule refused it.
+    pub(crate) path: AttrPath,
+    pub(crate) kind: InvalidCatalogRefKind,
 }
 
 /// Why a path cannot be a [CatalogRef]. None of these name anything the server
 /// can resolve, for different reasons.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
-pub enum InvalidCatalogRefKind {
+pub(crate) enum InvalidCatalogRefKind {
     /// The wire form drops the leading root component, leaving `*`.
     #[error("references the whole catalog namespace")]
     RootWildcard,
@@ -53,8 +56,9 @@ pub enum InvalidCatalogRefKind {
 }
 
 impl CatalogRef {
-    /// The path this reference locks.
-    pub fn path(&self) -> &AttrPath {
+    /// The path this reference locks. Crate-internal: a reference is a
+    /// [Display] value to consumers, and the wire form is built from it here.
+    pub(crate) fn path(&self) -> &AttrPath {
         &self.0
     }
 

--- a/cli/nef-lock-catalog/src/scan/mod.rs
+++ b/cli/nef-lock-catalog/src/scan/mod.rs
@@ -179,7 +179,7 @@ pub fn scan_package_with_roots(
     let mut graph = PackageGraph::new(base_dir, root_attributes);
     graph.add_root(rel_file)?;
     graph.expand_closure()?;
-    let references = graph.references();
+    let references = graph.references()?;
 
     debug!(references = references.len(), "scanned catalog references");
     Ok(references)
@@ -270,6 +270,23 @@ mod tests {
             Ok(reference) if reference.to_string() == "catalogs.myorg.pkg"
         );
         assert_matches!(serde_json::from_str::<CatalogRef>("\"catalogs.*\""), Err(_));
+    }
+
+    #[test]
+    fn root_wildcard_fails_the_scan() {
+        // The walk records the widening and the graph rejects it, once every
+        // path is back in the top-level namespace. The error still names the
+        // file and position the path was found at.
+        let base_dir = Path::new("test_data/catalog_refs");
+        let err =
+            scan_package(base_dir, Path::new("escaping-root.nix")).expect_err("scan should fail");
+        assert_matches!(
+            err,
+            ScanError::UnlockableReference { file, position, reason }
+                if file == base_dir.join("escaping-root.nix")
+                    && position == Some((4, 3))
+                    && reason == "'catalogs.*' references the whole catalog namespace"
+        );
     }
 
     #[test]

--- a/cli/nef-lock-catalog/src/scan/mod.rs
+++ b/cli/nef-lock-catalog/src/scan/mod.rs
@@ -11,7 +11,7 @@ mod attr_path;
 mod error;
 mod graph;
 
-pub use attr_path::{AttrPath, Component, InvalidAttrPath};
+pub use attr_path::{AttrPath, InvalidAttrPath};
 pub use error::{ImportSite, ScanError};
 use graph::PackageGraph;
 
@@ -103,10 +103,10 @@ impl TryFrom<AttrPath> for CatalogRef {
     type Error = InvalidCatalogRef;
 
     fn try_from(path: AttrPath) -> Result<Self, Self::Error> {
-        let kind = match (path.base().len(), path.is_wildcard()) {
-            // A wildcard stands for whatever it replaced, so a base naming a
-            // root and a catalog already reaches into one.
-            (2.., true) | (3.., false) => return Ok(Self(path)),
+        // A wildcard is always last and stands for whatever it replaced, so
+        // depth alone decides: root, catalog, and something within it.
+        let kind = match (path.len(), path.is_wildcard()) {
+            (3.., _) => return Ok(Self(path)),
             (_, true) => InvalidCatalogRefKind::RootWildcard,
             (2, false) => InvalidCatalogRefKind::CatalogLevel,
             (_, false) => InvalidCatalogRefKind::Rootless,

--- a/cli/nef-lock-catalog/src/scan/mod.rs
+++ b/cli/nef-lock-catalog/src/scan/mod.rs
@@ -3,6 +3,7 @@ use std::fmt::{self, Display};
 use std::path::Path;
 use std::str::FromStr;
 
+use flox_core::canonical_path::CanonicalPath;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, instrument};
 
@@ -180,10 +181,24 @@ pub fn scan_package_with_roots(
 ) -> Result<BTreeSet<CatalogRef>, ScanError> {
     let root_attributes: HashSet<String> = root_attributes.into_iter().map(Into::into).collect();
 
-    let mut graph = PackageGraph::new(base_dir, root_attributes);
-    graph.add_root(rel_file)?;
-    graph.expand_closure()?;
-    let references = graph.references()?;
+    // The scan names every file it reads canonically, so the root failures are
+    // re-expressed against has to be canonical too or nothing strips.
+    let base_dir = CanonicalPath::new(base_dir).map_err(|err| ScanError::UnreadableFile {
+        file: err.path,
+        source: err.err,
+        imported_from: None,
+    })?;
+
+    // Failures are re-expressed against the package-set root here, at the
+    // crate's boundary, so the paths a user reads name files the way they
+    // wrote them rather than wherever the scan happened to read them from.
+    let mut graph = PackageGraph::new(base_dir.clone(), root_attributes);
+    let scan = || {
+        graph.add_root(rel_file)?;
+        graph.expand_closure()?;
+        graph.references()
+    };
+    let references = scan().map_err(|err| err.relative_to(&base_dir))?;
 
     debug!(references = references.len(), "scanned catalog references");
     Ok(references)
@@ -278,15 +293,16 @@ mod tests {
     #[test]
     fn root_wildcard_fails_the_scan() {
         // The walk records the widening and the graph rejects it, once every
-        // path is back in the top-level namespace. The error still names the
-        // file and position the path was found at.
+        // path is back in the top-level namespace. The error names the file
+        // and position the path was found at, relative to the package-set
+        // root the caller named it under.
         let base_dir = Path::new("test_data/catalog_refs");
         let err =
             scan_package(base_dir, Path::new("escaping-root.nix")).expect_err("scan should fail");
         assert_matches!(
             err,
             ScanError::UnlockableReference { file, position, reason }
-                if file == base_dir.join("escaping-root.nix")
+                if file == Path::new("escaping-root.nix")
                     && position == Some((4, 3))
                     && reason == "'catalogs.*' references the whole catalog namespace"
         );
@@ -306,7 +322,7 @@ mod tests {
                 file,
                 source,
                 imported_from: None,
-            } if file == base_dir.join("no-such-package.nix")
+            } if file == Path::new("no-such-package.nix")
                 && source.kind() == std::io::ErrorKind::NotFound
         );
     }

--- a/cli/nef-lock-catalog/src/scan/mod.rs
+++ b/cli/nef-lock-catalog/src/scan/mod.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeSet, HashSet};
 use std::fmt::{self, Display};
 use std::path::Path;
+use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 use tracing::{debug, instrument};
@@ -17,26 +18,55 @@ use graph::PackageGraph;
 /// the tail to a `*` sentinel (e.g. `catalogs.myorg.*`).
 ///
 /// Distinct from a bare `String` so downstream lookup grouping consumes a
-/// typed reference rather than an arbitrary string.
+/// typed reference rather than an arbitrary string, and validated so that
+/// consumers need not re-check the shapes that could never resolve — see
+/// [CatalogRef::from_str].
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(try_from = "String")]
 pub struct CatalogRef(String);
+
+/// A string that cannot be a [CatalogRef].
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("'{0}' references the whole catalog namespace")]
+pub struct RootWildcard(pub String);
 
 impl CatalogRef {
     /// The reference as a dotted attr-path string.
     pub fn as_str(&self) -> &str {
         &self.0
     }
-}
 
-impl From<String> for CatalogRef {
-    fn from(value: String) -> Self {
-        Self(value)
+    /// Build a reference without checking the invariant, for tests and for the
+    /// scanner's own construction, which reports a violation with the source
+    /// location it alone has.
+    pub(crate) fn new_unchecked(value: impl Into<String>) -> Self {
+        Self(value.into())
     }
 }
 
-impl From<&str> for CatalogRef {
-    fn from(value: &str) -> Self {
-        Self(value.to_string())
+/// A reference is rooted and never a bare root wildcard.
+///
+/// The wire form drops the leading root segment, so `catalogs.*` would go out
+/// as `*` and a rootless reference as itself; neither names anything the
+/// server can resolve, and either would fail the whole lock. Rejecting them
+/// here means no consumer has to.
+impl FromStr for CatalogRef {
+    type Err = RootWildcard;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.split_once('.') {
+            None | Some((_, "*")) => Err(RootWildcard(value.to_string())),
+            Some(_) => Ok(Self(value.to_string())),
+        }
+    }
+}
+
+/// Deserialization goes through [FromStr] (see `#[serde(try_from)]`).
+impl TryFrom<String> for CatalogRef {
+    type Error = RootWildcard;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        value.parse()
     }
 }
 
@@ -117,7 +147,40 @@ mod tests {
     use super::*;
 
     fn set(items: &[&str]) -> BTreeSet<CatalogRef> {
-        items.iter().map(|s| CatalogRef::from(*s)).collect()
+        items
+            .iter()
+            .map(|s| CatalogRef::new_unchecked(*s))
+            .collect()
+    }
+
+    #[test]
+    fn catalog_ref_rejects_references_that_cannot_resolve() {
+        let cases = [
+            // Rooted references, whatever the depth or sentinel.
+            ("catalogs.myorg.pkg.readVersion", true),
+            ("catalogs.myorg.pkg", true),
+            ("catalogs.myorg.*", true),
+            // A root wildcard goes on the wire as `*`, a rootless reference as
+            // itself; neither names anything resolvable.
+            ("catalogs.*", false),
+            ("catalogs", false),
+        ];
+        let got: Vec<(&str, bool)> = cases
+            .iter()
+            .map(|(reference, _)| (*reference, reference.parse::<CatalogRef>().is_ok()))
+            .collect();
+        assert_eq!(got, cases.to_vec());
+    }
+
+    #[test]
+    fn catalog_ref_deserialization_upholds_the_invariant() {
+        // `#[serde(try_from)]` keeps the invariant on the way in; without it a
+        // lock file could reintroduce a reference the type rules out.
+        assert_matches!(
+            serde_json::from_str::<CatalogRef>("\"catalogs.myorg.pkg\""),
+            Ok(reference) if reference.as_str() == "catalogs.myorg.pkg"
+        );
+        assert_matches!(serde_json::from_str::<CatalogRef>("\"catalogs.*\""), Err(_));
     }
 
     #[test]

--- a/cli/nef-lock-catalog/src/scan/mod.rs
+++ b/cli/nef-lock-catalog/src/scan/mod.rs
@@ -9,7 +9,7 @@ mod analyze;
 mod error;
 mod graph;
 
-pub use error::ScanError;
+pub use error::{ImportSite, ScanError};
 use graph::PackageGraph;
 
 /// A single catalog attribute-path reference discovered by the scanner,
@@ -112,12 +112,41 @@ pub fn scan_package_with_roots(
 
 #[cfg(test)]
 mod tests {
-    use std::fs;
+    use std::{assert_matches, fs};
 
     use super::*;
 
     fn set(items: &[&str]) -> BTreeSet<CatalogRef> {
         items.iter().map(|s| CatalogRef::from(*s)).collect()
+    }
+
+    #[test]
+    fn unreadable_entry_fails_the_scan() {
+        // The entry names the file NEF would evaluate, so failing to read it
+        // must not resolve to an empty reference set: that would write a lock
+        // claiming the package has no catalog inputs.
+        let base_dir = Path::new("test_data/catalog_refs");
+        let err =
+            scan_package(base_dir, Path::new("no-such-package.nix")).expect_err("scan should fail");
+        assert_matches!(
+            err,
+            ScanError::UnreadableFile {
+                file,
+                source,
+                imported_from: None,
+            } if file == base_dir.join("no-such-package.nix")
+                && source.kind() == std::io::ErrorKind::NotFound
+        );
+    }
+
+    #[test]
+    fn dependency_argument_resolving_to_nothing_scans_clean() {
+        // An argument NEF satisfies from nixpkgs names no file in the package
+        // set. It is skipped, not read, so the tightened read path must not
+        // turn it into a failure.
+        let base_dir = Path::new("test_data/catalog_refs");
+        let got = scan_package(base_dir, Path::new("nixpkgs-arg.nix")).unwrap();
+        assert_eq!(got, set(&["catalogs.myorg.toolkit.readVersion"]));
     }
 
     #[test]

--- a/cli/nef-lock-catalog/test_data/catalog_refs/escaping-root.nix
+++ b/cli/nef-lock-catalog/test_data/catalog_refs/escaping-root.nix
@@ -1,0 +1,4 @@
+# The whole namespace escapes into an opaque function, widening to a root
+# wildcard, which names nothing the server can resolve.
+{ catalogs, f }:
+f catalogs

--- a/cli/nef-lock-catalog/test_data/catalog_refs/invalid-syntax.nix
+++ b/cli/nef-lock-catalog/test_data/catalog_refs/invalid-syntax.nix
@@ -1,0 +1,7 @@
+# Malformed Nix: the binding is missing its value. rnix recovers and yields a
+# partial tree, so an unchecked parse would silently drop `catalogs.myorg.beta`.
+{ catalogs }:
+{
+  alpha = ;
+  beta = catalogs.myorg.beta;
+}

--- a/cli/nef-lock-catalog/test_data/catalog_refs/narrowed-forward-cycle/entry.nix
+++ b/cli/nef-lock-catalog/test_data/catalog_refs/narrowed-forward-cycle/entry.nix
@@ -1,0 +1,8 @@
+# Pattern: a narrowed forward around an import cycle. The helper is handed
+# `myorg` and imports this file back under it, so every lap re-roots the
+# forward one component deeper. Judging the forward where it lands rather than
+# as written is what ends the walk.
+{ catalogs }:
+{
+  viaHelper = (import ./helper.nix { myorg = catalogs.myorg; }).fromHelper;
+}

--- a/cli/nef-lock-catalog/test_data/catalog_refs/narrowed-forward-cycle/helper.nix
+++ b/cli/nef-lock-catalog/test_data/catalog_refs/narrowed-forward-cycle/helper.nix
@@ -1,0 +1,8 @@
+# Closes the cycle by passing its own narrowed namespace back as `catalogs`.
+# Nix never forces `back`, so this evaluates fine; the scanner follows the
+# import anyway and has to terminate on its own.
+{ myorg }:
+{
+  fromHelper = myorg.pkg;
+  back = (import ./entry.nix { catalogs = myorg; }).viaHelper;
+}

--- a/cli/nef-lock-catalog/test_data/catalog_refs/narrowed-forward-deep/deep.nix
+++ b/cli/nef-lock-catalog/test_data/catalog_refs/narrowed-forward-deep/deep.nix
@@ -1,0 +1,5 @@
+# Reached only if the package-deep argument above is mistaken for a namespace.
+{ pkg }:
+{
+  version = pkg.version;
+}

--- a/cli/nef-lock-catalog/test_data/catalog_refs/narrowed-forward-deep/entry.nix
+++ b/cli/nef-lock-catalog/test_data/catalog_refs/narrowed-forward-deep/entry.nix
@@ -1,0 +1,3 @@
+# Forwards a catalog, whose helper then passes a package-deep path on into a
+# further import.
+{ catalogs }: (import ./helper.nix { myorg = catalogs.myorg; }).viaDeep

--- a/cli/nef-lock-catalog/test_data/catalog_refs/narrowed-forward-deep/helper.nix
+++ b/cli/nef-lock-catalog/test_data/catalog_refs/narrowed-forward-deep/helper.nix
@@ -1,0 +1,7 @@
+# `myorg.pkg` is two components as written here but already package-deep once
+# re-rooted under `catalogs.myorg`, so it is a package being passed, not a
+# namespace being forwarded.
+{ myorg }:
+{
+  viaDeep = (import ./deep.nix { pkg = myorg.pkg; }).version;
+}

--- a/cli/nef-lock-catalog/test_data/catalog_refs/narrowed-forward/entry.nix
+++ b/cli/nef-lock-catalog/test_data/catalog_refs/narrowed-forward/entry.nix
@@ -1,0 +1,4 @@
+# Forwards a catalog rather than the whole namespace. The helper receives
+# `myorg` and its refs come back rewritten under `catalogs.myorg`.
+{ catalogs }:
+(import ./helper.nix { myorg = catalogs.myorg; }).deep

--- a/cli/nef-lock-catalog/test_data/catalog_refs/narrowed-forward/helper.nix
+++ b/cli/nef-lock-catalog/test_data/catalog_refs/narrowed-forward/helper.nix
@@ -1,0 +1,7 @@
+# Scanned with `myorg` as its root, so `pkg` is one component here but already
+# package-deep once rewritten under `catalogs.myorg`.
+{ myorg }:
+{
+  deep = myorg.toolkit.readVersion;
+  shallow = myorg.pkg;
+}

--- a/cli/nef-lock-catalog/test_data/catalog_refs/nixpkgs-arg.nix
+++ b/cli/nef-lock-catalog/test_data/catalog_refs/nixpkgs-arg.nix
@@ -1,0 +1,5 @@
+# `stdenv` is supplied by nixpkgs, not by a file in the package set, so it
+# resolves to nothing on disk. That is not a failure: the argument is satisfied
+# outside the set.
+{ catalogs, stdenv }:
+catalogs.myorg.toolkit.readVersion

--- a/cli/nef-lock-catalog/test_data/catalog_refs/parse-error-import/broken.nix
+++ b/cli/nef-lock-catalog/test_data/catalog_refs/parse-error-import/broken.nix
@@ -1,0 +1,5 @@
+# Malformed helper: the binding is missing its value.
+{ catalogs }:
+{
+  result = ;
+}

--- a/cli/nef-lock-catalog/test_data/catalog_refs/parse-error-import/entry.nix
+++ b/cli/nef-lock-catalog/test_data/catalog_refs/parse-error-import/entry.nix
@@ -1,0 +1,4 @@
+# Entry that forwards the namespace into a helper that does not parse. The
+# error must name the helper, not this file.
+{ catalogs }:
+(import ./broken.nix { inherit catalogs; }).result

--- a/cli/nef-lock-catalog/test_data/catalog_refs/parse-error-import/whole-root.nix
+++ b/cli/nef-lock-catalog/test_data/catalog_refs/parse-error-import/whole-root.nix
@@ -1,0 +1,5 @@
+# Passes the whole namespace to a helper that does not parse. This reaches the
+# import through `top_ident_param`, which would otherwise read the unparsed file
+# as a pattern parameter and widen the root to a sentinel.
+{ catalogs }:
+(import ./broken.nix catalogs).result


### PR DESCRIPTION
Closes ECO-133. Stacked on #4538.

The `scan/` module degraded to a partial reference set instead of surfacing
failures, so `lock` could write a lock that silently under-locked a package.

## What changed

**Parse errors are checked.** rnix is error-tolerant, so `Parse::tree` returns
a partial tree for a malformed file and the references in the broken region
were dropped without a signal. Both parse sites now check `parse.errors()`.
The rnix error is carried as the error's source and `lock` prints the source
chain, so what the parser rejected reaches the user.

**Unreadable files fail.** `read_and_analyze` resolved a read failure to
`Ok(None)`, so an unreadable *entry* file made the whole scan a no-op. An
unreadable entry, dependency and import are one failure with different
provenance, so they became one `UnreadableFile` variant carrying the
`io::Error`. An argument naming nothing on disk still resolves to `Ok(None)` —
that is how an argument NEF satisfies from nixpkgs looks.

**Three "warnings" were always fatal.** Passing `catalogs` to an opaque
function, selecting a catalog dynamically, or forwarding through an import
that cannot be followed all widen to a root wildcard, whose wire form is `*`.
`lock_references` rejected that before every request, but with no file, line
or column. It is now rejected where the reference is finished, reported
against the source it was written at, and the downstream guard is deleted —
`CatalogRef` cannot hold one.

**Warnings are visible.** `EnvFilter::from_default_env` falls back to `error`,
and the package builder sets neither `RUST_LOG` nor `--verbose`, so every
scanner warning was dead output. This crate's floor is now `warn`.

## Along the way

Attribute paths were `Vec<String>` with `"*"` standing for an unresolved
component, joined so `CatalogRef` could split them apart again. They are now
`AttrPath` with an explicit `Wildcard` component, which made two latent
problems visible and fixable:

- `import ./h.nix { myorg = catalogs.myorg; }` was not followed, because only
  a whole root counted as forwarding; the argument escaped and locked
  `catalogs.myorg.*`. Forwarding now carries a path, so the helper is scanned
  through and locks what it uses.
- Depth was judged per file. A helper scanned through `myorg` writes
  `myorg.pkg`, which reads as catalog-level there but is package-deep once
  rewritten. Depth is now measured against where a path ends up.

## Raise in review

- **One parse error per run.** `parse.errors()` can hold several. Later ones
  are usually recovery cascades, but not always, and nothing else fills the
  gap: `lock` runs before `nix eval`, so failing here keeps Nix from parsing
  the file at all. A developer wanting every error needs a language server.
- **Warnings are tracing lines.** They land in `flox build` output with a
  timestamp, level, target and `key=value` fields, which is not what the CLI
  output conventions ask for. Carrying them as data and rendering them like
  the errors would also make them testable — none of the four is asserted
  anywhere today. This is the smaller change and does not preclude that one.
- **The wire form now quotes.** Dropping the root goes through `Display`, so
  an attribute Nix would not read bare is quoted. The dotted wire format
  cannot express a name containing a `.` any other way.

## Follow-ups filed

- Dependency arguments resolve only from `base_dir`, while nef resolves the
  package's own scope first, so `pkgs/foo/bar.nix` needing `helper` picks
  `pkgs/helper.nix` where nef picks `pkgs/foo/helper.nix`.
- Narrowed forwarding of a package-deep argument, and first-class warnings.

## Release Notes

`flox build` now fails with a source location when a Nix expression cannot be
parsed or read, or when it uses the catalog namespace in a way that cannot be
analyzed, instead of writing a lock with missing catalog inputs.
