### PR TITLE
fix(publish): drop userinfo from the published remote URL (CLI-185)

### DIFF
--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -158,6 +158,10 @@ pub trait Publisher {
 }
 
 /// Simple struct to hold the information of a locked URL.
+///
+/// Built only by `gather_build_repo_meta`, so `url` has already been through
+/// `parse_publishable_remote_url`.
+#[allow(clippy::manual_non_exhaustive)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RemoteBuildRepoMetadata {
     pub url: Url,
@@ -165,6 +169,7 @@ pub struct RemoteBuildRepoMetadata {
     pub rev: String,
     pub rev_count: u64,
     pub rev_date: DateTime<Utc>,
+    _private: (),
 }
 
 /// Ensures that the required metadata for publishing is consistent from the environment
@@ -1210,26 +1215,31 @@ fn check_env_files_tracked(
     Ok(())
 }
 
-/// Parse a git remote URL into the form published to FloxHub, dropping the
+/// Parse a git remote URL into the form published to FloxHub, dropping any
 /// userinfo the URL type can address.
 ///
-/// The URL identifies the source repo; userinfo is not needed for that. The
-/// setters only ever remove, and they decline to act on URLs that cannot
-/// carry userinfo, so this never publishes more than it did before.
-///
 /// The username is kept for ssh-family schemes: there it is the login
-/// (`git@github.com`) and the URL does not clone without it. Telling a login
-/// from any other value would be a guess, and a wrong guess breaks
-/// publishing.
-fn parse_publishable_remote_url(raw: &str) -> Result<Url, PublishError> {
-    let mut url = GitUrl::parse_to_url(raw)
-        .map_err(|err| build_repo_err(&format!("Could not parse the remote URL: {err}")))?;
+/// (`git@github.com`) and the URL does not clone without it. A login and a
+/// token are indistinguishable in that position. `GitUrl::trim_auth` is no
+/// substitute because it drops the user too.
+///
+/// Not every credential is reachable. `parse_to_url` returns `git://` with no
+/// host, and a remote-helper address like `hg::https://…` as
+/// `ssh://hg/:https://…` with the credential in the path. Those still publish
+/// in full; `publish_url_still_carries_userinfo_for_shapes_the_parser_mangles`
+/// pins them. An ssh remote with no path panics inside the parser rather than
+/// returning an error.
+fn parse_publishable_remote_url(raw: &str, remote_name: &str) -> Result<Url, PublishError> {
+    let mut url = GitUrl::parse_to_url(raw).map_err(|err| {
+        build_repo_err(&format!(
+            "Could not parse the URL for remote '{remote_name}': {err}"
+        ))
+    })?;
 
     let _ = url.set_password(None);
-    // Exhaustive for the ssh family: the parser folds every lowercase
-    // ssh-bearing scheme to plain `ssh`, and `url` lowercases the rest, so a
-    // mixed-case `GIT+SSH://` arrives as one of these three. A substring test
-    // would also match `notssh` and friends and keep their username.
+    // Every ssh remote lands on one of these: the parser folds lowercase
+    // schemes containing "ssh" to plain `ssh`, and `url` lowercases the rest,
+    // so `GIT+SSH://` arrives as `git+ssh`.
     if !matches!(url.scheme(), "ssh" | "git+ssh" | "ssh+git") {
         let _ = url.set_username("");
     }
@@ -1319,7 +1329,7 @@ fn gather_build_repo_meta(
         }));
     }
 
-    let url = parse_publishable_remote_url(&remote_info.url)?;
+    let url = parse_publishable_remote_url(&remote_info.url, &remote_info.name)?;
 
     Ok(RemoteBuildRepoMetadata {
         url,
@@ -1327,14 +1337,14 @@ fn gather_build_repo_meta(
         rev_count: status.rev_count,
         rev_date: status.rev_date,
         ref_: remote_info.reference,
+        _private: (),
     })
 }
 
 // TODO: remove after discussion reg UX of this change.
 //
