### PR TITLE
ci: bump `configure-nix-action` pin to the `node24` runtime

### DIFF
--- a/.github/actions/common-setup/action.yml
+++ b/.github/actions/common-setup/action.yml
@@ -37,7 +37,7 @@ runs:
       uses: cachix/install-nix-action@ab739621df7a23f52766f9ccc97f38da6b7af14f # v31
 
     - name: "Configure Nix"
-      uses: flox/configure-nix-action@1ee58d63463cb1870ab73d9df0acfd9d8ba671f8 # main
+      uses: flox/configure-nix-action@28a4eb7f63bf54c91670b4a698f0a9ebfb95384f # main
 
       if: ${{ inputs.SETUP_NIX }} == "true"
       with:


### PR DESCRIPTION
## Summary

`flox/configure-nix-action` now declares the Node 24 action runtime (flox/configure-nix-action#45): Node 20 reached end-of-life in April 2026 and GitHub removes it from Actions runners in fall 2026, so workflows consuming the action at an older pin emit a deprecation warning on every run. This advances the pin to the current head of the action's `main` (flox/configure-nix-action@28a4eb7f63bf54c91670b4a698f0a9ebfb95384f), silencing the warning and picking up the action's routine maintenance along the way. No workflow changes are needed beyond the pin; the action's bundled behavior is unchanged.

Part of [ECO-191](https://linear.app/floxdotdev/issue/ECO-191/migrate-configure-nix-action-to-the-node24-runtime).

### Test plan

- [ ] CI passes on this PR (the updated action runs in this repo's own workflows)