### PR TITLE
chore: lint with --all-targets so test-only dead code is caught

### DIFF
--- a/cli/flox/src/utils/detect_shell.rs
+++ b/cli/flox/src/utils/detect_shell.rs
@@ -54,6 +54,11 @@ pub(crate) fn detect_shell_for_subshell() -> ShellWithPath {
 
 /// Utility method for testing implementing the logic of shell detection
 /// for subshells, generically over a parent shell detection function.
+///
+/// Test-only: production resolves the chain once through
+/// [`SHELL_CHAIN_DETECTION`], so there is no non-test caller to keep the
+/// injected probe.
+#[cfg(test)]
 fn detect_shell_for_subshell_with(
     parent_shell_fn: impl Fn() -> Result<ShellWithPath>,
 ) -> ShellWithPath {

--- a/pkgs/pre-commit-check/default.nix
+++ b/pkgs/pre-commit-check/default.nix
@@ -52,10 +52,14 @@ pre-commit-hooks.lib.${stdenv.hostPlatform.system}.run {
       enable = true;
       settings = {
         denyWarnings = true;
-        # '--tests': ensure that #[cfg(test)] is linted as well
+        # '--all-targets': lint every target, not just the test build.
+        #   '--tests' alone compiles each binary with `cfg(test)` on, so a
+        #   helper whose only callers are in `#[cfg(test)]` modules still
+        #   looks live and `dead_code` never fires. Building the plain
+        #   targets too is what catches code that only tests still use.
         # '--workspace': lint all packages in the workspace
         # '--no-deps': don't lint dependencies
-        extraArgs = "--tests --workspace --no-deps";
+        extraArgs = "--all-targets --workspace --no-deps";
       };
     };
     commitizen = {


### PR DESCRIPTION
- **chore: lint with --all-targets so test-only dead code is caught**
  The clippy hook passed --tests, which compiles each binary with
  cfg(test) on. A helper whose only callers live in #[cfg(test)]
  modules therefore still looks live and dead_code never fires, so
  CI stayed green on code that a plain cargo check warns about.
  --all-targets builds the ordinary targets alongside the test ones,
  which is what surfaces the warning.
  
  Verified clean across the workspace under -D warnings.
  
  Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
  

- **fix: gate detect_shell_for_subshell_with behind cfg(test)**
  The function lost its production caller in 85ab7346f, which routed
  detect_shell_for_subshell() through the cached SHELL_CHAIN_DETECTION
  instead of the injectable probe. Its four remaining callers are all
  test assertions, so mark it test-only rather than deleting it and
  losing coverage of the subshell chain's bundled-bash fallback.
  
  Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
  