### PR TITLE
fix(executive): reset the loop guard when a PID detaches

### DIFF
--- a/cli/flox-activations/src/cli/executive/event_coordinator.rs
+++ b/cli/flox-activations/src/cli/executive/event_coordinator.rs
@@ -20,7 +20,7 @@ use notify::{Config, Event, EventKindMask, RecommendedWatcher, RecursiveMode, Wa
 use sentry::integrations::anyhow::capture_anyhow;
 use signal_hook::iterator::Signals;
 use time::OffsetDateTime;
-use tracing::{debug, error, trace, warn};
+use tracing::{debug, error, info, trace, warn};
 use waitpid_any::WaitHandle;
 
 /// Events that can occur during PID monitoring.
@@ -408,8 +408,11 @@ fn spawn_pid_watcher(
                 None
             },
             Err(err) => {
-                // Process likely already dead (ESRCH or similar)
-                debug!(pid, %err, "failed to open wait handle, process likely already exited");
+                // Process likely already dead (ESRCH or similar), or its
+                // status couldn't be read
+                // info so that Sentry breadcrumbs show where a ProcessExited
+                // event came from
+                info!(pid, %err, errno = ?err.raw_os_error(), "failed to open wait handle, process likely already exited");
                 // Ignore error since we're just going to return
                 let _ = sender.send(ExecutiveEvent::ProcessExited { pid });
                 return;
@@ -423,7 +426,7 @@ fn spawn_pid_watcher(
             loop {
                 match handle.wait() {
                     Ok(()) => {
-                        debug!(pid, "process exited");
+                        info!(pid, "process exited");
                         // Ignore error since we're just going to return
                         let _ = sender.send(ExecutiveEvent::ProcessExited { pid });
                         return;
@@ -459,7 +462,7 @@ fn spawn_pid_watcher(
 fn poll_until_exit(pid: i32, sender: &Sender<ExecutiveEvent>) {
     loop {
         if !pid_is_running(pid) {
-            debug!(pid, "process exited (polling)");
+            info!(pid, "process exited (polling)");
             // Ignore error since we're just going to return
             let _ = sender.send(ExecutiveEvent::ProcessExited { pid });
             return;

--- a/cli/flox-activations/src/cli/executive/mod.rs
+++ b/cli/flox-activations/src/cli/executive/mod.rs
@@ -328,7 +328,8 @@ fn run_event_loop(
 }
 
 /// Guards against infinite re-monitoring loops for the same PID.
-/// If a PID is re-monitored `limit` times consecutively, further re-monitoring is skipped.
+/// If a PID is re-monitored `limit` times without being detached in between,
+/// further re-monitoring is skipped.
 struct LoopGuard {
     pid: Option<i32>,
     count: u32,
@@ -353,6 +354,15 @@ impl LoopGuard {
             self.count = 1;
         }
         self.count <= self.limit
+    }
+
+    /// Record that a PID is no longer attached, clearing the counter if it
+    /// was tracking that PID.
+    fn reset_on_detach(&mut self, pid: i32) {
+        if self.pid == Some(pid) {
+            self.pid = None;
+            self.count = 0;
+        }
     }
 }
 
@@ -457,6 +467,8 @@ fn handle_process_exited(
                         "PID re-monitored too many times, skipping to prevent loop"
                     );
                 }
+            } else {
+                loop_guard.reset_on_detach(pid);
             }
 
             // Double check that all attached PIDs are monitored.
@@ -969,6 +981,90 @@ mod test {
             guard.allow_remonitor(pid),
             "counter should reset after different PID"
         );
+    }
+
+    #[test]
+    fn loop_guard_resets_when_tracked_pid_detaches() {
+        let mut guard = LoopGuard::new(2);
+        let pid = 12345;
+
+        assert!(guard.allow_remonitor(pid));
+        assert!(guard.allow_remonitor(pid));
+        assert!(!guard.allow_remonitor(pid));
+
+        // Detaching a different PID doesn't reset the counter
+        guard.reset_on_detach(67890);
+        assert!(!guard.allow_remonitor(pid));
+
+        guard.reset_on_detach(pid);
+        assert!(
+            guard.allow_remonitor(pid),
+            "counter should reset after the PID detached"
+        );
+    }
+
+    /// A PID exit that resolves in a detach rather than a re-attach resets
+    /// the loop guard so later legitimate re-attaches of the same PID aren't
+    /// blocked.
+    #[test]
+    fn handle_process_exited_resets_loop_guard_on_detach() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let runtime_dir = temp_dir.path();
+        let dot_flox_path = PathBuf::from(".flox");
+        let flox_env = dot_flox_path.join("run/test");
+        let store_path = "store_path".to_string();
+
+        // One PID that will exit and one that keeps the activation alive
+        let exited = start_process();
+        let exited_pid = exited.id() as i32;
+        let keeper = start_process();
+        let keeper_pid = keeper.id() as i32;
+
+        let mut state =
+            ActivationState::new(&ActivateMode::default(), Some(&dot_flox_path), &flox_env);
+        let result = state.start_or_attach(exited_pid, &store_path);
+        let StartOrAttachResult::Start { start_id, .. } = result else {
+            panic!("Expected Start")
+        };
+        state.set_ready(&start_id);
+        let result = state.start_or_attach(keeper_pid, &store_path);
+        let StartOrAttachResult::Attach { .. } = result else {
+            panic!("Expected Attach")
+        };
+        write_activation_state(runtime_dir, &dot_flox_path, state);
+
+        let activation_state_directory = activation_state_dir_path(runtime_dir, &dot_flox_path);
+        let state_json = state_json_path(&activation_state_directory);
+
+        let coordinator = EventCoordinator::new().unwrap();
+        let mut loop_guard = LoopGuard::new(2);
+        let (_attach, project) = test_context(&dot_flox_path, &flox_env.to_string_lossy());
+
+        // Exhaust the guard for the PID
+        assert!(loop_guard.allow_remonitor(exited_pid));
+        assert!(loop_guard.allow_remonitor(exited_pid));
+        assert!(!loop_guard.allow_remonitor(exited_pid));
+
+        stop_process(exited);
+
+        // The exited PID is detached, which resets the guard
+        let result = handle_process_exited(
+            exited_pid,
+            &coordinator,
+            &mut loop_guard,
+            &state_json,
+            &project.process_compose_bin,
+            &project.flox_services_socket,
+            &activation_state_directory,
+        );
+        assert!(matches!(result, Ok(false)), "keeper PID should remain");
+
+        assert!(
+            loop_guard.allow_remonitor(exited_pid),
+            "guard should reset after the PID detached"
+        );
+
+        stop_process(keeper);
     }
 
     /// Test that handle_process_exited increments the loop guard when a PID

--- a/cli/flox-activations/src/cli/executive/mod.rs
+++ b/cli/flox-activations/src/cli/executive/mod.rs
@@ -12,6 +12,7 @@ use flox_core::activations::{
     state_json_path,
     write_activations_json,
 };
+use flox_core::proc_status::read_pid_status;
 use flox_core::sentry::init_sentry;
 use flox_core::traceable_path;
 use fslock::LockFile;
@@ -431,13 +432,28 @@ fn handle_process_exited(
                 .find(|(attached_pid, _)| *attached_pid == pid);
             if let Some((pid, expiration)) = pid_reused {
                 if loop_guard.allow_remonitor(pid) {
-                    debug!(pid, "PID re-attached to activation, starting new monitor");
+                    // info so that Sentry breadcrumbs show every iteration
+                    // leading up to the loop guard tripping.
+                    // The status is included because read_pid_status reports
+                    // Dead both for a process that has exited and for one
+                    // whose status couldn't be read, and re-monitoring a PID
+                    // that doesn't report Running is what a loop looks like.
+                    info!(
+                        pid,
+                        ?expiration,
+                        status = ?read_pid_status(pid),
+                        count = loop_guard.count,
+                        "PID re-attached to activation, starting new monitor"
+                    );
                     coordinator
                         .start_monitoring(pid, expiration)
                         .context("failed to restart monitoring for re-attached PID")?;
                 } else {
                     error!(
                         pid,
+                        ?expiration,
+                        status = ?read_pid_status(pid),
+                        count = loop_guard.count,
                         "PID re-monitored too many times, skipping to prevent loop"
                     );
                 }

--- a/cli/flox-core/src/activations.rs
+++ b/cli/flox-core/src/activations.rs
@@ -9,7 +9,7 @@ use fslock::LockFile;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use time::OffsetDateTime;
-use tracing::{debug, trace};
+use tracing::{debug, info, trace};
 
 use crate::activate::mode::ActivateMode;
 use crate::proc_status::pid_is_running;
@@ -555,11 +555,13 @@ impl ActivationState {
         };
 
         if keep_attachment {
-            debug!(pid, "keeping attached PID");
+            // info so that Sentry breadcrumbs show why an exit event didn't
+            // detach the PID, mirroring "detaching terminated PID" below
+            info!(pid, expiration = ?attachment.expiration, "keeping attached PID");
             return (None, false);
         }
 
-        tracing::info!(pid, "detaching terminated PID");
+        info!(pid, "detaching terminated PID");
         let Ok(empty_start_id) = self.detach(pid) else {
             debug!(
                 pid,


### PR DESCRIPTION
- **feat(executive): add more info for Sentry**
  Add more info for Sentry reports so they're easier to debug
  

- **fix(executive): reset the loop guard when a PID detaches**
  Currently the loop guard is never reset for the executive's lifetime if
  PID stays the same. Reset it on successful detaches so it doesn't deny
  repeated re-attach of the same PID
  
  I'm not sure there's a likely scenario where this would actually happen,
  but we're getting reports of LoopMonitor denying PIDs so close this as a
  potential reason.
  