### PR TITLE
feat(activate): announce activations in every mode and simplify the prompt

### DIFF
--- a/assets/environment-interpreter/activate/activate
+++ b/assets/environment-interpreter/activate/activate
@@ -6,7 +6,7 @@
 #   2. (-vv) language-specific profile scripts
 #   3. (-vvv) zsh `autoload -U compinit` (very verbose)
 export _flox_activate_tracelevel="${_FLOX_SUBSYSTEM_VERBOSITY:-0}"
-[ "$_flox_activate_tracelevel" -eq 0 ] || set -x
+[ "$_flox_activate_tracelevel" -le 0 ] || set -x
 
 # Ensure that $_flox_activate_tracer is defined as an executable.
 if [ -z "${FLOX_ACTIVATE_TRACE-}" ]; then

--- a/assets/environment-interpreter/wrapper/wrapper
+++ b/assets/environment-interpreter/wrapper/wrapper
@@ -6,7 +6,7 @@
 #   2. (-vv) language-specific profile scripts
 #   3. (-vvv) zsh `autoload -U compinit` (very verbose)
 export _flox_activate_tracelevel="${_FLOX_SUBSYSTEM_VERBOSITY:-0}"
-[ "$_flox_activate_tracelevel" -eq 0 ] || set -x
+[ "$_flox_activate_tracelevel" -le 0 ] || set -x
 
 # Ensure that $_flox_activate_tracer is defined as an executable.
 if [ -z "${FLOX_ACTIVATE_TRACE-}" ]; then

--- a/cli/flox-activations/src/cli/activate.rs
+++ b/cli/flox-activations/src/cli/activate.rs
@@ -37,6 +37,27 @@ pub struct ActivateArgs {
     pub cmd: Option<Vec<String>>,
 }
 
