### PR TITLE
feat(activate): add an activation_notifications config option

### DIFF
--- a/cli/flox-config/src/config.rs
+++ b/cli/flox-config/src/config.rs
@@ -145,6 +145,17 @@ pub struct FloxConfig {
     /// (default: true)
     pub upgrade_notifications: Option<bool>,
 
+    /// Print a one-line notification naming the environment when it is
+    /// activated in the current shell, including by auto-activation.
+    /// The notification message is:
+    ///
+    /// ```text
+    /// You are now using the environment 'environment-name'
+    /// ```
+    ///
+    /// (default: true)
+    pub activation_notifications: Option<bool>,
+
     /// Configuration for 'flox publish'.
     pub publish: Option<PublishConfig>,
 

--- a/cli/flox-core/src/activate/context.rs
+++ b/cli/flox-core/src/activate/context.rs
@@ -124,10 +124,10 @@ pub struct ActivateCtx {
     /// stderr once it is in effect.
     ///
     /// Resolved by the `flox` crate because the decision depends on state only
-    /// the caller has: the user's real verbosity and whether the environment
-    /// was already active. Defaults to `false` so a context file written by an
-    /// older Flox stays quiet rather than gaining output the writer never
-    /// asked for.
+    /// the caller has: the user's configuration, their real verbosity, and
+    /// whether the environment was already active. Defaults to `false` so a
+    /// context file written by an older Flox stays quiet rather than gaining
+    /// output the writer never asked for.
     #[serde(default)]
     pub announce_activation: bool,
 }

--- a/cli/flox/doc/flox-config.md
+++ b/cli/flox/doc/flox-config.md
@@ -70,6 +70,29 @@ flox config --set 'trusted_environments."owner/name"' trust
 
 # SUPPORTED CONFIGURATION OPTIONS
 
+`activation_notifications`
+:   Print a notification naming the environment when it is activated in the
+    current shell.
+    Subshell activations print the environment and how to leave it:
+    ```console
+    ✔ You are now using the environment 'core'
+    To stop using this environment, run 'flox deactivate'
+    ```
+    In-place activations — including every auto-activation — print the same
+    message without the hint, since they recur on each new shell or each `cd`:
+    ```console
+    ✔ You are now using the environment 'core'
+    ```
+    Apart from subshell activations, which always announce, a notification is
+    printed only when stderr is a terminal, so a human sees the environment
+    named while output collected by CI or a script stays clean.
+    An environment that is already active is not announced again, so nested
+    shells and re-sourced rc files stay quiet.
+    Environments named `default` are never announced, and `-q` suppresses the
+    notification for every mode.
+
+    (default: true)
+
 `auto_activate`
 :   How auto-activation treats environments you have not yet allowed or denied.
     Possible values are `prompt` (default), `allowlist`, and `disabled`.

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -678,7 +678,8 @@ impl ActivateOptions {
         let announce_activation = mode_announces
             && !already_active
             && flox.verbosity >= 0
-            && now_active.name().as_ref() != DEFAULT_NAME;
+            && now_active.name().as_ref() != DEFAULT_NAME
+            && config.flox.activation_notifications.unwrap_or(true);
 
         let activate_data = ActivateCtx {
             flox_activate_store_path: store_path.to_string_lossy().to_string(),


### PR DESCRIPTION
## What

Adds an `activation_notifications` config option. Setting it to `false` turns off the activation announcement entirely.

The announcement defaults to on, and `-q` already silences a single invocation, so this is the persistent opt-out for users who never want it.

## Stack

PR 8 of 8 in the DEV-44 activation-visibility stack; based on `daniel/dev-44-prompt-detail`.

This carries the config option factored out of #4583 per review feedback, which asked that the option be reviewed separately from the behavior change and stacked so it can be dropped on its own. It sits at the very end of the stack, next to the other config option (#4587), because it may not be merged.

## Release Notes

- New config option `activation_notifications` (default `true`). Set it to `false` to turn off the message announcing which environment an activation entered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C6EywgcuUFb9rjSQEp7nB5
