### PR TITLE
fix(activate): honor FLOX_PROMPT in fish and tcsh when NO_COLOR is set

### DIFF
--- a/assets/environment-interpreter/activate/activate.d/set-prompt.fish
+++ b/assets/environment-interpreter/activate/activate.d/set-prompt.fish
@@ -15,7 +15,7 @@ if set -q FLOX_PROMPT_ENVIRONMENTS && test -n "$FLOX_PROMPT_ENVIRONMENTS"
     # script may be sourced inside a function (the auto-activate hook), where
     # an unscoped set on a new variable would vanish when the function returns.
     if set -q NO_COLOR
-        set -g _flox "flox [$FLOX_PROMPT_ENVIRONMENTS]"
+        set -g _flox "$FLOX_PROMPT [$FLOX_PROMPT_ENVIRONMENTS]"
     else
         set colorPrompt1 \e\[38\;5\;$FLOX_PROMPT_COLOR_1""m
         set colorPrompt2 \e\[38\;5\;$FLOX_PROMPT_COLOR_2""m

--- a/assets/environment-interpreter/activate/activate.d/set-prompt.tcsh
+++ b/assets/environment-interpreter/activate/activate.d/set-prompt.tcsh
@@ -29,7 +29,7 @@ if ( $?prompt && $_flox_have_envs ) then
     set _floxPrompt2 = "$colorPrompt2""[$FLOX_PROMPT_ENVIRONMENTS]"
 
     if $?NO_COLOR then
-        set _flox = "flox [$FLOX_PROMPT_ENVIRONMENTS]"
+        set _flox = "$FLOX_PROMPT [$FLOX_PROMPT_ENVIRONMENTS]"
     else
         set _flox = "$colorBold$_floxPrompt1 $_floxPrompt2$colorReset"
     endif


### PR DESCRIPTION
Fixes DEV-241.

## Summary

The `NO_COLOR` branches of the fish and tcsh set-prompt scripts hardcoded the `flox` prompt label even though both scripts default `FLOX_PROMPT` a few lines earlier, so a custom label — including one set via manifest `[vars]`, as documented in `flox-activate(1)` by #4590 — was silently ignored in those shells whenever `NO_COLOR` was set. bash (`set-prompt.bash:26`, `${FLOX_PROMPT-flox}`) and zsh already honor `FLOX_PROMPT` in their no-color paths.

Found while verifying the regression-test suggestion in https://github.com/flox/flox/pull/4590#discussion_r3716510243.

## Testing

Smoke-tested both scripts directly with `FLOX_PROMPT=acme`, `FLOX_PROMPT_ENVIRONMENTS=labeled`, and `NO_COLOR` set:

- tcsh: prompt renders `acme [labeled] % ` (was `flox [labeled] % `)
- fish: `_flox` indicator renders `acme [labeled]` (was `flox [labeled]`)

A bats regression test covering `[vars]`-sets-`FLOX_PROMPT` (per the review suggestion above) would pair well with this fix; left for when the issue is picked up from triage.

## Release Notes

- Fixed: fish and tcsh now honor `$FLOX_PROMPT` when `NO_COLOR` is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)