### PR TITLE
feat(auth): compile the default FloxHub authn mode into the build

### DIFF
--- a/cli/flox-config/src/config.rs
+++ b/cli/flox-config/src/config.rs
@@ -37,6 +37,55 @@ pub enum AuthnMode {
     Kerberos,
 }
 
+/// Default authentication mode compiled into this build, set via the
+/// `FLOX_DEFAULT_AUTHN_MODE` build-time environment variable
+/// ("token" or "kerberos"; unset means "token").
+///
+/// Deployments that authenticate via Kerberos compile their own CLI with
+/// `FLOX_DEFAULT_AUTHN_MODE=kerberos` so their users need no
+/// `floxhub_authn_mode` config, and the deployment is not named in source.
+/// The hosted FloxHub only supports token auth and overrides this default;
+/// see the `effective_authn_mode` helpers in consumers.
+const BUILD_DEFAULT_AUTHN_MODE: Option<&str> = option_env!("FLOX_DEFAULT_AUTHN_MODE");
+
+/// Reject a mistyped `FLOX_DEFAULT_AUTHN_MODE` at build time: a binary that
+/// silently fell back to token auth would fail exactly like a missing
+/// default, only harder to diagnose.
+const _: () = assert!(
+    match BUILD_DEFAULT_AUTHN_MODE {
+        None => true,
+        Some(mode) => const_str_eq(mode, "token") || const_str_eq(mode, "kerberos"),
+    },
+    "FLOX_DEFAULT_AUTHN_MODE must be 'token' or 'kerberos'"
+);
+
+/// `str` equality usable in `const` context (no const trait impls yet).
+const fn const_str_eq(a: &str, b: &str) -> bool {
+    let (a, b) = (a.as_bytes(), b.as_bytes());
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut i = 0;
+    while i < a.len() {
+        if a[i] != b[i] {
+            return false;
+        }
+        i += 1;
+    }
+    true
+}
+
+impl AuthnMode {
+    /// The default authentication mode compiled into this build
+    /// (see [`BUILD_DEFAULT_AUTHN_MODE`]).
+    pub fn build_default() -> Self {
+        match BUILD_DEFAULT_AUTHN_MODE {
+            Some("kerberos") => AuthnMode::Kerberos,
+            _ => AuthnMode::Token,
+        }
+    }
+}
+
 /// Where `flox auth login` stores the FloxHub token.
 #[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]

--- a/cli/flox-config/src/config.rs
+++ b/cli/flox-config/src/config.rs
@@ -37,6 +37,30 @@ pub enum AuthnMode {
     Kerberos,
 }
 
+impl Default for AuthnMode {
+    /// Default authentication mode compiled into this build, set via the
+    /// `FLOX_DEFAULT_AUTHN_MODE` build-time environment variable
+    /// ("token" or "kerberos"; unset means "token").
+    ///
+    /// Deployments that authenticate via Kerberos compile their own CLI with
+    /// `FLOX_DEFAULT_AUTHN_MODE=kerberos` so their users need no
+    /// `floxhub_authn_mode` config, and the deployment is not named in source.
+    /// The hosted FloxHub only supports token auth and overrides this default;
+    /// see the `effective_authn_mode` helpers in consumers.
+    ///
+    /// The Nix interface (`defaultAuthnMode` on `pkgs/flox-cli`) rejects
+    /// invalid values before invoking Cargo; a direct Cargo build with an
+    /// invalid value fails here on first use instead of silently falling
+    /// back to token auth.
+    fn default() -> Self {
+        match option_env!("FLOX_DEFAULT_AUTHN_MODE") {
+            Some("kerberos") => Self::Kerberos,
+            Some("token") | None => Self::Token,
+            Some(mode) => panic!("invalid FLOX_DEFAULT_AUTHN_MODE: {mode}"),
+        }
+    }
+}
+
 /// Where `flox auth login` stores the FloxHub token.
 #[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]

