### PR TITLE
feat(activate): announce activations in every mode

### DIFF
--- a/cli/flox-activations/src/cli/activate.rs
+++ b/cli/flox-activations/src/cli/activate.rs
@@ -37,6 +37,27 @@ pub struct ActivateArgs {
     pub cmd: Option<Vec<String>>,
 }
 
+/// Announce the activation by naming the environment on stderr.
+///
+/// The wording is the same in every mode; only whether the deactivate hint
+/// follows differs. A subshell activation is a place the user typed their way
+/// into and has to type their way out of, so the exit is worth stating; it is
+/// also printed at most once per subshell. In-place activations recur — every
+/// new shell for an rc-file activation, every `cd` for an auto-activation — so
+/// they omit the hint that would otherwise repeat all day.
+fn announce(context: &ActivateCtx, invocation_type: &InvocationType, transition: String) {
+    if !context.announce_activation {
+        return;
+    }
+    if *invocation_type == InvocationType::Interactive {
+        updated(formatdoc! {"{transition}
+            To stop using this environment, run 'flox deactivate'
+            "});
+    } else {
+        updated(transition);
+    }
+}
+
 impl ActivateArgs {
     pub fn handle(self, subsystem_verbosity: u32) -> Result<(), anyhow::Error> {
         let contents = fs::read_to_string(&self.activate_data)?;
@@ -65,7 +86,13 @@ impl ActivateArgs {
         match (context.invocation_type.as_ref(), run_args) {
             // This is a container invocation, and we need to set the invocation type
             // based on the presence of command arguments.
-            (None, None) => context.invocation_type = Some(InvocationType::Interactive),
+            (None, None) => {
+                context.invocation_type = Some(InvocationType::Interactive);
+                // The flox CLI that resolves `announce_activation` never runs
+                // in a container, so resolve it here: interactive containers
+                // announce, command invocations keep the silent default.
+                context.announce_activation = true;
+            },
             // This is a container invocation, and we need to set the invocation type
             // based on the presence of command arguments.
             (None, Some(args)) => {
@@ -135,32 +162,28 @@ impl ActivateArgs {
         let warning_interval = Duration::from_secs(5);
         let mut last_warning: Option<Instant> = None;
 
-        let deactivate_hint = "To stop using this environment, run 'flox deactivate'";
-
         loop {
             match self.try_start_or_attach(context, subsystem_verbosity, vars_from_env)? {
                 StartOrAttachResult::Start { start_id, .. } => {
-                    if *invocation_type == InvocationType::Interactive {
-                        updated(
-                            formatdoc! {"You are now using the environment '{env_description}'
-                                     {deactivate_hint}
-                                     ",
-                            env_description = context.attach_ctx.env_description,
-                            },
-                        );
-                    }
+                    announce(
+                        context,
+                        invocation_type,
+                        format!(
+                            "You are now using the environment '{}'",
+                            context.attach_ctx.env_description
+                        ),
+                    );
                     return Ok(start_id);
                 },
                 StartOrAttachResult::Attach { start_id, .. } => {
-                    if *invocation_type == InvocationType::Interactive {
-                        updated(
-                            formatdoc! {"Attached to existing activation of environment '{env_description}'
-                                     {deactivate_hint}
-                                     ",
-                            env_description = context.attach_ctx.env_description,
-                            },
-                        );
-                    }
+                    announce(
+                        context,
+                        invocation_type,
+                        format!(
+                            "Attached to existing activation of environment '{}'",
+                            context.attach_ctx.env_description
+                        ),
+                    );
                     return Ok(start_id);
                 },
                 StartOrAttachResult::AlreadyStarting {

--- a/cli/flox-activations/src/cli/activate.rs
+++ b/cli/flox-activations/src/cli/activate.rs
@@ -37,6 +37,48 @@ pub struct ActivateArgs {
     pub cmd: Option<Vec<String>>,
 }
 
+/// How an activation names itself on stderr once it is in effect.
+///
+/// The wording is the same in every mode; only whether the deactivate hint
+/// follows differs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ActivationAnnouncement {
+    /// Name the environment and how to leave it. A subshell activation is a
+    /// place the user typed their way into and has to type their way out of,
+    /// so the exit is worth stating; it is also printed at most once per
+    /// subshell.
+    Full,
+    /// Name the environment only. In-place activations recur — every new shell
+    /// for an rc-file activation, every `cd` for an auto-activation — so this
+    /// omits the hint that would otherwise repeat all day.
+    OneLine,
+    /// Say nothing.
+    Silent,
+}
+
+impl ActivationAnnouncement {
+    fn for_context(context: &ActivateCtx, invocation_type: &InvocationType) -> Self {
+        if !context.announce_activation {
+            return Self::Silent;
+        }
+        match invocation_type {
+            InvocationType::Interactive => Self::Full,
+            _ => Self::OneLine,
+        }
+    }
+
+    fn emit(self, transition: String) {
+        let deactivate_hint = "To stop using this environment, run 'flox deactivate'";
+        match self {
+            Self::Full => updated(formatdoc! {"{transition}
+                     {deactivate_hint}
+                     "}),
+            Self::OneLine => updated(transition),
+            Self::Silent => {},
+        }
+    }
+}
+
 impl ActivateArgs {
     pub fn handle(self, subsystem_verbosity: u32) -> Result<(), anyhow::Error> {
         let contents = fs::read_to_string(&self.activate_data)?;
@@ -65,7 +107,13 @@ impl ActivateArgs {
         match (context.invocation_type.as_ref(), run_args) {
             // This is a container invocation, and we need to set the invocation type
             // based on the presence of command arguments.
-            (None, None) => context.invocation_type = Some(InvocationType::Interactive),
+            (None, None) => {
+                context.invocation_type = Some(InvocationType::Interactive);
+                // The flox CLI that resolves `announce_activation` never runs
+                // in a container, so resolve it here: interactive containers
+                // announce, command invocations keep the silent default.
+                context.announce_activation = true;
+            },
             // This is a container invocation, and we need to set the invocation type
             // based on the presence of command arguments.
             (None, Some(args)) => {
@@ -135,32 +183,22 @@ impl ActivateArgs {
         let warning_interval = Duration::from_secs(5);
         let mut last_warning: Option<Instant> = None;
 
-        let deactivate_hint = "To stop using this environment, run 'flox deactivate'";
+        let announcement = ActivationAnnouncement::for_context(context, invocation_type);
 
         loop {
             match self.try_start_or_attach(context, subsystem_verbosity, vars_from_env)? {
                 StartOrAttachResult::Start { start_id, .. } => {
-                    if *invocation_type == InvocationType::Interactive {
-                        updated(
-                            formatdoc! {"You are now using the environment '{env_description}'
-                                     {deactivate_hint}
-                                     ",
-                            env_description = context.attach_ctx.env_description,
-                            },
-                        );
-                    }
+                    announcement.emit(format!(
+                        "You are now using the environment '{}'",
+                        context.attach_ctx.env_description
+                    ));
                     return Ok(start_id);
                 },
                 StartOrAttachResult::Attach { start_id, .. } => {
-                    if *invocation_type == InvocationType::Interactive {
-                        updated(
-                            formatdoc! {"Attached to existing activation of environment '{env_description}'
-                                     {deactivate_hint}
-                                     ",
-                            env_description = context.attach_ctx.env_description,
-                            },
-                        );
-                    }
+                    announcement.emit(format!(
+                        "Attached to existing activation of environment '{}'",
+                        context.attach_ctx.env_description
+                    ));
                     return Ok(start_id);
                 },
                 StartOrAttachResult::AlreadyStarting {

--- a/cli/flox-activations/src/gen_rc/mod.rs
+++ b/cli/flox-activations/src/gen_rc/mod.rs
@@ -175,6 +175,7 @@ pub(crate) mod test_helpers {
             disable_hook,
             flox_bin: "/flox".to_string(),
             auto_activate_fish_mode: None,
+            announce_activation: false,
         };
         let deleted_var = "DELETED_VAR".to_string();
         let modified_var = "MODIFIED_VAR".to_string();

--- a/cli/flox-core/src/activate/context.rs
+++ b/cli/flox-core/src/activate/context.rs
@@ -119,6 +119,17 @@ pub struct ActivateCtx {
     /// Controls how the fish shell hook responds to directory changes.
     #[serde(default)]
     pub auto_activate_fish_mode: Option<AutoActivateFishMode>,
+
+    /// Whether this activation announces itself by naming the environment on
+    /// stderr once it is in effect.
+    ///
+    /// Resolved by the `flox` crate because the decision depends on state only
+    /// the caller has: the user's real verbosity and whether the environment
+    /// was already active. Defaults to `false` so a context file written by an
+    /// older Flox stays quiet rather than gaining output the writer never
+    /// asked for.
+    #[serde(default)]
+    pub announce_activation: bool,
 }
 
 /// Fish shell hook mode, matching direnv's `direnv_fish_mode` values.

--- a/cli/flox/doc/flox-activate.md
+++ b/cli/flox/doc/flox-activate.md
@@ -218,8 +218,8 @@ options.
     environment.
 
 `$FLOX_PROMPT_ENVIRONMENTS`
-:   Contains a space-delimited list of the active environments,
-    e.g. `owner1/foo owner2/bar local_env`.
+:   Contains a space-delimited list of the names of the active environments,
+    e.g. `foo bar local_env`.
     If `hide_default_prompt` is set to `true`, environments named `default` are
     excluded.
 

--- a/cli/flox/doc/flox-activate.md
+++ b/cli/flox/doc/flox-activate.md
@@ -222,6 +222,10 @@ options.
     e.g. `foo bar local_env`.
     If `hide_default_prompt` is set to `true`, environments named `default` are
     excluded.
+    This variable is exported, so it is set even by activations that do not
+    modify the prompt, such as `flox activate -- <CMD>`.
+    A shell that manages its own prompt can render an indicator from it
+    directly.
 
 `$FLOX_ENV_CACHE`
 :   `activate` sets this variable to a directory that can be used by an
@@ -269,6 +273,19 @@ options.
          the `$FLOX_SHELL` variable,
          and if it cannot detect its parent shell type then will
          produce a script with syntax determined by `$SHELL`.
+
+`$FLOX_PROMPT`
+:   The label Flox puts at the front of the shell prompt, `flox` by default.
+    Set it to shorten the indicator, e.g. `f` to reclaim three columns,
+    or to rebrand it, for example with the name of an internal developer
+    platform built on Flox.
+    Because an environment's `[vars]` are applied before the prompt is set,
+    an environment can carry its own label in its manifest:
+
+    ```toml
+    [vars]
+    FLOX_PROMPT = "acme"
+    ```
 
 `$FLOX_PROMPT_COLOR_{1,2}`
 :   Flox adds text to the beginning of the shell prompt to indicate which

--- a/cli/flox/doc/flox-config.md
+++ b/cli/flox/doc/flox-config.md
@@ -126,7 +126,7 @@ flox config --set 'trusted_environments."owner/name"' trust
 
 `hide_default_prompt`
 :   Hide environments named 'default' from the shell prompt,
-    and don't add environments named 'default' to `$FLOX_PROMPT_ENVIRONMENTS` (default: true).
+    and don't add environments named 'default' to `$FLOX_PROMPT_ENVIRONMENTS` (default: false).
 
 `installer_channel`
 :   Release channel to use when checking for updates to Flox.

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -626,6 +626,51 @@ impl ActivateOptions {
 
         let activation_state_dir = activation_state_dir_path(&flox.runtime_dir, &dot_flox_path);
 
+        // Which modes announce.
+        //
+        // A subshell activation has always announced unconditionally, and
+        // callers depend on that, so it keeps doing so.
+        //
+        // Every other mode is newly announcing here, and each of them can also
+        // be driven by a program rather than a person: `eval "$(flox activate)"`
+        // from a script, `flox activate -- <CMD>` from CI. Requiring a terminal
+        // on stderr is what separates the two cases — a human watching, or a
+        // program collecting output something else will parse.
+        //
+        // That condition is also what lets the most invisible path speak.
+        // direnv's `use flox` activates via `flox activate -- direnv dump`, and
+        // direnv leaves stderr attached to the user's terminal (which is why its
+        // own `direnv: loading` lines are visible) while capturing only stdout.
+        // It is the one path where the prompt can never speak for Flox: exec
+        // mode renders no shell rc, so `set-prompt` never runs, and direnv
+        // declines to export `PS1` at all.
+        //
+        // An environment that is already active is not announced again: the
+        // shell is not transitioning anywhere, it is re-running an activation
+        // it already has — a nested shell re-sourcing an rc file, or a second
+        // in-place activation of the same environment.
+        //
+        // Environments named `default` are excluded for the same reason
+        // `hide_default_prompt` exists: the default environment is ambient
+        // rather than a place you arrived at, so its activation is not a
+        // transition worth reporting — and an rc-file activation of it would
+        // otherwise announce itself in every new shell.
+        // `-q` is resolved here rather than in `flox-activations`, which has no
+        // quiet mode of its own: the verbosity it receives below is clamped to
+        // `max(0)`, so a negative (quieter) verbosity never reaches it. Deciding
+        // here keeps the one place that knows the user's real verbosity as the
+        // one place that decides, and makes `flox -q activate` silent.
+        let mode_announces = match invocation_type {
+            InvocationType::Interactive => true,
+            InvocationType::InPlace
+            | InvocationType::ShellCommand(_)
+            | InvocationType::ExecCommand(_) => std::io::stderr().is_tty(),
+        };
+        let announce_activation = mode_announces
+            && !already_active
+            && flox.verbosity >= 0
+            && now_active.name().as_ref() != DEFAULT_NAME;
+
         let activate_data = ActivateCtx {
             flox_activate_store_path: store_path.to_string_lossy().to_string(),
             attach_ctx: core,
@@ -644,6 +689,7 @@ impl ActivateOptions {
                 .and_then(|p| p.to_str().map(String::from))
                 .unwrap_or_else(|| "flox".to_string()),
             auto_activate_fish_mode: config.flox.auto_activate_fish_mode,
+            announce_activation,
         };
 
         let tempfile = tempfile::NamedTempFile::new_in(flox.temp_dir)?;

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -834,7 +834,11 @@ impl ActivateOptions {
                 if hide_default_prompt && env.name().as_ref() == DEFAULT_NAME {
                     return None;
                 }
-                Some(env.bare_description())
+                // Deliberately narrower than `bare_description()`, which
+                // still backs the activation announcements and the exported
+                // `FLOX_ENV_DESCRIPTION` variable with the full `owner/name`
+                // form.
+                Some(env.name().to_string())
             })
             .collect();
 
@@ -1132,7 +1136,13 @@ pub fn write_auto_activation_preference(
 mod tests {
     use std::sync::LazyLock;
 
-    use flox_rust_sdk::models::environment::{DotFlox, EnvironmentPointer, PathPointer};
+    use flox_core::floxhub::{DEFAULT_FLOXHUB_URL, Floxhub};
+    use flox_rust_sdk::models::environment::{
+        DotFlox,
+        EnvironmentPointer,
+        ManagedPointer,
+        PathPointer,
+    };
 
     use super::*;
     use crate::commands::ActiveEnvironments;
@@ -1186,6 +1196,22 @@ mod tests {
         // with `hide_default_prompt = true` we should not see the default environment
         let prompt = ActivateOptions::make_prompt_environments(true, &active_environments);
         assert_eq!(prompt, "wichtig".to_string());
+    }
+
+    /// Remote environments only show the name, same as path environments.
+    #[test]
+    fn prompt_shows_only_the_environment_name_for_remote_environments() {
+        let floxhub = Floxhub::new(DEFAULT_FLOXHUB_URL.clone(), None, None).unwrap();
+        let remote_env = UninitializedEnvironment::Remote(ManagedPointer::new(
+            "acme".parse().unwrap(),
+            "core".parse().unwrap(),
+            &floxhub,
+        ));
+        let mut active_environments = ActiveEnvironments::default();
+        active_environments.set_last_active(remote_env, None, ActivateMode::Dev);
+
+        let prompt = ActivateOptions::make_prompt_environments(true, &active_environments);
+        assert_eq!(prompt, "core".to_string());
     }
 
     /// Build minimal ActivateOptions with only the service-related flags set.

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -546,7 +546,7 @@ impl ActivateOptions {
             "}),
             (set_prompt, hide_default_prompt, _) => (
                 set_prompt.unwrap_or(true),
-                hide_default_prompt.unwrap_or(true),
+                hide_default_prompt.unwrap_or(false),
             ),
         };
 

--- a/cli/tests/hook.bats
+++ b/cli/tests/hook.bats
@@ -363,12 +363,13 @@ EXPIRED_FLOXHUB_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3gu
 @test "fish: hook auto-activation sets the prompt" {
   project_setup
   project2_setup
-  # Mirror the reported scenario: the hook-registering outer activation is the
-  # 'default' env, which is hidden from FLOX_PROMPT_ENVIRONMENTS, so the outer
+  # Mirror the reported scenario: the hook-registering outer activation is a
+  # 'default' env hidden from FLOX_PROMPT_ENVIRONMENTS, so the outer
   # activation defines no prompt variables at the top level. (An unscoped fish
   # `set` reuses an existing variable's scope, so a visible outer env would
   # mask scoping bugs when the hook later sets prompt variables inside a
-  # function.)
+  # function.) Hiding is opt-in, so pin the config the scenario relies on.
+  "$FLOX_BIN" config --set hide_default_prompt true
   "$FLOX_BIN" edit -d "$PROJECT_DIR" --name default
   # Auto-activation is opt-in; allow the target before entering it.
   "$FLOX_BIN" activate allow -d "$PROJECT2_DIR"


### PR DESCRIPTION
## What

The `✔  You are now using the environment '<name>'` message was gated to interactive (subshell) activations. The most common activation paths — rc files, auto-activation, direnv — never name the environment, which is a large part of why Flox adoption stays invisible (DEV-44).

This PR extends the announcement to every activation mode:

- Subshell activations are unchanged: full message plus the `flox deactivate` hint.
- In-place, command (`-- <CMD>`), and exec activations print a one-line form without the hint, since they recur on every new shell and every `cd`.
- The wording is now identical in every mode (previously command-mode said "Activated Flox environment ...").

When it stays quiet:

| Condition | Behavior |
| --- | --- |
| stderr is not a terminal (non-interactive modes) | silent — output collected by CI or scripts stays clean |
| the environment is already active | silent — nested shells and re-sourced rc files don't repeat it |
| the environment is named `default` | silent — ambient, not a transition |
| `flox -q activate` | silent (previously `-q` did not suppress even the subshell message) |

The stderr-tty condition is also what lets the most invisible path speak: direnv's `use flox` runs `flox activate -- direnv dump` with stderr left on the user's terminal, so direnv users see the announcement without moving off direnv.

The persistent opt-out lives in #4589, which adds an `activation_notifications` config option. It was factored out of this PR per review feedback and sits at the end of the stack, so it can be dropped without disturbing this change.

## Review notes / open questions

- The skip-when-already-active gate is new relative to the prototype, added per review feedback.
- Environments named `default` are never announced — including an explicit interactive `flox activate` of a default env, which previously printed the message. Easy to loosen to non-interactive modes only if preferred.

## Stack

PR 2 of 8 in the DEV-44 activation-visibility stack; based on `daniel/dev-44-quiet-trace` (the `-q` fix is what makes `flox -q activate` fully silent).

## Release Notes

- Activations now announce the environment they enter in every activation mode — including in-place and auto-activations — when stderr is a terminal, using the same wording everywhere. Re-activations of an already-active environment and environments named `default` stay quiet.
- `flox -q activate` is now silent in every mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C6EywgcuUFb9rjSQEp7nB5
