### PR TITLE
feat(auth): show token expiry in status

### DIFF
--- a/cli/flox/doc/flox-auth.md
+++ b/cli/flox/doc/flox-auth.md
@@ -50,7 +50,7 @@ Logs out from FloxHub.
 
 ## `status`
 
-Print your current login status.
+Print your current login status and token expiry when known.
 
 ## `token`
 

--- a/cli/flox/src/commands/auth.rs
+++ b/cli/flox/src/commands/auth.rs
@@ -350,7 +350,7 @@ impl Auth {
                             flox.floxhub.base_url()
                         ));
                         if let Some(expires_at) = identity.expires_at {
-                            message::plain(format!("Expires at: {}.", expires_at.to_rfc3339()));
+                            message::plain(format!("Expires at: {expires_at}."));
                         }
                     },
                     Ok(None) => {

--- a/cli/flox/src/commands/auth.rs
+++ b/cli/flox/src/commands/auth.rs
@@ -349,6 +349,9 @@ impl Auth {
                             identity.handle,
                             flox.floxhub.base_url()
                         ));
+                        if let Some(expires_at) = identity.expires_at {
+                            message::plain(format!("Expires at: {}.", expires_at.to_rfc3339()));
+                        }
                     },
                     Ok(None) => {
                         message::warning(

--- a/cli/tests/auth-pat.bats
+++ b/cli/tests/auth-pat.bats
@@ -141,7 +141,7 @@ teardown() {
   run "$FLOX_BIN" auth status
   assert_success
   assert_output --partial "You are logged in as owner"
-  assert_output --partial "Expires at: 2030-01-01T00:00:00+00:00."
+  assert_output --partial "Expires at: 2030-01-01 00:00:00 UTC."
 }
 
 # bats test_tags=auth:pat:login

--- a/cli/tests/auth-pat.bats
+++ b/cli/tests/auth-pat.bats
@@ -133,6 +133,17 @@ teardown() {
   assert_output --partial "You are logged in as owner"
 }
 
+# bats test_tags=auth:pat:status,auth:sat
+@test "sat: auth status reports the handle and expiry from /me" {
+  export FLOX_FLOXHUB_TOKEN="flox_sat_expiring-secret"
+  export _FLOX_USE_CATALOG_MOCK="$MANUALLY_GENERATED/auth/me_service_expiring.yaml"
+
+  run "$FLOX_BIN" auth status
+  assert_success
+  assert_output --partial "You are logged in as owner"
+  assert_output --partial "Expires at: 2030-01-01T00:00:00+00:00."
+}
+
 # bats test_tags=auth:pat:login
 @test "pat: auth login --token-file logs in with a pat" {
   unset FLOX_FLOXHUB_TOKEN

--- a/test_data/manually_generated/auth/me_service_expiring.yaml
+++ b/test_data/manually_generated/auth/me_service_expiring.yaml
@@ -1,0 +1,12 @@
+when:
+  method: GET
+  path: /accounts/api/v1/accounts/me
+  header:
+  - name: authorization
+    value: bearer flox_sat_expiring-secret
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"user_id":"service|expiring","handle":"owner","expires_at":"2030-01-01T00:00:00Z"}'


### PR DESCRIPTION
## Summary

- display the active credential expiry in `flox auth status` when known
- format the expiry using the same UTC date display as `flox generations`
- keep the existing handle, authentication-state, and credential-storage behavior unchanged
- add focused SAT coverage for the handle and expiry returned by `/me`

## Server dependency

Depends on [flox/floxhub#2119](https://github.com/flox/floxhub/pull/2119) for SAT expiry from the authenticated `/me` response.

Authorization/access modeling remains deferred to [ENT-267](https://linear.app/floxdotdev/issue/ENT-267/design-a-generic-principal-access-model-for-auth-status).

## Validation

- `git diff --check` passed
- local builds and tests were not run
- GitHub CI is running against the latest commit

## Tracking

Closes ENT-256

## Release Notes

`flox auth status` now displays the active credential expiry when known.