### PR TITLE
feat(activate): add a prompt_detail config option

### DIFF
--- a/cli/flox-config/src/config.rs
+++ b/cli/flox-config/src/config.rs
@@ -130,6 +130,10 @@ pub struct FloxConfig {
     /// Hide environments named 'default' from the shell prompt
     pub hide_default_prompt: Option<bool>,
 
+    /// How much detail to show for each environment in the shell prompt.
+    /// Possible values: `name` (default), `full`.
+    pub prompt_detail: Option<PromptDetail>,
+
     /// Print notification if upgrades are available on `flox activate`.
     /// The notification message is:
     ///
@@ -189,6 +193,24 @@ pub enum EnvironmentPromptConfig {
     /// Change the shell prompt to show the active environments,
     /// but omit 'default' environments
     HideDefault,
+}
+
+/// How much of an environment's identity the shell prompt spells out.
+///
+/// The prompt is read on every command, so it pays a cost per glance that a
+/// one-time message does not. `Name` keeps the part that changes between
+/// environments and drops the part that is the same all day: the owner
+/// (the user already knows who they are) and the `(local)` marker, whose
+/// meaning — a local copy of a FloxHub environment rather than the upstream
+/// one — is not recoverable from the word itself.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PromptDetail {
+    /// Just the environment's name, e.g. `core`.
+    #[default]
+    Name,
+    /// Owner and locality as well, e.g. `acme/core (local)`.
+    Full,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/cli/flox-config/src/lib.rs
+++ b/cli/flox-config/src/lib.rs
@@ -19,6 +19,7 @@ pub use config::{
     FLOX_DIR_NAME,
     FloxConfig,
     InstallerChannel,
+    PromptDetail,
     PublishConfig,
     SearchLimit,
     TokenStorageMode,

--- a/cli/flox/doc/flox-activate.md
+++ b/cli/flox/doc/flox-activate.md
@@ -222,6 +222,8 @@ options.
     e.g. `foo bar local_env`.
     If `hide_default_prompt` is set to `true`, environments named `default` are
     excluded.
+    How much detail each entry carries is governed by `prompt_detail`; see
+    [`flox-config(1)`](./flox-config.md).
     This variable is exported, so it is set even by activations that do not
     modify the prompt, such as `flox activate -- <CMD>`.
     A shell that manages its own prompt can render an indicator from it

--- a/cli/flox/doc/flox-config.md
+++ b/cli/flox/doc/flox-config.md
@@ -133,6 +133,17 @@ flox config --set 'trusted_environments."owner/name"' trust
     Valid values are `stable`, `nightly`, or `qa`.
     (default: `stable`)
 
+`prompt_detail`
+:   How much detail to show for each environment in the shell prompt.
+    Valid values are `name` or `full` (default: `name`).
+
+    * `name`: the environment's name only, e.g. `flox [core]`
+    * `full`: the owner and locality as well, e.g. `flox [acme/core (local)]`
+
+    To change the `flox` label itself, set `$FLOX_PROMPT`.
+    See the *ENVIRONMENT VARIABLES* section of
+    [`flox-activate(1)`](./flox-activate.md).
+
 `search_limit`
 :   How many items `flox search` should show by default.
 

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -7,7 +7,7 @@ use std::{env, fs};
 use anyhow::{Context, Result, anyhow, bail};
 use bpaf::Bpaf;
 use crossterm::tty::IsTty;
-use flox_config::{AutoActivationPreference, Config, EnvironmentPromptConfig};
+use flox_config::{AutoActivationPreference, Config, EnvironmentPromptConfig, PromptDetail};
 use flox_core::activate::context::{
     ActivateCtx,
     ActivateMode,
@@ -559,8 +559,11 @@ impl ActivateOptions {
         // We don't have access to the current PS1 (it's not exported), so we
         // can't modify it. Instead set FLOX_PROMPT_ENVIRONMENTS and let the
         // activation script set PS1 based on that.
-        let flox_prompt_environments =
-            Self::make_prompt_environments(hide_default_prompt, &flox_active_environments);
+        let flox_prompt_environments = Self::make_prompt_environments(
+            hide_default_prompt,
+            config.flox.prompt_detail.unwrap_or_default(),
+            &flox_active_environments,
+        );
 
         let prompt_color_1 = env::var("FLOX_PROMPT_COLOR_1")
             .unwrap_or(utils::colors::INDIGO_400.to_ansi256().to_string());
@@ -832,6 +835,7 @@ impl ActivateOptions {
     /// [`None`] if the prompt is disabled, or filters removed all components.
     fn make_prompt_environments(
         hide_default_prompt: bool,
+        prompt_detail: PromptDetail,
         flox_active_environments: &super::ActiveEnvironments,
     ) -> String {
         let prompt_envs: Vec<_> = flox_active_environments
@@ -840,11 +844,14 @@ impl ActivateOptions {
                 if hide_default_prompt && env.name().as_ref() == DEFAULT_NAME {
                     return None;
                 }
-                // Deliberately narrower than `bare_description()`, which
-                // still backs the activation announcements and the exported
-                // `FLOX_ENV_DESCRIPTION` variable with the full `owner/name`
-                // form.
-                Some(env.name().to_string())
+                // `PromptDetail::Name` is deliberately narrower than
+                // `bare_description()`, which still backs the activation
+                // announcements and the exported `FLOX_ENV_DESCRIPTION`
+                // variable with the full `owner/name` form.
+                Some(match prompt_detail {
+                    PromptDetail::Full => env.bare_description(),
+                    PromptDetail::Name => env.name().to_string(),
+                })
             })
             .collect();
 
@@ -1170,7 +1177,11 @@ mod tests {
     #[test]
     fn test_shell_prompt_empty_without_active_environments() {
         let active_environments = ActiveEnvironments::default();
-        let prompt = ActivateOptions::make_prompt_environments(false, &active_environments);
+        let prompt = ActivateOptions::make_prompt_environments(
+            false,
+            PromptDetail::Name,
+            &active_environments,
+        );
 
         assert_eq!(prompt, "");
     }
@@ -1181,11 +1192,19 @@ mod tests {
         active_environments.set_last_active(DEFAULT_ENV.clone(), None, ActivateMode::Dev);
 
         // with `hide_default_prompt = false` we should see the default environment
-        let prompt = ActivateOptions::make_prompt_environments(false, &active_environments);
+        let prompt = ActivateOptions::make_prompt_environments(
+            false,
+            PromptDetail::Name,
+            &active_environments,
+        );
         assert_eq!(prompt, "default".to_string());
 
         // with `hide_default_prompt = true` we should not see the default environment
-        let prompt = ActivateOptions::make_prompt_environments(true, &active_environments);
+        let prompt = ActivateOptions::make_prompt_environments(
+            true,
+            PromptDetail::Name,
+            &active_environments,
+        );
         assert_eq!(prompt, "");
     }
 
@@ -1196,17 +1215,27 @@ mod tests {
         active_environments.set_last_active(NON_DEFAULT_ENV.clone(), None, ActivateMode::Dev);
 
         // with `hide_default_prompt = false` we should see the default environment
-        let prompt = ActivateOptions::make_prompt_environments(false, &active_environments);
+        let prompt = ActivateOptions::make_prompt_environments(
+            false,
+            PromptDetail::Name,
+            &active_environments,
+        );
         assert_eq!(prompt, "wichtig default".to_string());
 
         // with `hide_default_prompt = true` we should not see the default environment
-        let prompt = ActivateOptions::make_prompt_environments(true, &active_environments);
+        let prompt = ActivateOptions::make_prompt_environments(
+            true,
+            PromptDetail::Name,
+            &active_environments,
+        );
         assert_eq!(prompt, "wichtig".to_string());
     }
 
-    /// Remote environments only show the name, same as path environments.
+    /// A remote environment is the only case where the prompt detail levels
+    /// differ: `bare_description` decorates it with the owner and `(local)`,
+    /// which is the string DEV-44 reports as too long and unclear.
     #[test]
-    fn prompt_shows_only_the_environment_name_for_remote_environments() {
+    fn prompt_detail_narrows_remote_environment_to_its_name() {
         let floxhub = Floxhub::new(DEFAULT_FLOXHUB_URL.clone(), None, None).unwrap();
         let remote_env = UninitializedEnvironment::Remote(ManagedPointer::new(
             "acme".parse().unwrap(),
@@ -1216,8 +1245,19 @@ mod tests {
         let mut active_environments = ActiveEnvironments::default();
         active_environments.set_last_active(remote_env, None, ActivateMode::Dev);
 
-        let prompt = ActivateOptions::make_prompt_environments(true, &active_environments);
-        assert_eq!(prompt, "core".to_string());
+        let full = ActivateOptions::make_prompt_environments(
+            true,
+            PromptDetail::Full,
+            &active_environments,
+        );
+        assert_eq!(full, "acme/core (local)".to_string());
+
+        let name = ActivateOptions::make_prompt_environments(
+            true,
+            PromptDetail::Name,
+            &active_environments,
+        );
+        assert_eq!(name, "core".to_string());
     }
 
     /// Build minimal ActivateOptions with only the service-related flags set.


### PR DESCRIPTION
## What

Adds a `prompt_detail` config option controlling how much of an environment's identity the prompt spells out:

- `name` (default): just the environment name — `flox [core]`
- `full`: the previous rendering — `flox [acme/core (local)]`

The default matches the new default behavior from #4588, which narrows each prompt entry to the environment name; this PR only adds the option that restores the owner and the `(local)` marker. It was split out of the default-behavior change per review feedback, which asked for the two to be reviewed separately.

## ⚠️ Open design questions — up for discussion, may not ship as-is

Feedback on the prototype pushed back on hiding the owner outright:

- Identically-named environments from different owners (e.g. `alice/default` and `flox/default` both active) become indistinguishable in the prompt.
- FloxHub-managed and directory-based environments lose their remaining visual distinction.
- Counter-proposal from review: *abbreviate* instead of hide — a `~`-style placeholder when the owner is the logged-in user (the majority case), a distinct placeholder (`...`/`**`) for directory-based environments, and a separate rethink of the `(local)` marker.
- Also raised: `owner/name (local)` is disliked enough that preserving it behind a config option may not be the right shape at all — dropping `full` (or replacing it with the abbreviated form) is on the table.

This PR sits near the end of the stack, with the other config option (#4589), in merge-likelihood order: we likely won't merge it, and there it can be dropped or reworked without disturbing the rest.

## Stack

PR 7 of 8 in the DEV-44 activation-visibility stack; based on `daniel/dev-44-count-auto-activations`.

## Release Notes

- New config option `prompt_detail`. It defaults to `name`, which shows just the environment name in the prompt; set it to `full` to restore the `owner/name (local)` rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C6EywgcuUFb9rjSQEp7nB5
