### PR TITLE
feat(auth): DEV-225 extend lock warning to list, build, and containerize

### DIFF
--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -56,6 +56,7 @@ use crate::commands::general::update_config_with_query;
 use crate::commands::services::ServicesCommandsError;
 use crate::commands::{
     EnvironmentSelectError,
+    LOCKING_AUTH_REQUIRED_SOON,
     NoEnvironmentError,
     SHELL_COMPLETION_COMMAND,
     SHELL_COMPLETION_FILE,
@@ -229,9 +230,7 @@ impl Activate {
         if concrete_environment.existing_lockfile(&flox)?.is_none()
             && flox.auth_context.is_unauthenticated()
         {
-            message::warning(
-                "Locking environments will require authentication in an upcoming release. See https://flox.dev/docs/install-flox/ for more info.",
-            );
+            message::warning(LOCKING_AUTH_REQUIRED_SOON);
         }
 
         // Both telemetry stacks emit in parallel through the dormant

--- a/cli/flox/src/commands/build.rs
+++ b/cli/flox/src/commands/build.rs
@@ -38,7 +38,7 @@ use thiserror::Error;
 use tracing::{debug, instrument, trace};
 use url::Url;
 
-use super::{DirEnvironmentSelect, dir_environment_select};
+use super::{DirEnvironmentSelect, LOCKING_AUTH_REQUIRED_SOON, dir_environment_select};
 use crate::utils::events::duration_to_ms;
 use crate::utils::message;
 use crate::{environment_subcommand_metric, subcommand_metric};
@@ -193,6 +193,15 @@ impl Build {
                     .environment
                     .detect_concrete_environment(&mut flox, "Build packages of")?;
                 environment_subcommand_metric!("build", env);
+
+                // TODO(DEV-200): replace with actual docs URL when available
+                // Warn unauthenticated users before the first lock, which happens
+                // when no lockfile exists yet.
+                if env.existing_lockfile(&flox)?.is_none()
+                    && flox.auth_context.is_unauthenticated()
+                {
+                    message::warning(LOCKING_AUTH_REQUIRED_SOON);
+                }
 
                 Self::build(
                     flox,

--- a/cli/flox/src/commands/build.rs
+++ b/cli/flox/src/commands/build.rs
@@ -197,8 +197,7 @@ impl Build {
                 // TODO(DEV-200): replace with actual docs URL when available
                 // Warn unauthenticated users before the first lock, which happens
                 // when no lockfile exists yet.
-                if env.existing_lockfile(&flox)?.is_none()
-                    && flox.auth_context.is_unauthenticated()
+                if env.existing_lockfile(&flox)?.is_none() && flox.auth_context.is_unauthenticated()
                 {
                     message::warning(LOCKING_AUTH_REQUIRED_SOON);
                 }

--- a/cli/flox/src/commands/containerize/mod.rs
+++ b/cli/flox/src/commands/containerize/mod.rs
@@ -22,7 +22,7 @@ use macos_containerize_proxy::ContainerizeProxy;
 use tracing::{debug, info, instrument};
 
 use super::{EnvironmentSelect, environment_select};
-use crate::commands::SHELL_COMPLETION_FILE;
+use crate::commands::{LOCKING_AUTH_REQUIRED_SOON, SHELL_COMPLETION_FILE};
 use crate::environment_subcommand_metric;
 use crate::utils::events::env_detail_from_concrete;
 use crate::utils::message;
@@ -74,6 +74,13 @@ impl Containerize {
             CliEnvironmentPayload::new(env_detail_from_concrete(&flox, &env)),
         )) {
             debug!(error = %err, "Failed to record v2 event");
+        }
+
+        // TODO(DEV-200): replace with actual docs URL when available
+        // Warn unauthenticated users before the first lock, which happens
+        // when no lockfile exists yet.
+        if env.existing_lockfile(&flox)?.is_none() && flox.auth_context.is_unauthenticated() {
+            message::warning(LOCKING_AUTH_REQUIRED_SOON);
         }
 
         // Check that a specified runtime exists.

--- a/cli/flox/src/commands/list.rs
+++ b/cli/flox/src/commands/list.rs
@@ -19,7 +19,7 @@ use indoc::formatdoc;
 use itertools::Itertools;
 use tracing::{debug, instrument};
 
-use super::{EnvironmentSelect, environment_select};
+use super::{EnvironmentSelect, LOCKING_AUTH_REQUIRED_SOON, environment_select};
 use crate::commands::render_composition_manifest;
 use crate::environment_subcommand_metric;
 use crate::utils::events::env_detail_from_concrete;
@@ -72,6 +72,16 @@ impl List {
             CliEnvironmentPayload::new(env_detail_from_concrete(&flox, &env)),
         )) {
             debug!(error = %err, "Failed to record v2 event");
+        }
+
+        // TODO(DEV-200): replace with actual docs URL when available
+        // Warn unauthenticated users before the first lock, which happens
+        // when --upstream is not set and no lockfile exists yet.
+        if !self.upstream
+            && env.existing_lockfile(&flox)?.is_none()
+            && flox.auth_context.is_unauthenticated()
+        {
+            message::warning(LOCKING_AUTH_REQUIRED_SOON);
         }
 
         let (manifest_contents, lockfile) = match (&mut env, self.upstream) {

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -97,8 +97,7 @@ const SHELL_COMPLETION_COMMAND: ShellComp = ShellComp::Raw {
 /// Warning shown when an unauthenticated user runs a command that will perform
 /// the first lock of an environment (no lockfile exists yet).
 /// Once catalog auth gating is enforced, locking will require a login.
-pub(crate) const LOCKING_AUTH_REQUIRED_SOON: &str =
-    "Locking environments will require authentication in an upcoming release. See https://flox.dev/docs/install-flox/ for more info.";
+pub(crate) const LOCKING_AUTH_REQUIRED_SOON: &str = "Locking environments will require authentication in an upcoming release. See https://flox.dev/docs/install-flox/ for more info.";
 
 static FLOX_DESCRIPTION: &'_ str = indoc! {"
     Flox is a virtual environment and package manager all in one.\n\n

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -94,6 +94,12 @@ const SHELL_COMPLETION_COMMAND: ShellComp = ShellComp::Raw {
     elvish: "",
 };
 
+/// Warning shown when an unauthenticated user runs a command that will perform
+/// the first lock of an environment (no lockfile exists yet).
+/// Once catalog auth gating is enforced, locking will require a login.
+pub(crate) const LOCKING_AUTH_REQUIRED_SOON: &str =
+    "Locking environments will require authentication in an upcoming release. See https://flox.dev/docs/install-flox/ for more info.";
+
 static FLOX_DESCRIPTION: &'_ str = indoc! {"
     Flox is a virtual environment and package manager all in one.\n\n
 

--- a/cli/tests/catalog-auth-warnings.bats
+++ b/cli/tests/catalog-auth-warnings.bats
@@ -97,6 +97,7 @@ teardown() {
   "$FLOX_BIN" init
   # flox init creates a lockfile; list should NOT warn because lockfile exists
   run "$FLOX_BIN" list
+  assert_success
   # May print a "no packages" warning, but must not print the lock warning
   refute_output --partial "$LOCK_WARNING"
 }
@@ -108,5 +109,31 @@ teardown() {
   # flox init always creates a lockfile; remove it to simulate a pre-lockfile env
   rm .flox/env/manifest.lock
   run "$FLOX_BIN" list
+  assert_success
+  assert_output --partial "$LOCK_WARNING"
+}
+
+# ---------------------------------------------------------------------------- #
+# Conditional warning: build
+# ---------------------------------------------------------------------------- #
+
+@test "'flox build' with existing lockfile does NOT print lock warning" {
+  "$FLOX_BIN" init
+  # flox init creates a lockfile; build should NOT warn because lockfile exists
+  run "$FLOX_BIN" build
+  # Command fails because there are no build targets, but the lock warning
+  # must not appear — the lockfile gate prevents it regardless of auth state.
+  refute_output --partial "$LOCK_WARNING"
+}
+
+@test "'flox build' without lockfile prints lock warning" {
+  # The suite runs "logged in" by default; this test needs the logged-out state.
+  unset FLOX_FLOXHUB_TOKEN
+  "$FLOX_BIN" init
+  # flox init always creates a lockfile; remove it to simulate a pre-lockfile env
+  rm .flox/env/manifest.lock
+  run "$FLOX_BIN" build
+  # Command fails because there are no build targets, but the lock warning
+  # must appear before the build attempt when unauthenticated and no lockfile.
   assert_output --partial "$LOCK_WARNING"
 }

--- a/cli/tests/catalog-auth-warnings.bats
+++ b/cli/tests/catalog-auth-warnings.bats
@@ -87,3 +87,26 @@ teardown() {
   assert_success
   assert_output --partial "$LOCK_WARNING"
 }
+
+# ---------------------------------------------------------------------------- #
+# Conditional warning: list
+# ---------------------------------------------------------------------------- #
+
+@test "'flox list' with existing lockfile does NOT print lock warning" {
+  unset FLOX_FLOXHUB_TOKEN
+  "$FLOX_BIN" init
+  # flox init creates a lockfile; list should NOT warn because lockfile exists
+  run "$FLOX_BIN" list
+  # May print a "no packages" warning, but must not print the lock warning
+  refute_output --partial "$LOCK_WARNING"
+}
+
+@test "'flox list' without lockfile prints lock warning" {
+  # The suite runs "logged in" by default; this test needs the logged-out state.
+  unset FLOX_FLOXHUB_TOKEN
+  "$FLOX_BIN" init
+  # flox init always creates a lockfile; remove it to simulate a pre-lockfile env
+  rm .flox/env/manifest.lock
+  run "$FLOX_BIN" list
+  assert_output --partial "$LOCK_WARNING"
+}

--- a/cli/tests/catalog-auth-warnings.bats
+++ b/cli/tests/catalog-auth-warnings.bats
@@ -118,11 +118,13 @@ teardown() {
 # ---------------------------------------------------------------------------- #
 
 @test "'flox build' with existing lockfile does NOT print lock warning" {
+  # Log out so only the lockfile gate suppresses the warning (not the auth gate).
+  unset FLOX_FLOXHUB_TOKEN
   "$FLOX_BIN" init
-  # flox init creates a lockfile; build should NOT warn because lockfile exists
+  # flox init creates a lockfile; build should NOT warn because lockfile exists.
   run "$FLOX_BIN" build
   # Command fails because there are no build targets, but the lock warning
-  # must not appear — the lockfile gate prevents it regardless of auth state.
+  # must not appear — the lockfile gate prevents it.
   refute_output --partial "$LOCK_WARNING"
 }
 


### PR DESCRIPTION
## Proposed Changes

DEV-199 added a conditional "locking will require auth soon" warning to `flox activate`, firing only when no lockfile exists yet. `flox list` (and other commands) also create the lockfile on first invocation, but were not covered. This PR extends the warning to all commands that call `lockfile()` when no lockfile is present.

**Commands covered:**

- `flox list` — explicitly raised in the #4573 review; most common first-run scenario after `flox init`
- `flox build` (BuildTargets path)
- `flox containerize`

**Implementation:**

The inline warning string is extracted from `activate.rs` into a named constant `LOCKING_AUTH_REQUIRED_SOON` in `commands/mod.rs` so all commands share the same text. Each covered command checks `existing_lockfile().is_none() && auth_context.is_unauthenticated()` before calling `lockfile()`, matching the pattern established in `activate`.

Two bats tests added to `catalog-auth-warnings.bats` for `flox list`: one verifying no lock warning when a lockfile already exists, and one verifying the warning fires when the lockfile is absent (logged-out user).

Fixes DEV-225

Related: DEV-199, #4573

## Release Notes

N/A — warning message text is unchanged; only the set of commands that emit it is expanded.

---
*Via Forge (implementation-worker) • d5ed3916*