### PR TITLE
feat(manifest): add hook.on-deactivate

### DIFF
--- a/buildenv/buildenv.nix
+++ b/buildenv/buildenv.nix
@@ -126,6 +126,23 @@ let
       else
         ""
     )
+    (
+      if
+        (
+          builtins.hasAttr "on-deactivate" hookSection
+          && (builtins.getAttr "on-deactivate" hookSection) != null
+        )
+      then
+        let
+          contents = outdentScript (builtins.getAttr "on-deactivate" hookSection);
+          scriptFile = builtins.toFile "hook-on-deactivate" contents;
+        in
+        ''
+          "${coreutils}/bin/cp" ${scriptFile} $out/activate.d/hook-on-deactivate
+        ''
+      else
+        ""
+    )
     # service-config.yaml section
     (
       if (serviceConfigYaml == null) then

--- a/cli/flox-activations/src/cli/detach.rs
+++ b/cli/flox-activations/src/cli/detach.rs
@@ -58,20 +58,25 @@ impl DetachArgs {
         // runs its hook.on-deactivate, and removes the start state dir.
         // Without a running executive (e.g. containerize uses its own PID)
         // nothing would ever do that, so tear orphaned starts down inline; no
-        // hook runs in that case. Removal is best-effort, like the
-        // executive's sweep: a failure must not abort the detach before the
-        // state.json write below persists it.
-        if !state.executive_running() {
-            for start_id in state.remove_orphaned_starts().orphaned {
-                if let Err(err) = start_id.remove_start_state_dir(&self.activation_state_dir) {
-                    warn!(%err, ?start_id, "failed to remove start state dir after detach");
-                }
-            }
-        }
+        // hook runs in that case.
+        let orphaned = if state.executive_running() {
+            Vec::new()
+        } else {
+            state.remove_orphaned_starts().orphaned
+        };
 
         // This should trigger the executive to check if it needs to cleanup
         write_activations_json(&state, &activations_json_path, lock)
             .context("failed to write state.json after detach")?;
+
+        // Remove the orphaned starts' dirs only after their removal has been
+        // persisted, mirroring the executive's mutate -> write -> remove
+        // ordering. Removal is best-effort, like the executive's sweep.
+        for start_id in orphaned {
+            if let Err(err) = start_id.remove_start_state_dir(&self.activation_state_dir) {
+                warn!(%err, ?start_id, "failed to remove start state dir after detach");
+            }
+        }
 
         Ok(())
     }
@@ -224,6 +229,53 @@ mod test {
         assert!(
             !start_state_dir.exists(),
             "start state dir should be removed inline when no executive is running"
+        );
+    }
+
+    /// With two starts and no executive, detaching the last PID of one start
+    /// removes only that start's dir; the still-attached start survives.
+    #[test]
+    fn inline_teardown_only_removes_emptied_start() {
+        let tmp = TempDir::new().unwrap();
+        let dot_flox_path = tmp.path().join(".flox");
+
+        let mut state = ActivationState::new(
+            &ActivateMode::default(),
+            Some(&dot_flox_path),
+            dot_flox_path.join("run/default"),
+        );
+        state.set_executive_pid(start_dead_pid());
+        let StartOrAttachResult::Start { start_id: start_1 } =
+            state.start_or_attach(111, "/nix/store/one")
+        else {
+            panic!("expected Start");
+        };
+        state.set_ready(&start_1);
+        // A second activation supersedes the first with a new store path.
+        let StartOrAttachResult::Start { start_id: start_2 } =
+            state.start_or_attach(222, "/nix/store/two")
+        else {
+            panic!("expected Start");
+        };
+        state.set_ready(&start_2);
+
+        write_activation_state(tmp.path(), &dot_flox_path, state);
+        let activation_state_dir = activation_state_dir_path(tmp.path(), &dot_flox_path);
+        let dir_1 = start_1.start_state_dir(&activation_state_dir).unwrap();
+        let dir_2 = start_2.start_state_dir(&activation_state_dir).unwrap();
+        std::fs::create_dir_all(&dir_1).unwrap();
+        std::fs::create_dir_all(&dir_2).unwrap();
+
+        let args = DetachArgs {
+            activation_state_dir,
+            pid: 111,
+        };
+        args.handle().expect("detach should succeed");
+
+        assert!(!dir_1.exists(), "the emptied start's dir should be removed");
+        assert!(
+            dir_2.exists(),
+            "the still-attached start's dir should survive"
         );
     }
 

--- a/cli/flox-activations/src/cli/detach.rs
+++ b/cli/flox-activations/src/cli/detach.rs
@@ -51,20 +51,20 @@ impl DetachArgs {
             return Ok(());
         };
 
-        let empty_start_id = state.detach(self.pid)?;
+        state.detach(self.pid)?;
 
-        // An emptied start is normally handed off to the executive, which
-        // runs its hook.on-deactivate and then removes the start state dir
-        // once woken by the state.json write below. Without a running
-        // executive (e.g. containerize uses its own PID) nothing would ever
-        // sweep the directory, so remove it inline; no hook runs in that
-        // case.
-        if let Some(ref start_id) = empty_start_id
-            && !state.executive_running()
-        {
-            start_id
-                .remove_start_state_dir(&self.activation_state_dir)
-                .context("failed to remove start state dir after detach")?;
+        // An emptied start is normally torn down by the executive, woken by
+        // the state.json write below: it removes the start from state.json,
+        // runs its hook.on-deactivate, and removes the start state dir.
+        // Without a running executive (e.g. containerize uses its own PID)
+        // nothing would ever do that, so tear orphaned starts down inline; no
+        // hook runs in that case.
+        if !state.executive_running() {
+            for start_id in state.remove_orphaned_starts() {
+                start_id
+                    .remove_start_state_dir(&self.activation_state_dir)
+                    .context("failed to remove start state dir after detach")?;
+            }
         }
 
         // This should trigger the executive to check if it needs to cleanup
@@ -158,6 +158,10 @@ mod test {
         else {
             panic!("expected Start for pid");
         };
+        // Mirror the real lifecycle: the activation completes its hooks and
+        // marks the start ready before any detach happens. A start still in
+        // `Starting` is never torn down by detach.
+        state.set_ready(&start_id);
 
         write_activation_state(tmp.path(), dot_flox_path, state);
 

--- a/cli/flox-activations/src/cli/detach.rs
+++ b/cli/flox-activations/src/cli/detach.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use anyhow::Context;
 use clap::Args;
 use flox_core::activations::{read_activations_json, state_json_path, write_activations_json};
-use tracing::debug;
+use tracing::{debug, warn};
 
 use crate::Error;
 
@@ -58,12 +58,14 @@ impl DetachArgs {
         // runs its hook.on-deactivate, and removes the start state dir.
         // Without a running executive (e.g. containerize uses its own PID)
         // nothing would ever do that, so tear orphaned starts down inline; no
-        // hook runs in that case.
+        // hook runs in that case. Removal is best-effort, like the
+        // executive's sweep: a failure must not abort the detach before the
+        // state.json write below persists it.
         if !state.executive_running() {
-            for start_id in state.remove_orphaned_starts() {
-                start_id
-                    .remove_start_state_dir(&self.activation_state_dir)
-                    .context("failed to remove start state dir after detach")?;
+            for start_id in state.remove_orphaned_starts().orphaned {
+                if let Err(err) = start_id.remove_start_state_dir(&self.activation_state_dir) {
+                    warn!(%err, ?start_id, "failed to remove start state dir after detach");
+                }
             }
         }
 
@@ -222,6 +224,34 @@ mod test {
         assert!(
             !start_state_dir.exists(),
             "start state dir should be removed inline when no executive is running"
+        );
+    }
+
+    /// A start state dir that is already gone (e.g. removed by an earlier
+    /// crashed detach) must not wedge the detach: the PID removal still has
+    /// to be persisted to state.json.
+    #[test]
+    fn detach_persists_even_when_start_state_dir_is_missing() {
+        let tmp = TempDir::new().unwrap();
+        let dot_flox_path = tmp.path().join(".flox");
+        let pid = 12345_i32;
+
+        let dead_executive = start_dead_pid();
+        let (activation_state_dir, start_state_dir) =
+            setup_single_attachment(&tmp, &dot_flox_path, pid, dead_executive);
+        std::fs::remove_dir_all(&start_state_dir).unwrap();
+
+        let args = DetachArgs {
+            activation_state_dir,
+            pid,
+        };
+        args.handle()
+            .expect("detach should succeed despite the missing start state dir");
+
+        let updated = read_activation_state(tmp.path(), &dot_flox_path);
+        assert!(
+            updated.attached_pids_is_empty(),
+            "the detach should be persisted to state.json"
         );
     }
 

--- a/cli/flox-activations/src/cli/detach.rs
+++ b/cli/flox-activations/src/cli/detach.rs
@@ -53,11 +53,15 @@ impl DetachArgs {
 
         let empty_start_id = state.detach(self.pid)?;
 
-        // In the executive we only remove start state dir when we know
-        // cleanup_all won't trigger, but we can't know whether or not
-        // cleanup_all will trigger here because we're about to drop the lock.
-        // It won't hurt to remove this directory
-        if let Some(ref start_id) = empty_start_id {
+        // An emptied start is normally handed off to the executive, which
+        // runs its hook.on-deactivate and then removes the start state dir
+        // once woken by the state.json write below. Without a running
+        // executive (e.g. containerize uses its own PID) nothing would ever
+        // sweep the directory, so remove it inline; no hook runs in that
+        // case.
+        if let Some(ref start_id) = empty_start_id
+            && !state.executive_running()
+        {
             start_id
                 .remove_start_state_dir(&self.activation_state_dir)
                 .context("failed to remove start state dir after detach")?;
@@ -136,36 +140,74 @@ mod test {
             .expect("detach should be a no-op when state is missing");
     }
 
-    /// When the last PID overall detaches, its start state dir is removed
-    /// immediately rather than deferred to the executive's cleanup_all — so a
-    /// racing activation that supersedes this start can't leave it orphaned.
-    #[test]
-    fn start_state_dir_removed_when_last_pid_detaches() {
-        let tmp = TempDir::new().unwrap();
-        let dot_flox_path = tmp.path().join(".flox");
-        let pid = 12345_i32;
-
+    /// Set up state with a single attached PID and its start state dir,
+    /// returning the activation state dir and the start state dir.
+    fn setup_single_attachment(
+        tmp: &TempDir,
+        dot_flox_path: &std::path::Path,
+        pid: i32,
+        executive_pid: i32,
+    ) -> (std::path::PathBuf, std::path::PathBuf) {
         let mut state = ActivationState::new(
             &ActivateMode::default(),
-            Some(&dot_flox_path),
+            Some(dot_flox_path),
             dot_flox_path.join("run/default"),
         );
-        state.set_executive_pid(1);
+        state.set_executive_pid(executive_pid);
         let StartOrAttachResult::Start { start_id } = state.start_or_attach(pid, "/nix/store/test")
         else {
             panic!("expected Start for pid");
         };
 
-        write_activation_state(tmp.path(), &dot_flox_path, state);
+        write_activation_state(tmp.path(), dot_flox_path, state);
 
-        let activation_state_dir = activation_state_dir_path(tmp.path(), &dot_flox_path);
-
+        let activation_state_dir = activation_state_dir_path(tmp.path(), dot_flox_path);
         let start_state_dir = start_id.start_state_dir(&activation_state_dir).unwrap();
         std::fs::create_dir_all(&start_state_dir).unwrap();
         assert!(
             start_state_dir.exists(),
             "start state dir should exist before detach"
         );
+        (activation_state_dir, start_state_dir)
+    }
+
+    /// When the last PID detaches and an executive is running, the start
+    /// state dir is left in place: the executive runs hook.on-deactivate and
+    /// removes it.
+    #[test]
+    fn start_state_dir_handed_to_executive_when_last_pid_detaches() {
+        let tmp = TempDir::new().unwrap();
+        let dot_flox_path = tmp.path().join(".flox");
+        let pid = 12345_i32;
+
+        // PID 1 is always running, standing in for a live executive.
+        let (activation_state_dir, start_state_dir) =
+            setup_single_attachment(&tmp, &dot_flox_path, pid, 1);
+
+        let args = DetachArgs {
+            activation_state_dir,
+            pid,
+        };
+        args.handle().expect("detach should succeed");
+
+        assert!(
+            start_state_dir.exists(),
+            "start state dir should be left for the executive when it is running"
+        );
+    }
+
+    /// Without a running executive (e.g. containerize) nothing would ever
+    /// sweep the start state dir, so detach removes it inline.
+    #[test]
+    fn start_state_dir_removed_inline_without_executive() {
+        let tmp = TempDir::new().unwrap();
+        let dot_flox_path = tmp.path().join(".flox");
+        let pid = 12345_i32;
+
+        // An executive PID that is certainly not running.
+        let dead_executive = start_dead_pid();
+        let (activation_state_dir, start_state_dir) =
+            setup_single_attachment(&tmp, &dot_flox_path, pid, dead_executive);
 
         let args = DetachArgs {
             activation_state_dir,
@@ -175,7 +217,15 @@ mod test {
 
         assert!(
             !start_state_dir.exists(),
-            "start state dir should be removed when the last PID detaches"
+            "start state dir should be removed inline when no executive is running"
         );
+    }
+
+    /// Spawn and reap a short-lived process, returning its no-longer-running PID.
+    fn start_dead_pid() -> i32 {
+        let mut child = std::process::Command::new("true").spawn().unwrap();
+        let pid = child.id() as i32;
+        child.wait().unwrap();
+        pid
     }
 }

--- a/cli/flox-activations/src/cli/executive/mod.rs
+++ b/cli/flox-activations/src/cli/executive/mod.rs
@@ -301,19 +301,20 @@ fn run_event_loop(
                     // start from state.json under the lock, then tear it down
                     // with the lock released: its hook.on-deactivate has no
                     // timeout and must not block new activations. The write
-                    // retriggers StateFileChanged, which finds no orphans.
-                    let orphaned = activations.remove_orphaned_starts();
-                    if orphaned.is_empty() {
-                        drop(lock);
-                    } else {
+                    // retriggers StateFileChanged, which finds nothing
+                    // modified and takes the write-free branch.
+                    let removal = activations.remove_orphaned_starts();
+                    if removal.modified {
                         write_activations_json(&activations, &state_json_path, lock)?;
                         sweep_orphaned_starts(
                             subsystem_verbosity,
                             &initial_attach_ctx,
                             &project_ctx,
                             &activation_state_dir,
-                            orphaned,
+                            removal.orphaned,
                         );
+                    } else {
+                        drop(lock);
                     }
                 }
             },
@@ -765,7 +766,7 @@ fn cleanup_all(
     // is orphaned, including starts deferred by an explicit detach that the
     // executive never got to sweep. No state.json write is needed — the whole
     // directory is removed below.
-    let orphaned = activations_json.remove_orphaned_starts();
+    let orphaned = activations_json.remove_orphaned_starts().orphaned;
     sweep_orphaned_starts(
         subsystem_verbosity,
         initial_attach_ctx,

--- a/cli/flox-activations/src/cli/executive/mod.rs
+++ b/cli/flox-activations/src/cli/executive/mod.rs
@@ -28,7 +28,7 @@ use watcher::LockedActivationState;
 
 use crate::cli::activate::NO_REMOVE_ACTIVATION_FILES;
 use crate::logger::init_executive_logger;
-use crate::on_deactivate::{orphaned_start_ids, sweep_orphaned_starts};
+use crate::on_deactivate::sweep_orphaned_starts;
 use crate::process_compose::{process_compose_down, start_process_compose_no_services};
 
 mod event_coordinator;
@@ -255,7 +255,7 @@ fn run_event_loop(
             Ok(ExecutiveEvent::StateFileChanged) => {
                 debug!("state.json changed, checking for new PIDs to monitor");
                 let (state, lock) = read_activations_json(&state_json_path)?;
-                let Some(activations) = state else {
+                let Some(mut activations) = state else {
                     // state.json went away between the watcher observing it and
                     // this read. There is nothing left to monitor, so take the
                     // same exit as StateFileRemoved rather than erroring.
@@ -297,19 +297,24 @@ fn run_event_loop(
                 } else {
                     // A detach may have emptied a start while other
                     // attachments remain (e.g. an explicit `flox deactivate`
-                    // hands the start state dir off to the executive). Tear
-                    // down any such start, dropping the lock first: its
-                    // hook.on-deactivate has no timeout and must not block
-                    // new activations.
-                    let orphaned = orphaned_start_ids(&activation_state_dir, &activations);
-                    drop(lock);
-                    sweep_orphaned_starts(
-                        subsystem_verbosity,
-                        &initial_attach_ctx,
-                        &project_ctx,
-                        &activation_state_dir,
-                        orphaned,
-                    );
+                    // defers teardown to the executive). Remove any such
+                    // start from state.json under the lock, then tear it down
+                    // with the lock released: its hook.on-deactivate has no
+                    // timeout and must not block new activations. The write
+                    // retriggers StateFileChanged, which finds no orphans.
+                    let orphaned = activations.remove_orphaned_starts();
+                    if orphaned.is_empty() {
+                        drop(lock);
+                    } else {
+                        write_activations_json(&activations, &state_json_path, lock)?;
+                        sweep_orphaned_starts(
+                            subsystem_verbosity,
+                            &initial_attach_ctx,
+                            &project_ctx,
+                            &activation_state_dir,
+                            orphaned,
+                        );
+                    }
                 }
             },
             Ok(ExecutiveEvent::StateFileRemoved) => {
@@ -427,7 +432,7 @@ fn handle_process_exited(
 
     // Use PidWatcher to clean up the state
     match watcher::cleanup_pid((activations, lock), state_json_path, pid) {
-        Ok(None) => {
+        Ok(watcher::CleanupPidResult::Remaining { orphaned }) => {
             // Still have active PIDs - check if this PID re-attached
             // and needs to be monitored again.
             //
@@ -522,13 +527,14 @@ fn handle_process_exited(
             coordinator
                 .ensure_monitoring_pids(other_attached_pids)
                 .context("failed to ensure monitoring PIDs")?;
+            drop(lock);
 
             // The exited PID may have been the last attachment for its start
-            // even though other starts still have attachments. Tear down any
-            // such start, dropping the lock first: its hook.on-deactivate has
-            // no timeout and must not block new activations.
-            let orphaned = orphaned_start_ids(activation_state_dir, &activations);
-            drop(lock);
+            // even though other starts still have attachments. cleanup_pid
+            // removed any such start from state.json under its lock; tear
+            // them down now that no lock is held, because their
+            // hook.on-deactivate has no timeout and must not block new
+            // activations.
             sweep_orphaned_starts(
                 subsystem_verbosity,
                 initial_attach_ctx,
@@ -539,7 +545,7 @@ fn handle_process_exited(
 
             Ok(false)
         },
-        Ok(Some(locked_activations)) => {
+        Ok(watcher::CleanupPidResult::AllDetached(locked_activations)) => {
             info!("running cleanup after all PIDs terminated");
             let cleaned_up = cleanup_all(
                 locked_activations,
@@ -739,7 +745,7 @@ fn cleanup_all(
 ) -> Result<bool> {
     info!("running cleanup");
 
-    let (activations_json, _hold_the_lock) = locked_activations;
+    let (mut activations_json, hold_the_lock) = locked_activations;
 
     if !activations_json.attached_pids_is_empty() {
         warn!("cleanup called with PIDs still attached, skipping");
@@ -748,14 +754,18 @@ fn cleanup_all(
 
     shut_down_process_compose(process_compose_bin, socket_path.as_ref());
     let cleanup_path = rename_state_for_removal(activation_state_dir_path.as_ref())?;
+    // The rename already detached the state from new activations (they
+    // recreate the directory under its original name), so the lock guards
+    // nothing anymore; release it before running hooks.
+    drop(hold_the_lock);
 
     // Run hook.on-deactivate for the remaining start(s), mirroring the
     // activation order in reverse: services were shut down above, the hook
-    // bookends close last. This runs after the rename so a hanging hook can't
-    // block new activations — they recreate the directory under its original
-    // name — and it also covers starts handed off by an explicit detach that
-    // the executive never got to sweep.
-    let orphaned = orphaned_start_ids(&cleanup_path, &activations_json);
+    // bookends close last. With no attachments left every start in the state
+    // is orphaned, including starts deferred by an explicit detach that the
+    // executive never got to sweep. No state.json write is needed — the whole
+    // directory is removed below.
+    let orphaned = activations_json.remove_orphaned_starts();
     sweep_orphaned_starts(
         subsystem_verbosity,
         initial_attach_ctx,

--- a/cli/flox-activations/src/cli/executive/mod.rs
+++ b/cli/flox-activations/src/cli/executive/mod.rs
@@ -763,10 +763,11 @@ fn cleanup_all(
     // Run hook.on-deactivate for the remaining start(s), mirroring the
     // activation order in reverse: services were shut down above, the hook
     // bookends close last. With no attachments left every start in the state
-    // is orphaned, including starts deferred by an explicit detach that the
-    // executive never got to sweep. No state.json write is needed — the whole
-    // directory is removed below.
-    let orphaned = activations_json.remove_orphaned_starts().orphaned;
+    // is torn down, including starts deferred by an explicit detach that the
+    // executive never got to sweep and a `Starting` start whose PID died —
+    // its hook only runs if hook.on-activate completed. No state.json write
+    // is needed — the whole directory is removed below.
+    let orphaned = activations_json.drain_starts();
     sweep_orphaned_starts(
         subsystem_verbosity,
         initial_attach_ctx,

--- a/cli/flox-activations/src/cli/executive/mod.rs
+++ b/cli/flox-activations/src/cli/executive/mod.rs
@@ -28,6 +28,7 @@ use watcher::LockedActivationState;
 
 use crate::cli::activate::NO_REMOVE_ACTIVATION_FILES;
 use crate::logger::init_executive_logger;
+use crate::on_deactivate::{orphaned_start_ids, sweep_orphaned_starts};
 use crate::process_compose::{process_compose_down, start_process_compose_no_services};
 
 mod event_coordinator;
@@ -212,6 +213,9 @@ fn run_event_loop(
                     &process_compose_bin,
                     &socket_path,
                     &activation_state_dir,
+                    subsystem_verbosity,
+                    &initial_attach_ctx,
+                    &project_ctx,
                 )?;
                 if should_exit {
                     return Ok(());
@@ -280,6 +284,9 @@ fn run_event_loop(
                         &process_compose_bin,
                         &socket_path,
                         &activation_state_dir,
+                        subsystem_verbosity,
+                        &initial_attach_ctx,
+                        &project_ctx,
                     )
                     .context("cleanup failed after StateFileChanged with empty PIDs")?
                     {
@@ -287,8 +294,23 @@ fn run_event_loop(
                     }
                     // A PID raced in between the empty check and cleanup_all;
                     // continue the event loop so the new PID stays monitored.
+                } else {
+                    // A detach may have emptied a start while other
+                    // attachments remain (e.g. an explicit `flox deactivate`
+                    // hands the start state dir off to the executive). Tear
+                    // down any such start, dropping the lock first: its
+                    // hook.on-deactivate has no timeout and must not block
+                    // new activations.
+                    let orphaned = orphaned_start_ids(&activation_state_dir, &activations);
+                    drop(lock);
+                    sweep_orphaned_starts(
+                        subsystem_verbosity,
+                        &initial_attach_ctx,
+                        &project_ctx,
+                        &activation_state_dir,
+                        orphaned,
+                    );
                 }
-                // lock drops here when PIDs remain
             },
             Ok(ExecutiveEvent::StateFileRemoved) => {
                 // state.json existed when this executive started, so a removal
@@ -370,6 +392,7 @@ impl LoopGuard {
 ///
 /// Returns `true` if all PIDs have terminated and cleanup completed (exit the loop),
 /// or `false` if there are still active PIDs (continue the loop).
+#[allow(clippy::too_many_arguments)]
 fn handle_process_exited(
     pid: i32,
     coordinator: &EventCoordinator,
@@ -378,6 +401,9 @@ fn handle_process_exited(
     process_compose_bin: &Path,
     socket_path: &Path,
     activation_state_dir: &Path,
+    subsystem_verbosity: u32,
+    initial_attach_ctx: &AttachCtx,
+    project_ctx: &AttachProjectCtx,
 ) -> Result<bool> {
     // Remove from known_pids first so it can be re-monitored if it re-attached
     coordinator.stop_monitoring(pid);
@@ -400,12 +426,7 @@ fn handle_process_exited(
     };
 
     // Use PidWatcher to clean up the state
-    match watcher::cleanup_pid(
-        (activations, lock),
-        state_json_path,
-        activation_state_dir,
-        pid,
-    ) {
+    match watcher::cleanup_pid((activations, lock), state_json_path, pid) {
         Ok(None) => {
             // Still have active PIDs - check if this PID re-attached
             // and needs to be monitored again.
@@ -502,6 +523,20 @@ fn handle_process_exited(
                 .ensure_monitoring_pids(other_attached_pids)
                 .context("failed to ensure monitoring PIDs")?;
 
+            // The exited PID may have been the last attachment for its start
+            // even though other starts still have attachments. Tear down any
+            // such start, dropping the lock first: its hook.on-deactivate has
+            // no timeout and must not block new activations.
+            let orphaned = orphaned_start_ids(activation_state_dir, &activations);
+            drop(lock);
+            sweep_orphaned_starts(
+                subsystem_verbosity,
+                initial_attach_ctx,
+                project_ctx,
+                activation_state_dir,
+                orphaned,
+            );
+
             Ok(false)
         },
         Ok(Some(locked_activations)) => {
@@ -511,6 +546,9 @@ fn handle_process_exited(
                 process_compose_bin,
                 socket_path,
                 activation_state_dir,
+                subsystem_verbosity,
+                initial_attach_ctx,
+                project_ctx,
             )
             .context("cleanup failed")?;
             Ok(cleaned_up)
@@ -538,6 +576,9 @@ fn handle_process_exited(
                 process_compose_bin,
                 socket_path,
                 activation_state_dir,
+                subsystem_verbosity,
+                initial_attach_ctx,
+                project_ctx,
             );
             bail!(err.context("failed while waiting for termination"))
         },
@@ -642,12 +683,22 @@ fn cleanup_on_no_state(
 
 /// Shutdown `process-compose` if running and remove the activation state
 /// directory.
+///
+/// Used when state.json is gone and the starts on disk can't be trusted;
+/// no `hook.on-deactivate` runs on this path.
 fn shut_down_and_remove_state(
     process_compose_bin: &Path,
     socket_path: impl AsRef<Path>,
     activation_state_dir_path: impl AsRef<Path>,
 ) -> Result<()> {
-    let socket_path = socket_path.as_ref();
+    shut_down_process_compose(process_compose_bin, socket_path.as_ref());
+    let cleanup_path = rename_state_for_removal(activation_state_dir_path.as_ref())?;
+    fs::remove_dir_all(&cleanup_path).context("couldn't remove activations dir")?;
+    Ok(())
+}
+
+/// Shutdown `process-compose` if its socket is present.
+fn shut_down_process_compose(process_compose_bin: &Path, socket_path: &Path) {
     if !socket_path.exists() {
         info!(reason = "no socket", "did not shut down process-compose");
     } else if let Err(err) = process_compose_down(process_compose_bin, socket_path) {
@@ -655,30 +706,36 @@ fn shut_down_and_remove_state(
     } else {
         info!("shut down process-compose");
     }
+}
 
-    // Atomically remove the activation state directory
-    // We want to avoid a race where remove_dir_all removes the lock before
-    // removing activation state dir,
-    // and then another activation creates a lock and causes remove_dir_all to
-    // fail.
-    let activation_state_dir_path = activation_state_dir_path.as_ref();
+/// Atomically detach the activation state directory for removal by renaming
+/// it, returning the renamed path.
+///
+/// We want to avoid a race where remove_dir_all removes the lock before
+/// removing activation state dir,
+/// and then another activation creates a lock and causes remove_dir_all to
+/// fail.
+fn rename_state_for_removal(activation_state_dir_path: &Path) -> Result<PathBuf> {
     let cleanup_path =
         activation_state_dir_path.with_extension(format!("cleanup.{}", std::process::id()));
     fs::rename(activation_state_dir_path, &cleanup_path)
         .context("couldn't rename activations dir for cleanup")?;
-    fs::remove_dir_all(&cleanup_path).context("couldn't remove activations dir")?;
-
-    Ok(())
+    Ok(cleanup_path)
 }
 
-/// Shutdown `process-compose` if running and remove all activation state.
+/// Shutdown `process-compose` if running, run any `hook.on-deactivate`
+/// bookends, and remove all activation state.
 /// To be called when there are no longer any PIDs attached.
 /// Returns `true` if cleanup ran, `false` if PIDs were found and cleanup was skipped.
+#[allow(clippy::too_many_arguments)]
 fn cleanup_all(
     locked_activations: LockedActivationState,
     process_compose_bin: &Path,
     socket_path: impl AsRef<Path>,
     activation_state_dir_path: impl AsRef<Path>,
+    subsystem_verbosity: u32,
+    initial_attach_ctx: &AttachCtx,
+    project_ctx: &AttachProjectCtx,
 ) -> Result<bool> {
     info!("running cleanup");
 
@@ -689,7 +746,25 @@ fn cleanup_all(
         return Ok(false);
     }
 
-    shut_down_and_remove_state(process_compose_bin, socket_path, activation_state_dir_path)?;
+    shut_down_process_compose(process_compose_bin, socket_path.as_ref());
+    let cleanup_path = rename_state_for_removal(activation_state_dir_path.as_ref())?;
+
+    // Run hook.on-deactivate for the remaining start(s), mirroring the
+    // activation order in reverse: services were shut down above, the hook
+    // bookends close last. This runs after the rename so a hanging hook can't
+    // block new activations — they recreate the directory under its original
+    // name — and it also covers starts handed off by an explicit detach that
+    // the executive never got to sweep.
+    let orphaned = orphaned_start_ids(&cleanup_path, &activations_json);
+    sweep_orphaned_starts(
+        subsystem_verbosity,
+        initial_attach_ctx,
+        project_ctx,
+        &cleanup_path,
+        orphaned,
+    );
+
+    fs::remove_dir_all(&cleanup_path).context("couldn't remove activations dir")?;
 
     info!("finished cleanup");
 
@@ -705,35 +780,8 @@ mod test {
     use flox_core::activations::{ActivationState, StartOrAttachResult, activation_state_dir_path};
 
     use super::event_coordinator::{EventCoordinator, ExecutiveEvent};
-    use super::watcher::test::{start_process, stop_process};
+    use super::watcher::test::{start_process, stop_process, test_context};
     use super::*;
-
-    /// Create minimal context for testing.
-    /// The actual values don't matter since tests don't trigger SIGUSR1.
-    fn test_context(dot_flox_path: &Path, flox_env: &str) -> (AttachCtx, AttachProjectCtx) {
-        let attach = AttachCtx {
-            env: flox_env.to_string(),
-            env_description: "test".to_string(),
-            env_cache: dot_flox_path.join("cache"),
-            interpreter_path: PathBuf::from("/nix/store/fake"),
-            prompt_color_1: "".to_string(),
-            prompt_color_2: "".to_string(),
-            flox_prompt_environments: "".to_string(),
-            set_prompt: false,
-            flox_env_cuda_detection: "".to_string(),
-            add_sbin: false,
-            flox_active_environments: "".to_string(),
-        };
-        let project = AttachProjectCtx {
-            env_project: dot_flox_path.to_path_buf(),
-            dot_flox_path: dot_flox_path.to_path_buf(),
-            flox_env_log_dir: PathBuf::from("/tmp/test_log_dir"),
-            flox_services_socket: PathBuf::from("/does_not_exist"),
-            process_compose_bin: PathBuf::from("/nix/store/fake-process-compose"),
-            services_to_start: Vec::new(),
-        };
-        (attach, project)
-    }
 
     #[test]
     fn monitoring_loop_removes_state_on_cleanup() {
@@ -908,7 +956,7 @@ mod test {
         // These are all dummy values
         let coordinator = EventCoordinator::new().unwrap();
         let mut loop_guard = LoopGuard::new(5);
-        let (_attach, project) = test_context(&dot_flox_path, &flox_env.to_string_lossy());
+        let (attach, project) = test_context(&dot_flox_path, &flox_env.to_string_lossy());
 
         stop_process(proc1);
 
@@ -921,6 +969,9 @@ mod test {
             &project.process_compose_bin,
             &project.flox_services_socket,
             &activation_state_directory,
+            0,
+            &attach,
+            &project,
         );
 
         // No cleanup is needed while the replacement PID is active.
@@ -952,6 +1003,9 @@ mod test {
             &project.process_compose_bin,
             &project.flox_services_socket,
             &activation_state_directory,
+            0,
+            &attach,
+            &project,
         );
         assert!(
             matches!(result, Ok(true)),
@@ -1038,7 +1092,7 @@ mod test {
 
         let coordinator = EventCoordinator::new().unwrap();
         let mut loop_guard = LoopGuard::new(2);
-        let (_attach, project) = test_context(&dot_flox_path, &flox_env.to_string_lossy());
+        let (attach, project) = test_context(&dot_flox_path, &flox_env.to_string_lossy());
 
         // Exhaust the guard for the PID
         assert!(loop_guard.allow_remonitor(exited_pid));
@@ -1056,6 +1110,9 @@ mod test {
             &project.process_compose_bin,
             &project.flox_services_socket,
             &activation_state_directory,
+            0,
+            &attach,
+            &project,
         );
         assert!(matches!(result, Ok(false)), "keeper PID should remain");
 
@@ -1100,7 +1157,7 @@ mod test {
         let coordinator = EventCoordinator::new().unwrap();
         // Use a low limit so we can test hitting it
         let mut loop_guard = LoopGuard::new(2);
-        let (_attach, project) = test_context(&dot_flox_path, &flox_env.to_string_lossy());
+        let (attach, project) = test_context(&dot_flox_path, &flox_env.to_string_lossy());
 
         // First call: PID is in state and running, so it will be re-monitored.
         // loop_guard.allow_remonitor(pid) returns true (count=1 < limit=2)
@@ -1112,6 +1169,9 @@ mod test {
             &project.process_compose_bin,
             &project.flox_services_socket,
             &activation_state_directory,
+            0,
+            &attach,
+            &project,
         );
         assert!(matches!(result, Ok(false)), "first call should succeed");
 
@@ -1125,6 +1185,9 @@ mod test {
             &project.process_compose_bin,
             &project.flox_services_socket,
             &activation_state_directory,
+            0,
+            &attach,
+            &project,
         );
         assert!(matches!(result, Ok(false)), "second call should succeed");
 

--- a/cli/flox-activations/src/cli/executive/watcher.rs
+++ b/cli/flox-activations/src/cli/executive/watcher.rs
@@ -11,7 +11,7 @@
 use std::path::Path;
 
 use anyhow::Result;
-use flox_core::activations::{ActivationState, write_activations_json};
+use flox_core::activations::{ActivationState, StartIdentifier, write_activations_json};
 use flox_core::proc_status::pid_is_running;
 use fslock::LockFile;
 use time::OffsetDateTime;
@@ -24,45 +24,50 @@ type Error = anyhow::Error;
 /// TODO: there's probably a cleaner way to do this
 pub type LockedActivationState = (ActivationState, LockFile);
 
+/// Outcome of [cleanup_pid].
+pub enum CleanupPidResult {
+    /// All PIDs have terminated; the caller should run full cleanup while
+    /// still holding the lock.
+    AllDetached(LockedActivationState),
+    /// PIDs remain and the lock has been released. Starts left without
+    /// attachments were removed from state.json and must be torn down by the
+    /// caller (running their `hook.on-deactivate`).
+    Remaining { orphaned: Vec<StartIdentifier> },
+}
+
 /// Check if the provided PID is still running and clean it up if not.
 ///
 /// Takes the state already locked rather than reading it, so that whether
 /// state.json still exists is decided by the caller. Every arm of the event
 /// loop answers that the same way, and it is not this function's policy to set.
-///
-/// Returns `Some(LockedActivationState)` if all PIDs have terminated and
-/// cleanup should proceed.
-/// Returns `None` if there are still active PIDs.
 pub fn cleanup_pid(
     locked_activations: LockedActivationState,
     state_json_path: &Path,
     pid: i32,
-) -> Result<Option<LockedActivationState>, Error> {
+) -> Result<CleanupPidResult, Error> {
     let (mut activations, lock) = locked_activations;
 
     let now = OffsetDateTime::now_utc();
-    let (empty_start_id, modified) = activations.cleanup_pid(pid, pid_is_running, now);
+    let modified = activations.cleanup_pid(pid, pid_is_running, now);
 
     // If there are no more attached PIDs for any start, return early and
     // cleanup the entirety of the activation state directory
     if activations.attached_pids_is_empty() {
-        return Ok(Some((activations, lock)));
+        return Ok(CleanupPidResult::AllDetached((activations, lock)));
     }
 
-    // A start emptied by this PID is not torn down here: the caller sweeps it
-    // (running hook.on-deactivate first) after this function's lock has been
-    // released.
-    trace!(
-        ?empty_start_id,
-        "PID cleanup left start with no attachments"
-    );
+    // Remove starts left without attachments from state.json under the same
+    // lock that detached the PID, so they are handed to the caller's sweep
+    // exactly once. The sweep itself must run after the lock is released.
+    let orphaned = activations.remove_orphaned_starts();
+    trace!(?orphaned, "PID cleanup left starts with no attachments");
 
-    if modified {
+    if modified || !orphaned.is_empty() {
         trace!(?activations, "writing PID changes to activation");
         write_activations_json(&activations, state_json_path, lock)?;
     }
 
-    Ok(None)
+    Ok(CleanupPidResult::Remaining { orphaned })
 }
 
 #[cfg(test)]
@@ -84,7 +89,7 @@ pub mod test {
     use flox_core::proc_status::{ProcStatus, pid_is_running, read_pid_status};
 
     use super::*;
-    use crate::on_deactivate::{orphaned_start_ids, sweep_orphaned_starts};
+    use crate::on_deactivate::sweep_orphaned_starts;
 
     /// Create minimal context for testing.
     /// The actual values don't matter since tests don't trigger SIGUSR1.
@@ -202,16 +207,21 @@ pub mod test {
         let activation_state_dir = activation_state_dir_path(runtime_dir.path(), &dot_flox_path);
         let state_json_path = state_json_path(&activation_state_dir);
 
-        // Clean up first PID - should not trigger full cleanup yet
+        // Clean up first PID - should not trigger full cleanup yet, and the
+        // start still has pid2 attached so nothing is orphaned.
         stop_process(proc1);
         let result = cleanup_pid(locked_state(&state_json_path), &state_json_path, pid1).unwrap();
-        assert!(result.is_none(), "should not cleanup after first PID");
+        let CleanupPidResult::Remaining { orphaned } = result else {
+            panic!("should not cleanup after first PID");
+        };
+        assert_eq!(orphaned, Vec::new());
 
         // Clean up second PID - should trigger full cleanup
         stop_process(proc2);
-        let (state, _lock) = cleanup_pid(locked_state(&state_json_path), &state_json_path, pid2)
-            .unwrap()
-            .expect("should return cleanup result");
+        let result = cleanup_pid(locked_state(&state_json_path), &state_json_path, pid2).unwrap();
+        let CleanupPidResult::AllDetached((state, _lock)) = result else {
+            panic!("should return cleanup result");
+        };
         assert_eq!(
             state.attachments_by_start_id(),
             BTreeMap::new(),
@@ -260,27 +270,25 @@ pub mod test {
 
         write_activation_state(runtime_dir.path(), &dot_flox_path, state);
 
-        // Create both state directories with their start id markers
+        // Create both state directories
         let activation_state_dir = activation_state_dir_path(runtime_dir.path(), &dot_flox_path);
         let state_dir_1 = start_id_1.start_state_dir(&activation_state_dir).unwrap();
         let state_dir_2 = start_id_2.start_state_dir(&activation_state_dir).unwrap();
         std::fs::create_dir_all(&state_dir_1).unwrap();
         std::fs::create_dir_all(&state_dir_2).unwrap();
-        start_id_1
-            .write_to_start_state_dir(&activation_state_dir)
-            .unwrap();
-        start_id_2
-            .write_to_start_state_dir(&activation_state_dir)
-            .unwrap();
         assert!(state_dir_1.exists());
         assert!(state_dir_2.exists());
 
         let state_json_path = state_json_path(&activation_state_dir);
 
-        // Terminate proc1 and call cleanup_pid
+        // Terminate proc1 and call cleanup_pid: the emptied start is removed
+        // from state.json under the lock and returned for the sweep.
         stop_process(proc1);
         let result = cleanup_pid(locked_state(&state_json_path), &state_json_path, pid1).unwrap();
-        assert!(result.is_none(), "should not cleanup while pid2 is running");
+        let CleanupPidResult::Remaining { orphaned } = result else {
+            panic!("should not cleanup while pid2 is running");
+        };
+        assert_eq!(orphaned, vec![start_id_1.clone()]);
 
         // cleanup_pid leaves the emptied start's directory for the caller's
         // sweep, which runs hook.on-deactivate before removing it.
@@ -289,9 +297,6 @@ pub mod test {
             "state directory 1 should be handed off to the sweep, not removed"
         );
 
-        let (activations, lock) = read_activations_json(&state_json_path).unwrap();
-        let orphaned = orphaned_start_ids(&activation_state_dir, &activations.unwrap());
-        drop(lock);
         let (attach, project) = test_context(&dot_flox_path, &flox_env.to_string_lossy());
         sweep_orphaned_starts(0, &attach, &project, &activation_state_dir, orphaned);
 
@@ -299,11 +304,21 @@ pub mod test {
         assert!(!state_dir_1.exists(), "state directory 1 should be removed");
         assert!(state_dir_2.exists(), "state directory 2 should still exist");
 
+        // A second pass finds nothing: the orphaned start is gone from
+        // state.json, so it is only ever handed to the sweep once.
+        let (mut activations, lock) = {
+            let (activations, lock) = read_activations_json(&state_json_path).unwrap();
+            (activations.expect("state.json should exist"), lock)
+        };
+        assert_eq!(activations.remove_orphaned_starts(), Vec::new());
+        drop(lock);
+
         // Clean up
         stop_process(proc2);
-        let (state, _lock) = cleanup_pid(locked_state(&state_json_path), &state_json_path, pid2)
-            .unwrap()
-            .expect("should return cleanup result");
+        let result = cleanup_pid(locked_state(&state_json_path), &state_json_path, pid2).unwrap();
+        let CleanupPidResult::AllDetached((state, _lock)) = result else {
+            panic!("should return cleanup result");
+        };
         assert_eq!(
             state.attachments_by_start_id(),
             BTreeMap::new(),

--- a/cli/flox-activations/src/cli/executive/watcher.rs
+++ b/cli/flox-activations/src/cli/executive/watcher.rs
@@ -25,6 +25,7 @@ type Error = anyhow::Error;
 pub type LockedActivationState = (ActivationState, LockFile);
 
 /// Outcome of [cleanup_pid].
+#[derive(Debug)]
 pub enum CleanupPidResult {
     /// All PIDs have terminated; the caller should run full cleanup while
     /// still holding the lock.
@@ -231,6 +232,45 @@ pub mod test {
             state.attachments_by_start_id(),
             BTreeMap::new(),
             "should return empty state after cleanup"
+        );
+    }
+
+    /// A `ready` clear with no orphaned starts (e.g. state written by an
+    /// earlier binary without the starts field) is still persisted by
+    /// `cleanup_pid`, even when the PID itself is kept.
+    #[test]
+    fn persists_ready_clear_without_orphans() {
+        let runtime_dir = tempfile::tempdir().unwrap();
+        let dot_flox_path = PathBuf::from(".flox");
+        let flox_env = dot_flox_path.join("run/test");
+        let pid = std::process::id() as i32;
+
+        let mut state =
+            ActivationState::new(&ActivateMode::default(), Some(&dot_flox_path), &flox_env);
+        state.set_executive_pid(1);
+        let result = state.start_or_attach(pid, "attached_store_path");
+        assert!(matches!(result, StartOrAttachResult::Start { .. }));
+        // `ready` names a start absent from the starts list, standing in for
+        // state written by an earlier binary without the field.
+        state.set_ready(&StartIdentifier::new("untracked_store_path"));
+        write_activation_state(runtime_dir.path(), &dot_flox_path, state);
+
+        let activation_state_dir = activation_state_dir_path(runtime_dir.path(), &dot_flox_path);
+        let state_json_path = state_json_path(&activation_state_dir);
+
+        // The attached PID is this test process, so it is kept and nothing is
+        // orphaned; only the ready clear needs persisting.
+        let result = cleanup_pid(locked_state(&state_json_path), &state_json_path, pid).unwrap();
+        let CleanupPidResult::Remaining { orphaned } = result else {
+            panic!("PID is running, cleanup must not trigger");
+        };
+        assert_eq!(orphaned, Vec::new());
+
+        let (activations, _lock) = locked_state(&state_json_path);
+        assert_eq!(
+            activations.ready_start_id(),
+            None,
+            "the ready clear must be persisted to state.json"
         );
     }
 

--- a/cli/flox-activations/src/cli/executive/watcher.rs
+++ b/cli/flox-activations/src/cli/executive/watcher.rs
@@ -36,7 +36,6 @@ pub type LockedActivationState = (ActivationState, LockFile);
 pub fn cleanup_pid(
     locked_activations: LockedActivationState,
     state_json_path: &Path,
-    activation_state_dir: &Path,
     pid: i32,
 ) -> Result<Option<LockedActivationState>, Error> {
     let (mut activations, lock) = locked_activations;
@@ -50,17 +49,13 @@ pub fn cleanup_pid(
         return Ok(Some((activations, lock)));
     }
 
-    // Cleanup empty start ID
-    //
-    // We might want to skip this if start_id is the same as that in ready,
-    // since otherwise we'll do another start of the same environment when:
-    // 1. There were still some activations of the environment
-    // and
-    // 2. The environment was not modified
-    // But I think for now it's simpler to just treat all start_ids the same.
-    if let Some(start_id) = empty_start_id {
-        start_id.remove_start_state_dir(activation_state_dir)?;
-    }
+    // A start emptied by this PID is not torn down here: the caller sweeps it
+    // (running hook.on-deactivate first) after this function's lock has been
+    // released.
+    trace!(
+        ?empty_start_id,
+        "PID cleanup left start with no attachments"
+    );
 
     if modified {
         trace!(?activations, "writing PID changes to activation");
@@ -77,6 +72,7 @@ pub mod test {
     use std::process::{Child, Command};
     use std::time::Duration;
 
+    use flox_core::activate::context::{AttachCtx, AttachProjectCtx};
     use flox_core::activate::mode::ActivateMode;
     use flox_core::activations::test_helpers::write_activation_state;
     use flox_core::activations::{
@@ -88,6 +84,34 @@ pub mod test {
     use flox_core::proc_status::{ProcStatus, pid_is_running, read_pid_status};
 
     use super::*;
+    use crate::on_deactivate::{orphaned_start_ids, sweep_orphaned_starts};
+
+    /// Create minimal context for testing.
+    /// The actual values don't matter since tests don't trigger SIGUSR1.
+    pub fn test_context(dot_flox_path: &Path, flox_env: &str) -> (AttachCtx, AttachProjectCtx) {
+        let attach = AttachCtx {
+            env: flox_env.to_string(),
+            env_description: "test".to_string(),
+            env_cache: dot_flox_path.join("cache"),
+            interpreter_path: PathBuf::from("/nix/store/fake"),
+            prompt_color_1: "".to_string(),
+            prompt_color_2: "".to_string(),
+            flox_prompt_environments: "".to_string(),
+            set_prompt: false,
+            flox_env_cuda_detection: "".to_string(),
+            add_sbin: false,
+            flox_active_environments: "".to_string(),
+        };
+        let project = AttachProjectCtx {
+            env_project: dot_flox_path.to_path_buf(),
+            dot_flox_path: dot_flox_path.to_path_buf(),
+            flox_env_log_dir: PathBuf::from("/tmp/test_log_dir"),
+            flox_services_socket: PathBuf::from("/does_not_exist"),
+            process_compose_bin: PathBuf::from("/nix/store/fake-process-compose"),
+            services_to_start: Vec::new(),
+        };
+        (attach, project)
+    }
 
     /// Read and lock the state the way the event loop does before calling
     /// [`cleanup_pid`].
@@ -180,25 +204,14 @@ pub mod test {
 
         // Clean up first PID - should not trigger full cleanup yet
         stop_process(proc1);
-        let result = cleanup_pid(
-            locked_state(&state_json_path),
-            &state_json_path,
-            &activation_state_dir,
-            pid1,
-        )
-        .unwrap();
+        let result = cleanup_pid(locked_state(&state_json_path), &state_json_path, pid1).unwrap();
         assert!(result.is_none(), "should not cleanup after first PID");
 
         // Clean up second PID - should trigger full cleanup
         stop_process(proc2);
-        let (state, _lock) = cleanup_pid(
-            locked_state(&state_json_path),
-            &state_json_path,
-            &activation_state_dir,
-            pid2,
-        )
-        .unwrap()
-        .expect("should return cleanup result");
+        let (state, _lock) = cleanup_pid(locked_state(&state_json_path), &state_json_path, pid2)
+            .unwrap()
+            .expect("should return cleanup result");
         assert_eq!(
             state.attachments_by_start_id(),
             BTreeMap::new(),
@@ -206,7 +219,8 @@ pub mod test {
         );
     }
 
-    /// After all attachments to a start exit, start state directory is removed
+    /// After all attachments to a start exit, `cleanup_pid` hands the start
+    /// state directory off to the caller's sweep, which removes it.
     #[test]
     fn cleans_up_start_state_directory() {
         let runtime_dir = tempfile::tempdir().unwrap();
@@ -246,12 +260,18 @@ pub mod test {
 
         write_activation_state(runtime_dir.path(), &dot_flox_path, state);
 
-        // Create both state directories
+        // Create both state directories with their start id markers
         let activation_state_dir = activation_state_dir_path(runtime_dir.path(), &dot_flox_path);
         let state_dir_1 = start_id_1.start_state_dir(&activation_state_dir).unwrap();
         let state_dir_2 = start_id_2.start_state_dir(&activation_state_dir).unwrap();
         std::fs::create_dir_all(&state_dir_1).unwrap();
         std::fs::create_dir_all(&state_dir_2).unwrap();
+        start_id_1
+            .write_to_start_state_dir(&activation_state_dir)
+            .unwrap();
+        start_id_2
+            .write_to_start_state_dir(&activation_state_dir)
+            .unwrap();
         assert!(state_dir_1.exists());
         assert!(state_dir_2.exists());
 
@@ -259,14 +279,21 @@ pub mod test {
 
         // Terminate proc1 and call cleanup_pid
         stop_process(proc1);
-        let result = cleanup_pid(
-            locked_state(&state_json_path),
-            &state_json_path,
-            &activation_state_dir,
-            pid1,
-        )
-        .unwrap();
+        let result = cleanup_pid(locked_state(&state_json_path), &state_json_path, pid1).unwrap();
         assert!(result.is_none(), "should not cleanup while pid2 is running");
+
+        // cleanup_pid leaves the emptied start's directory for the caller's
+        // sweep, which runs hook.on-deactivate before removing it.
+        assert!(
+            state_dir_1.exists(),
+            "state directory 1 should be handed off to the sweep, not removed"
+        );
+
+        let (activations, lock) = read_activations_json(&state_json_path).unwrap();
+        let orphaned = orphaned_start_ids(&activation_state_dir, &activations.unwrap());
+        drop(lock);
+        let (attach, project) = test_context(&dot_flox_path, &flox_env.to_string_lossy());
+        sweep_orphaned_starts(0, &attach, &project, &activation_state_dir, orphaned);
 
         // Verify state_dir_1 has been removed but state_dir_2 still exists
         assert!(!state_dir_1.exists(), "state directory 1 should be removed");
@@ -274,14 +301,9 @@ pub mod test {
 
         // Clean up
         stop_process(proc2);
-        let (state, _lock) = cleanup_pid(
-            locked_state(&state_json_path),
-            &state_json_path,
-            &activation_state_dir,
-            pid2,
-        )
-        .unwrap()
-        .expect("should return cleanup result");
+        let (state, _lock) = cleanup_pid(locked_state(&state_json_path), &state_json_path, pid2)
+            .unwrap()
+            .expect("should return cleanup result");
         assert_eq!(
             state.attachments_by_start_id(),
             BTreeMap::new(),

--- a/cli/flox-activations/src/cli/executive/watcher.rs
+++ b/cli/flox-activations/src/cli/executive/watcher.rs
@@ -59,15 +59,20 @@ pub fn cleanup_pid(
     // Remove starts left without attachments from state.json under the same
     // lock that detached the PID, so they are handed to the caller's sweep
     // exactly once. The sweep itself must run after the lock is released.
-    let orphaned = activations.remove_orphaned_starts();
-    trace!(?orphaned, "PID cleanup left starts with no attachments");
+    let removal = activations.remove_orphaned_starts();
+    trace!(
+        orphaned = ?removal.orphaned,
+        "PID cleanup left starts with no attachments"
+    );
 
-    if modified || !orphaned.is_empty() {
+    if modified || removal.modified {
         trace!(?activations, "writing PID changes to activation");
         write_activations_json(&activations, state_json_path, lock)?;
     }
 
-    Ok(CleanupPidResult::Remaining { orphaned })
+    Ok(CleanupPidResult::Remaining {
+        orphaned: removal.orphaned,
+    })
 }
 
 #[cfg(test)]
@@ -306,11 +311,8 @@ pub mod test {
 
         // A second pass finds nothing: the orphaned start is gone from
         // state.json, so it is only ever handed to the sweep once.
-        let (mut activations, lock) = {
-            let (activations, lock) = read_activations_json(&state_json_path).unwrap();
-            (activations.expect("state.json should exist"), lock)
-        };
-        assert_eq!(activations.remove_orphaned_starts(), Vec::new());
+        let (mut activations, lock) = locked_state(&state_json_path);
+        assert_eq!(activations.remove_orphaned_starts().orphaned, Vec::new());
         drop(lock);
 
         // Clean up

--- a/cli/flox-activations/src/lib.rs
+++ b/cli/flox-activations/src/lib.rs
@@ -8,6 +8,7 @@ pub mod gen_rc;
 pub mod hook;
 pub mod logger;
 pub mod message;
+mod on_deactivate;
 mod process_compose;
 mod start;
 mod vars_from_env;

--- a/cli/flox-activations/src/on_deactivate.rs
+++ b/cli/flox-activations/src/on_deactivate.rs
@@ -1,0 +1,319 @@
+//! Runs `hook.on-deactivate` when the last attachment detaches from a start.
+//!
+//! `hook.on-activate` runs once per start; this module provides the matching
+//! bookend, executed by the executive as part of tearing down a start state
+//! directory. The hook runs in a flox provided bash with the environment as
+//! `hook.on-activate` left it (replayed from the start's env trace), with
+//! output captured into the executive log. Failures are logged and never
+//! block cleanup, and callers must not hold the state.json lock while the
+//! hook runs so a hanging script can't block new activations.
+
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+use anyhow::{Context, Result};
+use flox_core::activate::context::{AttachCtx, AttachProjectCtx};
+use flox_core::activations::{ActivationState, StartIdentifier, read_start_ids_from_disk};
+use tracing::{debug, info, warn};
+
+use crate::attach_diff::AttachDiff;
+use crate::env_trace::EnvTrace;
+use crate::vars_from_env::VarsFromEnvironment;
+
+const BASH_BIN: &str = env!("X_BASH_BIN");
+
+/// Relative path of the rendered `hook.on-deactivate` script within an
+/// environment's store path.
+const HOOK_ON_DEACTIVATE: &str = "activate.d/hook-on-deactivate";
+
+/// Enumerate the start state directories whose start has no remaining
+/// attachments.
+///
+/// This MUST be called while holding the state.json lock: a start being
+/// created writes its directory before registering itself in state.json
+/// (under the same lock), so enumerating without the lock could catch a
+/// directory whose start isn't visible in `state` yet. The returned starts
+/// can then be torn down after the lock drops — a start with no attachments
+/// can never gain new ones (only `ready` starts can be attached to, and an
+/// emptied start is never `ready`).
+pub fn orphaned_start_ids(
+    activation_state_dir: &Path,
+    state: &ActivationState,
+) -> Vec<StartIdentifier> {
+    let live = state.live_start_ids();
+    read_start_ids_from_disk(activation_state_dir)
+        .into_iter()
+        .filter(|start_id| !live.contains(start_id))
+        .collect()
+}
+
+/// Tear down the given start state directories, running each start's
+/// `hook.on-deactivate` first.
+///
+/// The `orphaned` list must come from [orphaned_start_ids], but the lock must
+/// be dropped before calling this: the hook has no timeout and must not block
+/// new activations. The sweep is idempotent — a start is torn down exactly
+/// once because its directory is removed immediately after its hook runs,
+/// and everything here runs on the executive's single event loop thread.
+pub fn sweep_orphaned_starts(
+    subsystem_verbosity: u32,
+    attach_ctx: &AttachCtx,
+    project: &AttachProjectCtx,
+    activation_state_dir: &Path,
+    orphaned: Vec<StartIdentifier>,
+) {
+    for start_id in orphaned {
+        info!(
+            ?start_id,
+            "tearing down start with no remaining attachments"
+        );
+        run_on_deactivate_hook(
+            subsystem_verbosity,
+            attach_ctx,
+            project,
+            &start_id,
+            activation_state_dir,
+        );
+        if let Err(err) = start_id.remove_start_state_dir(activation_state_dir) {
+            warn!(%err, ?start_id, "failed to remove start state dir");
+        }
+    }
+}
+
+/// Run the `hook.on-deactivate` script for a single start, if the rendered
+/// environment has one.
+///
+/// Failures (including a failing script) are logged and swallowed so that
+/// cleanup always proceeds.
+pub fn run_on_deactivate_hook(
+    subsystem_verbosity: u32,
+    attach_ctx: &AttachCtx,
+    project: &AttachProjectCtx,
+    start_id: &StartIdentifier,
+    activation_state_dir: &Path,
+) {
+    let script = start_id.store_path.join(HOOK_ON_DEACTIVATE);
+    if !script.exists() {
+        debug!(?script, "no hook.on-deactivate script, skipping");
+        return;
+    }
+    if let Err(err) = run_hook_script(
+        subsystem_verbosity,
+        attach_ctx,
+        project,
+        start_id,
+        activation_state_dir,
+        &script,
+    ) {
+        warn!(%err, ?script, "failed to run hook.on-deactivate; continuing cleanup");
+    }
+}
+
+fn run_hook_script(
+    subsystem_verbosity: u32,
+    attach_ctx: &AttachCtx,
+    project: &AttachProjectCtx,
+    start_id: &StartIdentifier,
+    activation_state_dir: &Path,
+    script: &Path,
+) -> Result<()> {
+    let start_state_dir = start_id.start_state_dir(activation_state_dir)?;
+
+    // Replay the activation's environment so the hook sees variables
+    // exported by hook.on-activate. A start without a usable trace never got
+    // through activation, so its bookend never opened; skip.
+    let vars_from_env = VarsFromEnvironment::get()?;
+    let env_trace = EnvTrace::from_state_dir(&start_state_dir)
+        .context("start has no usable env trace; hook.on-activate never completed")?;
+    let attach_diff = AttachDiff::new(
+        attach_ctx,
+        Some(project),
+        subsystem_verbosity,
+        vars_from_env,
+        &env_trace,
+        false,
+    )?;
+
+    let mut command = Command::new(BASH_BIN);
+    attach_diff.apply_to_command(&mut command);
+    command.arg(script);
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    info!(?script, "running hook.on-deactivate");
+    let output = command
+        .output()
+        .context("failed to spawn hook.on-deactivate")?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if !stdout.is_empty() {
+        info!(%stdout, "hook.on-deactivate stdout");
+    }
+    if !stderr.is_empty() {
+        info!(%stderr, "hook.on-deactivate stderr");
+    }
+    if !output.status.success() {
+        warn!(
+            status = %output.status,
+            "hook.on-deactivate failed; continuing cleanup"
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use std::path::PathBuf;
+
+    use flox_core::activations::StartIdentifier;
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::env_trace::ENV_TRACE_LOG;
+
+    /// Create minimal context for the hook runner.
+    fn test_context(dot_flox_path: &Path) -> (AttachCtx, AttachProjectCtx) {
+        let attach = AttachCtx {
+            env: "test".to_string(),
+            env_description: "test".to_string(),
+            env_cache: dot_flox_path.join("cache"),
+            interpreter_path: PathBuf::from("/nix/store/fake"),
+            prompt_color_1: "".to_string(),
+            prompt_color_2: "".to_string(),
+            flox_prompt_environments: "".to_string(),
+            set_prompt: false,
+            flox_env_cuda_detection: "".to_string(),
+            add_sbin: false,
+            flox_active_environments: "".to_string(),
+        };
+        let project = AttachProjectCtx {
+            env_project: dot_flox_path.to_path_buf(),
+            dot_flox_path: dot_flox_path.to_path_buf(),
+            flox_env_log_dir: PathBuf::from("/tmp/test_log_dir"),
+            flox_services_socket: PathBuf::from("/does_not_exist"),
+            process_compose_bin: PathBuf::from("/nix/store/fake-process-compose"),
+            services_to_start: Vec::new(),
+        };
+        (attach, project)
+    }
+
+    /// Set up a fake rendered environment and a start for it, optionally with
+    /// a hook.on-deactivate script. Returns the start id and its state dir.
+    fn setup_start(tmp: &TempDir, script: Option<&str>) -> (StartIdentifier, PathBuf, PathBuf) {
+        let store_path = tmp.path().join("store-path");
+        if let Some(script) = script {
+            let activate_d = store_path.join("activate.d");
+            std::fs::create_dir_all(&activate_d).unwrap();
+            std::fs::write(activate_d.join("hook-on-deactivate"), script).unwrap();
+        }
+
+        let activation_state_dir = tmp.path().join("activations");
+        let start_id = StartIdentifier::new(&store_path);
+        let start_state_dir = start_id.start_state_dir(&activation_state_dir).unwrap();
+        std::fs::create_dir_all(&start_state_dir).unwrap();
+        start_id
+            .write_to_start_state_dir(&activation_state_dir)
+            .unwrap();
+        // Trace recorded during activation: hook.on-activate exported
+        // ON_ACTIVATE_VAR. Fields are timestamp, op, exported flags, name,
+        // old value (@ = none), and operand, separated by US (0x1f).
+        std::fs::write(
+            start_state_dir.join(ENV_TRACE_LOG),
+            "1\u{1f}set\u{1f}11\u{1f}ON_ACTIVATE_VAR\u{1f}@\u{1f}:from-on-activate\n",
+        )
+        .unwrap();
+
+        (start_id, activation_state_dir, start_state_dir)
+    }
+
+    /// The sweep runs the hook with the end-of-activation environment
+    /// replayed, then removes the start state dir.
+    #[test]
+    fn sweep_runs_hook_with_replayed_env_and_removes_dir() {
+        let tmp = TempDir::new().unwrap();
+        let marker = tmp.path().join("marker");
+        let script = format!("echo -n \"$ON_ACTIVATE_VAR\" > '{}'\n", marker.display());
+        let (start_id, activation_state_dir, start_state_dir) = setup_start(&tmp, Some(&script));
+
+        let (attach, project) = test_context(tmp.path());
+        sweep_orphaned_starts(0, &attach, &project, &activation_state_dir, vec![start_id]);
+
+        assert_eq!(
+            std::fs::read_to_string(&marker).expect("hook should have run"),
+            "from-on-activate",
+            "hook should see variables exported by hook.on-activate"
+        );
+        assert!(
+            !start_state_dir.exists(),
+            "start state dir should be removed after the hook ran"
+        );
+    }
+
+    /// A start is orphaned once its last attachment detaches, and not before.
+    #[test]
+    fn orphaned_start_ids_excludes_live_starts() {
+        let tmp = TempDir::new().unwrap();
+        let activation_state_dir = tmp.path().join("activations");
+        let store_path = tmp.path().join("store-path");
+        let pid = std::process::id() as i32;
+
+        let mut state = flox_core::activations::ActivationState::new(
+            &flox_core::activate::mode::ActivateMode::default(),
+            Some(tmp.path().join(".flox")),
+            &store_path,
+        );
+        let flox_core::activations::StartOrAttachResult::Start { start_id } =
+            state.start_or_attach(pid, &store_path)
+        else {
+            panic!("expected Start");
+        };
+        state.set_ready(&start_id);
+        std::fs::create_dir_all(start_id.start_state_dir(&activation_state_dir).unwrap()).unwrap();
+        start_id
+            .write_to_start_state_dir(&activation_state_dir)
+            .unwrap();
+
+        assert_eq!(
+            orphaned_start_ids(&activation_state_dir, &state),
+            Vec::new(),
+            "a start with an attachment is not orphaned"
+        );
+
+        state.detach(pid).unwrap();
+        assert_eq!(
+            orphaned_start_ids(&activation_state_dir, &state),
+            vec![start_id],
+            "a start becomes orphaned when its last attachment detaches"
+        );
+    }
+
+    /// Without a script the sweep still removes the start state dir.
+    #[test]
+    fn sweep_removes_dir_when_no_script() {
+        let tmp = TempDir::new().unwrap();
+        let (start_id, activation_state_dir, start_state_dir) = setup_start(&tmp, None);
+
+        let (attach, project) = test_context(tmp.path());
+        sweep_orphaned_starts(0, &attach, &project, &activation_state_dir, vec![start_id]);
+
+        assert!(!start_state_dir.exists());
+    }
+
+    /// A failing hook doesn't block removal of the start state dir.
+    #[test]
+    fn sweep_removes_dir_when_hook_fails() {
+        let tmp = TempDir::new().unwrap();
+        let (start_id, activation_state_dir, start_state_dir) = setup_start(&tmp, Some("exit 1\n"));
+
+        let (attach, project) = test_context(tmp.path());
+        sweep_orphaned_starts(0, &attach, &project, &activation_state_dir, vec![start_id]);
+
+        assert!(
+            !start_state_dir.exists(),
+            "a failing hook must not block cleanup"
+        );
+    }
+}

--- a/cli/flox-activations/src/on_deactivate.rs
+++ b/cli/flox-activations/src/on_deactivate.rs
@@ -13,7 +13,7 @@ use std::process::{Command, Stdio};
 
 use anyhow::{Context, Result};
 use flox_core::activate::context::{AttachCtx, AttachProjectCtx};
-use flox_core::activations::{ActivationState, StartIdentifier, read_start_ids_from_disk};
+use flox_core::activations::StartIdentifier;
 use tracing::{debug, info, warn};
 
 use crate::attach_diff::AttachDiff;
@@ -26,35 +26,14 @@ const BASH_BIN: &str = env!("X_BASH_BIN");
 /// environment's store path.
 const HOOK_ON_DEACTIVATE: &str = "activate.d/hook-on-deactivate";
 
-/// Enumerate the start state directories whose start has no remaining
-/// attachments.
-///
-/// This MUST be called while holding the state.json lock: a start being
-/// created writes its directory before registering itself in state.json
-/// (under the same lock), so enumerating without the lock could catch a
-/// directory whose start isn't visible in `state` yet. The returned starts
-/// can then be torn down after the lock drops — a start with no attachments
-/// can never gain new ones (only `ready` starts can be attached to, and an
-/// emptied start is never `ready`).
-pub fn orphaned_start_ids(
-    activation_state_dir: &Path,
-    state: &ActivationState,
-) -> Vec<StartIdentifier> {
-    let live = state.live_start_ids();
-    read_start_ids_from_disk(activation_state_dir)
-        .into_iter()
-        .filter(|start_id| !live.contains(start_id))
-        .collect()
-}
-
 /// Tear down the given start state directories, running each start's
 /// `hook.on-deactivate` first.
 ///
-/// The `orphaned` list must come from [orphaned_start_ids], but the lock must
-/// be dropped before calling this: the hook has no timeout and must not block
-/// new activations. The sweep is idempotent — a start is torn down exactly
-/// once because its directory is removed immediately after its hook runs,
-/// and everything here runs on the executive's single event loop thread.
+/// The `orphaned` list must come from
+/// `ActivationState::remove_orphaned_starts`, called under the state.json
+/// lock and persisted so a start is only ever handed to this sweep once. The
+/// lock must be dropped before calling this: the hook has no timeout and must
+/// not block new activations.
 pub fn sweep_orphaned_starts(
     subsystem_verbosity: u32,
     attach_ctx: &AttachCtx,
@@ -214,9 +193,6 @@ mod test {
         let start_id = StartIdentifier::new(&store_path);
         let start_state_dir = start_id.start_state_dir(&activation_state_dir).unwrap();
         std::fs::create_dir_all(&start_state_dir).unwrap();
-        start_id
-            .write_to_start_state_dir(&activation_state_dir)
-            .unwrap();
         // Trace recorded during activation: hook.on-activate exported
         // ON_ACTIVATE_VAR. Fields are timestamp, op, exported flags, name,
         // old value (@ = none), and operand, separated by US (0x1f).
@@ -249,44 +225,6 @@ mod test {
         assert!(
             !start_state_dir.exists(),
             "start state dir should be removed after the hook ran"
-        );
-    }
-
-    /// A start is orphaned once its last attachment detaches, and not before.
-    #[test]
-    fn orphaned_start_ids_excludes_live_starts() {
-        let tmp = TempDir::new().unwrap();
-        let activation_state_dir = tmp.path().join("activations");
-        let store_path = tmp.path().join("store-path");
-        let pid = std::process::id() as i32;
-
-        let mut state = flox_core::activations::ActivationState::new(
-            &flox_core::activate::mode::ActivateMode::default(),
-            Some(tmp.path().join(".flox")),
-            &store_path,
-        );
-        let flox_core::activations::StartOrAttachResult::Start { start_id } =
-            state.start_or_attach(pid, &store_path)
-        else {
-            panic!("expected Start");
-        };
-        state.set_ready(&start_id);
-        std::fs::create_dir_all(start_id.start_state_dir(&activation_state_dir).unwrap()).unwrap();
-        start_id
-            .write_to_start_state_dir(&activation_state_dir)
-            .unwrap();
-
-        assert_eq!(
-            orphaned_start_ids(&activation_state_dir, &state),
-            Vec::new(),
-            "a start with an attachment is not orphaned"
-        );
-
-        state.detach(pid).unwrap();
-        assert_eq!(
-            orphaned_start_ids(&activation_state_dir, &state),
-            vec![start_id],
-            "a start becomes orphaned when its last attachment detaches"
         );
     }
 

--- a/cli/flox-activations/src/start.rs
+++ b/cli/flox-activations/src/start.rs
@@ -62,6 +62,7 @@ pub fn start(
         .recursive(true)
         .mode(0o700)
         .create(&start_state_dir)?;
+    start_id.write_to_start_state_dir(&context.activation_state_dir)?;
 
     let new_executive = match context.project_ctx.as_ref() {
         // Start a new executive.

--- a/cli/flox-activations/src/start.rs
+++ b/cli/flox-activations/src/start.rs
@@ -62,7 +62,6 @@ pub fn start(
         .recursive(true)
         .mode(0o700)
         .create(&start_state_dir)?;
-    start_id.write_to_start_state_dir(&context.activation_state_dir)?;
 
     let new_executive = match context.project_ctx.as_ref() {
         // Start a new executive.

--- a/cli/flox-core/src/activations.rs
+++ b/cli/flox-core/src/activations.rs
@@ -497,7 +497,10 @@ impl ActivationState {
         if let Ready::True(ref start_id) = self.ready
             && !live.contains(start_id)
         {
-            debug!(?start_id, "ready start has no attachments, marking as not ready");
+            debug!(
+                ?start_id,
+                "ready start has no attachments, marking as not ready"
+            );
             self.ready = Ready::False;
             ready_cleared = true;
         }
@@ -506,6 +509,17 @@ impl ActivationState {
             modified: !orphaned.is_empty() || ready_cleared,
             orphaned,
         }
+    }
+
+    /// Remove and return every start, including a `Ready::Starting` one.
+    ///
+    /// Only for terminal teardown, when no attachments remain and the whole
+    /// activation state is about to be removed: unlike
+    /// [Self::remove_orphaned_starts] there is no next `start_or_attach` to
+    /// hand a `Starting` start to, and its `hook.on-deactivate` bookend still
+    /// has to run if its `hook.on-activate` completed.
+    pub fn drain_starts(&mut self) -> Vec<StartIdentifier> {
+        std::mem::take(&mut self.starts).into_iter().collect()
     }
 
     /// Returns all attached PIDs and their expirations, flattened from all start IDs
@@ -1460,6 +1474,18 @@ mod tests {
             });
             assert_eq!(activations.starts, BTreeSet::from([start_id.clone()]));
             assert_eq!(activations.ready, Ready::Starting(100, start_id));
+        }
+
+        /// Terminal teardown drains every start, including a `Starting` one
+        /// that `remove_orphaned_starts` would protect.
+        #[test]
+        fn drain_starts_returns_starting_starts_too() {
+            let start_id = StartIdentifier::new("/nix/store/path1");
+            let mut activations = make_activations(Ready::Starting(100, start_id.clone()));
+            activations.starts.insert(start_id.clone());
+
+            assert_eq!(activations.drain_starts(), vec![start_id]);
+            assert_eq!(activations.starts, BTreeSet::new());
         }
     }
 

--- a/cli/flox-core/src/activations.rs
+++ b/cli/flox-core/src/activations.rs
@@ -9,7 +9,7 @@ use fslock::LockFile;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use time::OffsetDateTime;
-use tracing::{debug, info, trace, warn};
+use tracing::{debug, info, trace};
 
 use crate::activate::mode::ActivateMode;
 use crate::proc_status::pid_is_running;
@@ -341,59 +341,6 @@ impl StartIdentifier {
         Ok(())
     }
 
-    /// Persist this identifier inside its start state directory.
-    ///
-    /// The directory name only contains the store path basename, so this
-    /// marker is what lets a process holding just the activation state
-    /// directory (e.g. the executive sweeping starts with no remaining
-    /// attachments) reconstruct the full identifier and locate the rendered
-    /// environment for the `hook.on-deactivate` script.
-    pub fn write_to_start_state_dir(
-        &self,
-        activation_state_dir: impl AsRef<Path>,
-    ) -> Result<(), Error> {
-        let path = self
-            .start_state_dir(activation_state_dir)?
-            .join(START_ID_JSON);
-        let contents = serde_json::to_string(self).context("failed to serialize start id")?;
-        std::fs::write(&path, contents)
-            .with_context(|| format!("failed to write start id to '{}'", path.display()))?;
-        Ok(())
-    }
-}
-
-/// File name of the [StartIdentifier] marker within a start state directory.
-const START_ID_JSON: &str = "start_id.json";
-
-/// Read the [StartIdentifier] of every start state directory found in an
-/// activation state directory.
-///
-/// Directories without a readable marker (e.g. created by an older Flox
-/// version, or a start that died before writing it) are skipped with a
-/// warning; they are still removed wholesale when the whole activation state
-/// directory is torn down.
-pub fn read_start_ids_from_disk(activation_state_dir: impl AsRef<Path>) -> Vec<StartIdentifier> {
-    let Ok(entries) = std::fs::read_dir(activation_state_dir.as_ref()) else {
-        return Vec::new();
-    };
-    entries
-        .filter_map(|entry| {
-            let path = entry.ok()?.path();
-            if !path.is_dir() {
-                return None;
-            }
-            let marker = path.join(START_ID_JSON);
-            if !marker.exists() {
-                return None;
-            }
-            let contents = std::fs::read_to_string(&marker)
-                .inspect_err(|err| warn!(%err, ?marker, "failed to read start id marker"))
-                .ok()?;
-            serde_json::from_str(&contents)
-                .inspect_err(|err| warn!(%err, ?marker, "failed to parse start id marker"))
-                .ok()
-        })
-        .collect()
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -433,6 +380,13 @@ pub struct ActivationState {
     executive_pid: Pid,
     current_process_compose_store_path: Option<StartIdentifier>,
     attached_pids: BTreeMap<Pid, Attachment>,
+    /// Every start whose state directory has not been torn down yet.
+    ///
+    /// A start stays listed after its last attachment detaches; the executive
+    /// removes it via [Self::remove_orphaned_starts] when it tears the start
+    /// down (running `hook.on-deactivate` after releasing the lock).
+    #[serde(default)]
+    starts: BTreeSet<StartIdentifier>,
 }
 
 impl ActivationState {
@@ -452,6 +406,7 @@ impl ActivationState {
             executive_pid: EXECUTIVE_NOT_STARTED,
             current_process_compose_store_path: None,
             attached_pids: BTreeMap::new(),
+            starts: BTreeSet::new(),
         }
     }
 
@@ -487,25 +442,48 @@ impl ActivationState {
         self.attached_pids.is_empty()
     }
 
-    /// Returns the start IDs that are still in use: those referenced by an
-    /// attachment, plus a ready or currently starting activation (whose PID
-    /// may not have registered its start state directory contents yet).
+    /// Remove and return every start with no remaining attachments, clearing
+    /// `ready` if it names one of them.
     ///
-    /// Start state directories on disk whose ID is not in this set belong to
-    /// starts with no remaining attachments and are safe to tear down.
-    pub fn live_start_ids(&self) -> BTreeSet<StartIdentifier> {
+    /// `detach` leaves `ready` and the starts list untouched so that a new
+    /// activation arriving before this runs can still attach; once a start is
+    /// removed here that window is closed. The caller (normally the
+    /// executive) must persist the state and release the lock before tearing
+    /// the returned starts down, so a hanging `hook.on-deactivate` can't
+    /// block new activations.
+    ///
+    /// A `Ready::Starting` start is never returned even without an
+    /// attachment (its PID may have died mid-start): it stays owned by the
+    /// next `start_or_attach`.
+    pub fn remove_orphaned_starts(&mut self) -> Vec<StartIdentifier> {
         let mut live: BTreeSet<StartIdentifier> = self
             .attached_pids
             .values()
             .map(|attachment| attachment.start_id.clone())
             .collect();
-        match &self.ready {
-            Ready::True(start_id) | Ready::Starting(_, start_id) => {
-                live.insert(start_id.clone());
-            },
-            Ready::False => {},
+        if let Ready::Starting(_, ref start_id) = self.ready {
+            live.insert(start_id.clone());
         }
-        live
+
+        let orphaned: Vec<StartIdentifier> = self
+            .starts
+            .iter()
+            .filter(|start_id| !live.contains(start_id))
+            .cloned()
+            .collect();
+        for start_id in &orphaned {
+            debug!(?start_id, "removing start with no remaining attachments");
+            self.starts.remove(start_id);
+        }
+
+        if let Ready::True(ref start_id) = self.ready
+            && !live.contains(start_id)
+        {
+            debug!(?start_id, "ready start has no attachments, marking as not ready");
+            self.ready = Ready::False;
+        }
+
+        orphaned
     }
 
     /// Returns all attached PIDs and their expirations, flattened from all start IDs
@@ -570,32 +548,21 @@ impl ActivationState {
         self.ready = Ready::True(start_id.clone());
     }
 
-    /// Detach a PID from an activation, updating ready as needed.
+    /// Detach a PID from an activation.
     ///
-    /// Returns `Some(start_id)` if this was the last attachment for that
-    /// `StartIdentifier` (i.e. the caller should clean up the start state
-    /// directory), or `None` if there are still other PIDs attached to the
-    /// same start.
-    pub fn detach(&mut self, pid: Pid) -> Result<Option<StartIdentifier>, Error> {
+    /// `ready` and the starts list are deliberately left untouched even when
+    /// this was the last attachment for its start: teardown is deferred to
+    /// [Self::remove_orphaned_starts], and until that runs a new activation
+    /// of the same store path can still attach to the emptied start.
+    pub fn detach(&mut self, pid: Pid) -> Result<(), Error> {
         let removed = self.attached_pids.remove(&pid);
         debug!(pid, ?removed, "detaching from activation");
 
-        let Some(attachment) = removed else {
+        if removed.is_none() {
             bail!("PID {} is not attached to the activation", pid);
-        };
-
-        let start_id = attachment.start_id;
-
-        // Return the start_id only when no remaining attachment references it.
-        let has_remaining = self.attached_pids.values().any(|a| a.start_id == start_id);
-
-        self.update_ready_after_detach();
-
-        if has_remaining {
-            Ok(None)
-        } else {
-            Ok(Some(start_id))
         }
+
+        Ok(())
     }
 
     /// Clean up a specific terminated PID
@@ -605,20 +572,19 @@ impl ActivationState {
     /// is not protected by the state.json lock. Between detecting the exit and acquiring
     /// the lock, the PID could have been reused by another process.
     ///
-    /// Returns the start ID that needs to be cleaned up if it has no more attached PIDs
-    /// and a boolean indicating if the PID was detached.
+    /// Returns whether the PID was detached.
     pub fn cleanup_pid(
         &mut self,
         pid: Pid,
         pid_is_running: impl Fn(Pid) -> bool,
         now: OffsetDateTime,
-    ) -> (Option<StartIdentifier>, bool) {
+    ) -> bool {
         // Get the attachment for this PID
         let attachment = self.attached_pids.get(&pid).cloned();
 
         let Some(attachment) = attachment else {
             debug!(pid, "PID not found in attached_pids");
-            return (None, false);
+            return false;
         };
 
         // Check if we should keep this attachment
@@ -633,42 +599,19 @@ impl ActivationState {
             // info so that Sentry breadcrumbs show why an exit event didn't
             // detach the PID, mirroring "detaching terminated PID" below
             info!(pid, expiration = ?attachment.expiration, "keeping attached PID");
-            return (None, false);
+            return false;
         }
 
         info!(pid, "detaching terminated PID");
-        let Ok(empty_start_id) = self.detach(pid) else {
+        if self.detach(pid).is_err() {
             debug!(
                 pid,
                 "PID not found in attached_pids, this should be unreachable"
             );
-            return (None, false);
-        };
-
-        (empty_start_id, true)
-    }
-
-    /// Set ready to False if there are no more PIDs attached to the current start
-    ///
-    /// This includes the case where nothing is attached at all: the emptied
-    /// start's state directory is torn down asynchronously by the executive
-    /// (after running any `hook.on-deactivate`), so a `ready` left naming that
-    /// start would send the next activation down the attach path to read files
-    /// that may already be gone. The state has to be self-consistent the
-    /// moment the lock drops.
-    fn update_ready_after_detach(&mut self) {
-        match self.ready {
-            Ready::True(ref start_id) => {
-                if !self.attachments_by_start_id().contains_key(start_id) {
-                    debug!(?start_id, "no more attached PIDs, marking as not ready");
-                    self.ready = Ready::False;
-                }
-            },
-            // we'll let the starting process (or a subsequent start or
-            // attach) handle cleanup for a dead Starting PID
-            Ready::Starting(_, _) => {},
-            Ready::False => {}, // no-op
+            return false;
         }
+
+        true
     }
 
     fn start(&mut self, pid: Pid, store_path: impl AsRef<Path>) -> StartIdentifier {
@@ -681,6 +624,7 @@ impl ActivationState {
         debug!(pid, ?start_id, "starting new activation");
         self.ready = Ready::Starting(pid, start_id.clone());
         self.attached_pids.insert(pid, attachment);
+        self.starts.insert(start_id.clone());
         start_id
     }
 
@@ -976,6 +920,7 @@ mod tests {
             executive_pid: 1, // Not used, but will be running.
             current_process_compose_store_path: None,
             attached_pids: BTreeMap::new(),
+            starts: BTreeSet::new(),
         }
     }
 
@@ -1330,10 +1275,9 @@ mod tests {
         activations.attach(pid, attachment);
 
         // Cleanup with PID still running - should be kept
-        let (empty_start, modified) = activations.cleanup_pid(pid, |_| true, now);
+        let modified = activations.cleanup_pid(pid, |_| true, now);
         assert!(activations.attached_pids.contains_key(&pid));
         assert!(!modified);
-        assert!(empty_start.is_none());
     }
 
     #[test]
@@ -1352,39 +1296,125 @@ mod tests {
         activations.attach(pid, attachment);
 
         // Cleanup with PID not running but unexpired expiration - should be kept
-        let (empty_start, modified) = activations.cleanup_pid(pid, |_| false, now);
+        let modified = activations.cleanup_pid(pid, |_| false, now);
         assert!(activations.attached_pids.contains_key(&pid));
         assert!(!modified);
-        assert!(empty_start.is_none());
     }
 
     mod detach {
         use super::*;
 
-        /// `flox-activations detach` deletes the emptied start's state
-        /// directory as soon as the last PID detaches, so a re-activation that
-        /// beats the executive's `cleanup_all` must start fresh. Leaving
-        /// `ready` as `Ready::True(start_id)` sends it down the attach path
-        /// instead, to read an `envtrace.log` that is already gone.
+        /// Detach leaves `ready` set even when the last PID detaches: the
+        /// start's state directory is still on disk until the executive tears
+        /// it down, so a re-activation of the same store path in that window
+        /// can attach and avoid the teardown entirely.
         #[test]
-        fn reactivation_after_last_detach_starts_instead_of_attaching() {
+        fn reactivation_after_last_detach_attaches_within_window() {
             let start_id = StartIdentifier::new("/nix/store/path1");
             let mut activations = make_activations(Ready::True(start_id.clone()));
             let pid = 123;
             activations.attach(pid, make_attachment(start_id.clone()));
             activations.detach(pid).unwrap();
 
-            // Deliberately no assertion on the new StartIdentifier: it is
-            // millisecond-stamped, so a fast run mints one equal to the old.
-            // Taking the Start arm is the invariant that matters — it re-runs
-            // the activation and recreates the directory, where Attach would
-            // read the files detach removed.
             let result = activations.start_or_attach(456, &start_id.store_path);
 
-            assert!(
-                matches!(result, StartOrAttachResult::Start { .. }),
-                "Expected StartOrAttachResult::Start, got {result:?}"
+            assert_eq!(result, StartOrAttachResult::Attach {
+                start_id: start_id.clone()
+            });
+            assert_eq!(activations.ready, Ready::True(start_id));
+        }
+    }
+
+    mod remove_orphaned_starts {
+        use super::*;
+
+        /// A start with no remaining attachments is removed and returned, and
+        /// a `ready` naming it is cleared; a start that still has an
+        /// attachment is kept.
+        #[test]
+        fn removes_attachmentless_starts_and_clears_ready() {
+            let mut activations =
+                ActivationState::new(&ActivateMode::default(), Some("/test/.flox"), "/test/env");
+            activations.set_executive_pid(1);
+
+            let StartOrAttachResult::Start { start_id: old } =
+                activations.start_or_attach(100, "/nix/store/path1")
+            else {
+                panic!("expected Start");
+            };
+            activations.set_ready(&old);
+            // A second activation supersedes the first with a new store path.
+            let StartOrAttachResult::Start { start_id: new } =
+                activations.start_or_attach(200, "/nix/store/path2")
+            else {
+                panic!("expected Start");
+            };
+            activations.set_ready(&new);
+
+            assert_eq!(
+                activations.remove_orphaned_starts(),
+                Vec::new(),
+                "both starts still have an attachment"
             );
+
+            activations.detach(100).unwrap();
+            assert_eq!(activations.remove_orphaned_starts(), vec![old]);
+            assert_eq!(activations.starts, BTreeSet::from([new.clone()]));
+            assert_eq!(
+                activations.ready,
+                Ready::True(new),
+                "ready names the live start and must be kept"
+            );
+        }
+
+        /// When the last attachment of the ready start detaches, teardown of
+        /// that start (and the clearing of `ready`) happens here, not in
+        /// `detach`.
+        #[test]
+        fn clears_ready_deferred_from_last_detach() {
+            let mut activations =
+                ActivationState::new(&ActivateMode::default(), Some("/test/.flox"), "/test/env");
+            let StartOrAttachResult::Start { start_id } =
+                activations.start_or_attach(100, "/nix/store/path1")
+            else {
+                panic!("expected Start");
+            };
+            activations.set_ready(&start_id);
+            activations.detach(100).unwrap();
+            assert_eq!(activations.ready, Ready::True(start_id.clone()));
+
+            assert_eq!(activations.remove_orphaned_starts(), vec![start_id]);
+            assert_eq!(activations.ready, Ready::False);
+            assert_eq!(activations.starts, BTreeSet::new());
+        }
+
+        /// An attach arriving in the window between last detach and executive
+        /// cleanup keeps the start alive.
+        #[test]
+        fn attach_in_window_prevents_orphaning() {
+            let start_id = StartIdentifier::new("/nix/store/path1");
+            let mut activations = make_activations(Ready::True(start_id.clone()));
+            activations.starts.insert(start_id.clone());
+            activations.attach(100, make_attachment(start_id.clone()));
+            activations.detach(100).unwrap();
+            activations.attach(200, make_attachment(start_id.clone()));
+
+            assert_eq!(activations.remove_orphaned_starts(), Vec::new());
+            assert_eq!(activations.starts, BTreeSet::from([start_id.clone()]));
+            assert_eq!(activations.ready, Ready::True(start_id));
+        }
+
+        /// A `Starting` start is owned by the next `start_or_attach` even if
+        /// its starting PID's attachment is gone; it is never torn down here.
+        #[test]
+        fn starting_start_is_not_orphaned() {
+            let start_id = StartIdentifier::new("/nix/store/path1");
+            let mut activations = make_activations(Ready::Starting(100, start_id.clone()));
+            activations.starts.insert(start_id.clone());
+
+            assert_eq!(activations.remove_orphaned_starts(), Vec::new());
+            assert_eq!(activations.starts, BTreeSet::from([start_id.clone()]));
+            assert_eq!(activations.ready, Ready::Starting(100, start_id));
         }
     }
 

--- a/cli/flox-core/src/activations.rs
+++ b/cli/flox-core/src/activations.rs
@@ -340,13 +340,24 @@ impl StartIdentifier {
         })?;
         Ok(())
     }
-
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Attachment {
     start_id: StartIdentifier,
     expiration: Option<OffsetDateTime>,
+}
+
+/// Result of [ActivationState::remove_orphaned_starts].
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OrphanedStarts {
+    /// Starts removed from the state; their state directories should be torn
+    /// down (running any `hook.on-deactivate`) once the state has been
+    /// persisted and the lock released.
+    pub orphaned: Vec<StartIdentifier>,
+    /// Whether the state was mutated (starts removed or `ready` cleared) and
+    /// must be persisted before the lock is released.
+    pub modified: bool,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
@@ -421,6 +432,7 @@ impl ActivationState {
     }
 
     /// Returns a mapping of StartIdentifier to info for each attachment to that StartIdentifier
+    #[cfg(any(test, feature = "tests"))]
     pub fn attachments_by_start_id(
         &self,
     ) -> BTreeMap<StartIdentifier, Vec<(Pid, Option<OffsetDateTime>)>> {
@@ -442,20 +454,25 @@ impl ActivationState {
         self.attached_pids.is_empty()
     }
 
-    /// Remove and return every start with no remaining attachments, clearing
-    /// `ready` if it names one of them.
+    /// Remove every start with no remaining attachments, clearing `ready` if
+    /// it names a start without attachments.
     ///
     /// `detach` leaves `ready` and the starts list untouched so that a new
     /// activation arriving before this runs can still attach; once a start is
     /// removed here that window is closed. The caller (normally the
-    /// executive) must persist the state and release the lock before tearing
-    /// the returned starts down, so a hanging `hook.on-deactivate` can't
-    /// block new activations.
+    /// executive) must persist the state whenever `modified` is set and
+    /// release the lock before tearing the orphaned starts down, so a hanging
+    /// `hook.on-deactivate` can't block new activations.
     ///
-    /// A `Ready::Starting` start is never returned even without an
-    /// attachment (its PID may have died mid-start): it stays owned by the
-    /// next `start_or_attach`.
-    pub fn remove_orphaned_starts(&mut self) -> Vec<StartIdentifier> {
+    /// `ready` is cleared based on attachments rather than membership in the
+    /// starts list, so state where `ready` names an untracked start (e.g.
+    /// written by an earlier binary without the starts field) still heals —
+    /// that is why `modified` can be set even when `orphaned` is empty.
+    ///
+    /// A `Ready::Starting` start is never orphaned even without an attachment
+    /// (its PID may have died mid-start): it stays owned by the next
+    /// `start_or_attach`.
+    pub fn remove_orphaned_starts(&mut self) -> OrphanedStarts {
         let mut live: BTreeSet<StartIdentifier> = self
             .attached_pids
             .values()
@@ -476,14 +493,19 @@ impl ActivationState {
             self.starts.remove(start_id);
         }
 
+        let mut ready_cleared = false;
         if let Ready::True(ref start_id) = self.ready
             && !live.contains(start_id)
         {
             debug!(?start_id, "ready start has no attachments, marking as not ready");
             self.ready = Ready::False;
+            ready_cleared = true;
         }
 
-        orphaned
+        OrphanedStarts {
+            modified: !orphaned.is_empty() || ready_cleared,
+            orphaned,
+        }
     }
 
     /// Returns all attached PIDs and their expirations, flattened from all start IDs
@@ -579,16 +601,13 @@ impl ActivationState {
         pid_is_running: impl Fn(Pid) -> bool,
         now: OffsetDateTime,
     ) -> bool {
-        // Get the attachment for this PID
-        let attachment = self.attached_pids.get(&pid).cloned();
-
-        let Some(attachment) = attachment else {
+        let Some(expiration) = self.attached_pids.get(&pid).map(|a| a.expiration) else {
             debug!(pid, "PID not found in attached_pids");
             return false;
         };
 
         // Check if we should keep this attachment
-        let keep_attachment = if let Some(expiration) = attachment.expiration {
+        let keep_attachment = if let Some(expiration) = expiration {
             // If the PID has an unreached expiration, retain it even if it isn't running
             now < expiration || pid_is_running(pid)
         } else {
@@ -598,18 +617,13 @@ impl ActivationState {
         if keep_attachment {
             // info so that Sentry breadcrumbs show why an exit event didn't
             // detach the PID, mirroring "detaching terminated PID" below
-            info!(pid, expiration = ?attachment.expiration, "keeping attached PID");
+            info!(pid, ?expiration, "keeping attached PID");
             return false;
         }
 
         info!(pid, "detaching terminated PID");
-        if self.detach(pid).is_err() {
-            debug!(
-                pid,
-                "PID not found in attached_pids, this should be unreachable"
-            );
-            return false;
-        }
+        self.detach(pid)
+            .expect("attachment was just observed under &mut self");
 
         true
     }
@@ -1353,12 +1367,18 @@ mod tests {
 
             assert_eq!(
                 activations.remove_orphaned_starts(),
-                Vec::new(),
+                OrphanedStarts {
+                    orphaned: Vec::new(),
+                    modified: false,
+                },
                 "both starts still have an attachment"
             );
 
             activations.detach(100).unwrap();
-            assert_eq!(activations.remove_orphaned_starts(), vec![old]);
+            assert_eq!(activations.remove_orphaned_starts(), OrphanedStarts {
+                orphaned: vec![old],
+                modified: true,
+            });
             assert_eq!(activations.starts, BTreeSet::from([new.clone()]));
             assert_eq!(
                 activations.ready,
@@ -1383,9 +1403,28 @@ mod tests {
             activations.detach(100).unwrap();
             assert_eq!(activations.ready, Ready::True(start_id.clone()));
 
-            assert_eq!(activations.remove_orphaned_starts(), vec![start_id]);
+            assert_eq!(activations.remove_orphaned_starts(), OrphanedStarts {
+                orphaned: vec![start_id],
+                modified: true,
+            });
             assert_eq!(activations.ready, Ready::False);
             assert_eq!(activations.starts, BTreeSet::new());
+        }
+
+        /// `ready` naming a start missing from the starts list (e.g. state
+        /// written by an earlier binary without the field) is still cleared
+        /// once it has no attachments, and the mutation is reported so
+        /// callers persist it despite having no starts to sweep.
+        #[test]
+        fn clears_ready_missing_from_starts_and_reports_modified() {
+            let start_id = StartIdentifier::new("/nix/store/path1");
+            let mut activations = make_activations(Ready::True(start_id));
+
+            assert_eq!(activations.remove_orphaned_starts(), OrphanedStarts {
+                orphaned: Vec::new(),
+                modified: true,
+            });
+            assert_eq!(activations.ready, Ready::False);
         }
 
         /// An attach arriving in the window between last detach and executive
@@ -1399,7 +1438,10 @@ mod tests {
             activations.detach(100).unwrap();
             activations.attach(200, make_attachment(start_id.clone()));
 
-            assert_eq!(activations.remove_orphaned_starts(), Vec::new());
+            assert_eq!(activations.remove_orphaned_starts(), OrphanedStarts {
+                orphaned: Vec::new(),
+                modified: false,
+            });
             assert_eq!(activations.starts, BTreeSet::from([start_id.clone()]));
             assert_eq!(activations.ready, Ready::True(start_id));
         }
@@ -1412,7 +1454,10 @@ mod tests {
             let mut activations = make_activations(Ready::Starting(100, start_id.clone()));
             activations.starts.insert(start_id.clone());
 
-            assert_eq!(activations.remove_orphaned_starts(), Vec::new());
+            assert_eq!(activations.remove_orphaned_starts(), OrphanedStarts {
+                orphaned: Vec::new(),
+                modified: false,
+            });
             assert_eq!(activations.starts, BTreeSet::from([start_id.clone()]));
             assert_eq!(activations.ready, Ready::Starting(100, start_id));
         }

--- a/cli/flox-core/src/activations.rs
+++ b/cli/flox-core/src/activations.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs::DirBuilder;
 use std::ops::Deref;
 use std::os::unix::fs::DirBuilderExt;
@@ -9,7 +9,7 @@ use fslock::LockFile;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use time::OffsetDateTime;
-use tracing::{debug, info, trace};
+use tracing::{debug, info, trace, warn};
 
 use crate::activate::mode::ActivateMode;
 use crate::proc_status::pid_is_running;
@@ -340,6 +340,60 @@ impl StartIdentifier {
         })?;
         Ok(())
     }
+
+    /// Persist this identifier inside its start state directory.
+    ///
+    /// The directory name only contains the store path basename, so this
+    /// marker is what lets a process holding just the activation state
+    /// directory (e.g. the executive sweeping starts with no remaining
+    /// attachments) reconstruct the full identifier and locate the rendered
+    /// environment for the `hook.on-deactivate` script.
+    pub fn write_to_start_state_dir(
+        &self,
+        activation_state_dir: impl AsRef<Path>,
+    ) -> Result<(), Error> {
+        let path = self
+            .start_state_dir(activation_state_dir)?
+            .join(START_ID_JSON);
+        let contents = serde_json::to_string(self).context("failed to serialize start id")?;
+        std::fs::write(&path, contents)
+            .with_context(|| format!("failed to write start id to '{}'", path.display()))?;
+        Ok(())
+    }
+}
+
+/// File name of the [StartIdentifier] marker within a start state directory.
+const START_ID_JSON: &str = "start_id.json";
+
+/// Read the [StartIdentifier] of every start state directory found in an
+/// activation state directory.
+///
+/// Directories without a readable marker (e.g. created by an older Flox
+/// version, or a start that died before writing it) are skipped with a
+/// warning; they are still removed wholesale when the whole activation state
+/// directory is torn down.
+pub fn read_start_ids_from_disk(activation_state_dir: impl AsRef<Path>) -> Vec<StartIdentifier> {
+    let Ok(entries) = std::fs::read_dir(activation_state_dir.as_ref()) else {
+        return Vec::new();
+    };
+    entries
+        .filter_map(|entry| {
+            let path = entry.ok()?.path();
+            if !path.is_dir() {
+                return None;
+            }
+            let marker = path.join(START_ID_JSON);
+            if !marker.exists() {
+                return None;
+            }
+            let contents = std::fs::read_to_string(&marker)
+                .inspect_err(|err| warn!(%err, ?marker, "failed to read start id marker"))
+                .ok()?;
+            serde_json::from_str(&contents)
+                .inspect_err(|err| warn!(%err, ?marker, "failed to parse start id marker"))
+                .ok()
+        })
+        .collect()
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -431,6 +485,27 @@ impl ActivationState {
 
     pub fn attached_pids_is_empty(&self) -> bool {
         self.attached_pids.is_empty()
+    }
+
+    /// Returns the start IDs that are still in use: those referenced by an
+    /// attachment, plus a ready or currently starting activation (whose PID
+    /// may not have registered its start state directory contents yet).
+    ///
+    /// Start state directories on disk whose ID is not in this set belong to
+    /// starts with no remaining attachments and are safe to tear down.
+    pub fn live_start_ids(&self) -> BTreeSet<StartIdentifier> {
+        let mut live: BTreeSet<StartIdentifier> = self
+            .attached_pids
+            .values()
+            .map(|attachment| attachment.start_id.clone())
+            .collect();
+        match &self.ready {
+            Ready::True(start_id) | Ready::Starting(_, start_id) => {
+                live.insert(start_id.clone());
+            },
+            Ready::False => {},
+        }
+        live
     }
 
     /// Returns all attached PIDs and their expirations, flattened from all start IDs
@@ -575,13 +650,12 @@ impl ActivationState {
 
     /// Set ready to False if there are no more PIDs attached to the current start
     ///
-    /// This includes the case where nothing is attached at all: `detach`'s
-    /// caller removes the emptied start's state directory before dropping the
-    /// lock, so a `ready` left naming that start would send the next
-    /// activation down the attach path to read files that are already gone.
-    /// The whole activation state directory is torn down shortly afterwards by
-    /// the executive, but not under the same lock, so the state has to be
-    /// self-consistent in the meantime.
+    /// This includes the case where nothing is attached at all: the emptied
+    /// start's state directory is torn down asynchronously by the executive
+    /// (after running any `hook.on-deactivate`), so a `ready` left naming that
+    /// start would send the next activation down the attach path to read files
+    /// that may already be gone. The state has to be self-consistent the
+    /// moment the lock drops.
     fn update_ready_after_detach(&mut self) {
         match self.ready {
             Ready::True(ref start_id) => {

--- a/cli/flox-manifest/src/compose/shallow.rs
+++ b/cli/flox-manifest/src/compose/shallow.rs
@@ -15,13 +15,14 @@ use crate::parsed::common::{
     ActivateOptions,
     Allows,
     Containerize,
-    Hook,
     Include,
     Options,
     SemverOptions,
     Vars,
 };
-use crate::parsed::latest::{Install, ManifestLatest, MinimumCliVersion};
+// merge_hook operates on the latest schema's Hook (which carries
+// `on-deactivate`), so composing environments preserves the field.
+use crate::parsed::latest::{Hook, Install, ManifestLatest, MinimumCliVersion};
 // merge_build operates on the latest schema's Build (which carries
 // `sandbox-allow`), so composing environments preserves the field.
 use crate::parsed::v1_13_0::{Build, Profile, ProfileDeactivate, Services};
@@ -100,6 +101,14 @@ impl ShallowMerger {
                 on_activate: append_optional_strings(
                     low_priority.on_activate.as_ref(),
                     high_priority.on_activate.as_ref(),
+                ),
+                // Deactivation runs in reverse order from activation (LIFO
+                // cleanup), so a low-priority on-deactivate snippet should run
+                // *after* the high-priority one. Append accordingly: high
+                // first, then low.
+                on_deactivate: append_optional_strings(
+                    high_priority.on_deactivate.as_ref(),
+                    low_priority.on_deactivate.as_ref(),
                 ),
             })),
         }
@@ -538,17 +547,28 @@ mod tests {
 
         // Ensures that for any two manifests if they both have hooks, the merge joins them with a newline.
         // When one manifest has a hook and the other doesn't the hook that's present should be passed
-        // straight through.
+        // straight through. on-activate joins low priority first; on-deactivate joins in reverse
+        // (LIFO cleanup), high priority first.
         #[test]
         fn merges_hook_section(hook1 in any::<Option<Hook>>(), hook2 in any::<Option<Hook>>()) {
             let merged = ShallowMerger::merge_hook(hook1.as_ref(), hook2.as_ref()).unwrap();
-            let expected = match (hook1.unwrap_or_default().on_activate, hook2.unwrap_or_default().on_activate) {
+            let hook1 = hook1.unwrap_or_default();
+            let hook2 = hook2.unwrap_or_default();
+            let expected_on_activate = match (hook1.on_activate, hook2.on_activate) {
                 (Some(h1), Some(h2)) => Some(format!("{h1}\n{h2}")),
                 (Some(h1), None) => Some(h1.clone()),
                 (None, Some(h2)) => Some(h2.clone()),
                 (None, None) => None,
             };
-            prop_assert_eq!(merged.unwrap_or_default().on_activate, expected);
+            let expected_on_deactivate = match (hook1.on_deactivate, hook2.on_deactivate) {
+                (Some(h1), Some(h2)) => Some(format!("{h2}\n{h1}")),
+                (Some(h1), None) => Some(h1.clone()),
+                (None, Some(h2)) => Some(h2.clone()),
+                (None, None) => None,
+            };
+            let merged = merged.unwrap_or_default();
+            prop_assert_eq!(merged.on_activate, expected_on_activate);
+            prop_assert_eq!(merged.on_deactivate, expected_on_deactivate);
         }
 
         // Ensures that two arbitrary options sections are deep merged with the exception of

--- a/cli/flox-manifest/src/interfaces/common_fields.rs
+++ b/cli/flox-manifest/src/interfaces/common_fields.rs
@@ -22,6 +22,7 @@ impl CommonFields for Parsed {
             Parsed::V1_12_0(m) => &m.services.service_map,
             Parsed::V1_13_0(m) => &m.services.service_map,
             Parsed::V1_14_0(m) => &m.services.service_map,
+            Parsed::V1_15_0(m) => &m.services.service_map,
         }
     }
 
@@ -33,6 +34,7 @@ impl CommonFields for Parsed {
             Parsed::V1_12_0(m) => &m.options,
             Parsed::V1_13_0(m) => &m.options,
             Parsed::V1_14_0(m) => &m.options,
+            Parsed::V1_15_0(m) => &m.options,
         }
     }
 
@@ -45,6 +47,7 @@ impl CommonFields for Parsed {
             Parsed::V1_12_0(m) => &mut m.options,
             Parsed::V1_13_0(m) => &mut m.options,
             Parsed::V1_14_0(m) => &mut m.options,
+            Parsed::V1_15_0(m) => &mut m.options,
         }
     }
 }

--- a/cli/flox-manifest/src/interfaces/inner_manifest.rs
+++ b/cli/flox-manifest/src/interfaces/inner_manifest.rs
@@ -6,6 +6,7 @@ use crate::parsed::v1_11_0::ManifestV1_11_0;
 use crate::parsed::v1_12_0::ManifestV1_12_0;
 use crate::parsed::v1_13_0::ManifestV1_13_0;
 use crate::parsed::v1_14_0::ManifestV1_14_0;
+use crate::parsed::v1_15_0::ManifestV1_15_0;
 use crate::{Manifest, Migrated, MigratedTypedOnly, Parsed, TypedOnly, Validated};
 
 /// A trait that allows you to generically extract a concrete inner manifest
@@ -68,6 +69,7 @@ impl InnerManifestMarker for ManifestV1_11_0 {}
 impl InnerManifestMarker for ManifestV1_12_0 {}
 impl InnerManifestMarker for ManifestV1_13_0 {}
 impl InnerManifestMarker for ManifestV1_14_0 {}
+impl InnerManifestMarker for ManifestV1_15_0 {}
 
 /// This trait is used to define which concrete manifest types can
 /// be extracted from `Manifest<State>` and in which `State`s.
@@ -184,6 +186,24 @@ impl GetInnerManifest<ManifestV1_14_0> for Manifest<Validated> {
     }
 }
 
+impl GetInnerManifest<ManifestV1_15_0> for Manifest<Validated> {
+    fn get_inner_manifest(&self) -> Option<&ManifestV1_15_0> {
+        if let Parsed::V1_15_0(ref manifest) = self.inner.parsed {
+            Some(manifest)
+        } else {
+            None
+        }
+    }
+
+    fn get_inner_manifest_mut(&mut self) -> Option<&mut ManifestV1_15_0> {
+        if let Parsed::V1_15_0(ref mut manifest) = self.inner.parsed {
+            Some(manifest)
+        } else {
+            None
+        }
+    }
+}
+
 impl GetInnerManifest<ManifestV1> for Manifest<TypedOnly> {
     fn get_inner_manifest(&self) -> Option<&ManifestV1> {
         if let Parsed::V1(ref manifest) = self.inner.parsed {
@@ -292,6 +312,24 @@ impl GetInnerManifest<ManifestV1_14_0> for Manifest<TypedOnly> {
     }
 }
 
+impl GetInnerManifest<ManifestV1_15_0> for Manifest<TypedOnly> {
+    fn get_inner_manifest(&self) -> Option<&ManifestV1_15_0> {
+        if let Parsed::V1_15_0(ref manifest) = self.inner.parsed {
+            Some(manifest)
+        } else {
+            None
+        }
+    }
+
+    fn get_inner_manifest_mut(&mut self) -> Option<&mut ManifestV1_15_0> {
+        if let Parsed::V1_15_0(ref mut manifest) = self.inner.parsed {
+            Some(manifest)
+        } else {
+            None
+        }
+    }
+}
+
 impl GetInnerManifest<ManifestV1> for Manifest<Migrated> {
     fn get_inner_manifest(&self) -> Option<&ManifestV1> {
         None
@@ -344,10 +382,20 @@ impl GetInnerManifest<ManifestV1_13_0> for Manifest<Migrated> {
 
 impl GetInnerManifest<ManifestV1_14_0> for Manifest<Migrated> {
     fn get_inner_manifest(&self) -> Option<&ManifestV1_14_0> {
-        Some(&self.inner.migrated_parsed)
+        None
     }
 
     fn get_inner_manifest_mut(&mut self) -> Option<&mut ManifestV1_14_0> {
+        None
+    }
+}
+
+impl GetInnerManifest<ManifestV1_15_0> for Manifest<Migrated> {
+    fn get_inner_manifest(&self) -> Option<&ManifestV1_15_0> {
+        Some(&self.inner.migrated_parsed)
+    }
+
+    fn get_inner_manifest_mut(&mut self) -> Option<&mut ManifestV1_15_0> {
         Some(&mut self.inner.migrated_parsed)
     }
 }
@@ -404,10 +452,20 @@ impl GetInnerManifest<ManifestV1_13_0> for Manifest<MigratedTypedOnly> {
 
 impl GetInnerManifest<ManifestV1_14_0> for Manifest<MigratedTypedOnly> {
     fn get_inner_manifest(&self) -> Option<&ManifestV1_14_0> {
-        Some(&self.inner.migrated_parsed)
+        None
     }
 
     fn get_inner_manifest_mut(&mut self) -> Option<&mut ManifestV1_14_0> {
+        None
+    }
+}
+
+impl GetInnerManifest<ManifestV1_15_0> for Manifest<MigratedTypedOnly> {
+    fn get_inner_manifest(&self) -> Option<&ManifestV1_15_0> {
+        Some(&self.inner.migrated_parsed)
+    }
+
+    fn get_inner_manifest_mut(&mut self) -> Option<&mut ManifestV1_15_0> {
         Some(&mut self.inner.migrated_parsed)
     }
 }

--- a/cli/flox-manifest/src/lib.rs
+++ b/cli/flox-manifest/src/lib.rs
@@ -47,6 +47,7 @@ use crate::parsed::v1_11_0::ManifestV1_11_0;
 use crate::parsed::v1_12_0::ManifestV1_12_0;
 use crate::parsed::v1_13_0::ManifestV1_13_0;
 use crate::parsed::v1_14_0::ManifestV1_14_0;
+use crate::parsed::v1_15_0::ManifestV1_15_0;
 use crate::raw::{
     SyncTypedToRaw,
     TomlEditError,
@@ -238,13 +239,14 @@ enum Parsed {
     V1_12_0(ManifestV1_12_0),
     V1_13_0(ManifestV1_13_0),
     V1_14_0(ManifestV1_14_0),
+    V1_15_0(ManifestV1_15_0),
 }
 
 impl Parsed {
     /// A helper function for creating a [`Parsed`] from whatever the latest
     /// manifest schema version happens to be.
     pub(crate) fn from_latest(manifest: ManifestLatest) -> Self {
-        Self::V1_14_0(manifest)
+        Self::V1_15_0(manifest)
     }
 
     /// Returns the known schema version of the contained manifest.
@@ -259,6 +261,7 @@ impl Parsed {
             Parsed::V1_12_0(_) => KnownSchemaVersion::V1_12_0,
             Parsed::V1_13_0(_) => KnownSchemaVersion::V1_13_0,
             Parsed::V1_14_0(_) => KnownSchemaVersion::V1_14_0,
+            Parsed::V1_15_0(_) => KnownSchemaVersion::V1_15_0,
         }
     }
 }
@@ -521,6 +524,11 @@ impl<S: ManifestState> Manifest<S> {
                     .map_err(ManifestError::Invalid)?;
                 Ok(Parsed::V1_14_0(manifest))
             },
+            KnownSchemaVersion::V1_15_0 => {
+                let manifest = toml_edit::de::from_document::<ManifestV1_15_0>(toml.clone())
+                    .map_err(ManifestError::Invalid)?;
+                Ok(Parsed::V1_15_0(manifest))
+            },
         }
     }
 }
@@ -616,6 +624,16 @@ impl<'de> Deserialize<'de> for Manifest<TypedOnly> {
                 Ok(Manifest {
                     inner: TypedOnly {
                         parsed: Parsed::V1_14_0(manifest),
+                    },
+                })
+            },
+            KnownSchemaVersion::V1_15_0 => {
+                let d = untyped.into_deserializer();
+                let manifest = ManifestV1_15_0::deserialize(d)
+                    .map_err(|err| serde::de::Error::custom(err.to_string()))?;
+                Ok(Manifest {
+                    inner: TypedOnly {
+                        parsed: Parsed::V1_15_0(manifest),
                     },
                 })
             },

--- a/cli/flox-manifest/src/lockfile/compose.rs
+++ b/cli/flox-manifest/src/lockfile/compose.rs
@@ -38,6 +38,7 @@ impl Compose {
                 crate::Parsed::V1_12_0(manifest) => manifest.resolve_install_id(package, version),
                 crate::Parsed::V1_13_0(manifest) => manifest.resolve_install_id(package, version),
                 crate::Parsed::V1_14_0(manifest) => manifest.resolve_install_id(package, version),
+                crate::Parsed::V1_15_0(manifest) => manifest.resolve_install_id(package, version),
             };
             match res {
                 Ok(_) => return Ok(Some(include.clone())),

--- a/cli/flox-manifest/src/migrate/mod.rs
+++ b/cli/flox-manifest/src/migrate/mod.rs
@@ -4,6 +4,7 @@ use crate::migrate::v1_10_0_to_v1_11_0::migrate_manifest_v1_10_0_to_v1_11_0;
 use crate::migrate::v1_11_0_to_v1_12_0::migrate_manifest_v1_11_0_to_v1_12_0;
 use crate::migrate::v1_12_0_to_v1_13_0::migrate_manifest_v1_12_0_to_v1_13_0;
 use crate::migrate::v1_13_0_to_v1_14_0::migrate_manifest_v1_13_0_to_v1_14_0;
+use crate::migrate::v1_14_0_to_v1_15_0::migrate_manifest_v1_14_0_to_v1_15_0;
 use crate::migrate::v1_to_v1_10_0::migrate_manifest_v1_to_v1_10_0;
 use crate::parsed::common::KnownSchemaVersion;
 use crate::raw::SyncTypedToRaw;
@@ -13,6 +14,7 @@ mod v1_10_0_to_v1_11_0;
 mod v1_11_0_to_v1_12_0;
 mod v1_12_0_to_v1_13_0;
 mod v1_13_0_to_v1_14_0;
+mod v1_14_0_to_v1_15_0;
 mod v1_to_v1_10_0;
 
 #[derive(Debug, thiserror::Error)]
@@ -68,11 +70,15 @@ pub(crate) fn migrate_typed_only(
                 let migrated = migrate_manifest_v1_13_0_to_v1_14_0(manifest_v1_13_0)?;
                 inner = Parsed::V1_14_0(migrated);
             },
-            Parsed::V1_14_0(manifest_v1_14_0) => break Parsed::from_latest(manifest_v1_14_0),
+            Parsed::V1_14_0(manifest_v1_14_0) => {
+                let migrated = migrate_manifest_v1_14_0_to_v1_15_0(manifest_v1_14_0)?;
+                inner = Parsed::V1_15_0(migrated);
+            },
+            Parsed::V1_15_0(manifest_v1_15_0) => break Parsed::from_latest(manifest_v1_15_0),
         }
     };
     debug_assert_eq!(inner.schema_version(), KnownSchemaVersion::latest());
-    let Parsed::V1_14_0(migrated_manifest) = inner else {
+    let Parsed::V1_15_0(migrated_manifest) = inner else {
         unreachable!("already checked that manifest was latest schema version")
     };
     let migrated = Manifest {

--- a/cli/flox-manifest/src/migrate/v1_14_0_to_v1_15_0.rs
+++ b/cli/flox-manifest/src/migrate/v1_14_0_to_v1_15_0.rs
@@ -1,0 +1,59 @@
+use crate::migrate::MigrationError;
+use crate::parsed::v1_14_0::ManifestV1_14_0;
+use crate::parsed::v1_15_0::ManifestV1_15_0;
+
+/// Migrate a v1.14.0 manifest to a v1.15.0 manifest.
+///
+/// This is a lossless migration: V1_15_0 adds an optional `hook.on-deactivate`
+/// script. All V1_14_0 manifests are valid V1_15_0 manifests with
+/// `on-deactivate` unset.
+pub(crate) fn migrate_manifest_v1_14_0_to_v1_15_0(
+    manifest: ManifestV1_14_0,
+) -> Result<ManifestV1_15_0, MigrationError> {
+    Ok(ManifestV1_15_0 {
+        schema_version: "1.15.0".to_string(),
+        minimum_cli_version: manifest.minimum_cli_version,
+        install: manifest.install,
+        vars: manifest.vars,
+        hook: manifest.hook.map(Into::into),
+        profile: manifest.profile,
+        options: manifest.options,
+        services: manifest.services,
+        build: manifest.build,
+        containerize: manifest.containerize,
+        include: manifest.include,
+        plugins: manifest.plugins,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+
+    use super::*;
+
+    proptest! {
+        // The migration only sets the new schema version and defaults the new
+        // `hook.on-deactivate` script; everything else is carried over
+        // unchanged.
+        #[test]
+        fn migration_v1_14_0_to_v1_15_0_is_lossless(manifest in any::<ManifestV1_14_0>()) {
+            let migrated = migrate_manifest_v1_14_0_to_v1_15_0(manifest.clone()).unwrap();
+            let expected = ManifestV1_15_0 {
+                schema_version: "1.15.0".to_string(),
+                minimum_cli_version: manifest.minimum_cli_version,
+                install: manifest.install,
+                vars: manifest.vars,
+                hook: manifest.hook.map(Into::into),
+                profile: manifest.profile,
+                options: manifest.options,
+                services: manifest.services,
+                build: manifest.build,
+                containerize: manifest.containerize,
+                include: manifest.include,
+                plugins: manifest.plugins,
+            };
+            prop_assert_eq!(migrated, expected);
+        }
+    }
+}

--- a/cli/flox-manifest/src/parsed/common.rs
+++ b/cli/flox-manifest/src/parsed/common.rs
@@ -56,12 +56,13 @@ pub enum KnownSchemaVersion {
     V1_12_0,
     V1_13_0,
     V1_14_0,
+    V1_15_0,
 }
 
 impl KnownSchemaVersion {
     /// Returns the latest schema version.
     pub fn latest() -> Self {
-        KnownSchemaVersion::V1_14_0
+        KnownSchemaVersion::V1_15_0
     }
 
     /// Returns the oldest supported schema version.
@@ -78,6 +79,7 @@ impl KnownSchemaVersion {
             KnownSchemaVersion::V1_12_0,
             KnownSchemaVersion::V1_13_0,
             KnownSchemaVersion::V1_14_0,
+            KnownSchemaVersion::V1_15_0,
         ]
         .into_iter()
     }
@@ -104,6 +106,7 @@ impl TryFrom<VersionKind> for KnownSchemaVersion {
                 "1.12.0" => Ok(KnownSchemaVersion::V1_12_0),
                 "1.13.0" => Ok(KnownSchemaVersion::V1_13_0),
                 "1.14.0" => Ok(KnownSchemaVersion::V1_14_0),
+                "1.15.0" => Ok(KnownSchemaVersion::V1_15_0),
                 _ => Err(ManifestError::InvalidSchemaVersion(v.to_string())),
             },
         }
@@ -119,6 +122,7 @@ impl std::fmt::Display for KnownSchemaVersion {
             KnownSchemaVersion::V1_12_0 => write!(f, "1.12.0"),
             KnownSchemaVersion::V1_13_0 => write!(f, "1.13.0"),
             KnownSchemaVersion::V1_14_0 => write!(f, "1.14.0"),
+            KnownSchemaVersion::V1_15_0 => write!(f, "1.15.0"),
         }
     }
 }

--- a/cli/flox-manifest/src/parsed/latest.rs
+++ b/cli/flox-manifest/src/parsed/latest.rs
@@ -13,8 +13,11 @@ pub use crate::parsed::v1_11_0::MinimumCliVersion;
 // BuildSandbox is version-specific from V1_13_0 on (it adds `warn`/`enforce`),
 // so the latest schema re-exports that copy rather than common's.
 pub use crate::parsed::v1_13_0::BuildSandbox;
+// Hook is version-specific from V1_15_0 on (it adds `on-deactivate`),
+// so the latest schema re-exports that copy rather than common's.
+pub use crate::parsed::v1_15_0::Hook;
 use crate::{Manifest, ManifestError, TypedOnly};
-pub type ManifestLatest = crate::parsed::v1_14_0::ManifestV1_14_0;
+pub type ManifestLatest = crate::parsed::v1_15_0::ManifestV1_15_0;
 
 impl ManifestLatest {
     /// Try to return a manifest in its original schema
@@ -76,6 +79,15 @@ impl ManifestLatest {
                 untyped
             },
             KnownSchemaVersion::V1_14_0 => {
+                let mut untyped =
+                    serde_json::to_value(self).map_err(ManifestError::SerializeJson)?;
+                let map = untyped
+                    .as_object_mut()
+                    .expect("all valid manifests should serialize to JSON objects");
+                map.insert("schema-version".into(), "1.14.0".into());
+                untyped
+            },
+            KnownSchemaVersion::V1_15_0 => {
                 return Ok(Some(self.as_typed_only()));
             },
         };
@@ -125,12 +137,7 @@ mod tests {
     use crate::ManifestError;
     use crate::interfaces::{PackageLookup, SchemaVersion};
     use crate::parsed::Inner;
-    use crate::parsed::common::{
-        BuildVersion,
-        Hook,
-        IncludeDescriptor,
-        PackageDescriptorStorePath,
-    };
+    use crate::parsed::common::{BuildVersion, IncludeDescriptor, PackageDescriptorStorePath};
     // ManifestLatest's build section is the version-specific Build (with
     // `sandbox-allow`), so build assertions use the latest schema's types.
     use crate::parsed::v1_13_0::{Build, BuildDescriptor, Profile, ProfileDeactivate};
@@ -557,6 +564,79 @@ mod tests {
         let serialized = toml_edit::ser::to_string_pretty(&manifest).unwrap();
 
         assert!(!serialized.contains("[plugins"));
+    }
+
+    #[test]
+    fn hook_on_deactivate_rejected_by_v1_14_0_schema() {
+        let manifest = with_schema(KnownSchemaVersion::V1_14_0, indoc! {r#"
+            [hook]
+            on-deactivate = "rm -f $FLOX_ENV_CACHE/scratch"
+        "#});
+
+        let err = Manifest::parse_toml_typed(&manifest)
+            .expect_err("'hook.on-deactivate' should be rejected by the v1.14.0 schema");
+
+        let ManifestError::Invalid(err) = err else {
+            panic!("expected ManifestError::Invalid, got: {err:?}");
+        };
+        assert!(
+            err.message()
+                .starts_with("unknown field `on-deactivate`, expected"),
+            "unexpected error message: {err}",
+        );
+    }
+
+    #[test]
+    fn hook_on_deactivate_parses_with_latest_schema() {
+        let manifest = with_latest_schema(indoc! {r#"
+            [hook]
+            on-activate = "touch $FLOX_ENV_CACHE/scratch"
+            on-deactivate = "rm -f $FLOX_ENV_CACHE/scratch"
+        "#});
+
+        let parsed = toml_edit::de::from_str::<ManifestLatest>(&manifest).unwrap();
+
+        assert_eq!(
+            parsed.hook,
+            Some(Hook {
+                on_activate: Some("touch $FLOX_ENV_CACHE/scratch".to_string()),
+                on_deactivate: Some("rm -f $FLOX_ENV_CACHE/scratch".to_string()),
+            })
+        );
+    }
+
+    #[test]
+    fn downgrades_to_v1_14_0_when_on_deactivate_unused() {
+        let manifest = ManifestLatest {
+            hook: Some(Hook {
+                on_activate: Some("echo hello".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let compat = manifest
+            .as_maybe_backwards_compatible(KnownSchemaVersion::V1_14_0, None)
+            .unwrap();
+
+        assert_eq!(compat.get_schema_version(), KnownSchemaVersion::V1_14_0);
+    }
+
+    #[test]
+    fn stays_latest_schema_when_on_deactivate_used() {
+        let manifest = ManifestLatest {
+            hook: Some(Hook {
+                on_activate: None,
+                on_deactivate: Some("echo goodbye".to_string()),
+            }),
+            ..Default::default()
+        };
+
+        let compat = manifest
+            .as_maybe_backwards_compatible(KnownSchemaVersion::V1_14_0, None)
+            .unwrap();
+
+        assert_eq!(compat.get_schema_version(), KnownSchemaVersion::latest());
     }
 
     #[test]

--- a/cli/flox-manifest/src/parsed/mod.rs
+++ b/cli/flox-manifest/src/parsed/mod.rs
@@ -6,6 +6,7 @@ pub mod v1_11_0;
 pub mod v1_12_0;
 pub mod v1_13_0;
 pub mod v1_14_0;
+pub mod v1_15_0;
 
 /// An interface codifying how to access types that are just semantic wrappers
 /// around inner types. This impl may be generated with a macro.

--- a/cli/flox-manifest/src/parsed/v1_15_0/mod.rs
+++ b/cli/flox-manifest/src/parsed/v1_15_0/mod.rs
@@ -1,0 +1,168 @@
+use std::collections::BTreeMap;
+
+#[cfg(any(test, feature = "tests"))]
+use flox_test_utils::proptest::alphanum_and_whitespace_string;
+#[cfg(any(test, feature = "tests"))]
+use proptest::prelude::*;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
+
+use crate::interfaces::{AsTypedOnlyManifest, SchemaVersion, impl_pkg_lookup};
+use crate::parsed::common::{Containerize, Include, KnownSchemaVersion, Options, Vars};
+use crate::parsed::v1_10_0::{Install, ManifestPackageDescriptor};
+pub use crate::parsed::v1_11_0::MinimumCliVersion;
+pub use crate::parsed::v1_12_0::Services;
+pub use crate::parsed::v1_13_0::{
+    Build,
+    BuildDescriptor,
+    BuildSandbox,
+    Profile,
+    ProfileDeactivate,
+};
+pub use crate::parsed::v1_14_0::Plugins;
+use crate::parsed::{Inner, SkipSerializing};
+use crate::{Manifest, ManifestError, Parsed, TypedOnly};
+
+/// Not meant for writing manifest files, only for reading them.
+/// Modifications should be made using `manifest::raw`.
+
+// We use `skip_serializing_none` and `skip_serializing_if` throughout to reduce
+// the size of the lockfile and improve backwards compatibility when we
+// introduce fields.
+//
+// It would be better if we could deny_unknown_fields when we're deserializing
+// the user provided manifest but allow unknown fields when deserializing the
+// lockfile, but that doesn't seem worth the effort at the moment.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, JsonSchema)]
+#[cfg_attr(any(test, feature = "tests"), derive(proptest_derive::Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct ManifestV1_15_0 {
+    /// Which schema version this manifest adheres to.
+    ///
+    /// Must be a valid Flox CLI version listed in [`KnownSchemaVersion`].
+    #[serde(rename = "schema-version")]
+    pub schema_version: String,
+    /// The minimum CLI version that can activate this environment.
+    #[serde(rename = "minimum-cli-version")]
+    pub minimum_cli_version: Option<MinimumCliVersion>,
+    /// The packages to install in the form of a map from install_id
+    /// to package descriptor.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Install::skip_serializing")]
+    pub install: Install,
+    /// Variables that are exported to the shell environment upon activation.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Vars::skip_serializing")]
+    pub vars: Vars,
+    /// Hooks that are run at various times during the lifecycle of the manifest
+    /// in a known shell environment.
+    #[serde(default)]
+    pub hook: Option<Hook>,
+    /// Profile scripts that are run in the user's shell upon activation
+    /// (and, optionally, upon deactivation).
+    #[serde(default)]
+    pub profile: Option<Profile>,
+    /// Options that control the behavior of the manifest.
+    #[serde(default)]
+    pub options: Options,
+    /// Service definitions
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Services::skip_serializing")]
+    pub services: Services,
+    /// Package build definitions
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Build::skip_serializing")]
+    pub build: Build,
+    #[serde(default)]
+    pub containerize: Option<Containerize>,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Include::skip_serializing")]
+    pub include: Include,
+    /// Free-form data provided by installed plugins, keyed by plugin
+    /// package name (`[plugins.<pkg-name>]`). Each plugin defines and
+    /// validates the shape of its own table; Flox does not interpret it.
+    /// The convention for secrets plugins is a flat table of
+    /// `ENV_VAR_NAME = "path/to/secret/in/store"`, read by the plugin's
+    /// `profile.d` script at activation.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Plugins::skip_serializing")]
+    pub plugins: Plugins,
+}
+impl_pkg_lookup!(crate::parsed::v1_10_0, ManifestV1_15_0);
+
+// You can't derive `Default` because `schema-version` is a `String`,
+// which just defaults to an empty string.
+impl Default for ManifestV1_15_0 {
+    fn default() -> Self {
+        Self {
+            schema_version: "1.15.0".into(),
+            minimum_cli_version: Default::default(),
+            install: Default::default(),
+            vars: Default::default(),
+            hook: Default::default(),
+            profile: Default::default(),
+            options: Default::default(),
+            services: Default::default(),
+            build: Default::default(),
+            containerize: Default::default(),
+            include: Default::default(),
+            plugins: Default::default(),
+        }
+    }
+}
+
+impl AsTypedOnlyManifest for ManifestV1_15_0 {
+    fn as_typed_only(&self) -> crate::Manifest<TypedOnly> {
+        Manifest {
+            inner: TypedOnly {
+                parsed: Parsed::V1_15_0(self.clone()),
+            },
+        }
+    }
+}
+
+impl SchemaVersion for ManifestV1_15_0 {
+    fn get_schema_version(&self) -> KnownSchemaVersion {
+        KnownSchemaVersion::V1_15_0
+    }
+}
+
+/// Lifecycle hooks for V1_15_0: adds an optional `on-deactivate` script that
+/// is run when the last attachment detaches from an activation. The
+/// `on-activate` field is the same as earlier schema versions, which keep
+/// using `common::Hook`.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash, JsonSchema)]
+#[cfg_attr(any(test, feature = "tests"), derive(proptest_derive::Arbitrary))]
+#[serde(rename_all = "kebab-case")]
+#[serde(deny_unknown_fields)]
+pub struct Hook {
+    /// A script that is run at activation time,
+    /// in a flox provided bash shell
+    #[cfg_attr(
+        any(test, feature = "tests"),
+        proptest(strategy = "proptest::option::of(alphanum_and_whitespace_string(5))")
+    )]
+    pub(crate) on_activate: Option<String>,
+    /// A script that is run in a flox provided bash shell when the last
+    /// attachment detaches from an activation
+    #[cfg_attr(
+        any(test, feature = "tests"),
+        proptest(strategy = "proptest::option::of(alphanum_and_whitespace_string(5))")
+    )]
+    pub(crate) on_deactivate: Option<String>,
+}
+
+// Conversion from the common type, used by the V1_14_0 -> V1_15_0 migration.
+// The new `on_deactivate` field defaults to None, which is what makes the
+// migration lossless.
+impl From<crate::parsed::common::Hook> for Hook {
+    fn from(hook: crate::parsed::common::Hook) -> Self {
+        Hook {
+            on_activate: hook.on_activate,
+            on_deactivate: None,
+        }
+    }
+}

--- a/cli/flox-manifest/src/raw/mod.rs
+++ b/cli/flox-manifest/src/raw/mod.rs
@@ -1026,6 +1026,12 @@ fn update_raw_packages_from_typed_manifest(
             .keys()
             .cloned()
             .collect::<HashSet<String>>(),
+        Parsed::V1_15_0(manifest) => manifest
+            .install
+            .inner()
+            .keys()
+            .cloned()
+            .collect::<HashSet<String>>(),
     };
 
     // Don't create an [install] table if there are no packages in either
@@ -1163,6 +1169,19 @@ fn update_descriptor(
             }
         },
         Parsed::V1_14_0(manifest) => {
+            let typed = manifest
+                .install
+                .inner()
+                .get(install_id)
+                .ok_or(TomlEditError::PackageNotFound(install_id.to_string()))?;
+            use crate::parsed::v1_10_0::ManifestPackageDescriptor::*;
+            match typed {
+                Catalog(d) => update_v1_10_0_catalog_descriptor(raw, d),
+                FlakeRef(d) => update_v1_10_0_flake_descriptor(raw, d),
+                StorePath(d) => update_store_path_descriptor(raw, d),
+            }
+        },
+        Parsed::V1_15_0(manifest) => {
             let typed = manifest
                 .install
                 .inner()
@@ -2207,6 +2226,9 @@ curl.outputs = [\"bin\", \"man\"]
             Parsed::V1_14_0(m) => {
                 m.install.inner_mut().remove(id);
             },
+            Parsed::V1_15_0(m) => {
+                m.install.inner_mut().remove(id);
+            },
         }
     }
 
@@ -2230,6 +2252,9 @@ curl.outputs = [\"bin\", \"man\"]
                 m.install.inner_mut().insert(id.to_string(), descriptor);
             },
             Parsed::V1_14_0(m) => {
+                m.install.inner_mut().insert(id.to_string(), descriptor);
+            },
+            Parsed::V1_15_0(m) => {
                 m.install.inner_mut().insert(id.to_string(), descriptor);
             },
             _ => panic!("expected v1_10_0 or later manifest"),
@@ -2262,6 +2287,10 @@ curl.outputs = [\"bin\", \"man\"]
                 v1_10_0::ManifestPackageDescriptor::Catalog(desc) => Some(desc),
                 _ => None,
             },
+            Parsed::V1_15_0(m) => match m.install.inner_mut().get_mut(id)? {
+                v1_10_0::ManifestPackageDescriptor::Catalog(desc) => Some(desc),
+                _ => None,
+            },
             _ => panic!("expected v1_10_0 or later manifest"),
         }
     }
@@ -2283,7 +2312,7 @@ curl.outputs = [\"bin\", \"man\"]
         manifest.update_raw_packages_from_typed_manifest().unwrap();
         let output = manifest.inner.raw.to_string();
         expect![[r#"
-            schema-version = "1.14.0"
+            schema-version = "1.15.0"
 
             [install]
 
@@ -2321,7 +2350,7 @@ curl.outputs = [\"bin\", \"man\"]
         manifest.update_raw_packages_from_typed_manifest().unwrap();
         let output = manifest.inner.raw.to_string();
         expect![[r#"
-            schema-version = "1.14.0"
+            schema-version = "1.15.0"
 
             [install]
             # my favorite greeting program
@@ -2353,7 +2382,7 @@ curl.outputs = [\"bin\", \"man\"]
         manifest.update_raw_packages_from_typed_manifest().unwrap();
         let output = manifest.inner.raw.to_string();
         expect![[r#"
-            schema-version = "1.14.0"
+            schema-version = "1.15.0"
 
             [install]
             # keep this comment about hello
@@ -2381,7 +2410,7 @@ curl.outputs = [\"bin\", \"man\"]
         manifest.update_raw_packages_from_typed_manifest().unwrap();
         let output = manifest.inner.raw.to_string();
         expect![[r#"
-            schema-version = "1.14.0"
+            schema-version = "1.15.0"
 
             [install]
             hello.pkg-path = "hello" # this is important
@@ -2453,7 +2482,7 @@ curl.outputs = [\"bin\", \"man\"]
         manifest.update_raw_packages_from_typed_manifest().unwrap();
         let output = manifest.inner.raw.to_string();
         expect![[r#"
-            schema-version = "1.14.0"
+            schema-version = "1.15.0"
 
             [install]
             # this comment is above hello
@@ -2499,7 +2528,7 @@ curl.outputs = [\"bin\", \"man\"]
         manifest.update_systems().unwrap();
         let output = manifest.inner.raw.to_string();
         expect![[r#"
-            schema-version = "1.14.0"
+            schema-version = "1.15.0"
 
             [options]
             systems = ["aarch64-darwin", "x86_64-linux"]
@@ -2555,7 +2584,7 @@ curl.outputs = [\"bin\", \"man\"]
         manifest.update_raw_packages_from_typed_manifest().unwrap();
         let output = manifest.inner.raw.to_string();
         expect![[r#"
-            schema-version = "1.14.0"
+            schema-version = "1.15.0"
 
             [install]
             hello.pkg-path = "hello"
@@ -2580,7 +2609,7 @@ curl.outputs = [\"bin\", \"man\"]
         let output = migrated.inner.migrated_raw.to_string();
         expect![[r##"
             # this comment is above version
-            schema-version = "1.14.0"
+            schema-version = "1.15.0"
 
             [install]
             hello.pkg-path = "hello"

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -1649,7 +1649,7 @@ mod migration_tests {
             .to_string();
 
         expect![[r#"
-            schema-version = "1.14.0"
+            schema-version = "1.15.0"
         "#]]
         .assert_eq(&manifest_contents);
     }

--- a/cli/flox-rust-sdk/src/providers/buildenv.rs
+++ b/cli/flox-rust-sdk/src/providers/buildenv.rs
@@ -2436,9 +2436,45 @@ mod buildenv_tests {
 
         let runtime = &result.run;
         assert!(runtime.join("activate.d/hook-on-activate").exists());
+        assert!(!runtime.join("activate.d/hook-on-deactivate").exists());
 
         let develop = &result.dev;
         assert!(develop.join("activate.d/hook-on-activate").exists());
+        assert!(!develop.join("activate.d/hook-on-deactivate").exists());
+    }
+
+    #[test]
+    fn build_contains_on_deactivate_script() {
+        // The generated kitchen_sink lockfile predates `hook.on-deactivate`,
+        // so inject the field (and the schema version that introduced it)
+        // instead of regenerating the mock data.
+        let lockfile_path = GENERATED_DATA.join("envs/kitchen_sink/manifest.lock");
+        let mut lockfile_json: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&lockfile_path).unwrap()).unwrap();
+        let manifest = lockfile_json
+            .get_mut("manifest")
+            .and_then(|manifest| manifest.as_object_mut())
+            .unwrap();
+        manifest.insert("schema-version".into(), "1.15.0".into());
+        manifest
+            .get_mut("hook")
+            .and_then(|hook| hook.as_object_mut())
+            .unwrap()
+            .insert("on-deactivate".into(), "echo running on-deactivate".into());
+
+        let tempdir = tempfile::tempdir().unwrap();
+        let lockfile_path = tempdir.path().join("manifest.lock");
+        std::fs::write(&lockfile_path, lockfile_json.to_string()).unwrap();
+
+        let buildenv = buildenv_instance();
+        let client = MockClient::new();
+        let result = buildenv.build(&client, &lockfile_path, None, None).unwrap();
+
+        let runtime = &result.run;
+        assert!(runtime.join("activate.d/hook-on-deactivate").exists());
+
+        let develop = &result.dev;
+        assert!(develop.join("activate.d/hook-on-deactivate").exists());
     }
 
     #[test]

--- a/cli/flox-rust-sdk/src/providers/manifest_init.rs
+++ b/cli/flox-rust-sdk/src/providers/manifest_init.rs
@@ -465,7 +465,7 @@ mod tests {
             ##
             ## -------------------------------------------------------------------
             # Flox manifest version managed by Flox CLI
-            schema-version = "1.14.0"
+            schema-version = "1.15.0"
 
 
             ## Install Packages --------------------------------------------------
@@ -589,7 +589,7 @@ mod tests {
             ##
             ## -------------------------------------------------------------------
             # Flox manifest version managed by Flox CLI
-            schema-version = "1.14.0"
+            schema-version = "1.15.0"
 
 
             ## Install Packages --------------------------------------------------
@@ -716,7 +716,7 @@ mod tests {
             ##
             ## -------------------------------------------------------------------
             # Flox manifest version managed by Flox CLI
-            schema-version = "1.14.0"
+            schema-version = "1.15.0"
 
 
             ## Install Packages --------------------------------------------------
@@ -840,7 +840,7 @@ mod tests {
             ##
             ## -------------------------------------------------------------------
             # Flox manifest version managed by Flox CLI
-            schema-version = "1.14.0"
+            schema-version = "1.15.0"
 
 
             ## Install Packages --------------------------------------------------
@@ -953,7 +953,7 @@ mod tests {
             ##
             ## -------------------------------------------------------------------
             # Flox manifest version managed by Flox CLI
-            schema-version = "1.14.0"
+            schema-version = "1.15.0"
 
 
             ## Install Packages --------------------------------------------------

--- a/cli/flox/doc/manifest.toml.md
+++ b/cli/flox/doc/manifest.toml.md
@@ -52,6 +52,7 @@ Valid string values are:
 - `1.12.0`: introduced services `auto-start`
 - `1.13.0`: introduced `profile.deactivate` and build `sandbox-allow`
 - `1.14.0`: introduced `plugins`
+- `1.15.0`: introduced `hook.on-deactivate`
 
 Existing manifest schemas, including the older `version = 1` format, are
 automatically forward-migrated when using features that require a newer schema
@@ -412,6 +413,48 @@ run of the script for the first activation for your shell.
 
 It's also best practice to write hooks defensively, assuming the user is using
 the environment from any directory on their machine.
+
+### `on-deactivate`
+
+The `on-deactivate` script is the bookend to `on-activate`:
+think of an activation as a bookshelf, where `on-activate` and `on-deactivate`
+are the book ends and each attached shell or command is a book on the shelf.
+`on-activate` runs when the first attachment starts the activation,
+and `on-deactivate` runs once the last attachment for that activation goes
+away — whether via `flox deactivate` or by the shell or command exiting.
+
+Use it for cleanup that should happen after the whole activation winds down,
+such as removing temporary files or releasing external resources created by
+`on-activate`.
+It is not needed for stopping services — use `services.<name>.shutdown` for
+that; services are shut down before `on-deactivate` runs.
+
+Like `on-activate`, the script runs in a **bash** shell.
+It sees the environment as `on-activate` left it,
+so variables exported during `on-activate` are available for cleanup:
+
+```toml
+[hook]
+on-activate = """
+    venv_dir="$(mktemp -d)"
+    export venv_dir
+    python -m venv "$venv_dir"
+"""
+on-deactivate = """
+    rm -rf "$venv_dir"
+"""
+```
+
+The script runs in a background process, not in your shell,
+so it cannot prompt for input and its output does not appear in your
+terminal;
+output is captured in the environment's activation logs.
+A failing `on-deactivate` script is logged and never blocks deactivation.
+
+The script is best-effort: it does not run if the activation's background
+process is killed or the machine shuts down uncleanly.
+For per-shell cleanup that should run every time a shell detaches
+(the end of each "book" on the shelf), use `profile.deactivate` instead.
 
 ### `script` - DEPRECATED
 This field was deprecated in favor of the `profile` section.

--- a/cli/schemas/lockfile-v1.schema.json
+++ b/cli/schemas/lockfile-v1.schema.json
@@ -769,6 +769,27 @@
           },
           "type": "object"
         },
+        "Hook2": {
+          "additionalProperties": false,
+          "description": "Lifecycle hooks for V1_15_0: adds an optional `on-deactivate` script that\nis run when the last attachment detaches from an activation. The\n`on-activate` field is the same as earlier schema versions, which keep\nusing `common::Hook`.",
+          "properties": {
+            "on-activate": {
+              "description": "A script that is run at activation time,\nin a flox provided bash shell",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "on-deactivate": {
+              "description": "A script that is run in a flox provided bash shell when the last\nattachment detaches from an activation",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
         "Include": {
           "additionalProperties": false,
           "description": "The section where users can declare dependencies on other environments.",
@@ -1285,6 +1306,91 @@
               "anyOf": [
                 {
                   "$ref": "#/$defs/Hook"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Hooks that are run at various times during the lifecycle of the manifest\nin a known shell environment."
+            },
+            "include": {
+              "$ref": "#/$defs/Include"
+            },
+            "install": {
+              "$ref": "#/$defs/Install2",
+              "description": "The packages to install in the form of a map from install_id\nto package descriptor."
+            },
+            "minimum-cli-version": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/MinimumCliVersion"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The minimum CLI version that can activate this environment."
+            },
+            "options": {
+              "$ref": "#/$defs/Options",
+              "default": {},
+              "description": "Options that control the behavior of the manifest."
+            },
+            "plugins": {
+              "$ref": "#/$defs/Plugins",
+              "description": "Free-form data provided by installed plugins, keyed by plugin\npackage name (`[plugins.<pkg-name>]`). Each plugin defines and\nvalidates the shape of its own table; Flox does not interpret it.\nThe convention for secrets plugins is a flat table of\n`ENV_VAR_NAME = \"path/to/secret/in/store\"`, read by the plugin's\n`profile.d` script at activation."
+            },
+            "profile": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Profile2"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Profile scripts that are run in the user's shell upon activation\n(and, optionally, upon deactivation)."
+            },
+            "schema-version": {
+              "description": "Which schema version this manifest adheres to.\n\nMust be a valid Flox CLI version listed in [`KnownSchemaVersion`].",
+              "type": "string"
+            },
+            "services": {
+              "$ref": "#/$defs/Services2",
+              "description": "Service definitions"
+            },
+            "vars": {
+              "$ref": "#/$defs/Vars",
+              "description": "Variables that are exported to the shell environment upon activation."
+            }
+          },
+          "required": [
+            "schema-version"
+          ],
+          "type": "object"
+        },
+        "ManifestV1_15_0": {
+          "additionalProperties": false,
+          "description": "Not meant for writing manifest files, only for reading them.\nModifications should be made using `manifest::raw`.",
+          "properties": {
+            "build": {
+              "$ref": "#/$defs/Build2",
+              "description": "Package build definitions"
+            },
+            "containerize": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Containerize"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "hook": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Hook2"
                 },
                 {
                   "type": "null"
@@ -2406,6 +2512,9 @@
         },
         {
           "$ref": "#/$defs/ManifestV1_14_0"
+        },
+        {
+          "$ref": "#/$defs/ManifestV1_15_0"
         }
       ],
       "description": "A validated, typed manifest with a known schema.",

--- a/cli/schemas/manifest-v1.schema.json
+++ b/cli/schemas/manifest-v1.schema.json
@@ -372,6 +372,27 @@
       },
       "type": "object"
     },
+    "Hook2": {
+      "additionalProperties": false,
+      "description": "Lifecycle hooks for V1_15_0: adds an optional `on-deactivate` script that\nis run when the last attachment detaches from an activation. The\n`on-activate` field is the same as earlier schema versions, which keep\nusing `common::Hook`.",
+      "properties": {
+        "on-activate": {
+          "description": "A script that is run at activation time,\nin a flox provided bash shell",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "on-deactivate": {
+          "description": "A script that is run in a flox provided bash shell when the last\nattachment detaches from an activation",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
     "Include": {
       "additionalProperties": false,
       "description": "The section where users can declare dependencies on other environments.",
@@ -888,6 +909,91 @@
           "anyOf": [
             {
               "$ref": "#/$defs/Hook"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Hooks that are run at various times during the lifecycle of the manifest\nin a known shell environment."
+        },
+        "include": {
+          "$ref": "#/$defs/Include"
+        },
+        "install": {
+          "$ref": "#/$defs/Install2",
+          "description": "The packages to install in the form of a map from install_id\nto package descriptor."
+        },
+        "minimum-cli-version": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/MinimumCliVersion"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The minimum CLI version that can activate this environment."
+        },
+        "options": {
+          "$ref": "#/$defs/Options",
+          "default": {},
+          "description": "Options that control the behavior of the manifest."
+        },
+        "plugins": {
+          "$ref": "#/$defs/Plugins",
+          "description": "Free-form data provided by installed plugins, keyed by plugin\npackage name (`[plugins.<pkg-name>]`). Each plugin defines and\nvalidates the shape of its own table; Flox does not interpret it.\nThe convention for secrets plugins is a flat table of\n`ENV_VAR_NAME = \"path/to/secret/in/store\"`, read by the plugin's\n`profile.d` script at activation."
+        },
+        "profile": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Profile2"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Profile scripts that are run in the user's shell upon activation\n(and, optionally, upon deactivation)."
+        },
+        "schema-version": {
+          "description": "Which schema version this manifest adheres to.\n\nMust be a valid Flox CLI version listed in [`KnownSchemaVersion`].",
+          "type": "string"
+        },
+        "services": {
+          "$ref": "#/$defs/Services2",
+          "description": "Service definitions"
+        },
+        "vars": {
+          "$ref": "#/$defs/Vars",
+          "description": "Variables that are exported to the shell environment upon activation."
+        }
+      },
+      "required": [
+        "schema-version"
+      ],
+      "type": "object"
+    },
+    "ManifestV1_15_0": {
+      "additionalProperties": false,
+      "description": "Not meant for writing manifest files, only for reading them.\nModifications should be made using `manifest::raw`.",
+      "properties": {
+        "build": {
+          "$ref": "#/$defs/Build2",
+          "description": "Package build definitions"
+        },
+        "containerize": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Containerize"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "hook": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Hook2"
             },
             {
               "type": "null"
@@ -2009,6 +2115,9 @@
     },
     {
       "$ref": "#/$defs/ManifestV1_14_0"
+    },
+    {
+      "$ref": "#/$defs/ManifestV1_15_0"
     }
   ],
   "description": "A validated, typed manifest with a known schema.",

--- a/cli/tests/on_deactivate.bats
+++ b/cli/tests/on_deactivate.bats
@@ -1,0 +1,156 @@
+#! /usr/bin/env bats
+# -*- mode: bats; -*-
+# ============================================================================ #
+#
+# End-to-end tests for `[hook.on-deactivate]`: the full path from manifest
+# entry to buildenv emission to the executive running the hook when the last
+# attachment detaches from a start.
+#
+# The hook runs asynchronously in the executive, so tests synchronize on
+# `wait_for_activations` (the activation state dir is only removed after the
+# hook has run) before asserting on the hook's side effects.
+#
+# ---------------------------------------------------------------------------- #
+
+load test_support.bash
+
+# bats file_tags=on-deactivate
+
+# ---------------------------------------------------------------------------- #
+
+setup_file() {
+  common_file_setup
+}
+
+project_setup() {
+  export PROJECT_DIR="${BATS_TEST_TMPDIR?}/project-${BATS_TEST_NUMBER?}"
+  export PROJECT_NAME="${PROJECT_DIR##*/}"
+  rm -rf "$PROJECT_DIR"
+  mkdir -p "$PROJECT_DIR"
+  pushd "$PROJECT_DIR" >/dev/null || return
+  "$FLOX_BIN" init -d "$PROJECT_DIR"
+}
+
+project_teardown() {
+  popd >/dev/null || return
+  rm -rf "${PROJECT_DIR?}"
+  unset PROJECT_DIR
+  unset PROJECT_NAME
+}
+
+setup() {
+  common_test_setup
+  # `deactivate --print-script` after an in-place activation needs the
+  # `_FLOX_PROMPT_HOOK_VERSION` marker, so opt out of the suite-wide
+  # `disable_hook = true`.
+  enable_prompt_hook
+  home_setup test
+  setup_isolated_flox
+  export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/empty.yaml"
+  export MARKER="${BATS_TEST_TMPDIR?}/on-deactivate-marker"
+}
+
+teardown() {
+  cat_teardown_fifo
+  if [ -n "${PROJECT_DIR:-}" ]; then
+    wait_for_activations "$PROJECT_DIR" || return 1
+    project_teardown
+  fi
+  common_test_teardown
+}
+
+# ---------------------------------------------------------------------------- #
+
+# Write a manifest whose on-activate exports FOO and whose on-deactivate
+# appends its value to $MARKER, proving both that the hook ran (exactly as
+# many times as there are lines) and that it sees the environment as
+# hook.on-activate left it.
+_write_on_deactivate_manifest() {
+  cat <<EOF | "$FLOX_BIN" edit -f -
+schema-version = "1.15.0"
+
+[options]
+
+[hook]
+on-activate = 'export FOO="from-activate"'
+on-deactivate = 'echo "\$FOO" >> "$MARKER"'
+EOF
+}
+
+# bats test_tags=on-deactivate:deactivate
+@test "hook.on-deactivate runs on explicit deactivate with on-activate's environment" {
+  project_setup
+  _write_on_deactivate_manifest
+  FLOX_SHELL="bash" run --separate-stderr bash -c '
+    eval "$($FLOX_BIN activate --print-script)"
+    eval "$($FLOX_BIN deactivate --print-script "$_FLOX_INVOCATION_TYPES")"
+  '
+  assert_success
+
+  wait_for_activations "$PROJECT_DIR"
+  run cat "$MARKER"
+  assert_success
+  assert_output "from-activate"
+}
+
+# bats test_tags=on-deactivate:command-exit
+@test "hook.on-deactivate runs when a command-mode activation exits" {
+  project_setup
+  _write_on_deactivate_manifest
+  run "$FLOX_BIN" activate -- true
+  assert_success
+
+  wait_for_activations "$PROJECT_DIR"
+  run cat "$MARKER"
+  assert_success
+  assert_output "from-activate"
+}
+
+# bats test_tags=on-deactivate:attach
+@test "hook.on-deactivate does not run while other attachments remain" {
+  project_setup
+  _write_on_deactivate_manifest
+  FLOX_SHELL="bash" run --separate-stderr bash -c '
+    eval "$($FLOX_BIN activate --print-script)"
+    # A second attachment to the same start comes and goes; the hook must
+    # not fire because this shell is still attached.
+    "$FLOX_BIN" activate -- true
+    # Firing is asynchronous, so give the executive a moment to (wrongly)
+    # act before asserting the marker is absent.
+    sleep 1
+    if [ -e "$MARKER" ]; then
+      echo "marker-too-early"
+    else
+      echo "no-marker-while-attached"
+    fi
+    eval "$($FLOX_BIN deactivate --print-script "$_FLOX_INVOCATION_TYPES")"
+  '
+  assert_success
+  assert_line "no-marker-while-attached"
+  refute_line "marker-too-early"
+
+  wait_for_activations "$PROJECT_DIR"
+  # The hook ran exactly once for the start.
+  run cat "$MARKER"
+  assert_success
+  assert_output "from-activate"
+}
+
+# bats test_tags=on-deactivate:failure
+@test "a failing hook.on-deactivate does not block deactivation or cleanup" {
+  project_setup
+  cat <<EOF | "$FLOX_BIN" edit -f -
+schema-version = "1.15.0"
+
+[options]
+
+[hook]
+on-deactivate = "exit 1"
+EOF
+  run "$FLOX_BIN" activate -- true
+  assert_success
+
+  # Cleanup completes (state dir removed) despite the failing hook;
+  # wait_for_activations fails the test if it doesn't.
+  wait_for_activations "$PROJECT_DIR"
+}

--- a/cli/tests/on_deactivate.bats
+++ b/cli/tests/on_deactivate.bats
@@ -66,13 +66,22 @@ teardown() {
 # many times as there are lines) and that it sees the environment as
 # hook.on-activate left it.
 _write_on_deactivate_manifest() {
+  _write_on_deactivate_manifest_with_foo "from-activate"
+}
+
+# Same manifest with a caller-chosen FOO, so tests with several starts can
+# tell from $MARKER which start's hook ran. Editing the value also changes
+# the rendered store path, forcing the next activation to start rather than
+# attach.
+_write_on_deactivate_manifest_with_foo() {
+  local foo_value="$1"
   cat <<EOF | "$FLOX_BIN" edit -f -
 schema-version = "1.15.0"
 
 [options]
 
 [hook]
-on-activate = 'export FOO="from-activate"'
+on-activate = 'export FOO="$foo_value"'
 on-deactivate = 'echo "\$FOO" >> "$MARKER"'
 EOF
 }
@@ -134,6 +143,38 @@ EOF
   run cat "$MARKER"
   assert_success
   assert_output "from-activate"
+}
+
+# bats test_tags=on-deactivate:multi-start
+@test "hook.on-deactivate runs for a superseded start while another start remains attached" {
+  project_setup
+  _write_on_deactivate_manifest_with_foo "first-start"
+
+  mkfifo started1 hold1 started2
+  # Will get cat'ed in teardown
+  TEARDOWN_FIFO="$PROJECT_DIR/teardown_activate"
+  mkfifo "$TEARDOWN_FIFO"
+
+  # The timeout self-heals a failed test; on success `echo > hold1` below
+  # releases it immediately.
+  FLOX_SHELL=bash "$FLOX_BIN" activate -c "echo > started1 && timeout 30 cat hold1" > output1 2>&1 &
+  cat started1
+
+  # Editing the manifest gives the next activation a new store path, so it
+  # starts a second start instead of attaching to the first.
+  _write_on_deactivate_manifest_with_foo "second-start"
+  FLOX_SHELL=bash "$FLOX_BIN" activate -c "echo > started2 && echo > \"$TEARDOWN_FIFO\"" > output2 2>&1 &
+  cat started2
+
+  # Release the first activation: its start is emptied while the second
+  # start's attachment keeps the executive alive.
+  echo > hold1
+
+  # The executive sweeps the emptied start asynchronously; wait for its hook.
+  timeout 10 bash -c "until [ -e \"$MARKER\" ]; do sleep 0.1; done"
+  run cat "$MARKER"
+  assert_success
+  assert_output "first-start"
 }
 
 # bats test_tags=on-deactivate:failure

--- a/cli/tests/test_support.bash
+++ b/cli/tests/test_support.bash
@@ -392,9 +392,9 @@ ensure_remote_environment_built() {
 with_latest_schema() {
   body="$1"
   if [ -z "$body" ]; then
-    printf "schema-version = \"1.14.0\"\n"
+    printf "schema-version = \"1.15.0\"\n"
   else
-    printf "schema-version = \"1.14.0\"\n\n%s" "$body"
+    printf "schema-version = \"1.15.0\"\n\n%s" "$body"
   fi
 }
 


### PR DESCRIPTION
## Summary

This closes (DEV-109)[https://linear.app/floxdotdev/issue/DEV-109/add-hookon-deactivate-or-similar] Adds an `on-deactivate` script to the `[hook]` section as the bookend to `on-activate`: `on-activate` runs once per start, and `on-deactivate` runs once the last attachment for that start goes away — whether via `flox deactivate` or the shell/command exiting. Intended for environment-level cleanup after all attachments are gone (temp dirs, external resources); service cleanup stays with `services.<name>.shutdown`.

### Design

- **Mental model (docs):** an activation is a bookshelf — `on-activate`/`on-deactivate` are the book ends, each attachment is a book with `profile.*`/`profile.deactivate` as its own start/end.
- **Schema v1.15.0** (`flox-manifest`): `Hook` is de-shared from `parsed::common` into the new version (same precedent as `Profile` in v1.13.0 for `profile.deactivate`), so older schemas keep rejecting the field. Composition merges `on-deactivate` LIFO (high-priority first), mirroring `profile.deactivate`.
- **Rendering:** buildenv writes the script to `$out/activate.d/hook-on-deactivate`.
- **Runtime:** the executive runs the hook while tearing down a start with no remaining attachments:
  - starts persist a `start_id.json` marker in their start state dir, so orphaned starts can be reconstructed (also gives crash recovery for dirs left behind by a dead executive);
  - orphaned starts are enumerated under the state.json lock, then swept lock-free — a hanging hook cannot block new activations;
  - the hook runs in flox's bash with the end-of-activation environment replayed from the start's env diff, so variables exported by `on-activate` are available for cleanup;
  - output is captured in the executive log; a failing hook is logged and never blocks cleanup; no timeout in v1;
  - at final teardown services are shut down first, then the hook runs (LIFO bookends), then state is removed;
  - explicit `flox deactivate` now hands the start state dir to the executive instead of removing it inline (kept inline when no executive is running, e.g. containerize — no hook runs there).
- **Best-effort caveats:** the hook does not run if the executive is SIGTERM'd/killed (matching the existing no-cleanup policy) or when state.json is destroyed externally.

### Open question (from the issue discussion)

Where should hook stdio go? This PR lands the log-only core (the executive must be able to run the hook anyway for the shell-exit path). The alternatives — inheriting the activating terminal's fds in the executive, or running the hook in the detach client on explicit deactivate — are small increments on top of this and can be a follow-up once the fd-lifetime tradeoffs (e.g. holding ssh sessions open) are settled.

### Testing

- Unit: migration losslessness + LIFO merge proptests, v1.14.0-rejects-`on-deactivate` regression test, buildenv rendering assertions, runner/sweep tests (env replay, once-per-start, absent script, failing script), detach handoff tests.
- Integration: new `cli/tests/on_deactivate.bats` (fires on explicit deactivate with `on-activate`'s env, fires on command-mode exit, does not fire while attachments remain then fires exactly once, failing hook non-fatal). Regression: `deactivate.bats` (44), `deactivate_profile_e2e.bats` (4), hook-related `activate.bats` (56), `services.bats` (40) all pass locally.

## Release Notes

- Added `hook.on-deactivate` to the manifest: a bash script that runs once per activation when the last attachment goes away, with the environment as `hook.on-activate` left it. Use it for cleanup that should happen after an environment fully winds down; services should keep using `services.<name>.shutdown`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)