### PR TITLE
feat(events): distinguish auto-activations in activation events

### DIFF
--- a/cli/flox-activations/src/cli/activate.rs
+++ b/cli/flox-activations/src/cli/activate.rs
@@ -37,6 +37,48 @@ pub struct ActivateArgs {
     pub cmd: Option<Vec<String>>,
 }
 
+/// How an activation names itself on stderr once it is in effect.
+///
+/// The wording is the same in every mode; only whether the deactivate hint
+/// follows differs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ActivationAnnouncement {
+    /// Name the environment and how to leave it. A subshell activation is a
+    /// place the user typed their way into and has to type their way out of,
+    /// so the exit is worth stating; it is also printed at most once per
+    /// subshell.
+    Full,
+    /// Name the environment only. In-place activations recur — every new shell
+    /// for an rc-file activation, every `cd` for an auto-activation — so this
+    /// omits the hint that would otherwise repeat all day.
+    OneLine,
+    /// Say nothing.
+    Silent,
+}
+
+impl ActivationAnnouncement {
+    fn for_context(context: &ActivateCtx, invocation_type: &InvocationType) -> Self {
+        if !context.announce_activation {
+            return Self::Silent;
+        }
+        match invocation_type {
+            InvocationType::Interactive => Self::Full,
+            _ => Self::OneLine,
+        }
+    }
+
+    fn emit(self, transition: String) {
+        let deactivate_hint = "To stop using this environment, run 'flox deactivate'";
+        match self {
+            Self::Full => updated(formatdoc! {"{transition}
+                     {deactivate_hint}
+                     "}),
+            Self::OneLine => updated(transition),
+            Self::Silent => {},
+        }
+    }
+}
+
 impl ActivateArgs {
     pub fn handle(self, subsystem_verbosity: u32) -> Result<(), anyhow::Error> {
         let contents = fs::read_to_string(&self.activate_data)?;
@@ -65,7 +107,13 @@ impl ActivateArgs {
         match (context.invocation_type.as_ref(), run_args) {
             // This is a container invocation, and we need to set the invocation type
             // based on the presence of command arguments.
-            (None, None) => context.invocation_type = Some(InvocationType::Interactive),
+            (None, None) => {
+                context.invocation_type = Some(InvocationType::Interactive);
+                // The flox CLI that resolves `announce_activation` never runs
+                // in a container, so resolve it here: interactive containers
+                // announce, command invocations keep the silent default.
+                context.announce_activation = true;
+            },
             // This is a container invocation, and we need to set the invocation type
             // based on the presence of command arguments.
             (None, Some(args)) => {
@@ -135,32 +183,22 @@ impl ActivateArgs {
         let warning_interval = Duration::from_secs(5);
         let mut last_warning: Option<Instant> = None;
 
-        let deactivate_hint = "To stop using this environment, run 'flox deactivate'";
+        let announcement = ActivationAnnouncement::for_context(context, invocation_type);
 
         loop {
             match self.try_start_or_attach(context, subsystem_verbosity, vars_from_env)? {
                 StartOrAttachResult::Start { start_id, .. } => {
-                    if *invocation_type == InvocationType::Interactive {
-                        updated(
-                            formatdoc! {"You are now using the environment '{env_description}'
-                                     {deactivate_hint}
-                                     ",
-                            env_description = context.attach_ctx.env_description,
-                            },
-                        );
-                    }
+                    announcement.emit(format!(
+                        "You are now using the environment '{}'",
+                        context.attach_ctx.env_description
+                    ));
                     return Ok(start_id);
                 },
                 StartOrAttachResult::Attach { start_id, .. } => {
-                    if *invocation_type == InvocationType::Interactive {
-                        updated(
-                            formatdoc! {"Attached to existing activation of environment '{env_description}'
-                                     {deactivate_hint}
-                                     ",
-                            env_description = context.attach_ctx.env_description,
-                            },
-                        );
-                    }
+                    announcement.emit(format!(
+                        "Attached to existing activation of environment '{}'",
+                        context.attach_ctx.env_description
+                    ));
                     return Ok(start_id);
                 },
                 StartOrAttachResult::AlreadyStarting {

--- a/cli/flox-activations/src/cli/activate.rs
+++ b/cli/flox-activations/src/cli/activate.rs
@@ -37,45 +37,24 @@ pub struct ActivateArgs {
     pub cmd: Option<Vec<String>>,
 }
 
-/// How an activation names itself on stderr once it is in effect.
+/// Announce the activation by naming the environment on stderr.
 ///
 /// The wording is the same in every mode; only whether the deactivate hint
-/// follows differs.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ActivationAnnouncement {
-    /// Name the environment and how to leave it. A subshell activation is a
-    /// place the user typed their way into and has to type their way out of,
-    /// so the exit is worth stating; it is also printed at most once per
-    /// subshell.
-    Full,
-    /// Name the environment only. In-place activations recur — every new shell
-    /// for an rc-file activation, every `cd` for an auto-activation — so this
-    /// omits the hint that would otherwise repeat all day.
-    OneLine,
-    /// Say nothing.
-    Silent,
-}
-
-impl ActivationAnnouncement {
-    fn for_context(context: &ActivateCtx, invocation_type: &InvocationType) -> Self {
-        if !context.announce_activation {
-            return Self::Silent;
-        }
-        match invocation_type {
-            InvocationType::Interactive => Self::Full,
-            _ => Self::OneLine,
-        }
+/// follows differs. A subshell activation is a place the user typed their way
+/// into and has to type their way out of, so the exit is worth stating; it is
+/// also printed at most once per subshell. In-place activations recur — every
+/// new shell for an rc-file activation, every `cd` for an auto-activation — so
+/// they omit the hint that would otherwise repeat all day.
+fn announce(context: &ActivateCtx, invocation_type: &InvocationType, transition: String) {
+    if !context.announce_activation {
+        return;
     }
-
-    fn emit(self, transition: String) {
-        let deactivate_hint = "To stop using this environment, run 'flox deactivate'";
-        match self {
-            Self::Full => updated(formatdoc! {"{transition}
-                     {deactivate_hint}
-                     "}),
-            Self::OneLine => updated(transition),
-            Self::Silent => {},
-        }
+    if *invocation_type == InvocationType::Interactive {
+        updated(formatdoc! {"{transition}
+            To stop using this environment, run 'flox deactivate'
+            "});
+    } else {
+        updated(transition);
     }
 }
 
@@ -183,22 +162,28 @@ impl ActivateArgs {
         let warning_interval = Duration::from_secs(5);
         let mut last_warning: Option<Instant> = None;
 
-        let announcement = ActivationAnnouncement::for_context(context, invocation_type);
-
         loop {
             match self.try_start_or_attach(context, subsystem_verbosity, vars_from_env)? {
                 StartOrAttachResult::Start { start_id, .. } => {
-                    announcement.emit(format!(
-                        "You are now using the environment '{}'",
-                        context.attach_ctx.env_description
-                    ));
+                    announce(
+                        context,
+                        invocation_type,
+                        format!(
+                            "You are now using the environment '{}'",
+                            context.attach_ctx.env_description
+                        ),
+                    );
                     return Ok(start_id);
                 },
                 StartOrAttachResult::Attach { start_id, .. } => {
-                    announcement.emit(format!(
-                        "Attached to existing activation of environment '{}'",
-                        context.attach_ctx.env_description
-                    ));
+                    announce(
+                        context,
+                        invocation_type,
+                        format!(
+                            "Attached to existing activation of environment '{}'",
+                            context.attach_ctx.env_description
+                        ),
+                    );
                     return Ok(start_id);
                 },
                 StartOrAttachResult::AlreadyStarting {

--- a/cli/flox-activations/src/gen_rc/mod.rs
+++ b/cli/flox-activations/src/gen_rc/mod.rs
@@ -175,6 +175,7 @@ pub(crate) mod test_helpers {
             disable_hook,
             flox_bin: "/flox".to_string(),
             auto_activate_fish_mode: None,
+            announce_activation: false,
         };
         let deleted_var = "DELETED_VAR".to_string();
         let modified_var = "MODIFIED_VAR".to_string();

--- a/cli/flox-core/src/activate/context.rs
+++ b/cli/flox-core/src/activate/context.rs
@@ -119,6 +119,17 @@ pub struct ActivateCtx {
     /// Controls how the fish shell hook responds to directory changes.
     #[serde(default)]
     pub auto_activate_fish_mode: Option<AutoActivateFishMode>,
+
+    /// Whether this activation announces itself by naming the environment on
+    /// stderr once it is in effect.
+    ///
+    /// Resolved by the `flox` crate because the decision depends on state only
+    /// the caller has: the user's real verbosity and whether the environment
+    /// was already active. Defaults to `false` so a context file written by an
+    /// older Flox stays quiet rather than gaining output the writer never
+    /// asked for.
+    #[serde(default)]
+    pub announce_activation: bool,
 }
 
 /// Fish shell hook mode, matching direnv's `direnv_fish_mode` values.

--- a/cli/flox-events/src/lib.rs
+++ b/cli/flox-events/src/lib.rs
@@ -495,6 +495,11 @@ pub struct CliEnvironmentActivatePayload {
     manifest_version: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     shell: Option<String>,
+    /// `true` when the auto-activation prompt hook drove this activation.
+    /// `mode` cannot answer this on its own: the hook activates in-place, so
+    /// auto-activations and shell-rc activations share `mode: "inplace"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    auto_activated: Option<bool>,
 }
 
 impl CliEnvironmentActivatePayload {
@@ -509,7 +514,13 @@ impl CliEnvironmentActivatePayload {
             lockfile_version: None,
             manifest_version: None,
             shell: None,
+            auto_activated: None,
         }
+    }
+
+    pub fn with_auto_activated(mut self, value: bool) -> Self {
+        self.auto_activated = Some(value);
+        self
     }
 
     pub fn with_start_services(mut self, value: bool) -> Self {
@@ -1196,6 +1207,25 @@ mod tests {
             "env_ref_or_name": "alice/myenv",
             "start_services": false,
             "mode": "dev",
+        }));
+        assert_eq!(value, expected);
+    }
+
+    /// The prompt hook activates in-place, so `mode` cannot separate an
+    /// auto-activation from a shell-rc activation; `auto_activated` is the only
+    /// field that does.
+    #[test]
+    fn cli_environment_activate_auto_activated_envelope_golden() {
+        let payload = CliEnvironmentActivatePayload::new(env_detail("path", "myenv"))
+            .with_mode("dev")
+            .with_auto_activated(true);
+        let value = serde_json::to_value(fixed_event(EventKind::CliEnvironmentActivate(payload)))
+            .expect("event serializes");
+        let expected = activate_envelope_json(json!({
+            "env_kind": "path",
+            "env_ref_or_name": "myenv",
+            "mode": "dev",
+            "auto_activated": true,
         }));
         assert_eq!(value, expected);
     }

--- a/cli/flox/doc/flox-activate.md
+++ b/cli/flox/doc/flox-activate.md
@@ -276,9 +276,9 @@ options.
 
 `$FLOX_PROMPT`
 :   The label Flox puts at the front of the shell prompt, `flox` by default.
-    Set it to rebrand or shorten the indicator, e.g. `f` to reclaim three
-    columns, or the name of an internal platform that an environment belongs
-    to.
+    Set it to shorten the indicator, e.g. `f` to reclaim three columns,
+    or to rebrand it, for example with the name of an internal developer
+    platform built on Flox.
     Because an environment's `[vars]` are applied before the prompt is set,
     an environment can carry its own label in its manifest:
 

--- a/cli/flox/doc/flox-activate.md
+++ b/cli/flox/doc/flox-activate.md
@@ -218,8 +218,8 @@ options.
     environment.
 
 `$FLOX_PROMPT_ENVIRONMENTS`
-:   Contains a space-delimited list of the active environments,
-    e.g. `owner1/foo owner2/bar local_env`.
+:   Contains a space-delimited list of the names of the active environments,
+    e.g. `foo bar local_env`.
     If `hide_default_prompt` is set to `true`, environments named `default` are
     excluded.
 

--- a/cli/flox/doc/flox-activate.md
+++ b/cli/flox/doc/flox-activate.md
@@ -222,10 +222,10 @@ options.
     e.g. `foo bar local_env`.
     If `hide_default_prompt` is set to `true`, environments named `default` are
     excluded.
-    This variable is exported, so it is readable even by activations that do
-    not modify the prompt themselves — including `flox activate -- <CMD>`,
-    which is how direnv's `use flox` activates. A shell that manages its own
-    prompt can render an indicator from it directly.
+    This variable is exported, so it is set even by activations that do not
+    modify the prompt, such as `flox activate -- <CMD>`.
+    A shell that manages its own prompt can render an indicator from it
+    directly.
 
 `$FLOX_ENV_CACHE`
 :   `activate` sets this variable to a directory that can be used by an

--- a/cli/flox/doc/flox-activate.md
+++ b/cli/flox/doc/flox-activate.md
@@ -222,6 +222,10 @@ options.
     e.g. `foo bar local_env`.
     If `hide_default_prompt` is set to `true`, environments named `default` are
     excluded.
+    This variable is exported, so it is readable even by activations that do
+    not modify the prompt themselves — including `flox activate -- <CMD>`,
+    which is how direnv's `use flox` activates. A shell that manages its own
+    prompt can render an indicator from it directly.
 
 `$FLOX_ENV_CACHE`
 :   `activate` sets this variable to a directory that can be used by an
@@ -269,6 +273,19 @@ options.
          the `$FLOX_SHELL` variable,
          and if it cannot detect its parent shell type then will
          produce a script with syntax determined by `$SHELL`.
+
+`$FLOX_PROMPT`
+:   The label Flox puts at the front of the shell prompt, `flox` by default.
+    Set it to rebrand or shorten the indicator, e.g. `f` to reclaim three
+    columns, or the name of an internal platform that an environment belongs
+    to.
+    Because an environment's `[vars]` are applied before the prompt is set,
+    an environment can carry its own label in its manifest:
+
+    ```toml
+    [vars]
+    FLOX_PROMPT = "acme"
+    ```
 
 `$FLOX_PROMPT_COLOR_{1,2}`
 :   Flox adds text to the beginning of the shell prompt to indicate which

--- a/cli/flox/doc/flox-config.md
+++ b/cli/flox/doc/flox-config.md
@@ -126,7 +126,7 @@ flox config --set 'trusted_environments."owner/name"' trust
 
 `hide_default_prompt`
 :   Hide environments named 'default' from the shell prompt,
-    and don't add environments named 'default' to `$FLOX_PROMPT_ENVIRONMENTS` (default: true).
+    and don't add environments named 'default' to `$FLOX_PROMPT_ENVIRONMENTS` (default: false).
 
 `installer_channel`
 :   Release channel to use when checking for updates to Flox.

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -626,6 +626,51 @@ impl ActivateOptions {
 
         let activation_state_dir = activation_state_dir_path(&flox.runtime_dir, &dot_flox_path);
 
+        // Which modes announce.
+        //
+        // A subshell activation has always announced unconditionally, and
+        // callers depend on that, so it keeps doing so.
+        //
+        // Every other mode is newly announcing here, and each of them can also
+        // be driven by a program rather than a person: `eval "$(flox activate)"`
+        // from a script, `flox activate -- <CMD>` from CI. Requiring a terminal
+        // on stderr is what separates the two cases — a human watching, or a
+        // program collecting output something else will parse.
+        //
+        // That condition is also what lets the most invisible path speak.
+        // direnv's `use flox` activates via `flox activate -- direnv dump`, and
+        // direnv leaves stderr attached to the user's terminal (which is why its
+        // own `direnv: loading` lines are visible) while capturing only stdout.
+        // It is the one path where the prompt can never speak for Flox: exec
+        // mode renders no shell rc, so `set-prompt` never runs, and direnv
+        // declines to export `PS1` at all.
+        //
+        // An environment that is already active is not announced again: the
+        // shell is not transitioning anywhere, it is re-running an activation
+        // it already has — a nested shell re-sourcing an rc file, or a second
+        // in-place activation of the same environment.
+        //
+        // Environments named `default` are excluded for the same reason
+        // `hide_default_prompt` exists: the default environment is ambient
+        // rather than a place you arrived at, so its activation is not a
+        // transition worth reporting — and an rc-file activation of it would
+        // otherwise announce itself in every new shell.
+        // `-q` is resolved here rather than in `flox-activations`, which has no
+        // quiet mode of its own: the verbosity it receives below is clamped to
+        // `max(0)`, so a negative (quieter) verbosity never reaches it. Deciding
+        // here keeps the one place that knows the user's real verbosity as the
+        // one place that decides, and makes `flox -q activate` silent.
+        let mode_announces = match invocation_type {
+            InvocationType::Interactive => true,
+            InvocationType::InPlace
+            | InvocationType::ShellCommand(_)
+            | InvocationType::ExecCommand(_) => std::io::stderr().is_tty(),
+        };
+        let announce_activation = mode_announces
+            && !already_active
+            && flox.verbosity >= 0
+            && now_active.name().as_ref() != DEFAULT_NAME;
+
         let activate_data = ActivateCtx {
             flox_activate_store_path: store_path.to_string_lossy().to_string(),
             attach_ctx: core,
@@ -644,6 +689,7 @@ impl ActivateOptions {
                 .and_then(|p| p.to_str().map(String::from))
                 .unwrap_or_else(|| "flox".to_string()),
             auto_activate_fish_mode: config.flox.auto_activate_fish_mode,
+            announce_activation,
         };
 
         let tempfile = tempfile::NamedTempFile::new_in(flox.temp_dir)?;

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -169,6 +169,11 @@ pub struct ActivateOptions {
     #[bpaf(long, short)]
     pub generation: Option<GenerationId>,
 
+    /// Marks an activation as driven by the auto-activation prompt hook.
+    /// Set by `flox hook-env`, not by users.
+    #[bpaf(long("auto-activated"), hide)]
+    pub auto_activated: bool,
+
     #[bpaf(external(command_select), optional)]
     pub command: Option<CommandSelect>,
 }
@@ -253,7 +258,8 @@ impl Activate {
         if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentActivate(
             CliEnvironmentActivatePayload::new(v2_env_detail)
                 .with_start_services(options.start_services)
-                .with_mode(v2_mode),
+                .with_mode(v2_mode)
+                .with_auto_activated(options.auto_activated),
         )) {
             debug!(error = %err, "Failed to record v2 event");
         }
@@ -1226,6 +1232,7 @@ mod tests {
             no_start_services,
             mode: None,
             generation: None,
+            auto_activated: false,
             command: None,
         }
     }

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -546,7 +546,7 @@ impl ActivateOptions {
             "}),
             (set_prompt, hide_default_prompt, _) => (
                 set_prompt.unwrap_or(true),
-                hide_default_prompt.unwrap_or(true),
+                hide_default_prompt.unwrap_or(false),
             ),
         };
 

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -834,7 +834,10 @@ impl ActivateOptions {
                 if hide_default_prompt && env.name().as_ref() == DEFAULT_NAME {
                     return None;
                 }
-                Some(env.bare_description())
+                // `bare_description` is also what Bash activation errors
+                // quote, so the prompt narrows it here rather than changing
+                // the description itself.
+                Some(env.name().to_string())
             })
             .collect();
 
@@ -1132,7 +1135,13 @@ pub fn write_auto_activation_preference(
 mod tests {
     use std::sync::LazyLock;
 
-    use flox_rust_sdk::models::environment::{DotFlox, EnvironmentPointer, PathPointer};
+    use flox_core::floxhub::{DEFAULT_FLOXHUB_URL, Floxhub};
+    use flox_rust_sdk::models::environment::{
+        DotFlox,
+        EnvironmentPointer,
+        ManagedPointer,
+        PathPointer,
+    };
 
     use super::*;
     use crate::commands::ActiveEnvironments;
@@ -1186,6 +1195,22 @@ mod tests {
         // with `hide_default_prompt = true` we should not see the default environment
         let prompt = ActivateOptions::make_prompt_environments(true, &active_environments);
         assert_eq!(prompt, "wichtig".to_string());
+    }
+
+    /// Remote environments only show the name, same as path environments.
+    #[test]
+    fn prompt_shows_only_the_environment_name_for_remote_environments() {
+        let floxhub = Floxhub::new(DEFAULT_FLOXHUB_URL.clone(), None, None).unwrap();
+        let remote_env = UninitializedEnvironment::Remote(ManagedPointer::new(
+            "acme".parse().unwrap(),
+            "core".parse().unwrap(),
+            &floxhub,
+        ));
+        let mut active_environments = ActiveEnvironments::default();
+        active_environments.set_last_active(remote_env, None, ActivateMode::Dev);
+
+        let prompt = ActivateOptions::make_prompt_environments(true, &active_environments);
+        assert_eq!(prompt, "core".to_string());
     }
 
     /// Build minimal ActivateOptions with only the service-related flags set.

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -834,9 +834,10 @@ impl ActivateOptions {
                 if hide_default_prompt && env.name().as_ref() == DEFAULT_NAME {
                     return None;
                 }
-                // `bare_description` is also what Bash activation errors
-                // quote, so the prompt narrows it here rather than changing
-                // the description itself.
+                // Deliberately narrower than `bare_description()`, which
+                // still backs the activation announcements and the exported
+                // `FLOX_ENV_DESCRIPTION` variable with the full `owner/name`
+                // form.
                 Some(env.name().to_string())
             })
             .collect();

--- a/cli/flox/src/commands/hook_env.rs
+++ b/cli/flox/src/commands/hook_env.rs
@@ -981,23 +981,27 @@ fn write_activate_command(shell: Shell, project_dir: &Path, writer: &mut impl Wr
     let escaped_bin = shell_escape::escape(Cow::Borrowed(&*flox_bin));
     let dir = project_dir.to_string_lossy().to_string();
     let escaped_dir = shell_escape::escape(Cow::Borrowed(&*dir));
+    // `--auto-activated` is what distinguishes this call from a hand-written
+    // in-place activation: both arrive as `InvocationType::InPlace`, and
+    // without it the telemetry stream cannot tell the prompt hook's work
+    // apart from a shell rc file's.
     match shell {
         Shell::Bash | Shell::Zsh => {
             writeln!(
                 writer,
-                r#"eval "$({escaped_bin} activate --dir {escaped_dir})";"#
+                r#"eval "$({escaped_bin} activate --auto-activated --dir {escaped_dir})";"#
             )?;
         },
         Shell::Fish => {
             writeln!(
                 writer,
-                "{escaped_bin} activate --dir {escaped_dir} | source;"
+                "{escaped_bin} activate --auto-activated --dir {escaped_dir} | source;"
             )?;
         },
         Shell::Tcsh => {
             writeln!(
                 writer,
-                r#"eval "`{escaped_bin} activate --dir {escaped_dir}`";"#
+                r#"eval "`{escaped_bin} activate --auto-activated --dir {escaped_dir}`";"#
             )?;
         },
     }
@@ -1825,7 +1829,7 @@ mod tests {
         write_activate_command(Shell::Bash, Path::new("/home/user/my proj"), &mut buf).unwrap();
         let script = String::from_utf8(buf).unwrap();
         assert!(
-            script.contains("activate --dir '/home/user/my proj'"),
+            script.contains("activate --auto-activated --dir '/home/user/my proj'"),
             "{script}"
         );
         assert!(script.starts_with(r#"eval "$("#), "{script}");

--- a/cli/flox/src/commands/services/mod.rs
+++ b/cli/flox/src/commands/services/mod.rs
@@ -417,6 +417,7 @@ pub async fn start_services_with_new_process_compose(
         no_start_services: false,
         mode: Some(activate_mode),
         generation,
+        auto_activated: false,
         // this isn't actually used because we pass invocation type below
         command: Some(CommandSelect::ExecCommand {
             command: "true".to_string(),

--- a/cli/tests/hook.bats
+++ b/cli/tests/hook.bats
@@ -363,12 +363,13 @@ EXPIRED_FLOXHUB_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3gu
 @test "fish: hook auto-activation sets the prompt" {
   project_setup
   project2_setup
-  # Mirror the reported scenario: the hook-registering outer activation is the
-  # 'default' env, which is hidden from FLOX_PROMPT_ENVIRONMENTS, so the outer
+  # Mirror the reported scenario: the hook-registering outer activation is a
+  # 'default' env hidden from FLOX_PROMPT_ENVIRONMENTS, so the outer
   # activation defines no prompt variables at the top level. (An unscoped fish
   # `set` reuses an existing variable's scope, so a visible outer env would
   # mask scoping bugs when the hook later sets prompt variables inside a
-  # function.)
+  # function.) Hiding is opt-in, so pin the config the scenario relies on.
+  "$FLOX_BIN" config --set hide_default_prompt true
   "$FLOX_BIN" edit -d "$PROJECT_DIR" --name default
   # Auto-activation is opt-in; allow the target before entering it.
   "$FLOX_BIN" activate allow -d "$PROJECT2_DIR"


### PR DESCRIPTION
## What

The auto-activation prompt hook activates in-place, so auto-activations and shell-rc activations both arrive as `mode: "inplace"` in the event stream — auto-activation adoption can't be counted. The hook's generated command now passes a hidden `--auto-activated` flag, and the activation event carries it as an `auto_activated` field.

The prototype also threaded this flag into `ActivateCtx` (handed down to `flox-activations`), but nothing there reads it — the event is recorded in the `flox` crate from the CLI flag directly — so this PR deliberately keeps the flag out of the activation context.

## Stack

PR 6 of 8 in the DEV-44 activation-visibility stack; based on `daniel/dev-44-flox-prompt-docs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C6EywgcuUFb9rjSQEp7nB5
