### PR TITLE
fix: improve handling of removed state.json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1920,15 +1920,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
-name = "fsevent-sys"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "fslock"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2690,20 +2681,20 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.9.6"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+checksum = "153be1941a183ec9ccd095ddbe17a8b8d435ef6c76e9e02451b933c3999af2c8"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.13.0",
  "inotify-sys",
  "libc",
 ]
 
 [[package]]
 name = "inotify-sys"
-version = "0.1.5"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
 dependencies = [
  "libc",
 ]
@@ -3222,21 +3213,31 @@ dependencies = [
 
 [[package]]
 name = "notify"
-version = "6.1.1"
+version = "9.0.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+checksum = "b44b771d4dd781ef14c84078693e67495da6b47f609f72e8a4da8420a861240e"
 dependencies = [
  "bitflags 2.13.0",
- "crossbeam-channel",
- "filetime",
- "fsevent-sys",
  "inotify",
  "kqueue",
  "libc",
  "log",
- "mio 0.8.11",
+ "mio 1.0.2",
+ "notify-types",
+ "objc2-core-foundation",
+ "objc2-core-services",
  "walkdir",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.1",
+ "xxhash-rust",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -3389,6 +3390,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.13.0",
+]
+
+[[package]]
+name = "objc2-core-services"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583300ad934cba24ff5292aee751ecc070f7ca6b39a574cc21b7b5e588e06a0b"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -6697,6 +6708,12 @@ dependencies = [
  "schemars 1.2.1",
  "serde_json",
 ]
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aee1b19627c7c60102ab80d3a9cbe18de90bfe03bfa6c3715447681f0e8c8af6"
 
 [[package]]
 name = "yansi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1909,15 +1909,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
-name = "fsevent-sys"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "fslock"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2679,20 +2670,20 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.9.6"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+checksum = "153be1941a183ec9ccd095ddbe17a8b8d435ef6c76e9e02451b933c3999af2c8"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.13.0",
  "inotify-sys",
  "libc",
 ]
 
 [[package]]
 name = "inotify-sys"
-version = "0.1.5"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
 dependencies = [
  "libc",
 ]
@@ -3211,21 +3202,31 @@ dependencies = [
 
 [[package]]
 name = "notify"
-version = "6.1.1"
+version = "9.0.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+checksum = "b44b771d4dd781ef14c84078693e67495da6b47f609f72e8a4da8420a861240e"
 dependencies = [
  "bitflags 2.13.0",
- "crossbeam-channel",
- "filetime",
- "fsevent-sys",
  "inotify",
  "kqueue",
  "libc",
  "log",
- "mio 0.8.11",
+ "mio 1.0.2",
+ "notify-types",
+ "objc2-core-foundation",
+ "objc2-core-services",
  "walkdir",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.1",
+ "xxhash-rust",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -3378,6 +3379,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.13.0",
+]
+
+[[package]]
+name = "objc2-core-services"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583300ad934cba24ff5292aee751ecc070f7ca6b39a574cc21b7b5e588e06a0b"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -6686,6 +6697,12 @@ dependencies = [
  "schemars 1.2.1",
  "serde_json",
 ]
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aee1b19627c7c60102ab80d3a9cbe18de90bfe03bfa6c3715447681f0e8c8af6"
 
 [[package]]
 name = "yansi"

--- a/cli/flox-activations/Cargo.toml
+++ b/cli/flox-activations/Cargo.toml
@@ -35,7 +35,11 @@ dirs.workspace = true
 tempfile.workspace = true
 uuid.workspace = true
 waitpid-any = "0.3.0"
-notify = "6"
+# Pinned to a 9.0.0 release candidate for macOS: only since 9.0.0-rc.2 does
+# notify create its FSEvents stream with kFSEventStreamCreateFlagWatchRoot,
+# without which removing an ancestor of the watched directory produces no
+# event at all. Drop the pre-release pin once 9.0.0 is out.
+notify = "9.0.0-rc.4"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 kqueue.workspace = true

