### PR TITLE
docs(auth): clarify token-file validation

### DIFF
--- a/cli/flox/doc/flox-auth.md
+++ b/cli/flox/doc/flox-auth.md
@@ -36,9 +36,13 @@ If called interactively it can open the browser for you if you press `<enter>`.
 With `--token-file <path>` the login is non-interactive:
 the FloxHub token is read from `<path>` instead
 (pass `-` to read the token from stdin).
+The file can contain a JWT access token, a personal access token,
+or a service account token.
+Token-file login does not open a browser or prompt for input.
+A JWT access token is validated locally.
 FloxHub must be reachable to validate personal access tokens and
 service account tokens.
-The validated token is stored without opening a browser or prompting for input.
+The validated token is stored.
 Use this in CI, containers, and other scripted setups.
 
 See also: [`flox-push(1)`](./flox-push.md),

--- a/cli/flox/doc/flox-auth.md
+++ b/cli/flox/doc/flox-auth.md
@@ -36,8 +36,9 @@ If called interactively it can open the browser for you if you press `<enter>`.
 With `--token-file <path>` the login is non-interactive:
 the FloxHub token is read from `<path>` instead
 (pass `-` to read the token from stdin).
-The token is validated and stored,
-and no browser, prompt, or network access is involved.
+FloxHub must be reachable to validate personal access tokens and
+service account tokens.
+The validated token is stored without opening a browser or prompting for input.
 Use this in CI, containers, and other scripted setups.
 
 See also: [`flox-push(1)`](./flox-push.md),


### PR DESCRIPTION
## Proposed Changes

Clarify the canonical `flox auth login --token-file` man-page source:

- explicitly document support for JWT access tokens, personal access tokens, and service account tokens
- explain that token-file login does not open a browser or prompt for input
- distinguish locally validated JWT access tokens from opaque PATs and SATs, which require FloxHub connectivity for validation

The regenerated Mintlify page is included on top of [flox/docs#56](https://github.com/flox/docs/pull/56).

## Verification

- exercised a synthetic JWT token file successfully without a reachable FloxHub endpoint
- exercised PAT and SAT token files against a local fake FloxHub `/me` endpoint
- exercised `--token-file -` for PATs and SATs
- confirmed opaque token verification fails when FloxHub is unreachable
- `treefmt` passed in the pre-push hook

## Release Notes

N/A — documentation correction only.