### PR TITLE
docs(activate): document $FLOX_PROMPT and the exported prompt variables

### DIFF
--- a/cli/flox/doc/flox-activate.md
+++ b/cli/flox/doc/flox-activate.md
@@ -222,6 +222,10 @@ options.
     e.g. `foo bar local_env`.
     If `hide_default_prompt` is set to `true`, environments named `default` are
     excluded.
+    This variable is exported, so it is set even by activations that do not
+    modify the prompt, such as `flox activate -- <CMD>`.
+    A shell that manages its own prompt can render an indicator from it
+    directly.
 
 `$FLOX_ENV_CACHE`
 :   `activate` sets this variable to a directory that can be used by an
@@ -269,6 +273,19 @@ options.
          the `$FLOX_SHELL` variable,
          and if it cannot detect its parent shell type then will
          produce a script with syntax determined by `$SHELL`.
+
+`$FLOX_PROMPT`
+:   The label Flox puts at the front of the shell prompt, `flox` by default.
+    Set it to shorten the indicator, e.g. `f` to reclaim three columns,
+    or to rebrand it, for example with the name of an internal developer
+    platform built on Flox.
+    Because an environment's `[vars]` are applied before the prompt is set,
+    an environment can carry its own label in its manifest:
+
+    ```toml
+    [vars]
+    FLOX_PROMPT = "acme"
+    ```
 
 `$FLOX_PROMPT_COLOR_{1,2}`
 :   Flox adds text to the beginning of the shell prompt to indicate which


### PR DESCRIPTION
## What

Docs only, two additions to `flox-activate(1)`:

- Documents `$FLOX_PROMPT`, which already overrides the `flox` label at the front of the prompt in all four shells and can be set from an environment's `[vars]`.
- Notes under `$FLOX_PROMPT_ENVIRONMENTS` that the variable is exported, so shells and frameworks that manage their own prompt (starship users, direnv's `use flox` path) can render a Flox indicator from it directly.

## Review note

The docs describe the intended behavior, but there is a pre-existing interpreter gap: with `NO_COLOR` set, fish and tcsh hardcode the literal `flox` label instead of honoring `$FLOX_PROMPT` (`set-prompt.fish:18`, `set-prompt.tcsh:32`); bash and zsh honor it on both paths. Worth a small follow-up fix in the interpreter scripts rather than hedging the man page.

## Stack

PR 5 of 8 in the DEV-44 activation-visibility stack; based on `daniel/dev-44-prompt-name-only`.

Replaces #4586, which GitHub auto-closed as merged during the restack: this PR's branch moved ahead of `daniel/dev-44-count-auto-activations`, and the moment that former base branch contained this branch's commit, GitHub marked the PR merged and deleted the head branch. A merged PR cannot be reopened, so the same commit is proposed again here. The review discussion on #4586 remains readable there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C6EywgcuUFb9rjSQEp7nB5
