### PR TITLE
feat(activate): show only the environment name in the prompt

### DIFF
--- a/cli/flox/doc/flox-activate.md
+++ b/cli/flox/doc/flox-activate.md
@@ -218,8 +218,8 @@ options.
     environment.
 
 `$FLOX_PROMPT_ENVIRONMENTS`
-:   Contains a space-delimited list of the active environments,
-    e.g. `owner1/foo owner2/bar local_env`.
+:   Contains a space-delimited list of the names of the active environments,
+    e.g. `foo bar local_env`.
     If `hide_default_prompt` is set to `true`, environments named `default` are
     excluded.
 

--- a/cli/flox/doc/flox-activate.md
+++ b/cli/flox/doc/flox-activate.md
@@ -222,6 +222,10 @@ options.
     e.g. `foo bar local_env`.
     If `hide_default_prompt` is set to `true`, environments named `default` are
     excluded.
+    This variable is exported, so it is set even by activations that do not
+    modify the prompt, such as `flox activate -- <CMD>`.
+    A shell that manages its own prompt can render an indicator from it
+    directly.
 
 `$FLOX_ENV_CACHE`
 :   `activate` sets this variable to a directory that can be used by an
@@ -269,6 +273,19 @@ options.
          the `$FLOX_SHELL` variable,
          and if it cannot detect its parent shell type then will
          produce a script with syntax determined by `$SHELL`.
+
+`$FLOX_PROMPT`
+:   The label Flox puts at the front of the shell prompt, `flox` by default.
+    Set it to shorten the indicator, e.g. `f` to reclaim three columns,
+    or to rebrand it, for example with the name of an internal developer
+    platform built on Flox.
+    Because an environment's `[vars]` are applied before the prompt is set,
+    an environment can carry its own label in its manifest:
+
+    ```toml
+    [vars]
+    FLOX_PROMPT = "acme"
+    ```
 
 `$FLOX_PROMPT_COLOR_{1,2}`
 :   Flox adds text to the beginning of the shell prompt to indicate which

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -834,7 +834,11 @@ impl ActivateOptions {
                 if hide_default_prompt && env.name().as_ref() == DEFAULT_NAME {
                     return None;
                 }
-                Some(env.bare_description())
+                // Deliberately narrower than `bare_description()`, which
+                // still backs the activation announcements and the exported
+                // `FLOX_ENV_DESCRIPTION` variable with the full `owner/name`
+                // form.
+                Some(env.name().to_string())
             })
             .collect();
 
@@ -1132,7 +1136,13 @@ pub fn write_auto_activation_preference(
 mod tests {
     use std::sync::LazyLock;
 
-    use flox_rust_sdk::models::environment::{DotFlox, EnvironmentPointer, PathPointer};
+    use flox_core::floxhub::{DEFAULT_FLOXHUB_URL, Floxhub};
+    use flox_rust_sdk::models::environment::{
+        DotFlox,
+        EnvironmentPointer,
+        ManagedPointer,
+        PathPointer,
+    };
 
     use super::*;
     use crate::commands::ActiveEnvironments;
@@ -1186,6 +1196,22 @@ mod tests {
         // with `hide_default_prompt = true` we should not see the default environment
         let prompt = ActivateOptions::make_prompt_environments(true, &active_environments);
         assert_eq!(prompt, "wichtig".to_string());
+    }
+
+    /// Remote environments only show the name, same as path environments.
+    #[test]
+    fn prompt_shows_only_the_environment_name_for_remote_environments() {
+        let floxhub = Floxhub::new(DEFAULT_FLOXHUB_URL.clone(), None, None).unwrap();
+        let remote_env = UninitializedEnvironment::Remote(ManagedPointer::new(
+            "acme".parse().unwrap(),
+            "core".parse().unwrap(),
+            &floxhub,
+        ));
+        let mut active_environments = ActiveEnvironments::default();
+        active_environments.set_last_active(remote_env, None, ActivateMode::Dev);
+
+        let prompt = ActivateOptions::make_prompt_environments(true, &active_environments);
+        assert_eq!(prompt, "core".to_string());
     }
 
     /// Build minimal ActivateOptions with only the service-related flags set.


### PR DESCRIPTION
## What

The prompt rendered each active environment as `owner/name (local)`, which DEV-44 reports as long and unclear. The prompt is read on every command, so it pays a cost per glance that a one-time message does not.

Each prompt entry now carries only the part that changes between environments — the name:

- Before: `flox [acme/core (local)]`
- After: `flox [core]`

The owner is dropped because the user already knows it, and the `(local)` marker because its meaning is not recoverable from the word itself.

`bare_description` is left alone: Bash activation errors quote it too, so narrowing it would change more than the prompt. Only the prompt narrows.

## Stack

PR 4 of 8 in the DEV-44 activation-visibility stack; based on `daniel/dev-44-show-default-prompt`.

This carries the default-behavior half split out of #4587 per review feedback. #4587 asked for a change in default behavior and a config option to be reviewed separately; the config option (`prompt_detail`, with `full` restoring `owner/name (local)`) stays in #4587 at the end of the stack.

## Release Notes

- The shell prompt now shows just the environment name for each active environment, instead of `owner/name (local)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C6EywgcuUFb9rjSQEp7nB5
