### PR TITLE
fix(buildenv): Clearer errors for package and output conflicts

### DIFF
--- a/buildenv/builder.pl
+++ b/buildenv/builder.pl
@@ -33,6 +33,14 @@ my $FLOX_RECURSIVE_LINK = 0;
 # it is incremented for each propagated package to prevent collisions between them, and
 # starting at 1000 ensures that they have lower priority than explicitly installed packages.
 my $ignoreCollisionCounter = 0;
+
+# Maps the store path of each installed output to the install ID that pulled
+# it in. Nixpkgs pnames routinely differ from the install ID the user typed
+# ("nodejs_24" installs a "nodejs" derivation, "make" installs "gnumake"), and
+# only the install ID is meaningful to the rest of Flox, so collision messages
+# name packages from this map. Packages that Flox installs itself, such as the
+# interpreter, have no install ID and are absent.
+my %installIdByStorePath;
 # </flox>
 
 my $out = $ENV{"out"};
@@ -137,7 +145,9 @@ sub prependDangling {
 }
 
 # Parses a /nix/store/<checksum>-<name>-<version>/<basename> path and
-# returns its constituent (name, version, basename) parts.
+# returns its constituent (name, version, basename) parts, followed by the
+# "/nix/store/<checksum>-<name>-<version>" prefix itself so that callers can
+# identify which installed output the path belongs to.
 sub parseStorePath($) {
     my $path = shift;
     # Split the path into its components.
@@ -158,7 +168,7 @@ sub parseStorePath($) {
     my $name = shift @pkgParts;
     my $version = shift @pkgParts;
     my $basename = join "/", @path;
-    return ($name, $version, $basename);
+    return ($name, $version, $basename, $storePath);
 }
 
 # Given a parsed version string (the 2nd element of parseStorePath's
@@ -260,20 +270,34 @@ sub findFiles {
             return;
         } else {
             # Improve upon the default collision message from upstream.
-            my ($targetName, $targetVersion, $targetBasename) = parseStorePath($target);
-            my ($oldTargetName, $oldTargetVersion, $oldTargetBasename) = parseStorePath($oldTarget);
+            my ($targetName, $targetVersion, $targetBasename, $targetStorePath) =
+                parseStorePath($target);
+            my ($oldTargetName, $oldTargetVersion, $oldTargetBasename, $oldTargetStorePath) =
+                parseStorePath($oldTarget);
+            my $installId = $installIdByStorePath{$targetStorePath};
+            my $oldInstallId = $installIdByStorePath{$oldTargetStorePath};
+            # Fall back to the store path name for packages that Flox installs
+            # itself, which the user cannot refer to by any other name either.
+            my $name = $installId // $targetName;
+            my $oldName = $oldInstallId // $oldTargetName;
             my $errmsg;
-            if ($targetName eq $oldTargetName) {
+            # Equal install IDs can only mean two outputs of one entry in
+            # `[install]`. Every other pairing is two distinct packages, even
+            # when they are built from the same derivation name.
+            if (defined $installId && defined $oldInstallId && $installId eq $oldInstallId) {
                 my $oldOutput = parseOutputFromVersion($oldTargetVersion);
                 my $newOutput = parseOutputFromVersion($targetVersion);
+                # Two outputs can parse to the same name, because the version
+                # they are parsed out of may end in a digit group of its own.
+                # Naming neither beats naming both of them wrongly.
                 if ($oldOutput ne $newOutput) {
-                    $errmsg = "'$oldTargetName ($oldOutput)' conflicts with "
-                            . "'$targetName ($newOutput)'. ";
+                    $errmsg = "'$oldName ($oldOutput)' conflicts with "
+                            . "'$name ($newOutput)'. ";
                 } else {
-                    $errmsg = "'$oldTargetName' conflicts with '$targetName'. ";
+                    $errmsg = "'$oldName' conflicts with '$name'. ";
                 }
             } else {
-                $errmsg = "'$oldTargetName' conflicts with '$targetName'. ";
+                $errmsg = "'$oldName' conflicts with '$name'. ";
             }
             if ($targetBasename eq $oldTargetBasename) {
                 $errmsg .= "Both packages provide the file '$targetBasename'";
@@ -537,7 +561,8 @@ if ($manifest) {
                 if (defined $package->{"store_path"}) {
                     push @retarray, {
                         "paths" => [ $package->{"store_path"} ],
-                        "priority" => $package->{"priority"}
+                        "priority" => $package->{"priority"},
+                        "install_id" => $package->{"install_id"}
                     };
                     next;
                 }
@@ -593,7 +618,8 @@ if ($manifest) {
                     if (scalar @outputsToInstallPaths) {
                         push @retarray, {
                             "paths" => \@outputsToInstallPaths,
-                            "priority" => $package->{"priority"}
+                            "priority" => $package->{"priority"},
+                            "install_id" => $package->{"install_id"}
                         };
                     }
 
@@ -603,7 +629,8 @@ if ($manifest) {
                     foreach my $otherPath (@otherOutputPaths) {
                         push @retarray, {
                             "paths" => [ $otherPath ],
-                            "priority" => ((1000 * $package->{"priority"}) + $ignoreCollisionCounter++)
+                            "priority" => ((1000 * $package->{"priority"}) + $ignoreCollisionCounter++),
+                            "install_id" => $package->{"install_id"}
                         };
                     }
                 } elsif (exists $manifest->{"schema-version"}) {
@@ -616,7 +643,8 @@ if ($manifest) {
                     foreach my $path (@paths) {
                         push @retarray, {
                             "paths" => [ $path ],
-                            "priority" => $package->{"priority"}
+                            "priority" => $package->{"priority"},
+                            "install_id" => $package->{"install_id"}
                         };
                     }
                 } elsif (exists $manifest->{"schema-version"}) {
@@ -798,6 +826,13 @@ if ($manifest) {
         # user.
         for my $pkg (@{$pkgs}) {
             for my $path (sort byPackageName @{$pkg->{paths}}) {
+                # First write wins, matching `addPkg`, which links the first
+                # copy of a store path and skips the rest via `%done`. Two
+                # install IDs resolve to one store path when the same package
+                # is installed twice, and a collision has to name the ID whose
+                # copy was linked.
+                $installIdByStorePath{$path} //= $pkg->{install_id}
+                    if defined $pkg->{install_id};
                 addPkg($path,
                        $ENV{"ignoreCollisions"} eq "1",
                        $ENV{"checkCollisionContents"} eq "1",
@@ -970,6 +1005,7 @@ if ($manifest) {
         %postponed = ();
         %symlinks = ();
         %seen = ();
+        %installIdByStorePath = ();
         my $envName = $output->{"name"};
 
         my $path = $nix_attrs->{"outputs"}{$envName};

--- a/buildenv/builder.pl
+++ b/buildenv/builder.pl
@@ -41,6 +41,15 @@ my $ignoreCollisionCounter = 0;
 # name packages from this map. Packages that Flox installs itself, such as the
 # interpreter, have no install ID and are absent.
 my %installIdByStorePath;
+
+# Maps the store path of each installed output to the name of that output.
+# A store path spells its output as a trailing "-<output>" that cannot be told
+# apart from the tail of a version: "re2-2024-07-02-dev" and "hello-1.0-rc1"
+# have the same shape. Only the lockfile names outputs unambiguously, so
+# collision messages take them from this map. Filled in alongside
+# %installIdByStorePath, and likewise absent for anything installed by store
+# path or by Flox itself, neither of which the user selects by output.
+my %outputByStorePath;
 # </flox>
 
 my $out = $ENV{"out"};
@@ -171,34 +180,6 @@ sub parseStorePath($) {
     return ($name, $version, $basename, $storePath);
 }
 
-# Given a parsed version string (the 2nd element of parseStorePath's
-# return tuple), return the Nix output name encoded as a trailing
-# "-<output>" suffix, or "out" if no such suffix is present.
-#
-# parseStorePath splits the package-name-version on /-(?=\d)/, so for
-# a multi-output store path like ".../<hash>-kitty-0.47.4-kitten" the
-# returned version is "0.47.4-kitten" — the output suffix lands
-# inside the version field. An output name in Nixpkgs convention
-# starts with a lowercase letter and contains only alphanumeric or
-# underscore characters (e.g. "out", "dev", "lib", "kitten",
-# "shell_integration", "lib32"). It never contains a "." or "-",
-# which is how we distinguish it from a trailing version qualifier
-# such as "rc1" or "1.0.0-final".
-#
-# Common version qualifiers that would otherwise satisfy the shape
-# rule (rc, alpha, beta, pre, final, nightly, stable) are denied
-# explicitly to avoid rendering "1.0.0-alpha" as output "alpha".
-sub parseOutputFromVersion {
-    my $version = shift;
-    return "out" unless defined $version && $version =~ /-/;
-    my @parts = split /-/, $version;
-    my $last = $parts[-1];
-    return "out" unless $last =~ /^[a-z][a-zA-Z0-9_]*$/;
-    return "out" if $last =~
-        /^(rc|alpha|beta|pre|final|nightly|stable|snapshot|dirty)\d*$/i;
-    return $last;
-}
-
 sub findFiles {
     my ($relName, $target, $baseName, $ignoreCollisions, $checkCollisionContents, $priority) = @_;
 
@@ -270,10 +251,12 @@ sub findFiles {
             return;
         } else {
             # Improve upon the default collision message from upstream.
-            my ($targetName, $targetVersion, $targetBasename, $targetStorePath) =
-                parseStorePath($target);
-            my ($oldTargetName, $oldTargetVersion, $oldTargetBasename, $oldTargetStorePath) =
-                parseStorePath($oldTarget);
+            # Skips the version, the 2nd element of the tuple, which names
+            # neither the package nor the output.
+            my ($targetName, $targetBasename, $targetStorePath) =
+                (parseStorePath($target))[0, 2, 3];
+            my ($oldTargetName, $oldTargetBasename, $oldTargetStorePath) =
+                (parseStorePath($oldTarget))[0, 2, 3];
             my $installId = $installIdByStorePath{$targetStorePath};
             my $oldInstallId = $installIdByStorePath{$oldTargetStorePath};
             # Fall back to the store path name for packages that Flox installs
@@ -282,20 +265,15 @@ sub findFiles {
             my $oldName = $oldInstallId // $oldTargetName;
             my $errmsg;
             # Equal install IDs can only mean two outputs of one entry in
-            # `[install]`. Every other pairing is two distinct packages, even
-            # when they are built from the same derivation name.
+            # `[install]`, which is also the only way both paths can have come
+            # from an output selection, so %outputByStorePath names them both.
+            # Every other pairing is two distinct packages, even when they are
+            # built from the same derivation name.
             if (defined $installId && defined $oldInstallId && $installId eq $oldInstallId) {
-                my $oldOutput = parseOutputFromVersion($oldTargetVersion);
-                my $newOutput = parseOutputFromVersion($targetVersion);
-                # Two outputs can parse to the same name, because the version
-                # they are parsed out of may end in a digit group of its own.
-                # Naming neither beats naming both of them wrongly.
-                if ($oldOutput ne $newOutput) {
-                    $errmsg = "'$oldName ($oldOutput)' conflicts with "
-                            . "'$name ($newOutput)'. ";
-                } else {
-                    $errmsg = "'$oldName' conflicts with '$name'. ";
-                }
+                my $oldOutput = $outputByStorePath{$oldTargetStorePath};
+                my $newOutput = $outputByStorePath{$targetStorePath};
+                $errmsg = "'$oldName ($oldOutput)' conflicts with "
+                        . "'$name ($newOutput)'. ";
             } else {
                 $errmsg = "'$oldName' conflicts with '$name'. ";
             }
@@ -604,9 +582,11 @@ if ($manifest) {
                     my @outputs = getV1Outputs($package);
                     my @outputsToInstallPaths = ();
                     my @otherOutputPaths = ();
+                    my %outputByPath = ();
 
                     foreach my $output (@outputs) {
                         my $path = $package->{"outputs"}{$output};
+                        $outputByPath{$path} = $output;
                         if (grep { $_ eq $output } @{$outputsToInstall}) {
                             push @outputsToInstallPaths, $path;
                         } else {
@@ -619,7 +599,8 @@ if ($manifest) {
                         push @retarray, {
                             "paths" => \@outputsToInstallPaths,
                             "priority" => $package->{"priority"},
-                            "install_id" => $package->{"install_id"}
+                            "install_id" => $package->{"install_id"},
+                            "output_by_path" => \%outputByPath
                         };
                     }
 
@@ -630,21 +611,23 @@ if ($manifest) {
                         push @retarray, {
                             "paths" => [ $otherPath ],
                             "priority" => ((1000 * $package->{"priority"}) + $ignoreCollisionCounter++),
-                            "install_id" => $package->{"install_id"}
+                            "install_id" => $package->{"install_id"},
+                            "output_by_path" => \%outputByPath
                         };
                     }
                 } elsif (exists $manifest->{"schema-version"}) {
                     # v1.10.0 manifest logic: increment priority for all outputs
                     my @outputs = getSpecifiedOutputs($descriptor, $package, $outputsToInstall);
-                    my @paths = map { $package->{"outputs"}{$_} } @outputs;
 
-                    next unless scalar @paths;
+                    next unless scalar @outputs;
 
-                    foreach my $path (@paths) {
+                    foreach my $output (@outputs) {
+                        my $path = $package->{"outputs"}{$output};
                         push @retarray, {
                             "paths" => [ $path ],
                             "priority" => $package->{"priority"},
-                            "install_id" => $package->{"install_id"}
+                            "install_id" => $package->{"install_id"},
+                            "output_by_path" => { $path => $output }
                         };
                     }
                 } elsif (exists $manifest->{"schema-version"}) {
@@ -833,6 +816,8 @@ if ($manifest) {
                 # copy was linked.
                 $installIdByStorePath{$path} //= $pkg->{install_id}
                     if defined $pkg->{install_id};
+                $outputByStorePath{$path} //= $pkg->{output_by_path}{$path}
+                    if defined $pkg->{output_by_path};
                 addPkg($path,
                        $ENV{"ignoreCollisions"} eq "1",
                        $ENV{"checkCollisionContents"} eq "1",
@@ -1006,6 +991,7 @@ if ($manifest) {
         %symlinks = ();
         %seen = ();
         %installIdByStorePath = ();
+        %outputByStorePath = ();
         my $envName = $output->{"name"};
 
         my $path = $nix_attrs->{"outputs"}{$envName};

--- a/buildenv/builder.pl
+++ b/buildenv/builder.pl
@@ -180,6 +180,13 @@ sub parseStorePath($) {
     return ($name, $version, $basename, $storePath);
 }
 
+# Opening text shared by both of the collision hints below. The Rust provider
+# matches it to classify a buildenv failure as deterministic and skip its retry
+# loop, so building both hints from one variable keeps them from drifting apart
+# from each other or from `is_deterministic_buildenv_conflict` in
+# `cli/flox-rust-sdk/src/providers/buildenv.rs`.
+my $FLOX_CONFLICT_HINT_PREFIX = "Resolve by uninstalling one of the conflicting ";
+
 sub findFiles {
     my ($relName, $target, $baseName, $ignoreCollisions, $checkCollisionContents, $priority) = @_;
 
@@ -263,7 +270,7 @@ sub findFiles {
             # itself, which the user cannot refer to by any other name either.
             my $name = $installId // $targetName;
             my $oldName = $oldInstallId // $oldTargetName;
-            my $errmsg;
+            my ($errmsg, $subject, $hint);
             # Equal install IDs can only mean two outputs of one entry in
             # `[install]`, which is also the only way both paths can have come
             # from an output selection, so %outputByStorePath names them both.
@@ -272,21 +279,24 @@ sub findFiles {
             if (defined $installId && defined $oldInstallId && $installId eq $oldInstallId) {
                 my $oldOutput = $outputByStorePath{$oldTargetStorePath};
                 my $newOutput = $outputByStorePath{$targetStorePath};
-                $errmsg = "'$oldName ($oldOutput)' conflicts with "
-                        . "'$name ($newOutput)'. ";
+                $errmsg = "'$oldName^$oldOutput' conflicts with "
+                        . "'$name^$newOutput'. ";
+                $subject = "outputs of the same package";
+                $hint = $FLOX_CONFLICT_HINT_PREFIX . "outputs from '$name'";
             } else {
                 $errmsg = "'$oldName' conflicts with '$name'. ";
+                $subject = "packages";
+                $hint = $FLOX_CONFLICT_HINT_PREFIX . "packages or " .
+                        "setting the priority of the preferred package to a value " .
+                        "lower than '$oldPriority'";
             }
             if ($targetBasename eq $oldTargetBasename) {
-                $errmsg .= "Both packages provide the file '$targetBasename'";
+                $errmsg .= "Both $subject provide the file '$targetBasename'";
             } else {
                 # This is unexpected ... revert to reporting the exact refs encountered.
                 $errmsg .= "collision between $targetRef and $oldTargetRef";
             }
-            die $errmsg . "\n\n" .
-                "Resolve by uninstalling one of the conflicting packages or " .
-                "setting the priority of the preferred package to a value " .
-                "lower than '$oldPriority'\n";
+            die $errmsg . "\n\n" . $hint . "\n";
         }
     }
 

--- a/cli/flox-rust-sdk/src/providers/buildenv.rs
+++ b/cli/flox-rust-sdk/src/providers/buildenv.rs
@@ -1170,20 +1170,27 @@ fn nix_path_info_null_paths(paths: &[String]) -> Result<Vec<String>, std::io::Er
 /// `buildenv/builder.pl`. These errors are deterministic — the same lockfile
 /// will always produce the same conflict — and must not be retried.
 ///
-/// Matches on the conflict-specific resolution hint emitted at
-/// `buildenv/builder.pl:245` (`Resolve by uninstalling one of the conflicting
-/// packages`) rather than the broader `❌ ERROR:` sentinel installed by the
-/// `$SIG{__DIE__}` handler at `buildenv/builder.pl:13`. The broader sentinel
-/// covers builder.pl's filesystem `die` paths (EMFILE, ENOSPC, etc. during
-/// mkpath/symlink), which are genuinely transient and must remain retryable.
+/// Matches on the conflict-specific resolution hints emitted by
+/// `buildenv/builder.pl` (`Resolve by uninstalling one of the conflicting
+/// packages`/`outputs`) rather than the broader `❌ ERROR:` sentinel installed
+/// by the `$SIG{__DIE__}` handler at `buildenv/builder.pl:13`. The broader
+/// sentinel covers builder.pl's filesystem `die` paths (EMFILE, ENOSPC, etc.
+/// during mkpath/symlink), which are genuinely transient and must remain
+/// retryable.
 ///
-/// If `buildenv/builder.pl`'s conflict message changes, the unit test
+/// The matched text is `$FLOX_CONFLICT_HINT_PREFIX` in
+/// `buildenv/builder.pl`, which both hints are built from. Two tests run
+/// builder.pl for real and fail if it stops emitting that prefix:
+/// `buildenv_tests::detects_conflicting_packages` covers a conflict between
+/// packages and `buildenv_tests::detects_conflicting_outputs_of_one_package`
+/// one between outputs of a single package. The stubbed stderr in
 /// `materialise_retry_tests::deterministic_buildenv_conflict_short_circuits`
-/// will break and signal a contract update is needed.
+/// pins the retry behaviour but not the contract, so it would keep passing on
+/// its own.
 fn is_deterministic_buildenv_conflict(err: &BuildEnvError) -> bool {
     match err {
         BuildEnvError::Build(stderr) => {
-            stderr.contains("Resolve by uninstalling one of the conflicting packages")
+            stderr.contains("Resolve by uninstalling one of the conflicting")
         },
         _ => false,
     }
@@ -2569,8 +2576,8 @@ mod buildenv_tests {
         path
     }
 
-    /// Two outputs of a single installed package that both provide the same
-    /// file are reported as a conflict, and are not retried.
+    /// Two outputs of a single installed package are reported as a conflict
+    /// between that package's outputs, named by install ID.
     #[test]
     fn detects_conflicting_outputs_of_one_package() {
         let buildenv = buildenv_instance();
@@ -2589,7 +2596,7 @@ mod buildenv_tests {
             panic!("expected build to fail, got {}", err);
         };
 
-        let expected = "> ❌ ERROR: 'my_tool (out)' conflicts with 'my_tool (dev)'. Both packages provide the file 'bin/collide'";
+        let expected = "> ❌ ERROR: 'my_tool^out' conflicts with 'my_tool^dev'. Both outputs of the same package provide the file 'bin/collide'";
 
         assert!(
             output.contains(expected),
@@ -3275,45 +3282,59 @@ mod materialise_retry_tests {
     #[test]
     fn deterministic_buildenv_conflict_short_circuits() {
         init_tracing();
-        // build_env always returns a conflict error containing the
-        // builder.pl resolution hint. realise and missing_paths are
+        // build_env always returns a conflict error containing one of the
+        // builder.pl resolution hints. realise and missing_paths are
         // wired to never block progress so the conflict is the only
         // reason for failure.
-        let realise_calls = Cell::new(0usize);
-        let build_calls = Cell::new(0usize);
-        let conflict_stderr = "environment> ❌ ERROR: 'vim' conflicts with \
-                               'vim-full'. Both packages provide the file \
-                               'bin/ex'\nenvironment> \nenvironment> Resolve \
-                               by uninstalling one of the conflicting \
-                               packages or setting the priority of the \
-                               preferred package to a value lower than '5'"
-            .to_string();
-        let result: Result<(), _> = materialise_with_retry(
-            || {
-                realise_calls.set(realise_calls.get() + 1);
-                Ok(())
-            },
-            Vec::new, // paths always present
-            Vec::new,
-            || {
-                build_calls.set(build_calls.get() + 1);
-                Err(BuildEnvError::Build(conflict_stderr.clone()))
-            },
-        );
-        match result.unwrap_err() {
-            BuildEnvError::Build(msg) => assert_eq!(msg, conflict_stderr),
-            e => panic!("expected Build, got {e:?}"),
+        let cases = [
+            (
+                "cross-package conflict",
+                "environment> ❌ ERROR: 'vim' conflicts with 'vim-full'. \
+                 Both packages provide the file 'bin/ex'\nenvironment> \
+                 \nenvironment> Resolve by uninstalling one of the \
+                 conflicting packages or setting the priority of the \
+                 preferred package to a value lower than '5'",
+            ),
+            (
+                "same-package output conflict",
+                "environment> ❌ ERROR: 'nodejs^dev' conflicts with \
+                 'nodejs^out'. Both outputs of the same package provide \
+                 the file 'include/node/node.h'\nenvironment> \
+                 \nenvironment> Resolve by uninstalling one of the \
+                 conflicting outputs from 'nodejs'",
+            ),
+        ];
+        for (case, conflict_stderr) in cases {
+            let realise_calls = Cell::new(0usize);
+            let build_calls = Cell::new(0usize);
+            let conflict_stderr = conflict_stderr.to_string();
+            let result: Result<(), _> = materialise_with_retry(
+                || {
+                    realise_calls.set(realise_calls.get() + 1);
+                    Ok(())
+                },
+                Vec::new, // paths always present
+                Vec::new,
+                || {
+                    build_calls.set(build_calls.get() + 1);
+                    Err(BuildEnvError::Build(conflict_stderr.clone()))
+                },
+            );
+            match result.unwrap_err() {
+                BuildEnvError::Build(msg) => assert_eq!(msg, conflict_stderr),
+                e => panic!("{case}: expected Build, got {e:?}"),
+            }
+            assert_eq!(
+                build_calls.get(),
+                1,
+                "{case}: must not retry a deterministic file collision"
+            );
+            assert_eq!(
+                realise_calls.get(),
+                1,
+                "{case}: realise called once before short-circuit"
+            );
         }
-        assert_eq!(
-            build_calls.get(),
-            1,
-            "must not retry a deterministic file collision"
-        );
-        assert_eq!(
-            realise_calls.get(),
-            1,
-            "realise called once before short-circuit"
-        );
     }
 
     // --- realise errors ---

--- a/cli/flox-rust-sdk/src/providers/buildenv.rs
+++ b/cli/flox-rust-sdk/src/providers/buildenv.rs
@@ -2522,9 +2522,10 @@ mod buildenv_tests {
             .collect()
     }
 
-    /// Writes a lockfile installing [add_conflicting_outputs_to_store] under
-    /// the install ID `my_tool`, which deliberately differs from the package
-    /// name `collide`.
+    /// Writes a lockfile installing [add_conflicting_outputs_to_store] under an
+    /// install ID that deliberately differs from the package name, so that a
+    /// message naming the install ID can only have read it from the lockfile
+    /// rather than parsed it back out of the store path.
     ///
     /// The outputs are selected by name rather than with `outputs = "all"`,
     /// which is how a user hits this, because only the explicit list fixes the
@@ -2583,7 +2584,7 @@ mod buildenv_tests {
             panic!("expected build to fail, got {}", err);
         };
 
-        let expected = "> ❌ ERROR: 'collide (out)' conflicts with 'collide (dev)'. Both packages provide the file 'bin/collide'";
+        let expected = "> ❌ ERROR: 'my_tool (out)' conflicts with 'my_tool (dev)'. Both packages provide the file 'bin/collide'";
 
         assert!(
             output.contains(expected),

--- a/cli/flox-rust-sdk/src/providers/buildenv.rs
+++ b/cli/flox-rust-sdk/src/providers/buildenv.rs
@@ -2452,6 +2452,11 @@ mod buildenv_tests {
         let client = MockClient::new();
         let result = buildenv.build(&client, &lockfile_path, None, None);
         let err = result.expect_err("conflicting packages should fail to build");
+        assert!(
+            is_deterministic_buildenv_conflict(&err),
+            "a package conflict must be classified as deterministic so that it is not retried:\n\
+            actual: {err}"
+        );
 
         let BuildEnvError::Build(output) = err else {
             panic!("expected build to fail, got {}", err);

--- a/cli/flox-rust-sdk/src/providers/buildenv.rs
+++ b/cli/flox-rust-sdk/src/providers/buildenv.rs
@@ -1166,7 +1166,7 @@ fn nix_path_info_null_paths(paths: &[String]) -> Result<Vec<String>, std::io::Er
         .collect())
 }
 
-/// Returns true if `err` reports a buildenv package-output conflict from
+/// Returns true if `err` reports a buildenv file collision from
 /// `buildenv/builder.pl`. These errors are deterministic — the same lockfile
 /// will always produce the same conflict — and must not be retried.
 ///
@@ -1287,7 +1287,7 @@ pub fn materialise_with_retry<T>(
                     // daemon, leaving paths on disk but unregistered.
                     match nix_path_info_null_paths(&confirmed) {
                         Ok(null_paths) if null_paths.is_empty() => {
-                            // Short-circuit deterministic package-output conflicts
+                            // Short-circuit deterministic file collisions
                             // before spending retries. The same lockfile always
                             // produces the same conflict, so retrying cannot help.
                             if is_deterministic_buildenv_conflict(&e) {
@@ -1295,7 +1295,7 @@ pub fn materialise_with_retry<T>(
                                     error = %e,
                                     attempt,
                                     "buildenv.nix reported a deterministic \
-                                    package-output conflict — not retrying"
+                                    file collision — not retrying"
                                 );
                                 return Err(e);
                             }
@@ -3175,7 +3175,7 @@ mod materialise_retry_tests {
         assert_eq!(
             build_calls.get(),
             1,
-            "must not retry a deterministic package-output conflict"
+            "must not retry a deterministic file collision"
         );
         assert_eq!(
             realise_calls.get(),

--- a/cli/flox-rust-sdk/src/providers/buildenv.rs
+++ b/cli/flox-rust-sdk/src/providers/buildenv.rs
@@ -2302,10 +2302,16 @@ mod realise_batch_tests {
 
 #[cfg(test)]
 mod buildenv_tests {
-    use std::collections::HashSet;
+    use std::collections::{BTreeMap, HashSet};
+    use std::fs;
     use std::os::unix::fs::PermissionsExt;
 
+    use flox_manifest::interfaces::AsTypedOnlyManifest;
+    use flox_manifest::lockfile::test_helpers::fake_catalog_package_lock_with_outputs;
+    use flox_manifest::parsed::latest::ManifestPackageDescriptor;
+    use flox_manifest::raw::test_helpers::empty_test_migrated_manifest;
     use flox_test_utils::{GENERATED_DATA, MANUALLY_GENERATED};
+    use tempfile::TempDir;
     use test_helpers::buildenv_instance;
 
     use super::*;
@@ -2467,6 +2473,121 @@ mod buildenv_tests {
         assert!(
             output.contains(expected),
             "expected output to contain a conflict message:\n\
+            actual: {output}\n\
+            expected: {expected}"
+        );
+    }
+
+    /// Adds the given outputs of one package to the store, all providing
+    /// `bin/collide`, and returns them keyed by output name.
+    ///
+    /// Adds directories rather than building a multi-output derivation:
+    /// `nix store add` gives exact control over the store path names that
+    /// `parseStorePath` in `buildenv/builder.pl` decomposes into a package
+    /// name and an output, and needs no builder on `PATH`, which a bare
+    /// `/bin/sh` derivation has in neither sandbox. The paths are
+    /// content-addressed, so repeated runs reuse the same two, and nothing
+    /// roots them.
+    fn add_conflicting_outputs_to_store(outputs: &[&str]) -> BTreeMap<String, String> {
+        let sources = TempDir::new().unwrap();
+        outputs
+            .iter()
+            .map(|&output| {
+                let source = sources.path().join(output);
+                fs::create_dir_all(source.join("bin")).unwrap();
+                // Differing contents so that the paths collide even when
+                // `checkCollisionContents` is enabled.
+                fs::write(source.join("bin/collide"), output).unwrap();
+
+                // Nix names the primary output after the package and suffixes
+                // every other output with its own name.
+                let name = match output {
+                    "out" => "collide-1.0".to_string(),
+                    other => format!("collide-1.0-{other}"),
+                };
+                let added = nix_base_command()
+                    .args(["store", "add", "--name", &name])
+                    .arg(&source)
+                    .output()
+                    .unwrap();
+                assert!(
+                    added.status.success(),
+                    "failed to add '{name}' to the store: {}",
+                    String::from_utf8_lossy(&added.stderr)
+                );
+
+                let store_path = String::from_utf8(added.stdout).unwrap().trim().to_string();
+                (output.to_string(), store_path)
+            })
+            .collect()
+    }
+
+    /// Writes a lockfile installing [add_conflicting_outputs_to_store] under
+    /// the install ID `my_tool`, which deliberately differs from the package
+    /// name `collide`.
+    ///
+    /// The outputs are selected by name rather than with `outputs = "all"`,
+    /// which is how a user hits this, because only the explicit list fixes the
+    /// order in which `builder.pl` links them. Both spellings reach the same
+    /// collision, but `"all"` is an unordered hash lookup in `builder.pl`, so
+    /// it leaves which output is reported first up to Perl.
+    fn lockfile_with_conflicting_outputs(dir: &Path) -> PathBuf {
+        let outputs = ["out", "dev"];
+        let (mut descriptor, mut locked) =
+            fake_catalog_package_lock_with_outputs("my_tool", "collide", &outputs);
+        let ManifestPackageDescriptor::Catalog(ref mut catalog_descriptor) = descriptor else {
+            panic!("expected a catalog descriptor");
+        };
+        catalog_descriptor.outputs = Some(SelectedOutputs::Specific(
+            outputs.iter().map(|o| o.to_string()).collect(),
+        ));
+        catalog_descriptor.systems = Some(vec![env!("NIX_TARGET_SYSTEM").to_string()]);
+        locked.system = env!("NIX_TARGET_SYSTEM").to_string();
+        locked.outputs = add_conflicting_outputs_to_store(&outputs);
+
+        let mut manifest = empty_test_migrated_manifest();
+        manifest
+            .as_latest_schema_mut()
+            .install
+            .inner_mut()
+            .insert("my_tool".to_string(), descriptor);
+
+        let lockfile = Lockfile {
+            manifest: manifest.as_latest_schema().as_typed_only(),
+            packages: vec![locked.into()],
+            ..Default::default()
+        };
+
+        let path = dir.join("manifest.lock");
+        fs::write(&path, serde_json::to_string_pretty(&lockfile).unwrap()).unwrap();
+        path
+    }
+
+    /// Two outputs of a single installed package that both provide the same
+    /// file are reported as a conflict, and are not retried.
+    #[test]
+    fn detects_conflicting_outputs_of_one_package() {
+        let buildenv = buildenv_instance();
+        let dir = TempDir::new().unwrap();
+        let lockfile_path = lockfile_with_conflicting_outputs(dir.path());
+        let client = MockClient::new();
+        let result = buildenv.build(&client, &lockfile_path, None, None);
+        let err = result.expect_err("conflicting outputs should fail to build");
+        assert!(
+            is_deterministic_buildenv_conflict(&err),
+            "an output conflict must be classified as deterministic so that it is not retried:\n\
+            actual: {err}"
+        );
+
+        let BuildEnvError::Build(output) = err else {
+            panic!("expected build to fail, got {}", err);
+        };
+
+        let expected = "> ❌ ERROR: 'collide (out)' conflicts with 'collide (dev)'. Both packages provide the file 'bin/collide'";
+
+        assert!(
+            output.contains(expected),
+            "expected output to contain an output conflict message:\n\
             actual: {output}\n\
             expected: {expected}"
         );

--- a/cli/flox-rust-sdk/src/providers/buildenv.rs
+++ b/cli/flox-rust-sdk/src/providers/buildenv.rs
@@ -2482,12 +2482,17 @@ mod buildenv_tests {
     /// `bin/collide`, and returns them keyed by output name.
     ///
     /// Adds directories rather than building a multi-output derivation:
-    /// `nix store add` gives exact control over the store path names that
-    /// `parseStorePath` in `buildenv/builder.pl` decomposes into a package
-    /// name and an output, and needs no builder on `PATH`, which a bare
-    /// `/bin/sh` derivation has in neither sandbox. The paths are
-    /// content-addressed, so repeated runs reuse the same two, and nothing
-    /// roots them.
+    /// `nix store add` gives exact control over the store path names and
+    /// needs no builder on `PATH`, which a bare `/bin/sh` derivation has in
+    /// neither sandbox. The paths are content-addressed, so repeated runs
+    /// reuse the same two, and nothing roots them.
+    ///
+    /// The version is date-shaped because that is the case an output name
+    /// cannot be recovered from: `parseStorePath` in `buildenv/builder.pl`
+    /// splits on the first `-` followed by a digit, so `-dev` lands inside
+    /// the version of `collide-2024-07-02-dev` and reads no differently from
+    /// the `-02` before it. A message that still names `dev` can only have
+    /// taken it from the lockfile.
     fn add_conflicting_outputs_to_store(outputs: &[&str]) -> BTreeMap<String, String> {
         let sources = TempDir::new().unwrap();
         outputs
@@ -2502,8 +2507,8 @@ mod buildenv_tests {
                 // Nix names the primary output after the package and suffixes
                 // every other output with its own name.
                 let name = match output {
-                    "out" => "collide-1.0".to_string(),
-                    other => format!("collide-1.0-{other}"),
+                    "out" => "collide-2024-07-02".to_string(),
+                    other => format!("collide-2024-07-02-{other}"),
                 };
                 let added = nix_base_command()
                     .args(["store", "add", "--name", &name])


### PR DESCRIPTION
## Proposed Changes

Improve errors for file collisions between packages and outputs.

This is best reviewed commit-by-commit.

## Release Notes

Clearer errors and guidance is now provided when packages and package outputs have file collisions.