### PR TITLE
perf(nef-lock): only perform catalog requests IFF scan yields 1+ refs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,7 @@ members = [
     "cli/nef-lock-catalog",
     "cli/flox-manifest"
 ]
-default-members = ["cli/flox", "cli/flox-activations"]
-
+default-members = ["cli/flox", "cli/flox-activations", "cli/nef-lock-catalog"]
 resolver = "2"
 
 [workspace.package]

--- a/cli/nef-lock-catalog/Cargo.toml
+++ b/cli/nef-lock-catalog/Cargo.toml
@@ -3,6 +3,9 @@ name = "nef-lock-catalog"
 version.workspace = true
 edition.workspace = true
 
+[[bin]]
+name = "lock"
+
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true

--- a/cli/nef-lock-catalog/src/bin/lock.rs
+++ b/cli/nef-lock-catalog/src/bin/lock.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap};
 use std::io::IsTerminal;
 use std::path::PathBuf;
 use std::process::ExitCode;
@@ -18,6 +18,7 @@ use floxhub_client::{
     Stability,
 };
 use nef_lock_catalog::{
+    BuildLock,
     CatalogRef,
     LockError,
     lock_references,
@@ -145,24 +146,29 @@ async fn run(cli: Cli) -> Result<()> {
         references.extend(scan_package(&cli.base_dir, rel)?);
     }
 
-    // Render each failure to its message body at the boundary, while the
-    // structured data is still in hand; `main` adds the `✘ ERROR:` decoration.
-    let lock = match lock_references(&client, references, cli.stability).await {
-        Ok(lock) => lock,
-        // REQ-013: surface the unresolvable dependency chains.
-        Err(LockError::Unresolvable(entries)) => bail!(render_unresolvable(&entries)),
-        // An auth failure can only surface as an `APIError` (the sole variant
-        // carrying an HTTP status); only then is the token-state hint relevant.
-        //
-        // NOTE: `build_inputs_lookup` currently maps every failure to `Other`
-        // (the lookup endpoint's `HttpValidationError` schema divergence), so no
-        // `APIError` reaches here yet and the hint stays dormant until the
-        // backend declares `ErrorResponse` on that endpoint.
-        Err(LockError::Client(source @ FloxhubClientError::APIError(_))) => {
-            bail!(render_client_error(&format!("{source:#}"), token_present))
-        },
-        // Any other lock failure needs no special rendering.
-        Err(other) => return Err(other.into()),
+    // Lock references via the catalog or produce an empty lock file if no references were found.
+    let lock = if !references.is_empty() {
+        // Render each failure to its message body at the CLI boundary.
+        match lock_references(&client, references, cli.stability).await {
+            Ok(lock) => lock,
+            // REQ-013: surface the unresolvable dependency chains.
+            Err(LockError::Unresolvable(entries)) => bail!(render_unresolvable(&entries)),
+            // An auth failure can only surface as an `APIError` (the sole variant
+            // carrying an HTTP status); only then is the token-state hint relevant.
+            //
+            // NOTE: `build_inputs_lookup` currently maps every failure to `Other`
+            // (the lookup endpoint's `HttpValidationError` schema divergence), so no
+            // `APIError` reaches here yet and the hint stays dormant until the
+            // backend declares `ErrorResponse` on that endpoint.
+            Err(LockError::Client(source @ FloxhubClientError::APIError(_))) => {
+                bail!(render_client_error(&format!("{source:#}"), token_present))
+            },
+            // Any other lock failure needs no special rendering.
+            Err(other) => return Err(other.into()),
+        }
+    } else {
+        debug!("No catalog references found, nothing to lock.");
+        BuildLock::default()
     };
 
     // Write to the requested file, or print to stdout when `--out` is omitted

--- a/cli/nef-lock-catalog/src/bin/lock.rs
+++ b/cli/nef-lock-catalog/src/bin/lock.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeSet, HashMap};
+use std::collections::BTreeSet;
 use std::io::IsTerminal;
 use std::path::PathBuf;
 use std::process::ExitCode;

--- a/cli/nef-lock-catalog/src/lock/lookup.rs
+++ b/cli/nef-lock-catalog/src/lock/lookup.rs
@@ -48,7 +48,7 @@ pub enum LockError {
     Transform(#[from] anyhow::Error),
 }
 
-/// Lock a flat list of catalog references in a single batched request.
+/// Lock a flat list of catalog references in a single request.
 ///
 /// Builds the wire request internally (one synthetic group), performs one
 /// `/build-inputs/lookup` call, and maps the response to a [BuildLock].


### PR DESCRIPTION
Scan results are taken as is to `lock_references`
which locks them against the catalog server.
When passing an _empty_ set of references, the function will _always_ either return an empty lockfile, or fail due to network issues.

## Proposed Changes

As the intended result for empty lists is known upfront, we can avoid the whole request and substitute an empty lockfile instead avoiding the chance of network (or the lack thereof) to fail locking a package without references.

## Release Notes

Improve reliability of locking nix expressions without catalog references.