--- a/cli/flox-activations/src/cli/executive/event_coordinator.rs
+++ b/cli/flox-activations/src/cli/executive/event_coordinator.rs
@@ -92,6 +92,11 @@ impl EventCoordinator {
     pub fn spawn_all_watchers(&mut self, state_json_path: impl AsRef<Path>) -> Result<()> {
         let (activations_json, _lock) = read_activations_json(&state_json_path)?;
         let Some(activations) = activations_json else {
+            // TODO: we should probably call cleanup_on_no_state here, but it's
+            // a more complicated situation than other state.json missing cases
+            // because the executive hasn't yet sent SIGUSR1
+            // At the same time it's less likely to be reachable since we should
+            // be here soon after running a CLI command.
             return Err(
                 anyhow!("executive shouldn't be running when state.json doesn't exist")
                     .context("when spawning watchers"),

--- a/cli/flox-activations/src/cli/executive/event_coordinator.rs
+++ b/cli/flox-activations/src/cli/executive/event_coordinator.rs
@@ -16,7 +16,7 @@ use flox_core::proc_status::pid_is_running;
 /// How long to wait between polling iterations when pidfd is unavailable.
 const POLLING_INTERVAL: Duration = Duration::from_millis(100);
 use nix::libc::{SIGCHLD, SIGINT, SIGQUIT, SIGTERM};
-use notify::{Event, RecommendedWatcher, RecursiveMode, Watcher};
+use notify::{Config, Event, EventKindMask, RecommendedWatcher, RecursiveMode, Watcher};
 use signal_hook::iterator::Signals;
 use time::OffsetDateTime;
 use tracing::{debug, error, trace, warn};
@@ -35,7 +35,12 @@ pub enum ExecutiveEvent {
     StartServices,
     /// state.json was modified - check for new PIDs to monitor
     StateFileChanged,
+    /// state.json no longer exists - the activation state was deleted out
+    /// from under the executive, which should exit
+    StateFileRemoved,
 }
+
+const SANITY_CHECK_INTERVAL: Duration = Duration::from_mins(1);
 
 /// Coordinates PID monitoring across multiple threads.
 ///
@@ -98,7 +103,7 @@ impl EventCoordinator {
             .context("failed to ensure monitoring PIDs")?;
 
         // Watch state.json
-        let file_watcher = Self::start_state_watcher(state_json_path, self.sender.clone())
+        let file_watcher = Self::start_state_watcher(&state_json_path, self.sender.clone())
             .context("failed to start state file watcher")?;
         self._file_watcher = Some(file_watcher);
 
@@ -106,7 +111,28 @@ impl EventCoordinator {
         let signal_handler = Self::spawn_signal_handler(self.sender.clone())?;
         self._signal_handler = Some(signal_handler);
 
+        // Backstop thread to cleanup bad states
+        Self::spawn_sanity_check(&state_json_path, self.sender.clone());
+
         Ok(())
+    }
+
+    /// Periodically check if the executive should still be running
+    ///
+    /// For now this just checks if state.json still exists
+    fn spawn_sanity_check(state_json_path: impl AsRef<Path>, sender: Sender<ExecutiveEvent>) {
+        let state_json_path = state_json_path.as_ref().to_path_buf();
+        thread::spawn(move || {
+            loop {
+                // beware of logging in this loop since repeated logs can accumulate
+                thread::sleep(SANITY_CHECK_INTERVAL);
+                if !state_json_path.exists()
+                    && sender.send(ExecutiveEvent::StateFileRemoved).is_err()
+                {
+                    break;
+                }
+            }
+        });
     }
 
     /// Monitor PIDs not already monitored.
@@ -170,9 +196,22 @@ impl EventCoordinator {
             .context("state.json path has no filename")?
             .to_owned();
 
-        let mut watcher =
-            notify::recommended_watcher(move |res: notify::Result<notify::Event>| match res {
+        // We care about create, remove, and modify
+        let config = Config::default().with_event_kinds(EventKindMask::CORE);
+        let mut watcher = RecommendedWatcher::new(
+            move |res: notify::Result<notify::Event>| match res {
                 Ok(event) => {
+                    // Claude claims filtering on different kinds of events to
+                    // determine what's a removal will be too brittle, so just
+                    // check if state.json exists
+                    if !owned_state_json_path.exists() {
+                        debug!(?event, "state.json is gone, sending removal event to main loop");
+                        if sender.send(ExecutiveEvent::StateFileRemoved).is_err() {
+                            error!("failed to send StateFileRemoved event, channel closed");
+                        }
+                        return;
+                    }
+
                     if !should_emit_state_changed(&event, &owned_state_json_path, &filename) {
                         return;
                     }
@@ -192,8 +231,10 @@ impl EventCoordinator {
                 Err(err) => {
                     error!(%err, "file watcher error");
                 },
-            })
-            .context("failed to create file watcher")?;
+            },
+            config,
+        )
+        .context("failed to create file watcher")?;
 
         watcher
             .watch(&parent_dir, RecursiveMode::NonRecursive)
@@ -456,6 +497,55 @@ mod tests {
             .expect("should receive event within timeout");
 
         assert_eq!(event, ExecutiveEvent::StateFileChanged);
+    }
+
+    #[test]
+    fn state_watcher_detects_ancestor_dir_removal() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let watched_dir = temp_dir.path().join("activation");
+        fs::create_dir(&watched_dir).unwrap();
+        let state_json_path = watched_dir.join("state.json");
+        fs::write(&state_json_path, "{}").unwrap();
+
+        let (sender, receiver) = mpsc::channel();
+        let _watcher = EventCoordinator::start_state_watcher(&state_json_path, sender)
+            .expect("failed to start state watcher");
+
+        // Prove the watcher is live first, so that a missing event below
+        // cannot be explained by stream startup latency.
+        write_atomically(&state_json_path, "{\"modified\": true}").unwrap();
+        assert_eq!(
+            receiver.recv_timeout(Duration::from_secs(2)),
+            Ok(ExecutiveEvent::StateFileChanged)
+        );
+        // Drain coalesced trailing events from the write before deleting.
+        while receiver.recv_timeout(Duration::from_millis(500)).is_ok() {}
+
+        fs::remove_dir_all(temp_dir.path()).unwrap();
+
+        assert_eq!(
+            receiver.recv_timeout(Duration::from_secs(5)),
+            Ok(ExecutiveEvent::StateFileRemoved)
+        );
+    }
+
+    #[test]
+    fn state_watcher_sends_removed_when_state_json_deleted() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let state_json_path = temp_dir.path().join("state.json");
+        fs::write(&state_json_path, "{}").unwrap();
+
+        let (sender, receiver) = mpsc::channel();
+        let _watcher = EventCoordinator::start_state_watcher(&state_json_path, sender)
+            .expect("failed to start state watcher");
+
+        fs::remove_file(&state_json_path).unwrap();
+
+        let event = receiver
+            .recv_timeout(Duration::from_secs(2))
+            .expect("should receive event within timeout");
+
+        assert_eq!(event, ExecutiveEvent::StateFileRemoved);
     }
 
     mod should_emit_state_changed {

--- a/cli/flox-activations/src/cli/executive/event_coordinator.rs
+++ b/cli/flox-activations/src/cli/executive/event_coordinator.rs
@@ -213,7 +213,7 @@ impl EventCoordinator {
                         return;
                     }
 
-                    if !should_emit_state_changed(&event, &owned_state_json_path, &filename) {
+                    if !should_emit_state_changed(&event, &filename) {
                         return;
                     }
 
@@ -337,21 +337,20 @@ impl EventCoordinator {
 /// - File creation (atomic rename) or data modification.
 ///   This filters out Close, Access, Remove, and other irrelevant events
 ///   that would cause redundant state.json reads.
-/// - A rescan event, in which case the watcher is dropping events. In that case
-///   we have to double check state.json exists because the main loop assumes it
-///   does
-fn should_emit_state_changed(event: &Event, state_json_path: &Path, filename: &OsStr) -> bool {
+/// - A rescan event, in which case the watcher is dropping events and the main
+///   loop has to re-read to pick up whatever it missed.
+///
+/// Deliberately does not consider whether state.json still exists. A stat here
+/// could only report the past; the main loop re-checks under the lock, where
+/// the answer is authoritative, before acting on either outcome.
+fn should_emit_state_changed(event: &Event, filename: &OsStr) -> bool {
     let is_write_event = event.kind.is_modify() || event.kind.is_create();
     let is_state_json_event = event.paths.iter().any(|p| p.file_name() == Some(filename));
     if is_write_event && is_state_json_event {
         return true;
     }
 
-    if event.need_rescan() && state_json_path.exists() {
-        return true;
-    }
-
-    false
+    event.need_rescan()
 }
 
 /// Spawn a thread that waits for a specific PID to exit.
@@ -597,7 +596,7 @@ mod tests {
         use std::path::PathBuf;
 
         use notify::EventKind;
-        use notify::event::{CreateKind, Flag, ModifyKind, RenameMode};
+        use notify::event::{CreateKind, ModifyKind, RenameMode};
 
         use super::*;
 
@@ -607,10 +606,6 @@ mod tests {
             let state_json_path = temp_dir.path().join("state.json");
             fs::write(&state_json_path, "{}").unwrap();
             (temp_dir, state_json_path)
-        }
-
-        fn rescan_event() -> Event {
-            Event::new(EventKind::Other).set_flag(Flag::Rescan)
         }
 
         /// state.json is written by atomic rename, so the rename onto the
@@ -623,7 +618,6 @@ mod tests {
 
             assert!(should_emit_state_changed(
                 &event,
-                &state_json_path,
                 state_json_path.file_name().unwrap()
             ));
         }
@@ -638,47 +632,6 @@ mod tests {
 
             assert!(!should_emit_state_changed(
                 &event,
-                &state_json_path,
-                state_json_path.file_name().unwrap()
-            ));
-        }
-
-        /// A rescan is the backend saying it dropped events. It names no file
-        /// and its kind is neither create nor modify, so filtering on kind and
-        /// name alone would discard it — and with it any attach that happened
-        /// during the overflow, leaving that PID unmonitored forever.
-        #[test]
-        fn rescan_is_a_change_despite_naming_no_file() {
-            let (_temp_dir, state_json_path) = state_json_in_temp_dir();
-            let event = rescan_event();
-
-            assert!(
-                event.paths.is_empty(),
-                "a rescan carries no path to match on"
-            );
-            assert!(
-                !event.kind.is_modify() && !event.kind.is_create(),
-                "a rescan is neither a modify nor a create"
-            );
-            assert!(should_emit_state_changed(
-                &event,
-                &state_json_path,
-                state_json_path.file_name().unwrap()
-            ));
-        }
-
-        /// A rescan carries no timing guarantee, so it can arrive after the
-        /// activation was torn down. Signalling a re-read then would have the
-        /// loop treat the missing file as fatal, and reading it would recreate
-        /// the directory cleanup had just removed.
-        #[test]
-        fn rescan_after_state_json_is_gone_is_not_a_change() {
-            let (_temp_dir, state_json_path) = state_json_in_temp_dir();
-            fs::remove_file(&state_json_path).unwrap();
-
-            assert!(!should_emit_state_changed(
-                &rescan_event(),
-                &state_json_path,
                 state_json_path.file_name().unwrap()
             ));
         }

--- a/cli/flox-activations/src/cli/executive/event_coordinator.rs
+++ b/cli/flox-activations/src/cli/executive/event_coordinator.rs
@@ -16,7 +16,7 @@ use flox_core::proc_status::pid_is_running;
 /// How long to wait between polling iterations when pidfd is unavailable.
 const POLLING_INTERVAL: Duration = Duration::from_millis(100);
 use nix::libc::{SIGCHLD, SIGINT, SIGQUIT, SIGTERM};
-use notify::{Event, RecommendedWatcher, RecursiveMode, Watcher};
+use notify::{Config, Event, EventKindMask, RecommendedWatcher, RecursiveMode, Watcher};
 use sentry::integrations::anyhow::capture_anyhow;
 use signal_hook::iterator::Signals;
 use time::OffsetDateTime;
@@ -36,7 +36,12 @@ pub enum ExecutiveEvent {
     StartServices,
     /// state.json was modified - check for new PIDs to monitor
     StateFileChanged,
+    /// state.json no longer exists - the activation state was deleted out
+    /// from under the executive, which should exit
+    StateFileRemoved,
 }
+
+const SANITY_CHECK_INTERVAL: Duration = Duration::from_mins(1);
 
 /// Coordinates PID monitoring across multiple threads.
 ///
@@ -99,7 +104,7 @@ impl EventCoordinator {
             .context("failed to ensure monitoring PIDs")?;
 
         // Watch state.json
-        let file_watcher = Self::start_state_watcher(state_json_path, self.sender.clone())
+        let file_watcher = Self::start_state_watcher(&state_json_path, self.sender.clone())
             .context("failed to start state file watcher")?;
         self._file_watcher = Some(file_watcher);
 
@@ -107,7 +112,28 @@ impl EventCoordinator {
         let signal_handler = Self::spawn_signal_handler(self.sender.clone())?;
         self._signal_handler = Some(signal_handler);
 
+        // Backstop thread to cleanup bad states
+        Self::spawn_sanity_check(&state_json_path, self.sender.clone());
+
         Ok(())
+    }
+
+    /// Periodically check if the executive should still be running
+    ///
+    /// For now this just checks if state.json still exists
+    fn spawn_sanity_check(state_json_path: impl AsRef<Path>, sender: Sender<ExecutiveEvent>) {
+        let state_json_path = state_json_path.as_ref().to_path_buf();
+        thread::spawn(move || {
+            loop {
+                // beware of logging in this loop since repeated logs can accumulate
+                thread::sleep(SANITY_CHECK_INTERVAL);
+                if !state_json_path.exists()
+                    && sender.send(ExecutiveEvent::StateFileRemoved).is_err()
+                {
+                    break;
+                }
+            }
+        });
     }
 
     /// Monitor PIDs not already monitored.
@@ -171,9 +197,22 @@ impl EventCoordinator {
             .context("state.json path has no filename")?
             .to_owned();
 
-        let mut watcher =
-            notify::recommended_watcher(move |res: notify::Result<notify::Event>| match res {
+        // We care about create, remove, and modify
+        let config = Config::default().with_event_kinds(EventKindMask::CORE);
+        let mut watcher = RecommendedWatcher::new(
+            move |res: notify::Result<notify::Event>| match res {
                 Ok(event) => {
+                    // Claude claims filtering on different kinds of events to
+                    // determine what's a removal will be too brittle, so just
+                    // check if state.json exists
+                    if !owned_state_json_path.exists() {
+                        debug!(?event, "state.json is gone, sending removal event to main loop");
+                        if sender.send(ExecutiveEvent::StateFileRemoved).is_err() {
+                            error!("failed to send StateFileRemoved event, channel closed");
+                        }
+                        return;
+                    }
+
                     if !should_emit_state_changed(&event, &owned_state_json_path, &filename) {
                         return;
                     }
@@ -193,8 +232,10 @@ impl EventCoordinator {
                 Err(err) => {
                     error!(%err, "file watcher error");
                 },
-            })
-            .context("failed to create file watcher")?;
+            },
+            config,
+        )
+        .context("failed to create file watcher")?;
 
         watcher
             .watch(&parent_dir, RecursiveMode::NonRecursive)
@@ -501,6 +542,55 @@ mod tests {
             .expect("should receive event within timeout");
 
         assert_eq!(event, ExecutiveEvent::StateFileChanged);
+    }
+
+    #[test]
+    fn state_watcher_detects_ancestor_dir_removal() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let watched_dir = temp_dir.path().join("activation");
+        fs::create_dir(&watched_dir).unwrap();
+        let state_json_path = watched_dir.join("state.json");
+        fs::write(&state_json_path, "{}").unwrap();
+
+        let (sender, receiver) = mpsc::channel();
+        let _watcher = EventCoordinator::start_state_watcher(&state_json_path, sender)
+            .expect("failed to start state watcher");
+
+        // Prove the watcher is live first, so that a missing event below
+        // cannot be explained by stream startup latency.
+        write_atomically(&state_json_path, "{\"modified\": true}").unwrap();
+        assert_eq!(
+            receiver.recv_timeout(Duration::from_secs(2)),
+            Ok(ExecutiveEvent::StateFileChanged)
+        );
+        // Drain coalesced trailing events from the write before deleting.
+        while receiver.recv_timeout(Duration::from_millis(500)).is_ok() {}
+
+        fs::remove_dir_all(temp_dir.path()).unwrap();
+
+        assert_eq!(
+            receiver.recv_timeout(Duration::from_secs(5)),
+            Ok(ExecutiveEvent::StateFileRemoved)
+        );
+    }
+
+    #[test]
+    fn state_watcher_sends_removed_when_state_json_deleted() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let state_json_path = temp_dir.path().join("state.json");
+        fs::write(&state_json_path, "{}").unwrap();
+
+        let (sender, receiver) = mpsc::channel();
+        let _watcher = EventCoordinator::start_state_watcher(&state_json_path, sender)
+            .expect("failed to start state watcher");
+
+        fs::remove_file(&state_json_path).unwrap();
+
+        let event = receiver
+            .recv_timeout(Duration::from_secs(2))
+            .expect("should receive event within timeout");
+
+        assert_eq!(event, ExecutiveEvent::StateFileRemoved);
     }
 
     mod should_emit_state_changed {

--- a/cli/flox-activations/src/cli/executive/event_coordinator.rs
+++ b/cli/flox-activations/src/cli/executive/event_coordinator.rs
@@ -93,6 +93,11 @@ impl EventCoordinator {
     pub fn spawn_all_watchers(&mut self, state_json_path: impl AsRef<Path>) -> Result<()> {
         let (activations_json, _lock) = read_activations_json(&state_json_path)?;
         let Some(activations) = activations_json else {
+            // TODO: we should probably call cleanup_on_no_state here, but it's
+            // a more complicated situation than other state.json missing cases
+            // because the executive hasn't yet sent SIGUSR1
+            // At the same time it's less likely to be reachable since we should
+            // be here soon after running a CLI command.
             return Err(
                 anyhow!("executive shouldn't be running when state.json doesn't exist")
                     .context("when spawning watchers"),

--- a/cli/flox-activations/src/cli/executive/event_coordinator.rs
+++ b/cli/flox-activations/src/cli/executive/event_coordinator.rs
@@ -212,7 +212,7 @@ impl EventCoordinator {
                         return;
                     }
 
-                    if !should_emit_state_changed(&event, &owned_state_json_path, &filename) {
+                    if !should_emit_state_changed(&event, &filename) {
                         return;
                     }
 
@@ -336,21 +336,20 @@ impl EventCoordinator {
 /// - File creation (atomic rename) or data modification.
 ///   This filters out Close, Access, Remove, and other irrelevant events
 ///   that would cause redundant state.json reads.
-/// - A rescan event, in which case the watcher is dropping events. In that case
-///   we have to double check state.json exists because the main loop assumes it
-///   does
-fn should_emit_state_changed(event: &Event, state_json_path: &Path, filename: &OsStr) -> bool {
+/// - A rescan event, in which case the watcher is dropping events and the main
+///   loop has to re-read to pick up whatever it missed.
+///
+/// Deliberately does not consider whether state.json still exists. A stat here
+/// could only report the past; the main loop re-checks under the lock, where
+/// the answer is authoritative, before acting on either outcome.
+fn should_emit_state_changed(event: &Event, filename: &OsStr) -> bool {
     let is_write_event = event.kind.is_modify() || event.kind.is_create();
     let is_state_json_event = event.paths.iter().any(|p| p.file_name() == Some(filename));
     if is_write_event && is_state_json_event {
         return true;
     }
 
-    if event.need_rescan() && state_json_path.exists() {
-        return true;
-    }
-
-    false
+    event.need_rescan()
 }
 
 /// Spawn a thread that waits for a specific PID to exit.
@@ -552,7 +551,7 @@ mod tests {
         use std::path::PathBuf;
 
         use notify::EventKind;
-        use notify::event::{CreateKind, Flag, ModifyKind, RenameMode};
+        use notify::event::{CreateKind, ModifyKind, RenameMode};
 
         use super::*;
 
@@ -562,10 +561,6 @@ mod tests {
             let state_json_path = temp_dir.path().join("state.json");
             fs::write(&state_json_path, "{}").unwrap();
             (temp_dir, state_json_path)
-        }
-
-        fn rescan_event() -> Event {
-            Event::new(EventKind::Other).set_flag(Flag::Rescan)
         }
 
         /// state.json is written by atomic rename, so the rename onto the
@@ -578,7 +573,6 @@ mod tests {
 
             assert!(should_emit_state_changed(
                 &event,
-                &state_json_path,
                 state_json_path.file_name().unwrap()
             ));
         }
@@ -593,47 +587,6 @@ mod tests {
 
             assert!(!should_emit_state_changed(
                 &event,
-                &state_json_path,
-                state_json_path.file_name().unwrap()
-            ));
-        }
-
-        /// A rescan is the backend saying it dropped events. It names no file
-        /// and its kind is neither create nor modify, so filtering on kind and
-        /// name alone would discard it — and with it any attach that happened
-        /// during the overflow, leaving that PID unmonitored forever.
-        #[test]
-        fn rescan_is_a_change_despite_naming_no_file() {
-            let (_temp_dir, state_json_path) = state_json_in_temp_dir();
-            let event = rescan_event();
-
-            assert!(
-                event.paths.is_empty(),
-                "a rescan carries no path to match on"
-            );
-            assert!(
-                !event.kind.is_modify() && !event.kind.is_create(),
-                "a rescan is neither a modify nor a create"
-            );
-            assert!(should_emit_state_changed(
-                &event,
-                &state_json_path,
-                state_json_path.file_name().unwrap()
-            ));
-        }
-
-        /// A rescan carries no timing guarantee, so it can arrive after the
-        /// activation was torn down. Signalling a re-read then would have the
-        /// loop treat the missing file as fatal, and reading it would recreate
-        /// the directory cleanup had just removed.
-        #[test]
-        fn rescan_after_state_json_is_gone_is_not_a_change() {
-            let (_temp_dir, state_json_path) = state_json_in_temp_dir();
-            fs::remove_file(&state_json_path).unwrap();
-
-            assert!(!should_emit_state_changed(
-                &rescan_event(),
-                &state_json_path,
                 state_json_path.file_name().unwrap()
             ));
         }

--- a/cli/flox-activations/src/cli/executive/mod.rs
+++ b/cli/flox-activations/src/cli/executive/mod.rs
@@ -220,6 +220,11 @@ fn run_event_loop(
                 debug!("Received SIGUSR1, starting process-compose");
                 let (activations_json, lock) = read_activations_json(&state_json_path)?;
                 let Some(activations) = activations_json else {
+                    // TODO: we should probably call cleanup_on_no_state here, but it's
+                    // a more complicated situation than other state.json missing cases
+                    // because the executive hasn't started services yet.
+                    // At the same time it's less likely to be reachable since we should
+                    // be here soon after running a CLI command.
                     return Err(anyhow!(
                         "executive shouldn't be running when state.json doesn't exist"
                     )
@@ -251,6 +256,7 @@ fn run_event_loop(
                     // same exit as StateFileRemoved rather than erroring.
                     return cleanup_on_no_state(
                         lock,
+                        "handling a state.json change",
                         &state_json_path,
                         &process_compose_bin,
                         &socket_path,
@@ -295,6 +301,7 @@ fn run_event_loop(
                     .context("can't cleanup after state file removal")?;
                 return cleanup_on_no_state(
                     lock,
+                    "handling a state.json removal",
                     &state_json_path,
                     &process_compose_bin,
                     &socket_path,
@@ -364,8 +371,30 @@ fn handle_process_exited(
     // Remove from known_pids first so it can be re-monitored if it re-attached
     coordinator.stop_monitoring(pid);
 
+    // Read and lock here rather than inside cleanup_pid: every arm of the event
+    // loop answers "is there still activation state?" the same way, and keeping
+    // that decision in one layer means cleanup_pid can stay a function over
+    // state that is already known to exist.
+    let (activations_json, lock) = read_activations_json(state_json_path)?;
+    let Some(activations) = activations_json else {
+        cleanup_on_no_state(
+            lock,
+            "cleaning up an exited PID",
+            state_json_path,
+            process_compose_bin,
+            socket_path,
+            activation_state_dir,
+        )?;
+        return Ok(true);
+    };
+
     // Use PidWatcher to clean up the state
-    match watcher::cleanup_pid(state_json_path, activation_state_dir, pid) {
+    match watcher::cleanup_pid(
+        (activations, lock),
+        state_json_path,
+        activation_state_dir,
+        pid,
+    ) {
         Ok(None) => {
             // Still have active PIDs - check if this PID re-attached
             // and needs to be monitored again.
@@ -383,12 +412,17 @@ fn handle_process_exited(
             // That's not currently reachable because the watcher should sleep,
             // but the watcher shouldn't be treated as the authority on expired
             // PIDs.
-            let (activations_json, _lock) = read_activations_json(state_json_path)?;
+            let (activations_json, lock) = read_activations_json(state_json_path)?;
             let Some(activations) = activations_json else {
-                return Err(anyhow!(
-                    "executive shouldn't be running when state.json doesn't exist"
-                )
-                .context("when checking for re-attached PIDs"))?;
+                cleanup_on_no_state(
+                    lock,
+                    "checking for re-attached PIDs",
+                    state_json_path,
+                    process_compose_bin,
+                    socket_path,
+                    activation_state_dir,
+                )?;
+                return Ok(true);
             };
             // Check if the PID that triggered this event is still in state
             let pid_reused = activations
@@ -457,9 +491,19 @@ fn handle_process_exited(
             info!(%err, "running cleanup after error");
             let (activations_json, lock) = read_activations_json(state_json_path)?;
             let Some(activations) = activations_json else {
-                return Err(
-                    err.context("executive shouldn't be running when state.json doesn't exist")
+                // The original error is carried into the log rather than
+                // returned: with the state gone there is nothing left to
+                // recover, so exiting cleanly beats a failure the executive
+                // cannot act on.
+                cleanup_on_no_state(
+                    lock,
+                    &format!("cleaning up after error: {err}"),
+                    state_json_path,
+                    process_compose_bin,
+                    socket_path,
+                    activation_state_dir,
                 )?;
+                return Ok(true);
             };
             let _ = cleanup_all(
                 (activations, lock),
@@ -529,12 +573,19 @@ fn handle_start_services_signal(
 /// answer cannot change underneath us — unlike a bare `exists()`, which is only
 /// ever a statement about the past.
 ///
-/// Returns an error when the state really is gone: an activation destroyed out
-/// from under a running executive is an anomaly worth a non-zero exit, even
-/// though nothing here can recover from it. Cleanup still runs first. Returns
-/// `Ok` only for the benign case where a new activation has taken over.
+/// `discovered_during` names the operation that ran into the missing state.
+/// Several unrelated paths converge here, and which one noticed is the useful
+/// thing to know when reading an executive log, so it is carried into both
+/// outcomes.
+///
+/// Returns an error when the state really is gone: an activation being
+/// destroyed out from under a running executive is an anomaly worth a non-zero
+/// exit, even though nothing here can recover from it. Cleanup still runs
+/// first. Returns `Ok` only for the benign case where a new activation has
+/// taken over.
 fn cleanup_on_no_state(
     _hold_the_lock: LockFile,
+    discovered_during: &str,
     state_json_path: &Path,
     process_compose_bin: &Path,
     socket_path: &Path,
@@ -545,6 +596,7 @@ fn cleanup_on_no_state(
     // That is a handoff rather than a failure.
     if state_json_path.exists() {
         info!(
+            discovered_during,
             reason = "state.json recreated by a new activation",
             "exiting without cleanup"
         );
@@ -557,7 +609,7 @@ fn cleanup_on_no_state(
     shut_down_and_remove_state(process_compose_bin, socket_path, activation_state_dir_path)
         .context("failed to clean up after removed activation state")?;
 
-    bail!("activation state was removed while the executive was running")
+    bail!("activation state was removed while {discovered_during}")
 }
 
 /// Shutdown `process-compose` if running and remove the activation state

--- a/cli/flox-activations/src/cli/executive/mod.rs
+++ b/cli/flox-activations/src/cli/executive/mod.rs
@@ -6,9 +6,15 @@ use clap::Args;
 use event_coordinator::{EventCoordinator, ExecutiveEvent};
 use flox_core::activate::context::{AttachCtx, AttachProjectCtx};
 use flox_core::activate::vars::FLOX_EXECUTIVE_VERBOSITY_VAR;
-use flox_core::activations::{read_activations_json, state_json_path, write_activations_json};
+use flox_core::activations::{
+    acquire_activations_json_lock,
+    read_activations_json,
+    state_json_path,
+    write_activations_json,
+};
 use flox_core::sentry::init_sentry;
 use flox_core::traceable_path;
+use fslock::LockFile;
 use log_gc::{spawn_heartbeat_log, spawn_logs_gc_threads};
 use nix::sys::signal::Signal::SIGUSR1;
 use nix::sys::signal::kill;
@@ -271,6 +277,24 @@ fn run_event_loop(
                 }
                 // lock drops here when PIDs remain
             },
+            Ok(ExecutiveEvent::StateFileRemoved) => {
+                // state.json existed when this executive started, so a removal
+                // event means it was deleted at some point — typically by an
+                // external actor such as a test harness or manual cleanup
+                // removing the runtime dir. Either way this executive is done.
+                //
+                // The event only says state.json was missing at some point, so
+                // take the lock and let cleanup_on_no_state decide under it.
+                let lock = acquire_activations_json_lock(&state_json_path)
+                    .context("can't cleanup after state file removal")?;
+                return cleanup_on_no_state(
+                    lock,
+                    &state_json_path,
+                    &process_compose_bin,
+                    &socket_path,
+                    &activation_state_dir,
+                );
+            },
             Ok(ExecutiveEvent::SigChld) => {
                 reap_orphaned_children();
             },
@@ -487,23 +511,56 @@ fn handle_start_services_signal(
     Ok(Some((activations, lock)))
 }
 
-/// Shutdown `process-compose` if running and remove all activation state.
-/// To be called when there are no longer any PIDs attached.
-/// Returns `true` if cleanup ran, `false` if PIDs were found and cleanup was skipped.
-fn cleanup_all(
-    locked_activations: LockedActivationState,
+/// Shut down what can still be reached once state.json is gone.
+///
+/// Without state.json there is no attachment list to consult and no state left
+/// to remove, so stopping `process-compose` if its socket outlived the state is
+/// the only useful thing remaining. Attached processes may outlive the state;
+/// the executive can do nothing further for them.
+///
+/// Takes the lock rather than a path so that "state.json is absent" is decided
+/// while holding it. state.json cannot be written without the lock, so that
+/// answer cannot change underneath us — unlike a bare `exists()`, which is only
+/// ever a statement about the past.
+///
+/// Returns an error when the state really is gone: an activation destroyed out
+/// from under a running executive is an anomaly worth a non-zero exit, even
+/// though nothing here can recover from it. Cleanup still runs first. Returns
+/// `Ok` only for the benign case where a new activation has taken over.
+fn cleanup_on_no_state(
+    _hold_the_lock: LockFile,
+    state_json_path: &Path,
+    process_compose_bin: &Path,
+    socket_path: &Path,
+    activation_state_dir_path: &Path,
+) -> Result<()> {
+    // If state.json is back, it can only have been recreated by a new `start`,
+    // whose executive now owns the state and any services — leave both alone.
+    // That is a handoff rather than a failure.
+    if state_json_path.exists() {
+        info!(
+            reason = "state.json recreated by a new activation",
+            "exiting without cleanup"
+        );
+        return Ok(());
+    }
+
+    // Acquiring the lock recreates the state dir when an external `rm -rf` took
+    // it, so removing it here is what keeps this from leaving a directory and a
+    // stale state.lock behind.
+    shut_down_and_remove_state(process_compose_bin, socket_path, activation_state_dir_path)
+        .context("failed to clean up after removed activation state")?;
+
+    bail!("activation state was removed while the executive was running")
+}
+
+/// Shutdown `process-compose` if running and remove the activation state
+/// directory.
+fn shut_down_and_remove_state(
     process_compose_bin: &Path,
     socket_path: impl AsRef<Path>,
     activation_state_dir_path: impl AsRef<Path>,
-) -> Result<bool> {
-    info!("running cleanup");
-
-    let (activations_json, _hold_the_lock) = locked_activations;
-
-    if !activations_json.attached_pids_is_empty() {
-        warn!("cleanup called with PIDs still attached, skipping");
-        return Ok(false);
-    }
+) -> Result<()> {
     let socket_path = socket_path.as_ref();
     if socket_path.exists() {
         if let Err(err) = process_compose_down(process_compose_bin, socket_path) {
@@ -525,6 +582,29 @@ fn cleanup_all(
     fs::rename(activation_state_dir_path, &cleanup_path)
         .context("couldn't rename activations dir for cleanup")?;
     fs::remove_dir_all(&cleanup_path).context("couldn't remove activations dir")?;
+
+    Ok(())
+}
+
+/// Shutdown `process-compose` if running and remove all activation state.
+/// To be called when there are no longer any PIDs attached.
+/// Returns `true` if cleanup ran, `false` if PIDs were found and cleanup was skipped.
+fn cleanup_all(
+    locked_activations: LockedActivationState,
+    process_compose_bin: &Path,
+    socket_path: impl AsRef<Path>,
+    activation_state_dir_path: impl AsRef<Path>,
+) -> Result<bool> {
+    info!("running cleanup");
+
+    let (activations_json, _hold_the_lock) = locked_activations;
+
+    if !activations_json.attached_pids_is_empty() {
+        warn!("cleanup called with PIDs still attached, skipping");
+        return Ok(false);
+    }
+
+    shut_down_and_remove_state(process_compose_bin, socket_path, activation_state_dir_path)?;
 
     info!("finished cleanup");
 

--- a/cli/flox-activations/src/cli/executive/mod.rs
+++ b/cli/flox-activations/src/cli/executive/mod.rs
@@ -246,10 +246,16 @@ fn run_event_loop(
                 debug!("state.json changed, checking for new PIDs to monitor");
                 let (state, lock) = read_activations_json(&state_json_path)?;
                 let Some(activations) = state else {
-                    return Err(anyhow!(
-                        "executive shouldn't be running when state.json doesn't exist"
-                    )
-                    .context("when handling StateFileChanged"))?;
+                    // state.json went away between the watcher observing it and
+                    // this read. There is nothing left to monitor, so take the
+                    // same exit as StateFileRemoved rather than erroring.
+                    return cleanup_on_no_state(
+                        lock,
+                        &state_json_path,
+                        &process_compose_bin,
+                        &socket_path,
+                        &activation_state_dir,
+                    );
                 };
                 coordinator
                     .ensure_monitoring_pids(activations.all_attached_pids_and_expiration())

--- a/cli/flox-activations/src/cli/executive/mod.rs
+++ b/cli/flox-activations/src/cli/executive/mod.rs
@@ -620,13 +620,12 @@ fn shut_down_and_remove_state(
     activation_state_dir_path: impl AsRef<Path>,
 ) -> Result<()> {
     let socket_path = socket_path.as_ref();
-    if socket_path.exists() {
-        if let Err(err) = process_compose_down(process_compose_bin, socket_path) {
-            warn!(%err, "failed to run process-compose shutdown command");
-        }
-        info!("shut down process-compose");
-    } else {
+    if !socket_path.exists() {
         info!(reason = "no socket", "did not shut down process-compose");
+    } else if let Err(err) = process_compose_down(process_compose_bin, socket_path) {
+        warn!(%err, "failed to run process-compose shutdown command");
+    } else {
+        info!("shut down process-compose");
     }
 
     // Atomically remove the activation state directory

--- a/cli/flox-activations/src/cli/executive/watcher.rs
+++ b/cli/flox-activations/src/cli/executive/watcher.rs
@@ -10,8 +10,8 @@
 
 use std::path::Path;
 
-use anyhow::{Result, anyhow};
-use flox_core::activations::{ActivationState, read_activations_json, write_activations_json};
+use anyhow::Result;
+use flox_core::activations::{ActivationState, write_activations_json};
 use flox_core::proc_status::pid_is_running;
 use fslock::LockFile;
 use time::OffsetDateTime;
@@ -26,21 +26,20 @@ pub type LockedActivationState = (ActivationState, LockFile);
 
 /// Check if the provided PID is still running and clean it up if not.
 ///
+/// Takes the state already locked rather than reading it, so that whether
+/// state.json still exists is decided by the caller. Every arm of the event
+/// loop answers that the same way, and it is not this function's policy to set.
+///
 /// Returns `Some(LockedActivationState)` if all PIDs have terminated and
 /// cleanup should proceed.
 /// Returns `None` if there are still active PIDs.
 pub fn cleanup_pid(
+    locked_activations: LockedActivationState,
     state_json_path: &Path,
     activation_state_dir: &Path,
     pid: i32,
 ) -> Result<Option<LockedActivationState>, Error> {
-    let (activations_json, lock) = read_activations_json(state_json_path)?;
-    let Some(mut activations) = activations_json else {
-        return Err(
-            anyhow!("executive shouldn't be running when state.json doesn't exist")
-                .context(format!("when cleaning up PID {pid}")),
-        );
-    };
+    let (mut activations, lock) = locked_activations;
 
     let now = OffsetDateTime::now_utc();
     let (empty_start_id, modified) = activations.cleanup_pid(pid, pid_is_running, now);
@@ -80,10 +79,22 @@ pub mod test {
 
     use flox_core::activate::mode::ActivateMode;
     use flox_core::activations::test_helpers::write_activation_state;
-    use flox_core::activations::{StartOrAttachResult, activation_state_dir_path, state_json_path};
+    use flox_core::activations::{
+        StartOrAttachResult,
+        activation_state_dir_path,
+        read_activations_json,
+        state_json_path,
+    };
     use flox_core::proc_status::{ProcStatus, pid_is_running, read_pid_status};
 
     use super::*;
+
+    /// Read and lock the state the way the event loop does before calling
+    /// [`cleanup_pid`].
+    fn locked_state(state_json_path: &Path) -> LockedActivationState {
+        let (activations, lock) = read_activations_json(state_json_path).unwrap();
+        (activations.expect("state.json should exist"), lock)
+    }
 
     // NOTE: these two functions are copied from flox-rust-sdk since you can't
     //       share anything behind #[cfg(test)] across crates
@@ -169,14 +180,25 @@ pub mod test {
 
         // Clean up first PID - should not trigger full cleanup yet
         stop_process(proc1);
-        let result = cleanup_pid(&state_json_path, &activation_state_dir, pid1).unwrap();
+        let result = cleanup_pid(
+            locked_state(&state_json_path),
+            &state_json_path,
+            &activation_state_dir,
+            pid1,
+        )
+        .unwrap();
         assert!(result.is_none(), "should not cleanup after first PID");
 
         // Clean up second PID - should trigger full cleanup
         stop_process(proc2);
-        let (state, _lock) = cleanup_pid(&state_json_path, &activation_state_dir, pid2)
-            .unwrap()
-            .expect("should return cleanup result");
+        let (state, _lock) = cleanup_pid(
+            locked_state(&state_json_path),
+            &state_json_path,
+            &activation_state_dir,
+            pid2,
+        )
+        .unwrap()
+        .expect("should return cleanup result");
         assert_eq!(
             state.attachments_by_start_id(),
             BTreeMap::new(),
@@ -237,7 +259,13 @@ pub mod test {
 
         // Terminate proc1 and call cleanup_pid
         stop_process(proc1);
-        let result = cleanup_pid(&state_json_path, &activation_state_dir, pid1).unwrap();
+        let result = cleanup_pid(
+            locked_state(&state_json_path),
+            &state_json_path,
+            &activation_state_dir,
+            pid1,
+        )
+        .unwrap();
         assert!(result.is_none(), "should not cleanup while pid2 is running");
 
         // Verify state_dir_1 has been removed but state_dir_2 still exists
@@ -246,9 +274,14 @@ pub mod test {
 
         // Clean up
         stop_process(proc2);
-        let (state, _lock) = cleanup_pid(&state_json_path, &activation_state_dir, pid2)
-            .unwrap()
-            .expect("should return cleanup result");
+        let (state, _lock) = cleanup_pid(
+            locked_state(&state_json_path),
+            &state_json_path,
+            &activation_state_dir,
+            pid2,
+        )
+        .unwrap()
+        .expect("should return cleanup result");
         assert_eq!(
             state.attachments_by_start_id(),
             BTreeMap::new(),

--- a/cli/tests/test_support.bash
+++ b/cli/tests/test_support.bash
@@ -373,7 +373,12 @@ jq_edit() {
 
 cat_teardown_fifo() {
   if [ -n "${TEARDOWN_FIFO:-}" ]; then
-    timeout 1 cat "$TEARDOWN_FIFO"
+    # Wait generously: with a short timeout, a slow activation may reach its
+    # `echo > $TEARDOWN_FIFO` only after the reader has given up, after which
+    # the writer blocks in open() forever and project_teardown orphans the
+    # FIFO inode — leaking the activation process and its executive.
+    timeout 10 cat "$TEARDOWN_FIFO" \
+      || echo "cat_teardown_fifo: timed out waiting for writer on $TEARDOWN_FIFO" >&2
   fi
 
 }


### PR DESCRIPTION
- **test(activate): wait longer for the teardown FIFO**
  According to Claude a test like
  `config reload: activate: picks up environment modifications when all
  services have stopped`
  can leak an executive for an activation that takes >2s.
  
  For a >2s activation, `wait_for_file_content out foo_one` times out after
  1 second and then `timeout 1 cat "$TEARDOWN_FIFO"` times out. Then the
  activation never exits.
  
    `wait_for_activations` then times out, test file cleanup still fires
    removing state.json (which the executive doesn't currently handle), and
    the executive is left running forever.
  
  Claude claims to have reproduced this with FS load on aarch64-darwin
  with something like:
  
      LOAD=()
      for i in 1 2; do
        ( while :; do
            d=$(mktemp -d /tmp/churn.XXXXXX)
            for j in $(seq 500); do echo x >"$d/f$j"; done
            rm -rf "$d"
          done ) & LOAD+=($!)
      done
      yes >/dev/null & LOAD+=($!)
      yes >/dev/null & LOAD+=($!)
  
      # 4 concurrent runs of the services-heavy bats files.
      for r in 1 2 3 4; do
        FLOX_TEST_JOBS=16 ./fct/bin/flox-cli-tests \
          activate.bats services.bats deactivate.bats hook.bats \
          shell-state-restoration.bats deactivate_profile_e2e.bats \
          >/tmp/leakrun$r.log 2>&1 &
      done
  

- **fix(executive): exit when state.json is removed**
  Currently an executive will hang forever if state.json is removed by
  something outside of our control.
  
  Handle this more robustly in two ways:
  - Catch file removals in our state.json watcher. This required bumping
    notify to the latest RC since the version we're using doesn't catch
    parent directory removals
  - Add a 1 minute poll that checks if state.json is still present. We can
    use this polling thread to add more sanity checks in the future if
    needed. It's not very robust to hang forever if we reach a bad state.
  

- **fix(executive): decide "state.json is gone" under the lock**
- **fix(executive): clean up before failing on the PID-exit path**
- **fix(executive): only log a process-compose shutdown that happened**
  