### PR TITLE
feat(rust-review): add Rust review skills + per-area CLAUDE.md files

### DIFF
--- a/.claude/skills/flox-rust-review/SKILL.md
+++ b/.claude/skills/flox-rust-review/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: flox-rust-review
+description: Use when editing Rust in flox/flox. Encodes review-validated rules where the original code was wrong, buggy, or insufficient — error handling, type safety at boundaries, semantic correctness, testing patterns, provider-trait design, manifest-usage discipline, panic discipline. Mined from 944 review comments across 216 PRs (8 months). Complements AGENTS.md and lives alongside `flox-rust-stylistic-conventions`.
+---
+
+These rules are derived from substantiated PR review findings — cases where reviewers identified a concrete bug, missing correctness invariant, or structural flaw that the author subsequently fixed. Each rule names the specific Flox identifier, module, or pattern where the problem arose. Generic style preferences live in the sibling `flox-rust-stylistic-conventions` skill.
+
+---
+
+## Error handling
+
+**Add typed error variants for new failure modes; remove match arms for errors that can no longer occur.**
+When a new operation can fail in a way not yet represented in the error enum, add a variant rather than matching on `.to_string()` output or returning a generic string. Symmetrically, when a code path is removed, delete the corresponding match arm — dead arms mislead readers. (PRs #3646, #3673, #3794)
+
+**Propagate the full error chain; never flatten with `display_chain()` or `.to_string()` at intermediate layers.**
+`Box<dyn std::error::Error + Send + Sync>` or the `thiserror` `#[source]` attribute preserve context that callers need for logging and further classification. Converting to a string at an intermediate layer discards the chain permanently. Reserve `.display_chain()` for the point of final user presentation. (PRs #3673)
+
+**Check `.status.success()` on every `Command` invocation; do not silently swallow non-zero exits.**
+A process exit that goes undetected produces silent data corruption or misleading success messages. `output.status.success()` is the correct check; inspecting only `stdout` is insufficient when the command could fail. (PR #3794)
+
+**Map `NotFound` (ENOENT) at exec boundaries to an explicit user-facing error, not a generic I/O error.**
+When running an external binary with `Command::new`, the OS returns `ErrorKind::NotFound` if the binary is missing. Detect this at the call site and return a domain-specific error that names the missing tool, rather than propagating raw `std::io::Error` or silencing the failure. (PR #3803)
+
+**Cover all `ConcreteEnvironment` variants in match arms; do not write arms only for `Path`.**
+`ConcreteEnvironment` has `Path`, `Managed`, and `Remote` variants. Exhaustive match arms are not always enforced by the compiler when the match is over a method result; audit each new match to confirm all variants are handled correctly. (PR #3599)
+
+**Never silence errors from auth validation; surface them as distinct typed errors.**
+Auth-related code paths are particularly prone to swallowing errors (`let _ = ...` or ignoring `Err`) under the assumption that validation failure is not actionable. Each validation failure is an actionable error that should be returned to the caller. (PR #4047)
+
+---
+
+## Type safety
+
+**Use `&Url` (or `url::Url`) instead of `&str` for URL parameters through the entire call chain.**
+Accepting `&str` at any intermediate function allows callers to pass unvalidated strings and defers parse errors to unexpected sites. Parse once at the entry point (CLI argument parsing or API deserialization) and pass `&Url` through the chain. (PRs #4156, #4172)
+
+**Use `Option<&str>` (borrowed) instead of `Option<String>` (owned) when the data is already stored in `self`.**
+Returning or accepting `Option<String>` forces an unnecessary clone when the backing data lives in the struct. `Option<&str>` with a lifetime tied to `&self` avoids the allocation and makes ownership explicit. (PR #4172)
+
+**Use `NixFlakeRef` instead of `String` for Nix flake references; parse at CLI/API entry points.**
+`NixFlakeRef` is the domain type for flake references. Passing raw `String` through business logic means callers can never distinguish a flake ref from an arbitrary string, and validation is silently skipped. Parse at the outermost boundary (arg parsing or response deserialization) and propagate the typed value. (PRs #3599, #4156)
+
+**Use `Shell` (the `shell_gen` enum) instead of `&str` for shell-type parameters.**
+The `Shell` enum from the `shell_gen` crate enumerates the shells Flox supports. Passing `&str` requires every consumer to parse or match strings, creating divergence risk. Accept `Shell` at function boundaries. (PR #4231)
+
+**Encode auth-mode availability in an `AuthContext` enum type, not in stringly-typed or nullable fields.**
+The distinction between `Auth0(Option<Token>)` and `Kerberos(...)` auth modes is a domain invariant. Represent it as an enum variant so the compiler enforces correct handling. A missing token in Kerberos context is not an error; encoding this in a nullable field or `bool` flag makes it invisible. (PRs #4047, #4172)
+
+**Parse installable descriptor outputs (`^`) before version (`@`); the split order matters.**
+In Nix installable syntax, `pkg^output@version` must be split on `^` first to separate the output selector from the rest, then on `@` for the version. Reversing the order produces silently wrong parses that pass tests but fail on real inputs. (PR #3864)
+
+**Do not derive `Ord` on a type unless it is actually stored in an ordered collection (`BTreeSet` / `BTreeMap`).**
+`Ord` implies a total ordering that must be semantically meaningful. Deriving it for convenience (e.g., to silence a compiler warning) imposes an arbitrary ordering that can mislead callers and may later be relied on incorrectly. Add `Ord` only when the collection use requires it. (PR #3864)
+
+---
+
+## Semantic correctness
+
+**Use NUL-separated file lists (`find -print0` / `xargs -0` / `--null` flags) when passing filenames to shell commands.**
+File paths can contain spaces, newlines, and glob characters. Passing them as newline-separated or space-delimited strings to shell commands causes silent misparses and potential injection. Use `\0`-delimited lists end-to-end. (PR #4191)
+
+**Kerberos auth with a missing FloxHub token is not an error; do not treat `NixAuth { floxhub_token: None }` as a failure.**
+In Kerberos environments the `floxhub_token` field is legitimately absent. Returning an error when the token is `None` in this branch causes spurious failures in Kerberos deployments. Guard the error return on the auth mode, not on the presence of the token alone. (PR #4172)
+
+**Refactor shared activation logic (e.g., `apply_activation_env`) rather than duplicating it across call sites.**
+`apply_activation_env` and `collect_activate_exports` in `flox-activations` are the canonical implementation of activation environment setup. Duplicating logic adjacent to these functions diverges over time and causes subtle behavioral differences. Extract shared logic into a helper that both call sites invoke. (PR #4202)
+
+**Keep user-visible message construction in the CLI layer, not in the SDK.**
+`flox-rust-sdk` and `flox-core` are library crates. Embedding user-facing strings (messages, hints, formatting) inside SDK code couples the library to a specific presentation layer and prevents reuse. Move message construction to the command handler in `flox/src/commands/`. (PR #4094)
+
+**Do not return stale data when an upstream operation fails; propagate the error.**
+When an operation that refreshes or mutates state fails, the function must propagate the error rather than returning the pre-operation state. Returning stale data silently makes the caller believe the mutation succeeded. (PR #3599)
+
+---
+
+## Testing
+
+**Use `&mut impl Write` as the output sink in renderers so they can be unit-tested without spawning a process.**
+Functions that produce terminal output should accept a `&mut impl Write` parameter rather than writing to `stdout` directly. This allows unit tests to pass a `Vec<u8>` and assert on exact output without capturing process output. (PR #3695)
+
+**Use `assert_eq!` on the entire struct, not on individual fields.**
+Asserting on individual fields means new fields added to the struct are silently excluded from comparison. `assert_eq!` on the whole struct catches regressions in newly added fields automatically and produces diffs that show the full context of a failure. This is also stated in AGENTS.md.
+
+**Avoid non-deterministic test failures from unstable collection ordering; sort or use `BTreeSet` before asserting.**
+`HashMap` and `HashSet` iteration order is not guaranteed. Tests that assert on output derived from unordered collections can pass or fail depending on hash randomization. Sort the collection or use `BTreeSet`/`BTreeMap` in test assertions. (PR #3951)
+
+**Name tests descriptively for what they verify; do not prefix with `test_`.**
+The `#[test]` attribute already identifies a function as a test. The name should describe the invariant or scenario, e.g., `gather_repo_meta_no_upstream_suggests_set_upstream`. This is also stated in AGENTS.md.
+
+---
+
+## Provider traits
+
+**Add `unimplemented!()` bodies for deprecated `MockClient` dispatch methods in `catalog.rs`; do not extend the deprecated pattern.**
+`MockClient` in `flox-rust-sdk/src/providers/catalog.rs` uses a dispatch pattern that is being phased out. When a trait method must be satisfied but the implementation is intentionally unused, use `unimplemented!()` and note it in the PR rather than adding a working implementation to the deprecated machinery. (PR #4156)
+
+**Avoid associated types on provider traits unless alternative implementations (including mocks) are realistic.**
+Associated types on provider traits make bounds harder to write and in practice often constrain consumers to exactly one implementation. If a trait is only ever implemented by one concrete type, define a concrete type or use a simpler trait without associated types. This is also stated in AGENTS.md.
+
+**Take concrete types directly when a consumer only works with one implementation; do not hide that behind a pinned trait constraint.**
+Writing `impl GitProvider<GetOriginError = …>` constrains the generic to one implementation while pretending it is generic. This is worse than accepting the concrete type: it is misleading and makes the constraint harder to discover. (AGENTS.md)
+
+---
+
+## Manifest usage
+
+**Never pass manifest content as `String` or deserialize into inner types directly; always use `Manifest<S>` constructors.**
+The `Manifest<S>` type-state ensures that manifests pass through migration and validation before use. Bypassing constructors (e.g., calling `toml_edit::de::from_str::<ManifestLatest>()` at a call site) skips migration and produces a manifest that may be in an older schema version than expected. Use `Manifest::read_typed`, `Manifest::parse_toml_typed`, or `Manifest::read_and_migrate` as appropriate. (PR #4076; also in AGENTS.md)
+
+**Outside `flox-manifest`, operate on `ManifestLatest`; add accessor methods to `ManifestLatest` instead of introducing adapter traits.**
+Adapter traits like `CommonFields` that abstract over multiple schema versions make callers pretend all versions are interchangeable, which defeats the type-state migration model. After migration, code outside the `flox-manifest` crate should hold `ManifestLatest` and call methods on it. (PR #4094; also in AGENTS.md)
+
+**Never serialize manifests with `toml_edit::ser::to_string()` on inner types; use `manifest.as_writable().to_string()` or `write_to_file(path)`.**
+Manual serialization bypasses schema-version selection and format-preservation logic. The `as_writable()` method handles both. (AGENTS.md)
+
+---
+
+## Logging and tracing
+
+**Use structured `tracing` fields; do not interpolate variables into a single message string.**
+`tracing::debug!(token = %token, "auth resolved")` is correct; `tracing::debug!("auth resolved: {token}")` is not. Structured fields are queryable and filterable; interpolated strings are opaque to tracing subscribers. (AGENTS.md; reinforced by PR #4172)
+
+**Emit a `tracing::debug!` (or `tracing::trace!`) span at each auth-mode branch.**
+Auth mode selection is a critical control-flow branch for diagnosing production issues. Each branch (Auth0, Kerberos, unauthenticated) should emit a trace event with the selected mode so that log capture makes the decision observable. (PR #4172)
+
+---
+
+## Deprecated patterns
+
+**Do not extend the `apply_activation_env` single-caller pattern; prefer extracting shared helpers.**
+As of the PRs reviewed, `apply_activation_env` in `flox-activations` was being called in one place and the logic was being duplicated in an adjacent function. When extending activation behavior, extract the shared logic into a named helper rather than copying the implementation. (PR #4202)
+
+**Do not add implementations to deprecated `MockClient` dispatch methods in `flox-rust-sdk/src/providers/catalog.rs`.**
+The `MockClient` mock-dispatch approach in this file is explicitly being phased out. New provider methods should not receive working `MockClient` implementations; use `unimplemented!()` and document why in the PR. (PR #4156)
+
+---
+
+## When in doubt
+
+- **Prefer the typed domain value over `String` at every function boundary.** Parse once at the entry point; propagate `NixFlakeRef`, `Url`, `Shell`, `AuthContext`, `Manifest<S>`, etc.
+- **Error variants before error strings.** When a new failure mode appears, extend the error enum before reaching for `.to_string()` or a bare `anyhow` error.
+- **Test the whole struct.** `assert_eq!(actual, expected_struct)` catches regressions in new fields that field-by-field asserts miss.
+- **Keep user messages in the CLI layer.** SDK crates have no business knowing what the terminal should print.
+- **Check the existing error classification hierarchy** (`GitCommandError` → `GitRemoteCommandError`, `ManagedEnvironmentError`, etc.) before adding a new error type or matching on strings.

--- a/.claude/skills/flox-rust-stylistic-conventions/SKILL.md
+++ b/.claude/skills/flox-rust-stylistic-conventions/SKILL.md
@@ -1,0 +1,312 @@
+---
+name: flox-rust-stylistic-conventions
+description: Use when editing Rust in flox/flox. Encodes review-validated stylistic conventions — rules where the original code works but reviewers prefer a different shape. Covers naming conventions, formatting, imports, message wording style, and other taste-driven choices. Mined from 944 review comments across 216 PRs (8 months). Complements AGENTS.md and lives alongside `flox-rust-review`.
+---
+
+The flox team prioritizes legibility of intent over brevity: names should describe what a thing *does* or *represents*, not how it is triggered or which vendor powers it; user-facing strings are stretched past the 80-character source limit rather than broken mid-thought; warnings are reserved for conditions the user can act on; and every repeated literal or pattern gets extracted into a named constant or helper the moment it appears twice. Reviewers consistently nudge toward specificity — the right domain constant, the right qualifier on visibility, the right term used uniformly across all call sites.
+
+---
+
+## Naming
+
+**Use the `str_to_x` pattern for query-parameter parsers in `flox-catalog`; do not inline the parsing.**
+
+The file already has `str_to_catalog_name`, `str_to_package_name`, etc. A new parser for a system field must be named `str_to_system`, not `PackageSystem::from_str` inlined at the call site.
+
+```rust
+// before
+let system = api_types::PackageSystem::from_str(system).map_err(|_| { ... })?;
+
+// after
+let system = str_to_system(system)?;
+```
+
+Evidence: PR #4156. (reinforces AGENTS.md §Naming new helpers)
+
+---
+
+**Name a function by what it does, not what triggered it; when a name is opaque, add a doc comment.**
+
+`gather_services_for_flag` became `services_to_start`. `check_build` became `check_build_already_recorded` with a doc comment explaining it checks for duplicate builds in the catalog before spending time on a Nix build.
+
+Evidence: PR #4152, PR #4156. (reinforces AGENTS.md §Conventions)
+
+---
+
+**Name CLI positional arguments by their actual type (`installable`, `attrpath`), not an approximate concept (`expression`).**
+
+The positional argument in `#[bpaf(positional("expression"))]` was renamed to `"installable"` once the parameter accepted a flakeref + attrpath combined form.
+
+Evidence: PR #3599. (reinforces AGENTS.md §Conventions)
+
+---
+
+**Do not prefix test functions with `test_`.**
+
+`#[test]` and the `#[cfg(test)]` module already identify them. Name tests descriptively for what they verify: `gather_repo_meta_no_upstream_suggests_set_upstream`, not `test_gather_repo_meta`.
+
+Evidence: PR #4165. (reinforces AGENTS.md §Test naming)
+
+---
+
+**Use generic authentication terminology in type and variant names; do not surface provider names (`Auth0`, `Auth0Mode`) in the API.**
+
+The config-level type was renamed from `Auth0Mode` to `AuthnMode`. The distinction between `AuthnMode` (config-level policy) and `AuthContext` (runtime-materialized credential) should be visible in the name. Use a single term — `auth_context` — consistently across function parameters, struct fields, and test helpers.
+
+Evidence: PR #4172. (reinforces AGENTS.md §Conventions)
+
+---
+
+**Name structs by their purpose, not their implementation; prefer `DiffSerializer` over `ActivationDiff`.**
+
+When a struct serializes or transforms data rather than representing a domain concept, pick a name that describes its role (`DiffSerializer`) rather than the domain entity it was derived from (`ActivationDiff`).
+
+Evidence: PR #4202. (reinforces AGENTS.md §Conventions)
+
+---
+
+**Use domain-specific constants instead of magic numbers.**
+
+Replace bare integer literals like `2` for stderr with `nix::libc::STDERR_FILENO`.
+
+Evidence: PR #3801.
+
+---
+
+**Extract repeated string literals into named constants; do not repeat them across call sites.**
+
+When the same string appears more than once, define a constant. This is especially true for environment variable names and fixed command strings used in tests.
+
+Evidence: PR #4231. (reinforces AGENTS.md §Conventions)
+
+---
+
+**Use the `COMMON_NIXPKGS_URL` constant as the default nixpkgs flake reference, not the bare string `"nixpkgs"`.**
+
+```rust
+// before
+let flake_ref = nixpkgs_flake.as_deref().unwrap_or("nixpkgs");
+
+// after
+let flake_ref = nixpkgs_flake.as_deref().unwrap_or(&COMMON_NIXPKGS_URL);
+```
+
+Evidence: PR #3599. (reinforces AGENTS.md §Conventions)
+
+---
+
+**Keep shell-specific helpers in their respective modules; extract into subdirectories once a module grows large.**
+
+Shell helper code (bash, zsh, fish) belongs in per-shell modules, not a single shared file. When a single module exceeds a reasonable size, split into a subdirectory with `mod.rs`.
+
+Evidence: PR #4231. (reinforces AGENTS.md §Conventions)
+
+---
+
+**Document non-obvious structs explaining what they represent, their invariants, and their relationship to adjacent types.**
+
+A struct like `FloxmetaBranch` that is not self-explanatory needs a doc comment covering: what it wraps, what invariants hold, and how it differs from related types (`Generations`, `CoreEnvironment`).
+
+Evidence: PR #3813. (reinforces AGENTS.md §Conventions)
+
+---
+
+**Document trait methods, not trait implementations; omit doc comments from `impl` blocks that would duplicate the trait's own docs.**
+
+Evidence: PR #4076. (reinforces AGENTS.md §Conventions)
+
+---
+
+**Use semantic names in docs and user-facing text: "source reference" not "flake reference" when the value does not have to be a flake.**
+
+Evidence: PR #4183. (reinforces AGENTS.md §Conventions)
+
+---
+
+## Formatting
+
+**Use `formatdoc!` or `indoc!` for multiline formatted strings; never `format!` with `\` line continuations or raw strings.**
+
+```rust
+// before
+let msg = format!(r#"
+    First line {foo}
+    Second line {bar}
+"#);
+
+// after
+let msg = formatdoc! {"
+    First line {foo}
+    Second line {bar}
+"};
+```
+
+Evidence: PR #4156, PR #4165. (reinforces AGENTS.md §Conventions)
+
+---
+
+**Keep source code lines at 80 characters; stretch past 80 for user-facing string content rather than breaking mid-thought.**
+
+These are not contradictory: the 80-character limit governs code structure; user-visible messages are stretched because line breaks in `formatdoc!` appear verbatim in the terminal. When a message fits on one line under ~80 chars, keep it there. When it cannot, use `formatdoc!` and place natural sentence breaks at the wrapped line rather than source-column breaks.
+
+Evidence: PR #3646. (reinforces AGENTS.md §User-facing string literals)
+
+---
+
+**Use `pub(crate)` or `pub(super)` instead of bare `pub` for functions and constants that are not part of a stable public API.**
+
+Bare `pub` implies a commitment to external callers. Module-internal helpers, constants, and crate-only functions should use `pub(crate)` or `pub(super)`.
+
+```rust
+// before
+pub const SOME_INTERNAL_CONSTANT: &str = "...";
+
+// after
+pub(crate) const SOME_INTERNAL_CONSTANT: &str = "...";
+```
+
+Evidence: PR #4172, PR #3988. (reinforces AGENTS.md §Conventions)
+
+---
+
+**Break long method chains and assignments across lines at natural boundaries.**
+
+Evidence: PR #4093.
+
+---
+
+**Do not extract a helper function for a single-use operation; inline the code.**
+
+Helpers are for reuse. When a function is only ever called from one place, inline it rather than creating an indirection that obscures the reader's path through the code.
+
+Evidence: PR #4140. (reinforces AGENTS.md §Conventions)
+
+---
+
+**Add explanatory comments when non-obvious patterns (manual symlinks, recursion, catalog heuristics) are maintained by hand.**
+
+If the structure cannot be inferred from reading adjacent code, add a comment saying why.
+
+Evidence: PR #3960, PR #4122.
+
+---
+
+## Imports
+
+**Use workspace dependency versions in `Cargo.toml`; do not pin a version separately in a member crate when the workspace root already declares it.**
+
+Evidence: PR #3939.
+
+---
+
+**Import tracing macros (`warn!`, `debug!`, `info!`, `instrument`) at the module level with `use tracing::...`; do not qualify them with `tracing::` at each call site when the module already uses the crate.**
+
+Evidence: PR #4156. (reinforces AGENTS.md §use guidelines)
+
+---
+
+**Private modules implicitly narrow function visibility; understand this before adding `pub` to items inside a `mod` block that is not itself `pub`.**
+
+A `pub fn` inside a private `mod` is still invisible outside the file. Rely on module privacy instead of redundant `pub(crate)` annotations where the module already provides the restriction.
+
+Evidence: PR #4172.
+
+---
+
+## User-facing Message Style
+
+**Error messages must name the operation that failed, not a copy-pasted operation from nearby code.**
+
+When `update_catalogs` was added by copying `import_nixpkgs`, the error strings still said "Cannot import from nixpkgs…". Each operation must have its own wording describing what *it* does.
+
+```rust
+// before (copy-paste)
+bail!("Cannot import from nixpkgs in an environment on FloxHub.")
+
+// after (correct)
+bail!("Cannot update catalogs in a managed environment on FloxHub.")
+```
+
+Evidence: PR #3969. (reinforces AGENTS.md §User-visible message syntax)
+
+---
+
+**Error messages must describe the condition accurately; always verify what triggers the message before writing it.**
+
+Evidence: PR #3649, PR #4165. (reinforces AGENTS.md §Understand semantics before rewriting messages)
+
+---
+
+**Include actionable next steps at the end of error and restriction messages.**
+
+When a user hits a restriction ("Cannot change the owner of an environment already pushed to FloxHub."), the next line should tell them what to do instead.
+
+Evidence: PR #3649. (reinforces AGENTS.md §User-visible message syntax)
+
+---
+
+**Emit warnings only for conditions the user can act on; suppress noise from automatic actions.**
+
+When a service auto-starts on every activation, do not warn on every activation that "no services are defined." Reserve `message::warning` for `--start-services` being explicitly requested by the user. Auto-triggered code paths should fail silently or log at `debug!` level.
+
+Evidence: PR #4152. (reinforces AGENTS.md §User-visible message syntax)
+
+---
+
+**Keep user-facing messages concise when the state is unchanged; do not describe a non-event verbosely.**
+
+Evidence: PR #3869. (reinforces AGENTS.md §User-visible message syntax)
+
+---
+
+**Do not warn twice for the same condition; merge the user-visible warning into one clear sentence.**
+
+If a check fails, emit one `message::warning` with a plain-language explanation (e.g., "Unable to check if already published — continuing with build and publish."), and separately log the internal detail at `warn!` in tracing.
+
+Evidence: PR #4156. (reinforces AGENTS.md §User-visible message syntax)
+
+---
+
+**Show error messages with the full joined path (`{dir}/pkgs`), not path components the user must concatenate mentally.**
+
+Evidence: PR #4096. (reinforces AGENTS.md §User-visible message syntax)
+
+---
+
+**Show relative paths in error messages, not absolute paths from the Nix store or build checkout.**
+
+Evidence: PR #4102. (reinforces AGENTS.md §User-visible message syntax)
+
+---
+
+**Progress messages use gerund form ("Building…", "Publishing…") with quoted context details.**
+
+Match the form used by existing `message::*` calls throughout the CLI. Check existing patterns before inventing a new format.
+
+Evidence: PR #4140. (reinforces AGENTS.md §CLI output conventions)
+
+---
+
+**In documentation, present general forms before shorthand; introduce the structured syntax before URL syntax.**
+
+When documenting a configuration format that has both a `type`-based structured form and a URL shorthand, document the structured form first because the URL form is derived from it.
+
+Evidence: PR #4183.
+
+---
+
+**Provide complete documentation for configuration options: list possible values, explain the semantics of each, and describe the default.**
+
+Evidence: PR #4198. (reinforces AGENTS.md §Conventions)
+
+---
+
+---
+
+## Where reviewers most often nudge style
+
+1. **`formatdoc!`/`indoc!` discipline** — `format!` with `\` continuations or raw strings appear repeatedly; reviewers catch them in almost every PR.
+2. **Message accuracy** — copy-pasted error strings that describe the wrong operation, and messages that describe internal tool state rather than product-level meaning.
+3. **Naming specificity** — function names that describe a trigger (`gather_services_for_flag`) rather than a result (`services_to_start`), and provider-specific terms leaking into the type API (`Auth0Mode`, `Auth0`).
+4. **Visibility narrowing** — bare `pub` on helpers and constants that only need `pub(crate)` or `pub(super)`.
+5. **Warning noise** — warnings emitted unconditionally by auto-triggered code paths, and duplicate warnings for the same condition.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,13 @@
 @AGENTS.md
+
+## Rust-specific review rules
+
+When editing Rust under `cli/`, also consult:
+- `cli/CLAUDE.md` — Rust cross-cutting rules
+- `.claude/skills/flox-rust-review/SKILL.md` — substantive review rules mined from 8 months of PRs
+- `.claude/skills/flox-rust-stylistic-conventions/SKILL.md` — stylistic conventions
+
+For per-area context:
+- `cli/flox/src/commands/CLAUDE.md`
+- `cli/flox-rust-sdk/src/models/environment/CLAUDE.md`
+- `cli/flox-rust-sdk/src/providers/CLAUDE.md`

--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -1,0 +1,80 @@
+# Conventions for `cli/`
+
+This is the Rust workspace for Flox. All CLI commands, core SDK models, providers, and activation binaries live here. This file is auto-loaded by Claude Code whenever you edit anything under `cli/`, so its rules are active on every PR. They distil the highest-confidence cross-cutting patterns observed across 944 review comments spanning 216 PRs — the most common reasons reviewers asked for changes before approving.
+
+These rules complement, and never override, `AGENTS.md`. Where AGENTS.md and this file give the same guidance, the PR citations below are the supporting evidence. Where only this file speaks to a rule, treat it as a refinement mined from code review that AGENTS.md has not yet absorbed.
+
+## Where to look
+
+| You're editing… | Read first |
+|---|---|
+| Anywhere in `cli/` | This file + `AGENTS.md` |
+| `cli/flox/src/commands/` | `cli/flox/src/commands/CLAUDE.md` |
+| `cli/flox-rust-sdk/src/models/environment/` | `cli/flox-rust-sdk/src/models/environment/CLAUDE.md` |
+| `cli/flox-rust-sdk/src/providers/` | `cli/flox-rust-sdk/src/providers/CLAUDE.md` |
+| Any Rust area — review skills | `.claude/skills/flox-rust-review/SKILL.md` and `.claude/skills/flox-rust-stylistic-conventions/SKILL.md` |
+
+## Cross-cutting rules
+
+**1. Parse to a typed domain value at entry points; propagate it, never the raw string.**
+`NixFlakeRef` for flake references, `url::Url` for URLs, `Shell` for shell-type arguments, `AuthContext` for auth mode, `Manifest<S>` for manifests. Accepting `&str` at intermediate layers means every downstream consumer must parse and validate independently, producing divergent string-splitting that breaks on edge cases. Parse once at CLI arg-parsing or API deserialization; propagate the typed value.
+Evidence: PRs #3599, #4156, #4172, #4231. Reinforces AGENTS.md §Type safety at function boundaries.
+
+**2. Extend error enums with new variants; never string-match on `.to_string()` at call sites.**
+When a new failure mode appears, add a variant to the appropriate error enum (`GitCommandError` → `GitRemoteCommandError`, `ManagedEnvironmentError`, etc.). Matching on `.to_string()` output to detect specific failures ties code to display strings that can change at any time. Remove match arms for conditions that can no longer occur when variants are deleted.
+Evidence: PRs #3646, #3673, #4154, #4165. Reinforces AGENTS.md §Error handling architecture.
+
+**3. Preserve the full error chain; never flatten with `display_chain()` or `.to_string()` at intermediate layers.**
+`Box<dyn std::error::Error + Send + Sync>` or `thiserror`'s `#[source]` attribute preserve context that callers need for logging and classification. Converting to a string at an intermediate layer permanently discards that chain. Reserve `.display_chain()` for the final user-presentation point.
+Evidence: PR #3673. Covered by `flox-rust-review` SKILL.md §Error handling.
+
+**4. Keep user-facing message construction in the CLI layer (`cli/flox/src/commands/`), not in SDK crates.**
+`flox-rust-sdk` and `flox-core` are library crates. Embedding formatted user strings there couples the library to a specific presentation layer and blocks reuse. Move message construction to the command handler; let the SDK return typed errors whose `Display` provides a minimal technical description.
+Evidence: PR #4094. Covered by `flox-rust-review` SKILL.md §Semantic correctness.
+
+**5. `assert_eq!` on the whole struct, not on individual fields.**
+Field-by-field assertions silently exclude new fields added to the struct. `assert_eq!` on the entire expected struct catches regressions in newly added fields automatically and produces diffs that show the full context of a failure.
+Evidence: PRs #4076, #4114. Reinforces AGENTS.md §Use `assert_eq!` on entire structs.
+
+**6. Use `Manifest<S>` typed constructors; never pass manifest content as `String` or deserialize inner types directly.**
+The type-state pattern ensures every manifest passes through migration and validation before use. Calling `toml_edit::de::from_str::<ManifestLatest>()` at a call site bypasses migration. Outside `flox-manifest`, hold `ManifestLatest`; use `lockfile.migrated_manifest()` helpers rather than calling inner migration methods directly at call sites.
+Evidence: PRs #4076, #4094, #4161. Reinforces AGENTS.md §Manifest usage.
+
+**7. Use `formatdoc!` or `indoc!` for multi-line formatted strings; never `format!` with `\` line continuations or raw strings.**
+`formatdoc!` handles indentation correctly and makes strings readable in source. The backslash continuation and `r#"..."#` forms are fragile. Exception: proc-macro attributes (`#[error(...)]`, `#[bpaf(...)]`) require string literals.
+Evidence: PRs #4156, #4165. Reinforces AGENTS.md §Use `formatdoc!` or `indoc!`.
+
+**8. Use structured `tracing` fields; never interpolate variables into a single message string.**
+`tracing::debug!(token = %token, "auth resolved")` is correct; `tracing::debug!("auth resolved: {token}")` is not. Structured fields are queryable and filterable; interpolated strings are opaque to tracing subscribers. Add a `tracing::debug!` at each auth-mode branch (Auth0, Kerberos, unauthenticated) so log capture makes control-flow decisions observable.
+Evidence: PR #4172. Reinforces AGENTS.md §Use structured log and tracing fields.
+
+**9. Take the concrete provider type directly when only one implementation exists; do not pin associated types on provider traits.**
+`impl GitProvider<GetOriginError = GitCommandGetOriginError>` is a pinned-associated-type constraint that pretends to be generic while only ever accepting one concrete type. This makes bounds harder to write and hides the real dependency. Take `&GitCommandProvider` directly. Avoid associated types on provider traits unless alternative implementations (including mocks) are realistic.
+Evidence: PRs #4165, #4172. Reinforces AGENTS.md §Provider traits and associated types.
+
+**10. Do not extend deprecated infrastructure; use `unimplemented!()` and remove tests that depend on it.**
+The `MockClient` dispatch pattern in `cli/flox-rust-sdk/src/providers/catalog.rs` is being phased out. When a trait method must be satisfied by the deprecated mock, use `unimplemented!("not supported in MockClient")` rather than adding a working implementation. Delete unit tests that exercised the deprecated mock arm in the same PR.
+Evidence: PR #4156. Reinforces AGENTS.md §Deprecated infrastructure.
+
+**11. Do not prefix test functions with `test_`; name them descriptively for what they verify.**
+`#[test]` and `#[cfg(test)]` already identify a function as a test. The name should state the scenario or invariant: `gather_repo_meta_no_upstream_suggests_set_upstream`, not `test_gather_repo_meta`. Sorting also improves over time because descriptive names survive refactors.
+Evidence: PR #4165. Reinforces AGENTS.md §Test naming.
+
+**12. Use `pub(crate)` or `pub(super)` instead of bare `pub` for functions and constants that are not part of a stable public API.**
+Bare `pub` implies a commitment to external callers. Module-internal helpers, constants, and crate-only functions should be narrowed. Drop `pub` entirely on helpers that are only called from within a single module; they are implementation details.
+Evidence: PRs #3988, #4172. Covered by `flox-rust-stylistic-conventions` SKILL.md §Formatting.
+
+## When the rules conflict
+
+When the two skills, `AGENTS.md`, and this file disagree, the order of authority is:
+
+1. **`AGENTS.md`** — repo-wide conventions
+2. **`cli/CLAUDE.md`** (this file) — Rust cross-cutting refinements
+3. **`.claude/skills/flox-rust-review`** and **`.claude/skills/flox-rust-stylistic-conventions`** — review-mined detail
+4. **Area-specific `CLAUDE.md`** — most specific wins for that area
+
+One apparent tension worth noting: AGENTS.md says "wrap output at 80 characters," and the stylistic skill says "stretch past 80 for source lines containing user-visible strings." These are not in conflict — 80 chars governs terminal output width; source lines that embed user-facing `formatdoc!` content may be longer because line breaks inside `formatdoc!` appear verbatim to the user. The stylistic skill makes this explicit.
+
+## Source
+
+These rules were mined from 944 review comments across 216 PRs spanning approximately 8 months. The full evidence is in `scripts/pr-analysis/findings/` (key documents: `task9-review.md`, `gap-report.md`). The journey narrative is at `rust-pr-analysis-jouney-01.md` (note: "jouney" is the filename as-committed). Five HTML reports are at the worktree root: `rust-pr-analysis-dashboard-01.html`, `rust-pr-analysis-index-01.html`, `rust-pr-analysis-jouney-01.html`, `rust-pr-analysis-noise-deep-dive-01.html`, and `rust-pr-analysis-pipeline-01.html`.

--- a/cli/flox-rust-sdk/src/models/environment/CLAUDE.md
+++ b/cli/flox-rust-sdk/src/models/environment/CLAUDE.md
@@ -1,0 +1,132 @@
+# Conventions for `cli/flox-rust-sdk/src/models/environment/`
+
+This directory contains the core environment model implementations (`ManagedEnvironment`, `PathEnvironment`, `RemoteEnvironment`, `CoreEnvironment`) and their supporting modules (`floxmeta_branch`, `generations`, `install`, `uninstall`, `fetcher`). Reviewers most often catch: missing test coverage for new error paths; error chains being flattened to strings instead of boxed; raw manifest strings smuggled past the typed `Manifest<S>` boundary; auth-result errors silently swallowed via `.ok()`; and build-skipping or locking logic applied in one method but not in a parallel one that does the same operation.
+
+## Area-specific rules
+
+### Testing
+
+**Always add a unit or integration test for every new error path, including newly introduced variants such as `ManagedEnvironmentError::Diverged(DivergedMetadata)`.**
+New code paths without tests are routinely flagged as blocking. If a bats test already exists, add an assertion on the specific output rather than relying on the test passing silently.
+Evidence: PR #3646, PR #4076.
+
+**When adding assertions to integration tests, assert against the generated summary message content, not just exit codes.**
+Reviewers have pointed out cases where a bats test passes but says nothing about what the error message contains; a follow-up assertion against generation summary strings (e.g., local vs. remote generation descriptions) is expected.
+Evidence: PR #3646.
+
+**Use `assert_eq!` on the entire struct, not on individual fields, and do not drop output assertions when consolidating tests.**
+When collapsing multiple tests into one, check that every prior assertion is still present. A consolidation that silently removes the "Next steps" tip assertion is a coverage gap that reviewers will call out.
+Evidence: PR #4114.
+
+**Add unit tests for new helper functions extracted into their own files (e.g., `install.rs`, `uninstall.rs`) covering both the happy path and error paths.**
+Reviewers treating a new module without tests as a blocker is the established pattern in this area.
+Evidence: PR #4076.
+
+---
+
+### Error variant design
+
+**When multiple source error types must map to a single enum variant, wrap with `Box<dyn std::error::Error + Send + Sync>` or `io::Error::new(ErrorKind::Other, e)` — never convert to a display string via `display_chain()`.**
+Converting to a string destroys the error chain; downstream handlers and logging lose the ability to inspect the original cause. Prefer separate variants when they are semantically distinct.
+Evidence: PR #3673.
+
+**Fix typos in `#[error(...)]` strings immediately, and update all tests that assert on the exact text of that error.**
+A typo in an error variant that appears in bats test output will break CI. The fix and the test update belong in the same commit.
+Evidence: PR #3646.
+
+**Distinguish `CloneBranch` from `FetchBranch` error variants when routing git remote errors to typed environment errors.**
+These two variants represent different operations; conflating them misroutes access-denied and ref-not-found errors. Match on the correct variant at the relevant call site.
+Evidence: PR #3717.
+
+**Do not silently discard authentication errors by calling `.ok()` on the result of `get_handle()` or similar auth accessors.**
+Using `.ok()` hides whether the user is not logged in or whether there was a network/communication error. If the `None` case is intentional (no user hint available), document why in a comment.
+Evidence: PR #4047.
+
+**Use the return type (`Option` vs. `Result`) to encode authentication semantics explicitly.**
+`Option<String>` for a handle that may simply not exist is correct; `Result` is required when failure indicates a real problem (missing login, network error). Choosing the wrong type forces callers to discard error information.
+Evidence: PR #4047.
+
+---
+
+### Manifest lifecycle in environment models
+
+**Never store or pass raw manifest strings; use `Manifest<S>` typed constructors for every manifest read and write.**
+Returning `Option<String>` from `UninstallationAttempt` (instead of `Option<Manifest<Migrated>>`) re-introduces the untyped manifest anti-pattern that the type-state design eliminates. Use the typed constructors defined in the `flox-manifest` crate.
+Evidence: PR #4076.
+
+---
+
+### Build-skipping and locking consistency
+
+**When adding a new method that calls `build()` on a `CoreEnvironment`, check `rendered_env_links` (and any analogous method) for build-skipping logic and replicate it.**
+The existing `rendered_env_links` method contains caching/skipping logic (introduced in PR #2705) to avoid unnecessary Nix builds. A new method such as `rendered_env_links_for_generation` that bypasses this logic can trigger expensive redundant builds.
+Evidence: PR #3638.
+
+**Acquire the floxmeta lock at every entry point that may trigger a git fetch, not only at the outermost open call.**
+Git writes an `index.lock` during fetch; if a second code path (e.g., `ensure_generation_lock`) fetches without holding the floxmeta lock, concurrent operations will collide. Add lock acquisition at any boundary that issues a network-touching git operation.
+Evidence: PR #3717.
+
+**Document the intended scope and lifetime of each lock: must it be held through the entire build, or just through the git fetch?**
+Reviewers have flagged lock variables that are acquired but whose intended scope is unclear. A short comment (`// held through build to prevent concurrent fetch`) saves future confusion.
+Evidence: PR #3717.
+
+---
+
+### Semantic correctness and control flow
+
+**After any logic change to a branch condition, verify that all arms of the surrounding `if`/`match` remain reachable.**
+Introducing a new intermediate variable (e.g., `let is_uptodate = ...`) can silently make a branch dead. Run the affected tests and check with clippy before merging.
+Evidence: PR #3869.
+
+**Preserve the behavior of `--force` flags carefully: `flox pull --force` must reset local state to upstream even when the local branch is ahead.**
+The interaction between `checkout_valid`, `is_uptodate`, and `force` is subtle. A change that appears to simplify the condition can break the case where the user is ahead of FloxHub but wants to reset to it.
+Evidence: PR #3869.
+
+**Verify output message formatting makes semantic sense before changing a `Display` implementation or format string.**
+A change from `format!("{id} ({url})")` to `format!("{id} ({pkg})")` (delegating to `pkg`'s `Display`) must produce output that is meaningful to the user; reviewers will check what the rendered string looks like.
+Evidence: PR #4075.
+
+---
+
+### Documentation and comments
+
+**Add a doc comment to every non-obvious struct in this area — especially `FloxmetaBranch`, `Generations`, and `GenerationLock` — explaining what the type represents, its invariants, and how it relates to adjacent types.**
+These structs sit at the intersection of git, Nix, and environment lifecycle concerns; without a doc comment a reviewer has to reconstruct their semantics from the implementation. A one-paragraph description is sufficient.
+Evidence: PR #3813.
+
+**When a code path contains a deliberate shortcut for an edge case (e.g., `outputsToInstall = None`), document its practical rarity with concrete evidence (e.g., the nixpkgs `stdenv.mkDerivation` behavior) rather than merely noting the type is `None`.**
+A comment that says "this can be None" adds nothing beyond the type signature. A comment explaining that nixpkgs `stdenv` always populates `outputsToInstall` via `commonMeta`, so `None` only occurs in non-stdenv derivations or catalog bugs, gives reviewers the context to decide whether the shortcut is acceptable.
+Evidence: PR #4215.
+
+**Comments on `Option` fields must enumerate all semantically distinct `None` cases, including future ones.**
+If `None` currently means "currently live generation" but a future state could introduce "never been live", note both in the doc comment. A comment that only documents the current use case will silently mislead future engineers.
+Evidence: PR #3652.
+
+---
+
+### Code organization
+
+**Drop `pub` visibility on module-internal helper functions and order functions in dependency sequence (callers before callees, or by logical flow).**
+Functions that are implementation details of a single public entry point — such as a helper used only by `resolve_specs_to_modifications` — should not be `pub`. Ordering them after the public function they serve makes the module easier to read top-down.
+Evidence: PR #4076.
+
+---
+
+### Unrelated changes
+
+**If a PR includes an unrelated bug fix, make it explicit in the PR description and consider extracting it into a separate commit.**
+Reviewers will notice and ask. An unrelated fix buried in a feature PR can also break tests in unexpected ways if the two changes interact.
+Evidence: PR #3869.
+
+## Cross-cutting reminders
+
+- Error type hierarchy (extending variants vs. string-matching at call sites) — `.claude/skills/flox-rust-review/SKILL.md`
+- Provider trait and associated type design — `.claude/skills/flox-rust-review/SKILL.md`
+- Manifest type-state lifecycle (`Manifest<S>` constructors, `ManifestLatest`) — `.claude/skills/flox-rust-stylistic-conventions/SKILL.md`
+- User-facing message syntax, sentence structure, and emoji conventions — `.claude/skills/flox-rust-stylistic-conventions/SKILL.md`
+- Test naming (no `test_` prefix, descriptive names) — `.claude/skills/flox-rust-stylistic-conventions/SKILL.md`
+- `use` statement placement (module scope, not function scope) — `.claude/skills/flox-rust-stylistic-conventions/SKILL.md`
+
+## When in doubt
+
+Most active reviewers in this area: **ysndr** (T1), **dcarley** (T1) — the two with the highest comment counts. mkenigs (T1) is also active. Their prior comments are the best precedent — see PRs #3638, #3646, #3652, #3673, #3717, #3813, #3869, #4045, #4047, #4075, #4076, #4114, #4215.

--- a/cli/flox-rust-sdk/src/providers/CLAUDE.md
+++ b/cli/flox-rust-sdk/src/providers/CLAUDE.md
@@ -1,0 +1,140 @@
+# Conventions for `cli/flox-rust-sdk/src/providers/`
+
+Code review in the providers area consistently flags four themes: error-type hierarchy discipline (add typed enum variants rather than string-match at call sites), auth-flow correctness (Kerberos and Auth0 branches must each preserve pre-refactor behavior and be traced), deprecation hygiene (stale `MockClient` dispatch arms and competing `From` implementations must be actively removed rather than accumulated), and provider-trait design (prefer concrete types over unnecessary generic bounds or associated-type constraints). The `publish.rs` file receives the most attention and concentrates most of the rules below; `catalog.rs`, `auth.rs`, and `nix.rs` are the other high-traffic files.
+
+## Area-specific rules
+
+### Error classification at the provider boundary
+
+**Add typed enum variants for new failure modes; never match on `.to_string()` output at call sites.**
+The git provider uses `GitCommandError` → `GitRemoteCommandError` with typed variants (`AccessDenied`, `Diverged`, `RefNotFound`). When you need to classify a new failure, extend the enum at the provider boundary — not by string-matching inside `gather_build_repo_meta` or any downstream consumer.
+Evidence: PR #4165, PR #4154
+
+**Extend `GitCommandGetOriginError` with a `Remote(GitRemoteCommandError)` variant instead of re-implementing access-denied detection at call sites.**
+Keeping classification inside the provider means all callers automatically benefit from better error information. Checking `is_access_denied(&msg)` in `publish.rs` is a workaround that signals a missing variant.
+Evidence: PR #4165
+
+**Do not convert one typed error variant into a semantically different one to silence it.**
+Converting `CreateNetrc` into `NoToken` to avoid an early-return is a semantic lie — the real failure is netrc creation, not a missing token. Defer netrc creation to the point it is actually required so the error can be surfaced accurately.
+Evidence: PR #4154
+
+**Reserve `panic!` for programmer-error invariants; use typed variants or `Custom(Box<dyn Error + Send + Sync>)` for expected-but-unhandled operational errors.**
+Unexpected mutex poisoning or unrecoverable setup failures are acceptable `panic!` sites. File I/O failures and external-process errors that users may encounter must be surfaced as typed error variants or the `Custom` catch-all.
+Evidence: PR #3785
+
+**Trim stderr output before embedding it in error messages.**
+Trailing newlines from git or nix stderr will corrupt formatted messages. Apply `.trim()` before interpolating into a message string.
+Evidence: PR #4096
+
+**Treat expected I/O failures as first-class error variants, not `.unwrap()` or `expect()`.**
+File I/O inside providers (reading netrc, checking git ls-files output, etc.) can fail for legitimate operational reasons. Model them as typed variants so callers can distinguish them.
+Evidence: PR #3785
+
+### Auth-flow correctness and tracing
+
+**Preserve pre-refactor behavior for each `AuthContext` branch when restructuring auth provider construction.**
+Kerberos mode must construct `NixAuth { floxhub_token: None, ... }` because `create_netrc()` handles missing tokens gracefully (`NoToken` / `None` returns). Returning an error from the Kerberos arm is a regression that breaks all auth'ed nix operations for Kerberos users.
+Evidence: PR #4172
+
+**Add a `tracing::debug!` call at each auth-flow branch so the chosen mode is visible in traces.**
+A log line like `"Kerberos mode — git auth handled natively via ccache"` is the minimum. Each `AuthContext` arm in `apply_git_auth` / `authenticate` should have a distinct log statement so traces are self-explanatory without reading source.
+Evidence: PR #4172
+
+**Extract git-auth application logic as an extension trait (`GitCommandOptionsExt`) rather than a free function.**
+An extension trait keeps authentication per-variant logic close to the type it operates on and makes the three distinct behaviors (bearer, Kerberos no-op, empty credential helper) discoverable at the trait call site.
+Evidence: PR #4172
+
+### Deprecated infrastructure: active removal
+
+**When a new `MockClient` method is needed but the mock dispatch pattern is being deprecated, use `unimplemented!()` and remove any `Response::*` enum arm.**
+Do not add new `Response::CheckBuild` dispatch logic to `MockClient`. Use `unimplemented!("... not supported in MockClient")` and also delete any unit tests that were exercising the deprecated mock arm.
+Evidence: PR #4156
+
+**Delete deprecated `From` implementations when adding schema-version-specific converters.**
+Adding a new `impl From<ServicesV1> for ProcessComposeConfig` while leaving the old `impl From<Services>` creates competing converters. Remove the deprecated one in the same PR.
+Evidence: PR #4152
+
+### Provider trait design
+
+**When only one implementation exists and mocks are not realistic, take the concrete type directly.**
+`gather_build_repo_meta(git: &impl GitProvider<GetOriginError = GitCommandGetOriginError>)` is a pinned-associated-type constraint that hides the fact that only `GitCommandProvider` is ever used. Take `&GitCommandProvider` directly instead.
+Evidence: PR #4165
+
+**Move helper logic to provider trait methods to ensure consistency across call sites.**
+If `check_env_files_tracked` runs git commands that make sense as part of the git provider's contract, move them to the provider rather than reimplementing raw subprocess calls in `publish.rs`.
+Evidence: PR #4102
+
+**Use singular form for enum variant names** (e.g., `AuthStrategies::Auth0`, not `AuthStrategies::Auth0s`).
+The codebase uses singular names throughout (`AuthStrategy::Auth0`, `AuthStrategy::Kerberos`). Follow this convention for new auth-related enums.
+Evidence: PR #3870
+
+### Manifest constructor discipline in providers
+
+**Use `lockfile.migrated_manifest()` / `lockfile.migrated_user_manifest()` — never call `lockfile.manifest.migrate_typed_only(Some(&lockfile))` directly.**
+The helper methods encapsulate the migration logic. Calling the inner method directly at call sites bypasses that encapsulation and will require manual updates when the API changes.
+Evidence: PR #4161
+
+### User-facing messages at the provider boundary
+
+**Show the joined path in error messages, not path components separately.**
+Write `{expression_dir}/pkgs` rather than `{expression_dir}` + `"pkgs"` so users do not have to mentally concatenate path segments.
+Evidence: PR #4096
+
+**Use relative paths (relative to the user's project) in error messages, not absolute paths from internal clean-checkout directories.**
+Users do not know about temporary clean-checkout paths. Show paths relative to the working tree root the user is actually in.
+Evidence: PR #4102
+
+**When an error references a missing upstream, name the actual remote.**
+`"Current branch 'main' has no upstream remote configured. Set one with 'git branch --set-upstream-to=<remote>/main'"` is more actionable when `<remote>` is replaced by the actual remote name discovered at runtime (e.g., via `git.remotes()`).
+Evidence: PR #4165
+
+**Verify what condition actually triggers an error message before changing it.**
+Branch names and remote branches may diverge — what is required is that the rev exists on the remote branch, not that the branch names match. Describe the actual invariant being checked, not an approximation.
+Evidence: PR #4165
+
+**Point catalog signing-key errors at documentation covering both default (Flox-installer) and custom catalog-store setups.**
+An error like `BuildPublishedPackage` or `UntrustedPublicKey` that appears during custom catalog store usage should link to docs that address both cases, since users may be in either situation.
+Evidence: PR #3992
+
+### Code organization and style
+
+**Use `formatdoc!` for all multi-line formatted strings; avoid `format!` with backslash line continuations.**
+`formatdoc!` from the `indoc` crate handles indentation correctly and makes strings readable in source. The backslash continuation form is fragile and harder to read.
+Evidence: PR #4165
+
+**Consolidate parallel code paths into a single helper when they are semantically equivalent.**
+`get_build_output_nar_infos_local` duplicated `get_build_output_nar_infos` when calling with `"daemon"` as the store URL would have been sufficient. Prefer a single function with a parameter over parallel copies.
+Evidence: PR #4140
+
+**Use explicit auth-method constants in tests — not `Default::default()` — to make test intent unambiguous.**
+`Default::default()` for `AuthMethod` may change meaning as new auth modes are added. Tests that require a specific auth mode should name it: `AuthMethod::Auth0`.
+Evidence: PR #4047
+
+**Use table-driven tests when many small cases share the same fixture boilerplate.**
+Evidence: PR #3772
+
+### Semantic correctness checks before merging
+
+**Verify field relationships match the domain model before merging.**
+`dot_flox_dir` should be the `.flox` directory itself, not its parent. Double-check ownership semantics and directory relationships when mapping environment metadata to API request payloads.
+Evidence: PR #4096
+
+**Confirm which context an error path assumes (custom catalog vs. custom catalog store).**
+The distinction matters for error messages and for which documentation to point users toward. Verify the assumption is correct for all paths that reach the error.
+Evidence: PR #3992
+
+**Coordinate header-format migrations with the catalog server team.**
+When changing from a boolean header (`flox-ci: true`) to a structured multi-value header, confirm whether the server needs to support both formats during a transition window. Document the migration plan in a code comment.
+Evidence: PR #3939
+
+## Cross-cutting reminders
+
+- Error-type hierarchy, typed variants, and `Display`-impl sanitization — `AGENTS.md` "Error handling architecture" section
+- Provider trait vs. concrete type tradeoffs, associated-type constraints — `AGENTS.md` "Provider traits and associated types" section
+- Manifest constructor discipline (`Manifest::read_typed`, `migrated_manifest()`) — `AGENTS.md` "Manifest usage" section
+- User-visible message structure, sentence case, no-dead-ends, emoji map — `AGENTS.md` "User-visible message syntax" section
+- Deprecated infrastructure identification before adding implementations — `AGENTS.md` "Deprecated infrastructure" section
+
+## When in doubt
+
+Most active reviewers: **ysndr** (T1), **mkenigs** (T1), **dcarley** (T1). The provider layer has heavy AGENTS.md coverage on error-type hierarchy and trait-vs-concrete-type tradeoffs — re-read those sections when refactoring auth, git, or catalog providers. For publish-specific questions, `dcarley` and `ysndr` have reviewed nearly every PR touching `publish.rs`.

--- a/cli/flox/src/commands/CLAUDE.md
+++ b/cli/flox/src/commands/CLAUDE.md
@@ -1,0 +1,164 @@
+# Conventions for `cli/flox/src/commands/`
+
+Reviewers in this area most often catch three categories of problem: (1) typed domain values being passed as raw strings — especially flake references, shell types, and URLs — when purpose-built types already exist; (2) user-facing messages that are inaccurate, noisy, or missing actionable next steps; and (3) test coverage that either tests bpaf plumbing instead of behavior, or is missing entirely for new command paths. A smaller but steady stream of comments addresses incomplete `ConcreteEnvironment` match arms, redundant parsing of already-parsed values, and helper functions whose names describe how they were triggered rather than what they do.
+
+## Area-specific rules
+
+### Type safety at CLI boundaries
+
+**Use `NixFlakeRef` (or equivalent typed flake-reference type) for any field that holds a Nix flake reference; parse it at the CLI arg-parsing boundary and propagate the typed value.**
+Raw strings force every downstream consumer to parse and validate independently, producing brittle string-splitting logic such as `.split("?rev=").nth(1)`. The typed accessor (e.g. `.rev()`) replaces that.
+Evidence: PR #3599, PR #4156
+
+**Default to `COMMON_NIXPKGS_URL` (the project-wide constant) rather than the bare string `"nixpkgs"` when constructing a fallback flake reference.**
+Using a bare `"nixpkgs"` string resolves to whichever nixpkgs is on the user's registry, which may differ from the pinned nixpkgs Flox uses for builds and evaluation.
+Evidence: PR #3599
+
+**Use the `Shell` enum (from `shell_gen`) rather than a plain `String` when a CLI argument represents a shell name.**
+An untyped string reaches a `_ => {}` wildcard arm and silently does nothing for unsupported shells; the enum turns that into a compile-time exhaustiveness check.
+Evidence: PR #4231
+
+**Parse URLs with `url::Url` at CLI boundaries and update downstream consumers to use typed accessors.**
+Parsing a URL string deep inside command logic forces re-parsing at each call site and prevents the type system from guaranteeing well-formedness.
+Evidence: PR #4156
+
+**Access manifest descriptor fields directly instead of reconstructing equivalent data from the locked/catalog entry.**
+`PackageToList::Catalog` carries both the manifest descriptor and the locked entry. When the descriptor already has the authoritative value (e.g. `pkg_path`), use it directly rather than reconstructing from catalog fields.
+Evidence: PR #3700
+
+### Error handling in command implementations
+
+**Match all `ConcreteEnvironment` variants (Path, Managed, Remote) when gating a feature to a subset; do not silently exclude variants.**
+A `match` that only handles `Path` and bails on `Managed` with "not supported" may be wrong — check whether the operation actually makes sense for the other variants before blocking them.
+Evidence: PR #3599
+
+**Remove obsolete string-matching branches after introducing a typed error variant.**
+When a new enum variant (e.g. `ManagedEnvironmentError::UpstreamAlreadyExists`) supersedes a string-match guard, delete the old branch; leaving it produces dead code that diverges over time.
+Evidence: PR #3646
+
+**Distinguish auth context in user-facing messages: do not say "not logged in" when the user is authenticated via Kerberos.**
+`flox auth status` reporting "You are not currently logged in to FloxHub" is inaccurate when `AuthContext` is `Krb`. The message must reflect the actual auth state. Add a `TODO` tracking the full Kerberos handling if deferring.
+Evidence: PR #4172
+
+**Add a `TODO` comment (with ticket reference where possible) when an auth flow is undefined for a given configuration mode; do not silently fall through.**
+`flox auth login` invoked under a Kerberos configuration has no meaningful effect. Mark the gap explicitly rather than letting the code succeed silently.
+Evidence: PR #4047
+
+**Surface specific error conditions at call boundaries with `.context()`; do not use `.unwrap()` in command logic.**
+Commands run in user-facing paths. An `.unwrap()` panic produces an unhelpful backtrace; `.context("Failed to …")` attaches the surrounding operation so the user and the error chain both understand what went wrong.
+Evidence: PR #4096
+
+### CLI flag placement and bpaf usage
+
+**Place flags that modify the overall command at the top-level struct rather than duplicating them inside each variant of a nested enum.**
+Positional ambiguity grows when flags appear only on some variants; hoisting shared flags to the parent struct eliminates the ambiguity and simplifies help text.
+Evidence: PR #3715
+
+**Name positional arguments by their actual type (`installable`, `attrpath`), not by an approximate concept (`expression`, `package-name`).**
+The argument name appears in `--help` and shell completions. Users familiar with Nix expect `installable` to mean `[flake-ref#]attr-path`; `expression` implies Nix language syntax, which is wrong here.
+Evidence: PR #3599
+
+**Prefix intentionally unused function parameters with `_` (e.g. `_flox`).**
+The compiler warning confirms the parameter is not accidentally forgotten. Reviewers will flag unnamed unused parameters as a readability issue.
+Evidence: PR #4219
+
+**Rename functions to describe what they do, not what triggered them.**
+A function named after its trigger (e.g. `gather_services_for_flag`) misleads callers about its actual contract. Use a name that describes the computation (e.g. `services_to_start`).
+Evidence: PR #4152
+
+### Command output and user-facing messages
+
+**Use the `message::` helpers (`message::updated`, `message::warning`, `message::plain`, etc.) for all terminal output; do not `println!` directly.**
+The helpers enforce consistent formatting and the correct emoji/icon for the message kind (see AGENTS.md for the standard emoji map).
+Evidence: PR #3902
+
+**Emit warnings only for conditions that require user action; suppress noise for outcomes triggered automatically.**
+If Flox auto-started services and the result is expected, no warning is needed. Warnings are for situations where the user must do something differently next time.
+Evidence: PR #4152
+
+**Keep messages concise when the state has not changed; avoid verbose "nothing to do" phrasing.**
+Saying "Environment is already up to date. No packages were upgraded." repeats itself. One short sentence suffices.
+Evidence: PR #3869
+
+**Eliminate redundant warnings; use terminology that is accurate for all contexts, not just the current tool.**
+A message that copies tool-specific language (e.g. "nix build failed") surfaces internals. Rewrite at the product level and apply consistently to every build back-end.
+Evidence: PR #4156
+
+**Rewrite copy-pasted error messages to describe the actual operation, not the operation that was copied from.**
+Copy-paste errors are common when adding new commands. Always verify each message is accurate for its specific context before submitting.
+Evidence: PR #3969
+
+**Provide actionable next steps in error messages when users encounter a restriction.**
+"Cannot do X in a managed environment." leaves users stuck. Follow it with "Use `flox edit` to modify the environment locally, then push."
+Evidence: PR #3649
+
+**Use precise terminology: prefer `targets` over `artifacts` when store paths are unavailable; prefer generic `build` over tool-specific terms in user messages.**
+Precision matters when users paste messages into bug reports or search for help. Inaccurate vocabulary creates a vocabulary mismatch.
+Evidence: PR #4232, PR #4156
+
+### Control flow and implementation structure
+
+**Use `tokio::select!` to wait for either a signal handler or CLI completion, ensuring the temp directory and guards are dropped on interrupt.**
+Signal handlers must race against the CLI worker so that `Ctrl-C` triggers cleanup (dropping `temp_dir`, metrics guards, sentry). Blocking on the CLI future alone leaves cleanup uncalled on interrupt.
+Evidence: PR #3600
+
+**Apply early-return guards with `let Some(x) = y && condition` to skip expensive operations when they are unnecessary.**
+Reading generation metadata to compare a generation number is wasteful when no generation was requested. Short-circuit before the metadata read.
+Evidence: PR #3715
+
+**Refactor duplicated logic into a single unified function to prevent message inconsistencies across code paths.**
+When the same service-start logic appears in two branches with slightly different messages, the branches diverge over time. Extract to one function; adjust the message at the call site if needed.
+Evidence: PR #4152
+
+**Clone shared data at the ownership boundary, not throughout the function body.**
+A clone that appears inside a conditional or repeated in several arms should be hoisted to the point where ownership transfers, making the intent explicit.
+Evidence: PR #4172
+
+**Remove wrapper methods that simply delegate to a field's method.**
+`Flox::get_handle()` wrapping `flox.auth_context.handle()` adds indirection with no benefit. Callers should access the field method directly.
+Evidence: PR #4172
+
+**Use `nix_expression_dir(&env)` and other existing path helpers instead of re-constructing paths from `env.parent_path()` manually.**
+Constructing `.flox/pkgs/` by hand diverges from the canonical path if the helper's logic changes. Always prefer the established helper.
+Evidence: PR #3599
+
+**When writing file content fetched as bytes, use `fs::write` directly on the byte slice; do not round-trip through `String`.**
+Converting bytes to `String` to write them back to disk adds a UTF-8 validation that is unnecessary for binary or opaque content and silently drops non-UTF-8 data.
+Evidence: PR #3599
+
+### Testing in command implementations
+
+**Write unit tests for formatting functions by accepting `&mut impl Write` so tests can write to a `Vec<u8>` buffer.**
+Formatting logic that writes directly to stdout cannot be unit-tested without capturing output. Accepting a writer makes the function testable without subprocess overhead.
+Evidence: PR #3695
+
+**Add integration (bats) tests that verify real workflows end-to-end for new commands, not only unit mocks.**
+A new command that only has unit tests may pass CI while being broken in practice. At minimum, add a happy-path integration test that exercises the full CLI stack.
+Evidence: PR #3969
+
+**Remove trivial tests that only verify bpaf parser mechanics (e.g., that a flag parses to `true`).**
+bpaf is a library with its own test suite. Testing that `--force` sets `force: true` adds no value; test what the command *does* with the flag.
+Evidence: PR #4200
+
+**After changing shell completion output, verify completions work end-to-end in the actual shell, not only by checking static `--bpaf-complete*` strings.**
+Static completion strings can be correct while the shell integration is broken. Provide a concrete test command (e.g. `flox activate -- fzf<TAB>`) that exercises the live completion path.
+Evidence: PR #3988
+
+**Use `mock_managed_environment_in` for managed environment tests and extract environment-existence checks into a shared helper.**
+Copy-pasting setup boilerplate into multiple tests causes subtle divergence. The shared helper is the canonical setup.
+Evidence: PR #3599
+
+## Cross-cutting reminders
+
+These cross-cutting themes hit this area often — see the parent skills for the full text:
+
+- Error type hierarchy (extend enum variants; do not string-match on `.to_string()`) — `.claude/skills/flox-rust-review/SKILL.md`
+- `use` statement placement (module scope, not function scope; update when moving code) — `.claude/skills/flox-rust-stylistic-conventions/SKILL.md`
+- `formatdoc!` / `indoc!` for multiline strings (not `format!` with `r#"..."#`) — `.claude/skills/flox-rust-stylistic-conventions/SKILL.md`
+- User-visible message structure (sentence case, no subject "flox/we/I", one sentence per line, actionable last line) — `.claude/skills/flox-rust-review/SKILL.md`
+- Test naming (no `test_` prefix; descriptive names that state what is verified) — `.claude/skills/flox-rust-stylistic-conventions/SKILL.md`
+- Manifest type-state (`Manifest<S>` constructors; never deserialize inner types directly) — `.claude/skills/flox-rust-review/SKILL.md`
+
+## When in doubt
+
+The most active reviewers in this area are `ysndr` (Tier 1) and `dcarley` (Tier 1). Their prior comments are the best precedent — when uncertain, search PR history for similar work in `cli/flox/src/commands/`. `mkenigs` (Tier 1) contributes heavily on `activate.rs` and service-related files.


### PR DESCRIPTION
## Proposed Changes

Adds two Claude Code **skills** and a set of **`CLAUDE.md`** guidance files that
encode Rust review conventions mined from this repo's own PR history. Everything
here is agent-guidance documentation (Markdown) — **no product code and no
runtime behavior change**.

The rules were extracted from **944 review line-comments across 216 merged,
Rust-touching PRs (~8 months)**, reviewer-weighted toward the most active
reviewers, then cross-referenced against `AGENTS.md` so they complement rather
than duplicate it.

### What's included (7 files, +984 lines)

| File | Lines | Purpose |
|------|------:|---------|
| `.claude/skills/flox-rust-review/SKILL.md` | 144 | Substantive review rules — cases where code was wrong, buggy, or insufficient: error handling, type safety at boundaries, semantic correctness, testing patterns, provider-trait design, manifest-usage discipline, panic discipline. |
| `.claude/skills/flox-rust-stylistic-conventions/SKILL.md` | 312 | Taste-driven conventions — naming, formatting, imports, message wording. |
| `cli/CLAUDE.md` | 80 | Rust cross-cutting conventions for the `cli/` tree. |
| `cli/flox/src/commands/CLAUDE.md` | 164 | Area-specific conventions for commands. |
| `cli/flox-rust-sdk/src/models/environment/CLAUDE.md` | 132 | Area-specific conventions for environment models. |
| `cli/flox-rust-sdk/src/providers/CLAUDE.md` | 140 | Area-specific conventions for providers. |
| `CLAUDE.md` | +12 | Appends a pointer section to the above (keeps the existing `@AGENTS.md` include). |

### How to review

- These are **opt-in guidance** for Claude Code / agents editing Rust — they do
  not change the build, tests, or CLI behavior.
- The most valuable review is a **sanity check that each rule reflects the
  team's actual practice.** Please push back on anything that does not — many
  rules derive from a single reviewer comment, so some are "a reviewer raised
  this once," not "consistently enforced."
- Start with the two `SKILL.md` files; the per-area `CLAUDE.md` files drill into
  the three hottest subsystems (`commands`, `models/environment`, `providers`).

### Provenance & evidence

- AGENTS.md before/after diff (with green-light inserts):
  https://gist.github.com/smorin/03a82c7842aecefb09a697bcc52daa3f
- The full mining pipeline, SQLite corpus, and analytics dashboards live on the
  companion branches `rust-pr-analysis-pipeline` and
  `worktree-rust-pr-analysis-skill` — analysis scaffolding, **not** proposed for
  merge.
- A follow-up PR will propose specific `AGENTS.md` amendments (30 candidates in
  the gap report), kept separate so this PR stays scoped to the skills and
  `CLAUDE.md` files.

### Scope note

Intentionally excludes any `AGENTS.md` edits and any pipeline code — just the
guidance artifacts.

## Release Notes

N/A — agent-guidance documentation only; no user-facing changes.