--- a/cli/flox-core/src/floxhub.rs
+++ b/cli/flox-core/src/floxhub.rs
@@ -151,6 +151,23 @@ impl Floxhub {
         &self.base_url
     }
 
+    /// Whether this FloxHub is the hosted (SaaS) deployment.
+    ///
+    /// Keys on the same `hub.<...>.flox.dev` host shape as
+    /// [`Self::resolve_effective_url`], so staging and preview bases count as
+    /// hosted while enterprise / on-premise deployments never match.
+    pub fn is_hosted(&self) -> bool {
+        let Some(host) = self.base_url.host_str() else {
+            return false;
+        };
+        matches!(host.split('.').collect::<Vec<_>>().as_slice(), [
+            "hub",
+            ..,
+            "flox",
+            "dev"
+        ])
+    }
+
     /// Return the url of the FloxHub api endpoint
     ///
     /// If the environment variable `FLOX_CATALOG_URL` is set,
@@ -272,6 +289,28 @@ mod tests {
                     .as_str(),
                 format!("https://{host}/git"),
             );
+        }
+    }
+
+    #[test]
+    fn is_hosted_keys_on_saas_host_shape() {
+        // Hosted bases match the anchored `hub.<...>.flox.dev` shape,
+        // including staging/preview intermediates; anything else — enterprise
+        // hosts and near-misses on either anchor — is not hosted.
+        for (host, hosted) in [
+            ("hub.flox.dev", true),
+            ("hub.staging.flox.dev", true),
+            ("nothub.flox.dev", false),
+            ("hub.flox.example.com", false),
+            ("floxhub.example.internal", false),
+        ] {
+            let floxhub = Floxhub::new(
+                Url::from_str(&format!("https://{host}")).unwrap(),
+                None,
+                None,
+            )
+            .unwrap();
+            assert_eq!(floxhub.is_hosted(), hosted, "host: {host}");
         }
     }
 

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -347,10 +347,8 @@ impl FloxArgs {
         // absent — an accepted gap; a prompt hook must never trigger a
         // keyring unlock.
         let stores = CredentialStores::new(floxhub.base_url(), &config.flox.config_dir);
-        let is_auth0 = !matches!(
-            config.flox.floxhub_authn_mode,
-            Some(flox_config::AuthnMode::Kerberos)
-        );
+        let authn_mode = effective_authn_mode(&config, &floxhub);
+        let is_auth0 = matches!(authn_mode, flox_config::AuthnMode::Token);
         let should_store_credentials = is_auth0 && !self.is_prompt_hook_flow();
         if should_store_credentials {
             match stores.resolve_into(&mut config) {
@@ -365,7 +363,7 @@ impl FloxArgs {
             }
         }
 
-        let credential = self.resolve_auth_context(&config, &stores);
+        let credential = self.resolve_auth_context(&config, &authn_mode, &stores);
 
         if let Some(events_client) = build_events_client(
             &config,
@@ -552,10 +550,15 @@ impl FloxArgs {
     /// A `flox_pat_` token is opaque: it is never parsed, never wiped as
     /// invalid, and its expiry is unknown until it is lazily resolved via
     /// /me — so no startup warning applies to it.
-    fn resolve_auth_context(&self, config: &Config, stores: &CredentialStores) -> AuthContext {
+    fn resolve_auth_context(
+        &self,
+        config: &Config,
+        authn_mode: &flox_config::AuthnMode,
+        stores: &CredentialStores,
+    ) -> AuthContext {
         // Kerberos does not use FloxHub tokens; the stored token is not
         // consumed (and none of the token warnings below apply).
-        if let Some(flox_config::AuthnMode::Kerberos) = config.flox.floxhub_authn_mode {
+        if let flox_config::AuthnMode::Kerberos = authn_mode {
             return AuthContext::new_kerberos();
         }
 
@@ -613,6 +616,18 @@ impl FloxArgs {
                 auth_context
             },
         }
+    }
+}
+
+/// Resolve the effective authn mode.
+/// When `floxhub_authn_mode` is unset, the hosted FloxHub always
+/// authenticates via token (Auth0); other deployments get the default
+/// compiled into this build.
+fn effective_authn_mode(config: &Config, floxhub: &Floxhub) -> flox_config::AuthnMode {
+    match &config.flox.floxhub_authn_mode {
+        Some(mode) => mode.clone(),
+        None if floxhub.is_hosted() => flox_config::AuthnMode::Token,
+        None => flox_config::AuthnMode::build_default(),
     }
 }
 

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -347,10 +347,8 @@ impl FloxArgs {
         // absent — an accepted gap; a prompt hook must never trigger a
         // keyring unlock.
         let stores = CredentialStores::new(floxhub.base_url(), &config.flox.config_dir);
-        let is_auth0 = !matches!(
-            config.flox.floxhub_authn_mode,
-            Some(flox_config::AuthnMode::Kerberos)
-        );
+        let authn_mode = effective_authn_mode(&config, &floxhub);
+        let is_auth0 = matches!(authn_mode, flox_config::AuthnMode::Token);
         let should_store_credentials = is_auth0 && !self.is_prompt_hook_flow();
         if should_store_credentials {
             match stores.resolve_into(&mut config) {
@@ -365,7 +363,7 @@ impl FloxArgs {
             }
         }
 
-        let credential = self.resolve_auth_context(&config, &stores);
+        let credential = self.resolve_auth_context(&config, &authn_mode, &stores);
 
         if let Some(events_client) = build_events_client(
             &config,
@@ -557,10 +555,15 @@ impl FloxArgs {
     /// A `flox_pat_` token is opaque: it is never parsed, never wiped as
     /// invalid, and its expiry is unknown until it is lazily resolved via
     /// /me — so it counts as logged in and no startup warning applies to it.
-    fn resolve_auth_context(&self, config: &Config, stores: &CredentialStores) -> AuthContext {
+    fn resolve_auth_context(
+        &self,
+        config: &Config,
+        authn_mode: &flox_config::AuthnMode,
+        stores: &CredentialStores,
+    ) -> AuthContext {
         // Kerberos does not use FloxHub tokens; the stored token is not
         // consumed (and none of the token warnings below apply).
-        if let Some(flox_config::AuthnMode::Kerberos) = config.flox.floxhub_authn_mode {
+        if let flox_config::AuthnMode::Kerberos = authn_mode {
             return AuthContext::new_kerberos();
         }
 
@@ -621,6 +624,18 @@ impl FloxArgs {
                 auth_context
             },
         }
+    }
+}
+
+/// Resolve the effective authn mode.
+/// When `floxhub_authn_mode` is unset, the hosted FloxHub always
+/// authenticates via token (Auth0); other deployments get the default
+/// compiled into this build.
+fn effective_authn_mode(config: &Config, floxhub: &Floxhub) -> flox_config::AuthnMode {
+    match &config.flox.floxhub_authn_mode {
+        Some(mode) => mode.clone(),
+        None if floxhub.is_hosted() => flox_config::AuthnMode::Token,
+        None => flox_config::AuthnMode::default(),
     }
 }
 

--- a/cli/nef-lock-catalog/src/bin/lock.rs
+++ b/cli/nef-lock-catalog/src/bin/lock.rs
@@ -195,9 +195,9 @@ fn build_client(config: &Config, floxhub_token: Option<String>) -> Result<Floxhu
         "configured catalog client",
     );
 
-    let auth_context = match config.flox.floxhub_authn_mode {
-        Some(flox_config::AuthnMode::Kerberos) => AuthContext::new_kerberos(),
-        _ => AuthContext::new_from_token(floxhub_token.as_deref())?,
+    let auth_context = match effective_authn_mode(config, &floxhub) {
+        flox_config::AuthnMode::Kerberos => AuthContext::new_kerberos(),
+        flox_config::AuthnMode::Token => AuthContext::new_from_token(floxhub_token.as_deref())?,
     };
 
     let config = FloxhubClientConfig {
@@ -213,6 +213,18 @@ fn build_client(config: &Config, floxhub_token: Option<String>) -> Result<Floxhu
     };
 
     Ok(FloxhubClient::new(config)?)
+}
+
+/// Resolve the effective authn mode.
+/// When `floxhub_authn_mode` is unset, the hosted FloxHub always
+/// authenticates via token (Auth0); other deployments get the default
+/// compiled into this build.
+fn effective_authn_mode(config: &Config, floxhub: &Floxhub) -> flox_config::AuthnMode {
+    match &config.flox.floxhub_authn_mode {
+        Some(mode) => mode.clone(),
+        None if floxhub.is_hosted() => flox_config::AuthnMode::Token,
+        None => flox_config::AuthnMode::build_default(),
+    }
 }
 
 /// Render an authentication-related catalog failure with a token-aware hint.

--- a/cli/nef-lock-catalog/src/bin/lock.rs
+++ b/cli/nef-lock-catalog/src/bin/lock.rs
@@ -195,9 +195,9 @@ fn build_client(config: &Config, floxhub_token: Option<String>) -> Result<Floxhu
         "configured catalog client",
     );
 
-    let auth_context = match config.flox.floxhub_authn_mode {
-        Some(flox_config::AuthnMode::Kerberos) => AuthContext::new_kerberos(),
-        _ => AuthContext::new_from_token(floxhub_token.as_deref())?,
+    let auth_context = match effective_authn_mode(config, &floxhub) {
+        flox_config::AuthnMode::Kerberos => AuthContext::new_kerberos(),
+        flox_config::AuthnMode::Token => AuthContext::new_from_token(floxhub_token.as_deref())?,
     };
 
     let config = FloxhubClientConfig {
@@ -213,6 +213,18 @@ fn build_client(config: &Config, floxhub_token: Option<String>) -> Result<Floxhu
     };
 
     Ok(FloxhubClient::new(config)?)
+}
+
+/// Resolve the effective authn mode.
+/// When `floxhub_authn_mode` is unset, the hosted FloxHub always
+/// authenticates via token (Auth0); other deployments get the default
+/// compiled into this build.
+fn effective_authn_mode(config: &Config, floxhub: &Floxhub) -> flox_config::AuthnMode {
+    match &config.flox.floxhub_authn_mode {
+        Some(mode) => mode.clone(),
+        None if floxhub.is_hosted() => flox_config::AuthnMode::Token,
+        None => flox_config::AuthnMode::default(),
+    }
 }
 
 /// Render an authentication-related catalog failure with a token-aware hint.

--- a/pkgs/flox-cli/default.nix
+++ b/pkgs/flox-cli/default.nix
@@ -18,6 +18,10 @@
   rust-toolchain,
   rustfmt ? rust-toolchain.rustfmt,
   stdenv,
+  # Default FloxHub authentication mode compiled into the binary
+  # ("token" or "kerberos"). Kerberos-authenticated on-premise deployments
+  # build with "kerberos"; the hosted FloxHub always uses Auth0 regardless.
+  defaultAuthnMode ? null,
 }:
 let
   FLOX_VERSION = lib.fileContents ./../../VERSION;
@@ -70,6 +74,9 @@ let
     }
     // lib.optionalAttrs stdenv.hostPlatform.isLinux {
       LOCALE_ARCHIVE = "${glibcLocalesUtf8}/lib/locale/locale-archive";
+    }
+    // lib.optionalAttrs (defaultAuthnMode != null) {
+      FLOX_DEFAULT_AUTHN_MODE = defaultAuthnMode;
     }
     // rust-internal-deps.passthru.envs;
 in

--- a/pkgs/flox-cli/default.nix
+++ b/pkgs/flox-cli/default.nix
@@ -18,6 +18,10 @@
   rust-toolchain,
   rustfmt ? rust-toolchain.rustfmt,
   stdenv,
+  # Default FloxHub authentication mode compiled into the binary
+  # ("token" or "kerberos"). Kerberos-authenticated on-premise deployments
+  # build with "kerberos"; the hosted FloxHub always uses Auth0 regardless.
+  defaultAuthnMode ? null,
 }:
 let
   FLOX_VERSION = lib.fileContents ./../../VERSION;
@@ -71,8 +75,18 @@ let
     // lib.optionalAttrs stdenv.hostPlatform.isLinux {
       LOCALE_ARCHIVE = "${glibcLocalesUtf8}/lib/locale/locale-archive";
     }
