### PR TITLE
feat: add 'service' alias for 'flox services'

### DIFF
--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -798,7 +798,7 @@ enum UseCommands {
     Run(#[bpaf(external(run::run))] run::Run),
 
     /// Manage services in an environment
-    #[bpaf(command)]
+    #[bpaf(command, long("service"))]
     Services(
         #[bpaf(
             external(services::services_commands),


### PR DESCRIPTION
I can't always remember whether this command is singular or plural, and
I don't think having an alias will hurt anything.
