### PR TITLE
docs(agents): don't link Slack threads in PR descriptions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,6 +162,10 @@ If so, add a `## Release Notes` section to the PR description describing the cha
 
 Update your branch against `main` by rebasing — never a merge commit.
 
+Don't link to Slack threads in PR descriptions — those links don't resolve for
+anyone outside the workspace. If a Linear issue tracks the work, link that
+instead.
+
 **Never mention customer names.** This is a public repository — keep
 customer and prospect names out of everything that lands on GitHub:
 PR titles and descriptions, commit messages, code comments, branch


### PR DESCRIPTION
## Summary
- Adds a short rule to `AGENTS.md`'s Pull Requests section: don't link Slack threads in PR descriptions, since they don't resolve for anyone outside the workspace. Link the tracking Linear issue instead when one exists.

Prompted by a team discussion in #pod-workflows about a PR that linked a Slack thread instead of the Linear issue tracking the same work.

## Test plan
- [x] Doc-only change, no code paths affected