+/// Announce the activation by naming the environment on stderr.
+///
+/// The wording is the same in every mode; only whether the deactivate hint
+/// follows differs. A subshell activation is a place the user typed their way
+/// into and has to type their way out of, so the exit is worth stating; it is
+/// also printed at most once per subshell. In-place activations recur — every
+/// new shell for an rc-file activation, every `cd` for an auto-activation — so
+/// they omit the hint that would otherwise repeat all day.
+fn announce(context: &ActivateCtx, invocation_type: &InvocationType, transition: String) {
+    if !context.announce_activation {
+        return;
+    }
+    if *invocation_type == InvocationType::Interactive {
+        updated(formatdoc! {"{transition}
+            To stop using this environment, run 'flox deactivate'
+            "});
+    } else {
+        updated(transition);
+    }
+}
+
 impl ActivateArgs {
     pub fn handle(self, subsystem_verbosity: u32) -> Result<(), anyhow::Error> {
         let contents = fs::read_to_string(&self.activate_data)?;
@@ -65,7 +86,13 @@ impl ActivateArgs {
         match (context.invocation_type.as_ref(), run_args) {
             // This is a container invocation, and we need to set the invocation type
             // based on the presence of command arguments.
-            (None, None) => context.invocation_type = Some(InvocationType::Interactive),
+            (None, None) => {
+                context.invocation_type = Some(InvocationType::Interactive);
+                // The flox CLI that resolves `announce_activation` never runs
+                // in a container, so resolve it here: interactive containers
+                // announce, command invocations keep the silent default.
+                context.announce_activation = true;
+            },
             // This is a container invocation, and we need to set the invocation type
             // based on the presence of command arguments.
             (None, Some(args)) => {
@@ -135,32 +162,28 @@ impl ActivateArgs {
         let warning_interval = Duration::from_secs(5);
         let mut last_warning: Option<Instant> = None;
 
-        let deactivate_hint = "To stop using this environment, run 'flox deactivate'";
-
         loop {
             match self.try_start_or_attach(context, subsystem_verbosity, vars_from_env)? {
                 StartOrAttachResult::Start { start_id, .. } => {
-                    if *invocation_type == InvocationType::Interactive {
-                        updated(
-                            formatdoc! {"You are now using the environment '{env_description}'
-                                     {deactivate_hint}
-                                     ",
-                            env_description = context.attach_ctx.env_description,
-                            },
-                        );
-                    }
+                    announce(
+                        context,
+                        invocation_type,
+                        format!(
+                            "You are now using the environment '{}'",
+                            context.attach_ctx.env_description
+                        ),
+                    );
                     return Ok(start_id);
                 },
                 StartOrAttachResult::Attach { start_id, .. } => {
-                    if *invocation_type == InvocationType::Interactive {
-                        updated(
-                            formatdoc! {"Attached to existing activation of environment '{env_description}'
-                                     {deactivate_hint}
-                                     ",
-                            env_description = context.attach_ctx.env_description,
-                            },
-                        );
-                    }
+                    announce(
+                        context,
+                        invocation_type,
+                        format!(
+                            "Attached to existing activation of environment '{}'",
+                            context.attach_ctx.env_description
+                        ),
+                    );
                     return Ok(start_id);
                 },
                 StartOrAttachResult::AlreadyStarting {

--- a/cli/flox-activations/src/gen_rc/mod.rs
+++ b/cli/flox-activations/src/gen_rc/mod.rs
@@ -176,6 +176,7 @@ pub(crate) mod test_helpers {
             disable_hook,
             flox_bin: "/flox".to_string(),
             auto_activate_fish_mode: None,
+            announce_activation: false,
         };
         let deleted_var = "DELETED_VAR".to_string();
         let modified_var = "MODIFIED_VAR".to_string();

--- a/cli/flox-core/src/activate/context.rs
+++ b/cli/flox-core/src/activate/context.rs
@@ -125,6 +125,17 @@ pub struct ActivateCtx {
     /// Controls how the fish shell hook responds to directory changes.
     #[serde(default)]
     pub auto_activate_fish_mode: Option<AutoActivateFishMode>,
+
+    /// Whether this activation announces itself by naming the environment on
+    /// stderr once it is in effect.
+    ///
+    /// Resolved by the `flox` crate because the decision depends on state only
+    /// the caller has: the user's real verbosity and whether the environment
+    /// was already active. Defaults to `false` so a context file written by an
+    /// older Flox stays quiet rather than gaining output the writer never
+    /// asked for.
+    #[serde(default)]
+    pub announce_activation: bool,
 }
 
 /// Fish shell hook mode, matching direnv's `direnv_fish_mode` values.

--- a/cli/flox/doc/flox-activate.md
+++ b/cli/flox/doc/flox-activate.md
@@ -231,8 +231,8 @@ options.
     environment.
 
 `$FLOX_PROMPT_ENVIRONMENTS`
-:   Contains a space-delimited list of the active environments,
-    e.g. `owner1/foo owner2/bar local_env`.
+:   Contains a space-delimited list of the names of the active environments,
+    e.g. `foo bar local_env`.
     If `hide_default_prompt` is set to `true`, environments named `default` are
     excluded.
 

--- a/cli/flox/doc/flox-activate.md
+++ b/cli/flox/doc/flox-activate.md
@@ -235,6 +235,10 @@ options.
     e.g. `foo bar local_env`.
     If `hide_default_prompt` is set to `true`, environments named `default` are
     excluded.
+    This variable is exported, so it is set even by activations that do not
+    modify the prompt, such as `flox activate -- <CMD>`.
+    A shell that manages its own prompt can render an indicator from it
+    directly.
 
 `$FLOX_ENV_CACHE`
 :   `activate` sets this variable to a directory that can be used by an
@@ -282,6 +286,19 @@ options.
          the `$FLOX_SHELL` variable,
          and if it cannot detect its parent shell type then will
          produce a script with syntax determined by `$SHELL`.
+
+`$FLOX_PROMPT`
+:   The label Flox puts at the front of the shell prompt, `flox` by default.
+    Set it to shorten the indicator, e.g. `f` to reclaim three columns,
+    or to rebrand it, for example with the name of an internal developer
+    platform built on Flox.
+    Because an environment's `[vars]` are applied before the prompt is set,
+    an environment can carry its own label in its manifest:
+
+    ```toml
+    [vars]
+    FLOX_PROMPT = "acme"
+    ```
 
 `$FLOX_PROMPT_COLOR_{1,2}`
 :   Flox adds text to the beginning of the shell prompt to indicate which

--- a/cli/flox/doc/flox-config.md
+++ b/cli/flox/doc/flox-config.md
@@ -126,7 +126,7 @@ flox config --set 'trusted_environments."owner/name"' trust
 
 `hide_default_prompt`
 :   Hide environments named 'default' from the shell prompt,
-    and don't add environments named 'default' to `$FLOX_PROMPT_ENVIRONMENTS` (default: true).
+    and don't add environments named 'default' to `$FLOX_PROMPT_ENVIRONMENTS` (default: false).
 
 `installer_channel`
 :   Release channel to use when checking for updates to Flox.

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -549,7 +549,7 @@ impl ActivateOptions {
             "}),
             (set_prompt, hide_default_prompt, _) => (
                 set_prompt.unwrap_or(true),
-                hide_default_prompt.unwrap_or(true),
+                hide_default_prompt.unwrap_or(false),
             ),
         };
 

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -632,6 +632,51 @@ impl ActivateOptions {
 
         let activation_state_dir = activation_state_dir_path(&flox.runtime_dir, &dot_flox_path);
 
+        // Which modes announce.
+        //
+        // A subshell activation has always announced unconditionally, and
+        // callers depend on that, so it keeps doing so.
+        //
+        // Every other mode is newly announcing here, and each of them can also
+        // be driven by a program rather than a person: `eval "$(flox activate)"`
+        // from a script, `flox activate -- <CMD>` from CI. Requiring a terminal
+        // on stderr is what separates the two cases — a human watching, or a
+        // program collecting output something else will parse.
+        //
+        // That condition is also what lets the most invisible path speak.
+        // direnv's `use flox` activates via `flox activate -- direnv dump`, and
+        // direnv leaves stderr attached to the user's terminal (which is why its
+        // own `direnv: loading` lines are visible) while capturing only stdout.
+        // It is the one path where the prompt can never speak for Flox: exec
+        // mode renders no shell rc, so `set-prompt` never runs, and direnv
+        // declines to export `PS1` at all.
+        //
+        // An environment that is already active is not announced again: the
+        // shell is not transitioning anywhere, it is re-running an activation
+        // it already has — a nested shell re-sourcing an rc file, or a second
+        // in-place activation of the same environment.
+        //
+        // Environments named `default` are excluded for the same reason
+        // `hide_default_prompt` exists: the default environment is ambient
+        // rather than a place you arrived at, so its activation is not a
+        // transition worth reporting — and an rc-file activation of it would
+        // otherwise announce itself in every new shell.
+        // `-q` is resolved here rather than in `flox-activations`, which has no
+        // quiet mode of its own: the verbosity it receives below is clamped to
+        // `max(0)`, so a negative (quieter) verbosity never reaches it. Deciding
+        // here keeps the one place that knows the user's real verbosity as the
+        // one place that decides, and makes `flox -q activate` silent.
+        let mode_announces = match invocation_type {
+            InvocationType::Interactive => true,
+            InvocationType::InPlace
+            | InvocationType::ShellCommand(_)
+            | InvocationType::ExecCommand(_) => std::io::stderr().is_tty(),
+        };
+        let announce_activation = mode_announces
+            && !already_active
+            && flox.verbosity >= 0
+            && now_active.name().as_ref() != DEFAULT_NAME;
+
         let activate_data = ActivateCtx {
             flox_activate_store_path: store_path.to_string_lossy().to_string(),
             attach_ctx: core,
@@ -650,6 +695,7 @@ impl ActivateOptions {
                 .and_then(|p| p.to_str().map(String::from))
                 .unwrap_or_else(|| "flox".to_string()),
             auto_activate_fish_mode: config.flox.auto_activate_fish_mode,
+            announce_activation,
         };
 
         let tempfile = tempfile::NamedTempFile::new_in(flox.temp_dir)?;

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -840,7 +840,11 @@ impl ActivateOptions {
                 if hide_default_prompt && env.name().as_ref() == DEFAULT_NAME {
                     return None;
                 }
-                Some(env.bare_description())
+                // Deliberately narrower than `bare_description()`, which
+                // still backs the activation announcements and the exported
+                // `FLOX_ENV_DESCRIPTION` variable with the full `owner/name`
+                // form.
+                Some(env.name().to_string())
             })
             .collect();
 
@@ -1138,7 +1142,13 @@ pub fn write_auto_activation_preference(
 mod tests {
     use std::sync::LazyLock;
 
-    use flox_rust_sdk::models::environment::{DotFlox, EnvironmentPointer, PathPointer};
+    use flox_core::floxhub::{DEFAULT_FLOXHUB_URL, Floxhub};
+    use flox_rust_sdk::models::environment::{
+        DotFlox,
+        EnvironmentPointer,
+        ManagedPointer,
+        PathPointer,
+    };
 
     use super::*;
     use crate::commands::ActiveEnvironments;
@@ -1192,6 +1202,22 @@ mod tests {
         // with `hide_default_prompt = true` we should not see the default environment
         let prompt = ActivateOptions::make_prompt_environments(true, &active_environments);
         assert_eq!(prompt, "wichtig".to_string());
+    }
+
+    /// Remote environments only show the name, same as path environments.
+    #[test]
+    fn prompt_shows_only_the_environment_name_for_remote_environments() {
+        let floxhub = Floxhub::new(DEFAULT_FLOXHUB_URL.clone(), None, None).unwrap();
+        let remote_env = UninitializedEnvironment::Remote(ManagedPointer::new(
+            "acme".parse().unwrap(),
+            "core".parse().unwrap(),
+            &floxhub,
+        ));
+        let mut active_environments = ActiveEnvironments::default();
+        active_environments.set_last_active(remote_env, None, ActivateMode::Dev);
+
+        let prompt = ActivateOptions::make_prompt_environments(true, &active_environments);
+        assert_eq!(prompt, "core".to_string());
     }
 
     /// Build minimal ActivateOptions with only the service-related flags set.

--- a/cli/flox/src/main.rs
+++ b/cli/flox/src/main.rs
@@ -124,14 +124,18 @@ fn main() -> ExitCode {
     let _metrics_guard = Hub::global().try_guard().ok();
     let _v2_events_guard = EventsHub::global().try_guard().ok();
 
-    // Pass down the verbosity level to all sub-processes
+    // Pass down the verbosity level to all sub-processes. Subsystems have no
+    // quiet mode, so `-q` is clamped to 0 rather than passed through as -1:
+    // the interpreter scripts treat any nonzero tracelevel as `set -x`, which
+    // would turn a request for quiet into a full execution trace.
+    let subsystem_verbosity = verbosity.to_i32().max(0);
     unsafe {
         std::env::set_var(
             "_FLOX_SUBSYSTEM_VERBOSITY",
-            format!("{}", verbosity.to_i32()),
+            format!("{subsystem_verbosity}"),
         );
     }
-    debug!("set _FLOX_SUBSYSTEM_VERBOSITY={}", verbosity.to_i32());
+    debug!("set _FLOX_SUBSYSTEM_VERBOSITY={subsystem_verbosity}");
 
     // Run the argument parser
     //

--- a/cli/flox/src/main.rs
+++ b/cli/flox/src/main.rs
@@ -125,14 +125,18 @@ fn main() -> ExitCode {
     let _metrics_guard = Hub::global().try_guard().ok();
     let _v2_events_guard = EventsHub::global().try_guard().ok();
 
-    // Pass down the verbosity level to all sub-processes
+    // Pass down the verbosity level to all sub-processes. Subsystems have no
+    // quiet mode, so `-q` is clamped to 0 rather than passed through as -1:
+    // the interpreter scripts treat any nonzero tracelevel as `set -x`, which
+    // would turn a request for quiet into a full execution trace.
+    let subsystem_verbosity = verbosity.to_i32().max(0);
     unsafe {
         std::env::set_var(
             "_FLOX_SUBSYSTEM_VERBOSITY",
-            format!("{}", verbosity.to_i32()),
+            format!("{subsystem_verbosity}"),
         );
     }
-    debug!("set _FLOX_SUBSYSTEM_VERBOSITY={}", verbosity.to_i32());
+    debug!("set _FLOX_SUBSYSTEM_VERBOSITY={subsystem_verbosity}");
 
     // Run the argument parser
     //

--- a/cli/tests/hook.bats
+++ b/cli/tests/hook.bats
@@ -363,12 +363,13 @@ EXPIRED_FLOXHUB_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3gu
 @test "fish: hook auto-activation sets the prompt" {
   project_setup
   project2_setup
-  # Mirror the reported scenario: the hook-registering outer activation is the
-  # 'default' env, which is hidden from FLOX_PROMPT_ENVIRONMENTS, so the outer
+  # Mirror the reported scenario: the hook-registering outer activation is a
+  # 'default' env hidden from FLOX_PROMPT_ENVIRONMENTS, so the outer
   # activation defines no prompt variables at the top level. (An unscoped fish
   # `set` reuses an existing variable's scope, so a visible outer env would
   # mask scoping bugs when the hook later sets prompt variables inside a
-  # function.)
+  # function.) Hiding is opt-in, so pin the config the scenario relies on.
+  "$FLOX_BIN" config --set hide_default_prompt true
   "$FLOX_BIN" edit -d "$PROJECT_DIR" --name default
   # Auto-activation is opt-in; allow the target before entering it.
   "$FLOX_BIN" activate allow -d "$PROJECT2_DIR"


### PR DESCRIPTION
## What

This PR carries the consolidated, approved front of the DEV-44 activation-visibility stack — one commit per original PR, merged top-down (#4590 → #4588 → #4584 → #4583 → here):

1. **`fix(cli): keep 'flox -q' from tracing the activation scripts`** (this PR's original scope)
   `flox -q` exported `_FLOX_SUBSYSTEM_VERBOSITY=-1`, and the interpreter scripts enable `set -x` for any tracelevel other than 0 — so asking for *quiet* produced a full execution trace. The CLI clamps the exported verbosity to 0; the interpreter guards treat only positive tracelevels as trace requests (`-le 0`). For the `activate` script the guard change only keeps the two preambles identical — the interpreter ships with the CLI — but the same preamble is baked into build artifacts by the executable wrapper, and an artifact built with this wrapper can later execute where an older CLI still exports `-1` under `-q`.

2. **`feat(activate): announce activations in every mode`** (#4583)
   The `✔  You are now using the environment '<name>'` message was gated to interactive subshells; rc-file, auto-activation, and direnv paths never named the environment. Now every mode announces with identical wording — subshells keep the `flox deactivate` hint, recurring modes (in-place, command, exec) print a one-line form without it. Stays quiet when stderr is not a terminal (CI/scripts), when the environment is already active, when it is named `default`, and under `flox -q`.

3. **`feat(activate): show environments named 'default' in the prompt by default`** (#4584)
   Flips `hide_default_prompt` to `false`: users whose only environment is a default environment now see Flox in their shell. `flox config --set hide_default_prompt true` restores the old behavior.

4. **`feat(activate): show only the environment name in the prompt`** (#4588)
   Prompt entries drop the owner and `(local)` marker: `flox [acme/core (local)]` → `flox [core]`. The `prompt_detail` config option that restores the full rendering stays in draft #4587.

5. **`docs(activate): document $FLOX_PROMPT and the exported prompt variables`** (#4590)
   `flox-activate(1)` now documents `$FLOX_PROMPT` (overrides the `flox` label at the front of the prompt, settable from an environment's `[vars]`) and notes that `$FLOX_PROMPT_ENVIRONMENTS` is exported for shells and frameworks that manage their own prompt. Known pre-existing gap: fish and tcsh ignore `$FLOX_PROMPT` under `NO_COLOR` — fix underway in #4597.

## Stack

The remaining tail of the DEV-44 stack (#4585 auto-activation events, #4587 `prompt_detail`, #4589 `activation_notifications`) stays stacked on `daniel/dev-44-flox-prompt-docs` and is not part of this PR.

## Release Notes

- Activations now announce the environment they enter in every activation mode — including in-place and auto-activations — when stderr is a terminal, using the same wording everywhere. Re-activations of an already-active environment and environments named `default` stay quiet.
- `flox -q activate` is now silent in every mode, and no longer prints an execution trace of the activation scripts.
- Environments named `default` now appear in the shell prompt by default. Set `hide_default_prompt = true` to hide them again.
- The shell prompt now shows just the environment name for each active environment, instead of `owner/name (local)`.
- `flox-activate(1)` now documents `$FLOX_PROMPT` and the exported prompt variables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C6EywgcuUFb9rjSQEp7nB5
