### PR TITLE
docs(agents): keep customer names out of PRs, commits, and code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,6 +162,12 @@ If so, add a `## Release Notes` section to the PR description describing the cha
 
 Update your branch against `main` by rebasing — never a merge commit.
 
+**Never mention customer names.** This is a public repository — keep
+customer and prospect names out of everything that lands on GitHub:
+PR titles and descriptions, commit messages, code comments, branch
+names, test names, and test data. Refer to "a customer" and link the
+internal Linear issue instead.
+
 ## Conventions
 
 - **Rust style:**


### PR DESCRIPTION
## Proposed Changes

Add a guideline to `AGENTS.md` making explicit that customer and prospect
names must not appear in anything that lands on GitHub — PR titles and
descriptions, commit messages, code comments, branch names, test names, or
test data. Since this is a public repository, references should say
"a customer" and link the internal Linear issue instead.

`AGENTS.md` previously had no guidance on this.

## Release Notes

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
