### PR TITLE
fix(build/publish): Hint for managed envs

### DIFF
--- a/cli/flox/src/commands/build.rs
+++ b/cli/flox/src/commands/build.rs
@@ -39,7 +39,7 @@ use thiserror::Error;
 use tracing::{debug, instrument, trace};
 use url::Url;
 
-use super::{DirEnvironmentSelect, dir_environment_select};
+use super::{DirEnvironmentSelect, dir_environment_select, needs_project_files_error};
 use crate::utils::events::duration_to_ms;
 use crate::utils::message;
 use crate::{environment_subcommand_metric, subcommand_metric};
@@ -211,10 +211,11 @@ impl Build {
     async fn clean(flox: Flox, mut env: ConcreteEnvironment, packages: Vec<String>) -> Result<()> {
         match &env {
             ConcreteEnvironment::Path(_) => (),
-            ConcreteEnvironment::Managed(_) => {
-                bail!("Cannot build from an environment on FloxHub.")
+            ConcreteEnvironment::Managed(managed) => {
+                bail!(needs_project_files_error(managed, "build"))
             },
             ConcreteEnvironment::Remote(_) => {
+                // guarded by DirEnvironmentSelect
                 unreachable!("Cannot build from a remote environment")
             },
         };
@@ -259,10 +260,11 @@ impl Build {
     ) -> Result<()> {
         match &env {
             ConcreteEnvironment::Path(_) => (),
-            ConcreteEnvironment::Managed(_) => {
-                bail!("Cannot build from an environment on FloxHub.")
+            ConcreteEnvironment::Managed(managed) => {
+                bail!(needs_project_files_error(managed, "build"))
             },
             ConcreteEnvironment::Remote(_) => {
+                // guarded by DirEnvironmentSelect
                 unreachable!("Cannot build from a remote environment")
             },
         };
@@ -466,10 +468,11 @@ impl Build {
     ) -> Result<()> {
         match &env {
             ConcreteEnvironment::Path(_) => (),
-            ConcreteEnvironment::Managed(_) => {
-                bail!("Cannot import from nixpkgs in an environment on FloxHub.")
+            ConcreteEnvironment::Managed(managed) => {
+                bail!(needs_project_files_error(managed, "import"))
             },
             ConcreteEnvironment::Remote(_) => {
+                // guarded by DirEnvironmentSelect
                 unreachable!("Cannot import from nixpkgs in a remote environment")
             },
         };

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -48,6 +48,7 @@ use flox_rust_sdk::flox::{AuthContext, FLOX_VERSION, Flox, FloxhubTokenError};
 use flox_rust_sdk::models::env_registry;
 use flox_rust_sdk::models::env_registry::{ENV_REGISTRY_FILENAME, EnvRegistry};
 use flox_rust_sdk::models::environment::generations::GenerationId;
+use flox_rust_sdk::models::environment::managed_environment::ManagedEnvironment;
 use flox_rust_sdk::models::environment::remote_environment::RemoteEnvironment;
 use flox_rust_sdk::models::environment::{
     ConcreteEnvironment,
@@ -100,6 +101,29 @@ static FLOX_DESCRIPTION: &'_ str = indoc! {"
     With Flox you create environments that layer and replace dependencies just where it matters,
     making them portable across the full software lifecycle."
 };
+
+/// Error for the commands that need the whole project rather than just the
+/// environment, when the environment is linked to FloxHub. `action` is the
+/// verb the caller is refusing, e.g. "build".
+///
+/// `flox pull --copy` without an `<OWNER>/<NAME>` argument converts a
+/// ManagedEnvironment into a PathEnvironment in place.
+pub(crate) fn needs_project_files_error(env: &ManagedEnvironment, action: &str) -> String {
+    let pointer = env.pointer();
+    formatdoc! {"
+        Cannot {action} from an environment on FloxHub.
+
+        A pushed or pulled environment cannot be assumed to have its project files.
+        If this directory no longer needs to track FloxHub, disconnect it with:
+
+          flox pull --copy -d '{dir}'
+
+        The environment {owner}/{name} will remain available on FloxHub.",
+        owner = pointer.owner,
+        name = pointer.name,
+        dir = env.parent_path().expect(".flox is not '/'").display(),
+    }
+}
 
 fn vec_len<T>(x: Vec<T>) -> usize {
     Vec::len(&x)

--- a/cli/flox/src/commands/publish.rs
+++ b/cli/flox/src/commands/publish.rs
@@ -38,7 +38,7 @@ use crate::commands::build::{
     prefetch_flake_ref,
     system_override,
 };
-use crate::commands::{SHELL_COMPLETION_FILE, ensure_auth};
+use crate::commands::{SHELL_COMPLETION_FILE, ensure_auth, needs_project_files_error};
 use crate::utils::errors::display_chain;
 use crate::utils::events::env_detail_from_concrete;
 use crate::utils::message;
@@ -191,8 +191,8 @@ impl Publish {
         let env_detail = env_detail_from_concrete(&flox, &env);
         let path_env = match env {
             ConcreteEnvironment::Path(path_env) => path_env,
-            ConcreteEnvironment::Managed(_) => {
-                bail!("Cannot publish from an environment on FloxHub.")
+            ConcreteEnvironment::Managed(managed) => {
+                bail!(needs_project_files_error(&managed, "publish"))
             },
             ConcreteEnvironment::Remote(_) => {
                 // guarded by DirEnvironmentSelect


### PR DESCRIPTION
## Proposed Changes

Add an explanation of why `flox build` and `flox publish` aren't allowed from "managed" environments, hint at how the user might have ended up in that situation, and offer a possible solution.

A user recently reported that `flox build` had stopped working from a git committed "path" environment, which we believe was caused by `flox push` being run at an intervening time.

The same can also occur if you `flox pull` a "remote" environment into a "managed" environment. In both cases we can't guarantee that NEF expressions and other non-Flox project files that are required for build/publish will be present in the directory because they're not tracked by FloxHub generations.

Considerations from many rounds of iteration on the messaging:

- "pushed or pulled" indicate how they might have got here
- "project files" encompasses everything not tracked by generation
- "if no longer needs to track" caveats the solution
- re-assure that disconnecting won't delete from FloxHub

Out of scope:

- any form of environment "capabilities" like Yannik has been describing and like we have half-baked in `ServicsEnvironment` that would allow us to emit warnings in other places like `flox push` if an environment had builds defined
- product decision on whether we continue to support "managed" environments, which are this weird halfway house between "path" and "remote", in the future

## Release Notes

N/A, not worth mentioning