-// SECURITY: if re-enabled, route the return value through
-// `parse_publishable_remote_url`. It returns raw `git remote get-url` output,
-// which can carry a credential in its userinfo.
+// SECURITY: returns raw `git remote get-url` output, which can carry a
+// credential. If re-enabled, pass the result through `parse_publishable_remote_url`.
 #[allow(unused)]
 fn url_for_remote_containing_current_rev(
     git: &impl GitProvider,
@@ -2236,6 +2246,7 @@ pub mod tests {
                 ref_: "dummy".to_string(),
                 rev_count: 0,
                 rev_date: "2025-01-01T12:00:00Z".parse::<DateTime<Utc>>().unwrap(),
+                _private: (),
             },
 
             _private: (),
@@ -2914,12 +2925,20 @@ pub mod tests {
     /// Fails GitHub's token checksum, so no scanner mistakes it for live.
     const FAKE_TOKEN: &str = "ghs_EXAMPLEnotarealtoken0000000000000";
 
-    /// Asserted on the whole serialized URL; component-only assertions hid a
-    /// mangled path in an earlier revision.
+    /// Whole serialized URL, so a mangled path cannot hide behind a passing
+    /// component check.
     fn published(raw: &str) -> String {
-        parse_publishable_remote_url(raw)
+        parse_publishable_remote_url(raw, "origin")
             .unwrap_or_else(|e| panic!("refused {raw}: {e}"))
             .to_string()
+    }
+
+    /// The message shown when the parser will not accept a remote at all.
+    fn refused(raw: &str) -> String {
+        match parse_publishable_remote_url(raw, "origin") {
+            Ok(url) => panic!("expected {raw} to be refused, got {url}"),
+            Err(err) => err.to_string(),
+        }
     }
 
     #[test]
@@ -2947,9 +2966,8 @@ pub mod tests {
 
     #[test]
     fn publish_url_retains_any_ssh_username() {
-        // scp syntax normalizes to scheme ssh, so every username in that
-        // position is kept, not just a login. Unchanged from before; telling
-        // them apart would be a guess.
+        // scp syntax normalizes to scheme ssh, so any username in that
+        // position is kept; a login and a token look the same there.
         let raw = format!("{FAKE_TOKEN}@github.com:org/repo.git");
 
         assert_eq!(
@@ -2972,13 +2990,12 @@ pub mod tests {
                 "http://github.com/floxy/myrepo",
             ),
         ] {
-            assert_eq!(published(&raw), expected);
+            assert_eq!(published(&raw), expected, "for {raw}");
         }
     }
 
     #[test]
     fn publish_url_leaves_an_at_sign_in_the_path_alone() {
-        // `myprofile` in the codecommit form is an AWS CLI profile name.
         for (raw, expected) in [
             (
                 "/srv/git/team@acme/repo.git",
@@ -2992,12 +3009,8 @@ pub mod tests {
                 "https://github.com/o/r-with@sign.git",
                 "https://github.com/o/r-with@sign.git",
             ),
-            (
-                "codecommit::us-east-1://myprofile@myrepo",
-                "ssh://codecommit/:us-east-1://myprofile@myrepo",
-            ),
         ] {
-            assert_eq!(published(raw), expected);
+            assert_eq!(published(raw), expected, "for {raw}");
         }
     }
 
@@ -3026,28 +3039,79 @@ pub mod tests {
     }
 
     #[test]
-    fn publish_url_passes_through_shapes_the_parser_mangles() {
-        // These come back re-spelled, with the original address in the path or
-        // with no host at all, so the URL type has no userinfo to address and
-        // the setters decline. Returned exactly as before this change.
-        for raw in [
-            format!("hg::https://x-access-token:{FAKE_TOKEN}@bitbucket.org/o/r"),
-            format!("git://x-access-token:{FAKE_TOKEN}@corp.example/o/r"),
-            "codecommit::us-east-1://myprofile@myrepo".to_string(),
+    fn publish_url_still_carries_userinfo_for_shapes_the_parser_mangles() {
+        // These shapes still ship the credential: the parser moves it into the
+        // path or drops the host, out of the setters' reach. Expected values
+        // are literals so a parser change fails here rather than moving both
+        // sides of the comparison.
+        for (raw, expected) in [
+            (
+                format!("git://x-access-token:{FAKE_TOKEN}@corp.example/o/r"),
+                format!("git:////x-access-token:{FAKE_TOKEN}@corp.example/o/r"),
+            ),
+            (
+                format!("hg::https://x-access-token:{FAKE_TOKEN}@bitbucket.org/o/r"),
+                format!("ssh://hg/:https://x-access-token:{FAKE_TOKEN}@bitbucket.org/o/r"),
+            ),
+            (
+                format!("codecommit::us-east-1://{FAKE_TOKEN}@myrepo"),
+                format!("ssh://codecommit/:us-east-1://{FAKE_TOKEN}@myrepo"),
+            ),
         ] {
-            assert_eq!(
-                published(&raw),
-                GitUrl::parse_to_url(&raw).unwrap().to_string()
+            assert_eq!(published(&raw), expected, "for {raw}");
+            assert!(
+                published(&raw).contains(FAKE_TOKEN),
+                "this test exists to pin that the token still ships: {raw}"
             );
         }
     }
 
     #[test]
+    fn publish_url_refuses_remotes_the_parser_rejects() {
+        // Pre-existing refusals, including Azure DevOps' documented PAT form.
+        // Pinned so a parser that starts accepting one cannot slip it through
+        // the strip untested.
+        for raw in [
+            format!("https://:{FAKE_TOKEN}@dev.azure.com/org/proj/_git/repo"),
+            "https://user:@github.com/o/r.git".to_string(),
+            "https://user%40corp:p%40ss@github.com/o/r.git".to_string(),
+        ] {
+            assert_eq!(
+                refused(&raw),
+                "The environment is in an unsupported state for publishing: \
+                 Could not parse the URL for remote 'origin': Git Url must have a path",
+                "for {raw}"
+            );
+            assert!(
+                !refused(&raw).contains(FAKE_TOKEN),
+                "token echoed for {raw}"
+            );
+        }
+
+        let percent_encoded = "https://x-access-token:tok%2Fen@github.com/o/r";
+        assert_eq!(
+            refused(percent_encoded),
+            "The environment is in an unsupported state for publishing: \
+             Could not parse the URL for remote 'origin': Invalid port number"
+        );
+    }
+
+    #[test]
+    fn publish_url_refusal_names_the_remote_and_not_the_url() {
+        // Echoing the URL would put the credential in the error.
+        let raw = format!("https://:{FAKE_TOKEN}@dev.azure.com/org/proj/_git/repo");
+        let message = parse_publishable_remote_url(&raw, "upstream")
+            .unwrap_err()
+            .to_string();
+
+        assert!(message.contains("remote 'upstream'"), "{message}");
+        assert!(!message.contains(FAKE_TOKEN), "{message}");
+    }
+
+    #[test]
     fn publish_url_covers_every_known_remote_shape() {
-        // One table, exact expected output per shape, so any change in
-        // behaviour shows up here rather than in a property that happens to
-        // stay true. Rows that keep their userinfo are the documented
-        // pass-throughs: the parser leaves them with nothing addressable.
+        // Exact expected output per shape. Rows that keep their userinfo are
+        // the documented pass-throughs.
         for (raw, expected) in [
             (
                 format!("https://x-access-token:{FAKE_TOKEN}@github.com/o/r"),
@@ -3087,8 +3151,8 @@ pub mod tests {
                 format!("GIT+SSH://user:{FAKE_TOKEN}@github.com/o/r.git"),
                 "git+ssh://user@github.com/o/r.git".to_string(),
             ),
-            // Schemes that merely contain "ssh" are not ssh: a substring test
-            // would keep these usernames.
+            // Uppercase schemes that merely contain "ssh" are not ssh, and
+            // the parser leaves them alone, so the exact match strips them.
             (
                 format!("NOTSSH://user:{FAKE_TOKEN}@host/o/r"),
                 "notssh://host/o/r".to_string(),
@@ -3096,6 +3160,16 @@ pub mod tests {
             (
                 format!("SSH-TUNNEL://user:{FAKE_TOKEN}@host/o/r"),
                 "ssh-tunnel://host/o/r".to_string(),
+            ),
+            // Lowercase, the parser folds these to `ssh` before the match runs,
+            // so they keep their username under any test.
+            (
+                format!("notssh://{FAKE_TOKEN}@host/o/r"),
+                format!("ssh://{FAKE_TOKEN}@host/o/r"),
+            ),
+            (
+                format!("ssh-tunnel://{FAKE_TOKEN}@host/o/r"),
+                format!("ssh://{FAKE_TOKEN}@host/o/r"),
             ),
             (
                 format!("{FAKE_TOKEN}@github.com:o/r.git"),
@@ -3120,6 +3194,16 @@ pub mod tests {
             (
                 format!("https://user:{FAKE_TOKEN}@git.example.com:8443/o/r"),
                 "https://git.example.com:8443//o/r".to_string(),
+            ),
+            // An `@` inside the password is not a second delimiter.
+            (
+                "https://user:tok@en@github.com/o/r".to_string(),
+                "https://github.com/o/r".to_string(),
+            ),
+            // Gerrit needs the https username to clone; dropping it is intended.
+            (
+                "https://user@gerrit.example.com/a/project".to_string(),
+                "https://gerrit.example.com/a/project".to_string(),
             ),
         ] {
             assert_eq!(published(&raw), expected, "for {raw}");

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -1210,6 +1210,33 @@ fn check_env_files_tracked(
     Ok(())
 }
 
+/// Parse a git remote URL into the form published to FloxHub, dropping the
+/// userinfo the URL type can address.
+///
+/// The URL identifies the source repo; userinfo is not needed for that. The
+/// setters only ever remove, and they decline to act on URLs that cannot
+/// carry userinfo, so this never publishes more than it did before.
+///
+/// The username is kept for ssh-family schemes: there it is the login
+/// (`git@github.com`) and the URL does not clone without it. Telling a login
+/// from any other value would be a guess, and a wrong guess breaks
+/// publishing.
+fn parse_publishable_remote_url(raw: &str) -> Result<Url, PublishError> {
+    let mut url = GitUrl::parse_to_url(raw)
+        .map_err(|err| build_repo_err(&format!("Could not parse the remote URL: {err}")))?;
+
+    let _ = url.set_password(None);
+    // Exhaustive for the ssh family: the parser folds every lowercase
+    // ssh-bearing scheme to plain `ssh`, and `url` lowercases the rest, so a
+    // mixed-case `GIT+SSH://` arrives as one of these three. A substring test
+    // would also match `notssh` and friends and keep their username.
+    if !matches!(url.scheme(), "ssh" | "git+ssh" | "ssh+git") {
+        let _ = url.set_username("");
+    }
+
+    Ok(url)
+}
+
 /// Check the local repo that the build source is in to make sure that it's in
 /// a state amenable to publishing an artifact built from it.
 ///
@@ -1292,8 +1319,7 @@ fn gather_build_repo_meta(
         }));
     }
 
-    let url =
-        GitUrl::parse_to_url(&remote_info.url).map_err(|err| build_repo_err(&err.to_string()))?;
+    let url = parse_publishable_remote_url(&remote_info.url)?;
 
     Ok(RemoteBuildRepoMetadata {
         url,
@@ -1305,6 +1331,10 @@ fn gather_build_repo_meta(
 }
 
 // TODO: remove after discussion reg UX of this change.
+//
+// SECURITY: if re-enabled, route the return value through
+// `parse_publishable_remote_url`. It returns raw `git remote get-url` output,
+// which can carry a credential in its userinfo.
 #[allow(unused)]
 fn url_for_remote_containing_current_rev(
     git: &impl GitProvider,
@@ -2877,6 +2907,223 @@ pub mod tests {
                 "404 Not Found: The package with name {recording_name} in catalog {user_handle} was not found"
             )
         );
+    }
+
+    // ---- published remote URL ----
+
+    /// Fails GitHub's token checksum, so no scanner mistakes it for live.
+    const FAKE_TOKEN: &str = "ghs_EXAMPLEnotarealtoken0000000000000";
+
+    /// Asserted on the whole serialized URL; component-only assertions hid a
+    /// mangled path in an earlier revision.
+    fn published(raw: &str) -> String {
+        parse_publishable_remote_url(raw)
+            .unwrap_or_else(|e| panic!("refused {raw}: {e}"))
+            .to_string()
+    }
+
+    #[test]
+    fn publish_url_drops_user_and_password() {
+        let raw = format!("https://x-access-token:{FAKE_TOKEN}@github.com/floxy/myrepo");
+
+        assert_eq!(published(&raw), "https://github.com/floxy/myrepo");
+    }
+
+    #[test]
+    fn publish_url_drops_a_username_with_no_password() {
+        let raw = format!("https://{FAKE_TOKEN}@github.com/floxy/myrepo");
+
+        assert_eq!(published(&raw), "https://github.com/floxy/myrepo");
+    }
+
+    #[test]
+    fn publish_url_keeps_the_ssh_login() {
+        // The URL does not clone without it.
+        assert_eq!(
+            published("git@github.com:floxy/myrepo.git"),
+            "ssh://git@github.com/floxy/myrepo.git"
+        );
+    }
+
+    #[test]
+    fn publish_url_retains_any_ssh_username() {
+        // scp syntax normalizes to scheme ssh, so every username in that
+        // position is kept, not just a login. Unchanged from before; telling
+        // them apart would be a guess.
+        let raw = format!("{FAKE_TOKEN}@github.com:org/repo.git");
+
+        assert_eq!(
+            published(&raw),
+            format!("ssh://{FAKE_TOKEN}@github.com/org/repo.git")
+        );
+    }
+
+    #[test]
+    fn publish_url_drops_userinfo_from_http_like_schemes() {
+        // `git remote get-url` returns whatever is in .git/config, so the
+        // scheme is not limited to https.
+        for (raw, expected) in [
+            (
+                format!("git+https://x-access-token:{FAKE_TOKEN}@github.com/floxy/myrepo"),
+                "git+https://github.com/floxy/myrepo",
+            ),
+            (
+                format!("http://x-access-token:{FAKE_TOKEN}@github.com/floxy/myrepo"),
+                "http://github.com/floxy/myrepo",
+            ),
+        ] {
+            assert_eq!(published(&raw), expected);
+        }
+    }
+
+    #[test]
+    fn publish_url_leaves_an_at_sign_in_the_path_alone() {
+        // `myprofile` in the codecommit form is an AWS CLI profile name.
+        for (raw, expected) in [
+            (
+                "/srv/git/team@acme/repo.git",
+                "file:///srv/git/team@acme/repo.git",
+            ),
+            (
+                "file:///srv/git/team@acme/repo.git",
+                "file:///srv/git/team@acme/repo.git",
+            ),
+            (
+                "https://github.com/o/r-with@sign.git",
+                "https://github.com/o/r-with@sign.git",
+            ),
+            (
+                "codecommit::us-east-1://myprofile@myrepo",
+                "ssh://codecommit/:us-east-1://myprofile@myrepo",
+            ),
+        ] {
+            assert_eq!(published(raw), expected);
+        }
+    }
+
+    #[test]
+    fn publish_url_leaves_a_clean_url_untouched() {
+        assert_eq!(
+            published("https://github.com/floxy/myrepo"),
+            "https://github.com/floxy/myrepo"
+        );
+    }
+
+    #[test]
+    fn publish_url_accepts_a_local_file_remote() {
+        // The test harness uses file:// remotes throughout.
+        assert_eq!(published("file:///home/me/repo"), "file:///home/me/repo");
+    }
+
+    #[test]
+    fn publish_url_preserves_scheme_host_port_and_path() {
+        // The doubled segment comes from the URL parser and predates this
+        // change; pinned so a future change to normalization is visible.
+        assert_eq!(
+            published("https://git.example.com:8443/o/r"),
+            "https://git.example.com:8443//o/r"
+        );
+    }
+
+    #[test]
+    fn publish_url_passes_through_shapes_the_parser_mangles() {
+        // These come back re-spelled, with the original address in the path or
+        // with no host at all, so the URL type has no userinfo to address and
+        // the setters decline. Returned exactly as before this change.
+        for raw in [
+            format!("hg::https://x-access-token:{FAKE_TOKEN}@bitbucket.org/o/r"),
+            format!("git://x-access-token:{FAKE_TOKEN}@corp.example/o/r"),
+            "codecommit::us-east-1://myprofile@myrepo".to_string(),
+        ] {
+            assert_eq!(
+                published(&raw),
+                GitUrl::parse_to_url(&raw).unwrap().to_string()
+            );
+        }
+    }
+
+    #[test]
+    fn publish_url_covers_every_known_remote_shape() {
+        // One table, exact expected output per shape, so any change in
+        // behaviour shows up here rather than in a property that happens to
+        // stay true. Rows that keep their userinfo are the documented
+        // pass-throughs: the parser leaves them with nothing addressable.
+        for (raw, expected) in [
+            (
+                format!("https://x-access-token:{FAKE_TOKEN}@github.com/o/r"),
+                "https://github.com/o/r".to_string(),
+            ),
+            (
+                format!("https://{FAKE_TOKEN}@github.com/o/r"),
+                "https://github.com/o/r".to_string(),
+            ),
+            (
+                format!("http://x-access-token:{FAKE_TOKEN}@github.com/o/r"),
+                "http://github.com/o/r".to_string(),
+            ),
+            (
+                format!("git+https://x-access-token:{FAKE_TOKEN}@github.com/o/r"),
+                "git+https://github.com/o/r".to_string(),
+            ),
+            (
+                "git@github.com:o/r.git".to_string(),
+                "ssh://git@github.com/o/r.git".to_string(),
+            ),
+            (
+                "git+ssh://git@github.com/o/r.git".to_string(),
+                "ssh://git@github.com/o/r.git".to_string(),
+            ),
+            (
+                "GIT+SSH://git@github.com/o/r.git".to_string(),
+                "git+ssh://git@github.com/o/r.git".to_string(),
+            ),
+            (
+                "SSH+GIT://git@github.com/o/r.git".to_string(),
+                "ssh+git://git@github.com/o/r.git".to_string(),
+            ),
+            // A compound ssh scheme still loses its password; only the login
+            // position is kept.
+            (
+                format!("GIT+SSH://user:{FAKE_TOKEN}@github.com/o/r.git"),
+                "git+ssh://user@github.com/o/r.git".to_string(),
+            ),
+            // Schemes that merely contain "ssh" are not ssh: a substring test
+            // would keep these usernames.
+            (
+                format!("NOTSSH://user:{FAKE_TOKEN}@host/o/r"),
+                "notssh://host/o/r".to_string(),
+            ),
+            (
+                format!("SSH-TUNNEL://user:{FAKE_TOKEN}@host/o/r"),
+                "ssh-tunnel://host/o/r".to_string(),
+            ),
+            (
+                format!("{FAKE_TOKEN}@github.com:o/r.git"),
+                format!("ssh://{FAKE_TOKEN}@github.com/o/r.git"),
+            ),
+            (
+                "https://github.com/o/r".to_string(),
+                "https://github.com/o/r".to_string(),
+            ),
+            (
+                "https://github.com/o/r-with@sign.git".to_string(),
+                "https://github.com/o/r-with@sign.git".to_string(),
+            ),
+            (
+                "file:///srv/git/team@acme/repo.git".to_string(),
+                "file:///srv/git/team@acme/repo.git".to_string(),
+            ),
+            (
+                "https://git.example.com:8443/o/r".to_string(),
+                "https://git.example.com:8443//o/r".to_string(),
+            ),
+            (
+                format!("https://user:{FAKE_TOKEN}@git.example.com:8443/o/r"),
+                "https://git.example.com:8443//o/r".to_string(),
+            ),
+        ] {
+            assert_eq!(published(&raw), expected, "for {raw}");
+        }
     }
 
     // ---- gather_build_repo_meta error differentiation tests ----


### PR DESCRIPTION
## Proposed Changes

`flox publish` sent the git remote URL exactly as `git remote get-url` returns it. Some CI setups and `gh auth setup-git` configure remotes as `https://<user>:<token>@host/owner/repo`, so that userinfo was transmitted with every publish and retained by whatever consumed it.

The URL identifies the source repo, and `https://host/owner/repo` does that. The userinfo is not needed for it, so it is dropped at the single point where the remote URL is parsed, before it reaches any consumer.

Resolves CLI-185.

### The strip is two setters, nothing more

`url::Url`'s `set_password`/`set_username` only ever remove, so the output is never broader than what the parser produced. No predicate, no matching against credential shapes, no new refusals.

That does not make it complete. `GitUrl::parse_to_url` re-spells some addresses before the setters see them, and for those there is nothing in the userinfo position to remove:

* `git://user:secret@host/o/r` comes back with **no host**; both setters return `Err` and the credential stays in the path.
* Remote-helper addresses (`hg::https://user:secret@host/o/r`, `codecommit::…`) come back as `ssh://hg/:https://user:secret@host/o/r` — a real host (`hg`), an empty userinfo, and the whole original address in the path. The setters succeed and remove nothing.

Same outcome either way: **those three shapes still publish the credential in full**, exactly as before this change. They are pinned by exact expected output in `publish_url_still_carries_userinfo_for_shapes_the_parser_mangles`, with an explicit assertion that the token is present, so the gap is a documented boundary rather than a silent one. Closing it needs a parser that models git remote addresses faithfully — worth doing on its own, not against a freeze.

An earlier revision gated the strip on a predicate. It changed the output for exactly one input class, and there it suppressed a correct strip, so it was deleted. Three earlier designs failed in ways this one avoids: a post-state check on `username()`/`password()` (which report empty in exactly the cases that matter); an `@`-count over the serialized URL (which rejected legitimate paths like `team@acme`); and a component rebuild plus a path guard (which over-fired on ported remotes). `GitUrl::trim_auth()` was also rejected: it nulls the user along with the password, which destroys the ssh login.

### The username is kept for ssh-family schemes

There it is the login (`git@github.com`) and the URL does not clone without it. The check is `matches!(url.scheme(), "ssh" | "git+ssh" | "ssh+git")`. That set is exhaustive for real ssh remotes however they were spelled: the parser folds any lowercase scheme containing `ssh` down to plain `ssh`, and `url` lowercases the rest, so a mixed-case `GIT+SSH://` arrives as `git+ssh`.

The exact match rather than a substring test is what keeps the username out of an uppercase `NOTSSH://` or `SSH-TUNNEL://` remote. It does **not** save the lowercase spellings: the parser has already folded `notssh://` to `ssh` before the match runs, and it keeps its username under either test. Both spellings are in the table so the boundary is visible. No real git scheme lands on the wrong side.

That keeps any other value in the login position too, since scp syntax normalizes to scheme `ssh` — telling a login from anything else would be a guess, and a wrong guess breaks publishing for every ssh remote.

### What changes and what does not

| Remote | Before | After |
|---|---|---|
| `https://user:secret@host/o/r` | sent as-is | **userinfo dropped** |
| `https://secret@host/o/r` | sent as-is | **userinfo dropped** |
| `https://user@gerrit.example.com/a/project` | sent as-is | **username dropped** (see rebuild note below) |
| `git@github.com:o/r.git` | sent as-is | unchanged (login kept) |
| `<anything>@github.com:o/r.git` | sent as-is | unchanged (scp → ssh) |
| `GIT+SSH://git@host/o/r` | sent as-is | unchanged (login kept) |
| `git://user:secret@host/o/r` | sent as-is | **unchanged — credential still sent** (no host to address) |
| remote-helper (`hg::…`, `codecommit::…`) | sent as-is | **unchanged — credential still sent** (address moved to path) |
| `https://github.com/o/r-with@sign.git` | sent as-is | unchanged |
| `file:///srv/git/team@acme/repo.git` | sent as-is | unchanged |

Every row, including the pass-throughs, is pinned by exact expected output, so the boundary is documented rather than assumed.

Userinfo can also still reach the terminal and CI logs by other paths (git prints the username position in its own diagnostics, and a clone URL appears in argv under `-vv`); that is a separate change, deliberately not folded in here after review showed it to be broader than one function.

### Smaller changes in the same diff

* When the parser refuses a remote, the error now names the remote (`Could not parse the URL for remote 'origin': …`) rather than the URL, so it is diagnosable without echoing a credential. `GitUrlParseError` has two input-bearing variants (`NomParseError`, `ProviderParseFail`), but neither is reachable through `parse_to_url`, which swallows the nom failure. That is a property of the dependency, not the type, so `publish_url_refuses_remotes_the_parser_rejects` pins no-token-in-error across every refused shape and fails if a bump surfaces one.
* `RemoteBuildRepoMetadata` gains the `_private: ()` marker its sibling types already carry, so it can only be built inside the module — that is, by `gather_build_repo_meta`, after sanitisation. It closes the construction hole rather than relying on a comment.
* The disabled `url_for_remote_containing_current_rev` returns raw `git remote get-url` output and would bypass that path if re-enabled. It now carries a `SECURITY:` note saying so. It is kept (with its seven tests) because it encodes a remote-preference policy that is still pending a UX decision; deleting it is that decision, not this PR's.

## Test plan

Thirteen tests, all asserting the **whole serialized URL** through shared helpers — component-only assertions hid a mangled path in an earlier revision.

`publish_url_covers_every_known_remote_shape` is a table of exact expected output for twenty-one shapes: every row of the table above, plus the ssh-family scheme spellings, both cases of the pseudo-ssh schemes, an `@` inside a password, and a ported URL carrying userinfo. An earlier revision used a property assertion here instead; it turned out to be unconditionally true, so it could not have caught a regression. The table can.

`publish_url_still_carries_userinfo_for_shapes_the_parser_mangles` pins the three uncovered shapes with literal expected strings. An earlier revision derived the expected value from the parser itself, which moved both sides of the comparison together on a dependency bump; the literals do not.

`publish_url_refuses_remotes_the_parser_rejects` pins four shapes the parser rejects outright, including Azure DevOps' documented `https://:<PAT>@dev.azure.com/…` form. Pre-existing refusals, none introduced here — but they are the highest-stakes inputs, and without this a dependency bump that started accepting one would run it through the strip untested.

Verified in `nix develop`:

* `cargo nextest --profile ci run -p flox-rust-sdk -E 'test(providers::publish)'` — **48/48 pass**
* `cargo clippy -p flox-rust-sdk --all-targets` — zero warnings
* `cargo fmt --check` — clean
* Mutation-verified: skipping the password strip, inverting the ssh carve-out, and swapping the exact scheme match for a `contains("ssh")` substring test each fail tests. The last is caught by the table's uppercase `NOTSSH://` rows.

The publish suite is flaky on macOS: a leaked subprocess handle in one of the git-fixture tests, a different test failing per run, and `main` reproduces it identically. It shows under `cargo nextest` as well as `cargo test`, less often. The thirteen URL tests are pure and passed in every run.

## Release Notes

`flox publish` no longer sends the user and password portion of an http(s) git remote URL, or the password portion of an ssh one. Where a remote is configured as `https://<user>:<token>@host/owner/repo`, only `https://host/owner/repo` is sent; the repository is identified the same way. ssh remotes keep their login (`git@github.com`) and are otherwise unaffected.

This does not cover every remote shape. A credential in a `git://` remote, or in a remote-helper address such as `hg::https://…` or `codecommit::…`, is still sent in full. If a token is configured in one of those, it will continue to be recorded until a follow-up lands.

Source URLs recorded by publishes made **before** this release may include userinfo for any shape. If a token was configured in a remote, rotate it.

## Coordination before merge

* **Server-side normalisation should land first or alongside**, not after. While older clients remain in the fleet — CI images pin versions for months — the same repo keeps being recorded under two different URL strings depending on which client ran. Normalising on receipt makes client adoption irrelevant, and it needs a pass over already-stored values; changing what is sent does not change what is stored.
* **One redundant publish per package at cutover.** The dedup pre-check matches the source URL by exact string, so a package recorded under the old URL misses once. This is a net improvement: short-lived CI tokens meant every CI publish already produced a distinct URL, so that pre-check could never match from CI in the first place.
* **Sign-off needed on rebuild behaviour.** The recorded URL is what the build coordinator clones, and it has no credential of its own. Rebuilds of private repos that currently succeed on a long-lived token will stop. The same applies to Gerrit-style `https://user@host/a/project` remotes, where the username is required to clone and is now dropped. That is the intended outcome, but it should be a decision rather than a discovery. Tracked separately.
* The three points above are platform-side claims about how the stored URL is matched and consumed. Nothing in this PR verifies them; they need FloxHub-side confirmation rather than acceptance from this description.

## Follow-ups (not in this PR)

* **The URL parser panics rather than erroring on an ssh remote with an empty path** — `ssh://host`, `ssh://git@host`, and any IPv6-literal form (`ssh://git@[::1]/repo.git`, with or without a port). The doc comment on `parse_publishable_remote_url` implies parse failures return `PublishError`; for these it aborts. Pre-existing, `main` panics identically. A missing path is a far more ordinary misconfiguration than an IPv6 literal.
* Ported http(s) remotes get a doubled path segment from the parser — pre-existing; now pinned by a test so a future change to normalisation is visible.
* `original_url` on the create-package call is a deprecated field the server never reads; it should stop being sent.
* The three parser-mangled shapes that still carry a credential need a faithful git-remote parser to fix, not a wider strip here.

