### PR TITLE
fix(ci): run podman without the host systemd on Linux

### DIFF
--- a/cli/tests/containerize.bats
+++ b/cli/tests/containerize.bats
@@ -162,6 +162,21 @@ setup_file() {
   mkdir -p "$XDG_CONFIG_HOME/containers"
   echo '{ "default": [ {"type": "insecureAcceptAnything"} ] }' > "$XDG_CONFIG_HOME/containers/policy.json"
 
+  # A self-hosted builder began denying crun's sd-bus call on 07-30, failing
+  # every `podman run` with "crun: sd-bus call: Permission denied". The session
+  # bus is reachable and restoring XDG_RUNTIME_DIR does not help, so the call
+  # itself is refused; cgroupfs sets the cgroup up directly and needs no bus.
+  # Stopgap until that host is repaired. macOS runs podman in its own VM.
+  if is_linux; then
+    # _OVERRIDE layers over the system and user config rather than replacing
+    # the chain, and the tmpdir keeps us out of a developer's containers.conf.
+    export CONTAINERS_CONF_OVERRIDE="$BATS_SUITE_TMPDIR/containers.conf"
+    cat > "$CONTAINERS_CONF_OVERRIDE" << 'EOF'
+[engine]
+cgroup_manager = "cgroupfs"
+EOF
+  fi
+
   # flox does not allow to set a $HOME
   # that does not correspond to the effective user's,
   # but podman requires the policy.json set in the **test user's** $HOME,


### PR DESCRIPTION
## Proposed Changes

`remote (aarch64-linux, containerize)` is red on every branch. Every test that
starts a container dies with:

```
Error: crun: sd-bus call: Permission denied: Permission denied: OCI permission denied
status : 126
```

Tests that only build and write an image pass. Everything that calls
`podman run` fails.

`crun` asks systemd over sd-bus to set up the cgroup, and the host running the
tests now refuses that call. `cgroup_manager = "cgroupfs"` sets the cgroup up
directly and needs no bus.

macOS is untouched — podman runs in its own VM there, and those jobs are green.

## Where this actually fails

Not on the GitHub runner. The bats suite is executed **over ssh on a
self-hosted builder** (`.github/scripts/remote-execute-integration-tests.sh`);
the ubuntu runner only orchestrates the ssh and never runs podman. The builder
is picked per job by `shuf | grep $system | head -1` over `/etc/nix/machines`.

Every failure I looked at, and the run validating this fix, landed on
**`hetzner-aarch64-indigo-03`**:

| Job | Result | Builder |
|---|---|---|
| 91228741669 (pr13) | fail | hetzner-aarch64-indigo-03 |
| 91251242854 (pr13, rerun) | fail | hetzner-aarch64-indigo-03 |
| 91253472458 (**main**, unchanged) | fail | hetzner-aarch64-indigo-03 |
| 91256836538 (pr13) | fail | hetzner-aarch64-indigo-03 |
| 91262033432 (this fix) | **pass** | hetzner-aarch64-indigo-03 |

Same host, same code, one config change, red → green.

## It is a refusal, not a missing bus

The obvious cheaper fix — that `unset XDG_RUNTIME_DIR` a few lines above leaves
crun with no session bus address — was tested on branch
`dsawyer/ci-probe-xdg-runtime-dir` and **does not work**. That probe found a
live session bus socket at `/run/user/1006/bus`, exported `XDG_RUNTIME_DIR` and
`DBUS_SESSION_BUS_ADDRESS` to match, and failed identically
([run 30665225024](https://github.com/flox/flox/actions/runs/30665225024)).

That also rules out the user session or lingering having disappeared: the bus
is there and reachable, and the call is refused anyway. Something changed the
authorization on that builder, and we have not identified what.

## This is a stopgap

The builder still needs repair. Until then this is the only demonstrated way to
run these tests, and CI is blocked for everyone without it.

Worth being explicit about the cost: the sd-bus failure was a signal about that
host, and this removes it. Real Linux users get the systemd cgroup manager by
default, so CI now exercises a non-default path. In practice the exposure is
small — flox only shells out to `podman load`, and the `podman run` assertions
cover entrypoint, user/group, working dir and env vars, none of which depend on
the cgroup manager — but rootless cgroupfs does silently ignore `--memory`,
`--cpus` and `--pids-limit`, so a future test using any of them would pass
without applying them.

## Notes on the change

- **`CONTAINERS_CONF_OVERRIDE`, not `CONTAINERS_CONF`.** The plain variable
  replaces podman's entire config chain; the override layers on top, so the
  system and user `containers.conf` still apply. podman 5.8.1 from nix supports
  both spellings.
- **Written to `BATS_SUITE_TMPDIR`**, not `$XDG_CONFIG_HOME/containers/`, so a
  developer running the suite against their real home never has their own
  `containers.conf` rewritten. Same pattern `setup_suite.bash` uses for
  `GIT_CONFIG_SYSTEM`.
- An earlier revision also set `events_logger = "file"`. Dropped: journald
  never appears in the failure, so it was unjustified scope.

## Release Notes

None. CI only.
