### PR TITLE
test: reinstate release tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,13 @@ concurrency:
 env:
   # Also set in setup_suite.bash but set here for consistency
   FLOX_DISABLE_METRICS: "true"
+  # "true" when this run is part of cutting a release, i.e. the PR from a
+  # `release-*` branch to `main`, or a PR backporting into a `release-*`
+  # branch.  Some invariants only hold once `VERSION` has been bumped, which
+  # happens on the release branch; tests assert those only when this is set.
+  # `head_ref`/`base_ref` are empty outside `pull_request`, so pushes to `main`
+  # and tag pushes correctly yield "false".
+  FLOX_RUNNING_RELEASE: "${{ startsWith(github.head_ref, 'release-') || startsWith(github.base_ref, 'release-') }}"
 
 jobs:
   nix-plugins-dev:

--- a/cli/flox-manifest/src/parsed/common.rs
+++ b/cli/flox-manifest/src/parsed/common.rs
@@ -714,9 +714,16 @@ mod tests {
     /// `schema-version` is a Flox CLI release version. If someone adds a newer
     /// schema (e.g. `1.14.0`) without bumping `VERSION`, new manifests would
     /// claim a newer Flox release than the CLI reports.
+    ///
+    /// `VERSION` is bumped on the release branch, so for most of a development
+    /// cycle a newly added schema is legitimately ahead of it. The invariant
+    /// only has to hold at release time, so it is asserted only in release CI.
     #[test]
-    #[ignore = "VERSION is bumped by the release process which we need to add a workaround for"]
     fn cli_version_is_at_least_latest_schema_version() {
+        if std::env::var("FLOX_RUNNING_RELEASE").as_deref() != Ok("true") {
+            return;
+        }
+
         let version_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../VERSION");
         let cli_version: FloxVersion = std::fs::read_to_string(&version_path)
             .expect("failed to read VERSION")
@@ -729,8 +736,15 @@ mod tests {
             .parse()
             .expect("latest schema version must be valid FloxVersion");
 
+        // Compare base semvers: release candidates reach this check as
+        // `1.14.0-rc.1`, which orders below the `1.14.0` schema they ship.
+        let cli_base: FloxVersion = cli_version
+            .base_semver()
+            .parse()
+            .expect("base semver of VERSION should be valid FloxVersion");
+
         assert!(
-            cli_version >= latest_schema,
+            cli_base >= latest_schema,
             "VERSION ({cli_version}) must be >= latest schema-version ({latest_schema}).\n\
              When adding a new manifest schema, bump the VERSION file."
         );

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -4231,19 +4231,11 @@ attach_previous_release() {
   # v1.12.1), so the current binary can attach to a previous-release activation.
   incrementing_version_this_release="false"
 
-  # The GC root symlink naming convention changed in this release from
-  # dot-separator (<system>.<name>.dev / <system>.<name>.run) to
-  # dash-separator (<system>.<name>-dev / <system>.<name>-run).  The previous
-  # release (v1.12.1) creates symlinks with the old naming; the current binary
-  # looks for symlinks with the new naming.  Cross-version attach fails to find
-  # the existing GC root symlinks, causing it to start a new activation instead
-  # of attaching and making the test fail for the wrong reason.
-  #
   # Set to "true" whenever the buildenv format changes and FLOX_LATEST_VERSION
   # still points to a release that uses the old format.  Set back to "false"
   # once FLOX_LATEST_VERSION is a release that already uses the new format
   # (so both sides use the same GC root symlink paths and attachment succeeds).
-  buildenv_format_changed_this_release="true"
+  buildenv_format_changed_this_release="false"
   if [ "$buildenv_format_changed_this_release" = "true" ]; then
     skip "buildenv output format changed in this release; cross-version attach requires matching GC root symlink paths (set buildenv_format_changed_this_release=false once FLOX_LATEST_VERSION uses the new format)"
   fi


### PR DESCRIPTION
- **test(manifest): gate the schema/CLI version check on release CI**
  `cli_version_is_at_least_latest_schema_version` was added to ensure Flox
  minor version and manifest schema version don't drift, but it didn't
  take into account that schema is bumped prior to the release PR that
  bumps VERSION.
  
  It was skipped last time we bumped the schema, but we can now re-instate
  it by only running it during release.
  

- **test(activate): re-enable previous-release attach tests**
  The release this test was disabled for is now several releases ago.
  