+    // lib.optionalAttrs (defaultAuthnMode != null) {
+      FLOX_DEFAULT_AUTHN_MODE = defaultAuthnMode;
+    }
     // rust-internal-deps.passthru.envs;
 in
+assert lib.assertMsg (
+  defaultAuthnMode == null
+  || builtins.elem defaultAuthnMode [
+    "token"
+    "kerberos"
+  ]
+) "defaultAuthnMode must be null, \"token\", or \"kerberos\"";
 craneLib.buildPackage (
   {
     pname = "flox";


### PR DESCRIPTION
## Problem

Removing the dedicated Kerberos build along with the `floxhub-authn-kerberos`
feature flag (#4508) left Kerberos-authenticated FloxHub deployments dependent
on every user setting `floxhub_authn_mode = "kerberos"` in their own config.
With the setting unset, the CLI silently falls back to token auth against a
Kerberos-only FloxHub, with three compounding symptoms:

- the OS keyring probe (gated on token mode) stalls for ~45s on headless hosts
  that have a session D-Bus but no Secret Service provider,
- git sends a stale bearer token as basic auth, which the deployment rejects,
  surfacing as the misleading "Environment not found in FloxHub.", and
- the user handle is derived from the stale token instead of the Kerberos
  principal, so `flox activate -D` resolves the wrong `<owner>/default`
  environment and misses the on-disk floxmeta clone.

## Solution

Restore a build-level default without naming any deployment in public source:

- `flox-config`: the `Default` impl for `AuthnMode` reads the new
  `FLOX_DEFAULT_AUTHN_MODE` build-time environment variable (`"token"` or
  `"kerberos"`; unset means `"token"`). Any other value panics at first use
  of the default, so a mistyped variable cannot silently fall back to token
  auth — and only non-hosted deployments ever evaluate the default.
- `flox-core`: `Floxhub::is_hosted()` recognises the hosted
  `hub.<...>.flox.dev` host shape (same anchored match as
  `resolve_effective_url`).
- `flox` and `nef-lock-catalog`: `effective_authn_mode` resolves in order:
  explicit `floxhub_authn_mode` config, then token auth forced for the hosted
  FloxHub, then the build default.
- `pkgs/flox-cli`: a new optional `defaultAuthnMode` argument injects the
  variable into the build, so an on-premise overlay can use
  `flox-cli.override { defaultAuthnMode = "kerberos"; }` without patching
  source. Invalid values are rejected at eval time with `lib.assertMsg`,
  before the build starts.

Official builds are unchanged: without `FLOX_DEFAULT_AUTHN_MODE` the default
remains token auth for every deployment, so no release notes section is
included.

## Testing

- `cargo check` clean for `flox-config`, `flox-core`, `flox`, and
  `nef-lock-catalog`, both without the variable and with
  `FLOX_DEFAULT_AUTHN_MODE=kerberos`.
- `flox-cli.override { defaultAuthnMode = "bogus"; }` fails evaluation with
  `defaultAuthnMode must be null, "token", or "kerberos"`, while the
  `"kerberos"` override evaluates cleanly.
- An invalid `FLOX_DEFAULT_AUTHN_MODE` under a direct Cargo build compiles
  (validation is at runtime: first use of the default panics with
  `invalid FLOX_DEFAULT_AUTHN_MODE`).
- New unit test `is_hosted_keys_on_saas_host_shape` covering hosted,
  staging, and near-miss/enterprise hosts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
