### PR TITLE
fix(auth): redact FloxHub tokens from debug

### DIFF
--- a/cli/flox/src/commands/auth.rs
+++ b/cli/flox/src/commands/auth.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 
@@ -42,13 +43,22 @@ use crate::utils::message;
 use crate::utils::openers::Browser;
 use crate::{Exit, subcommand_metric};
 
-#[derive(Debug, Default, Clone, Serialize)]
+#[derive(Default, Clone, Serialize)]
 pub struct Credential {
     pub token: String,
     /// Wall-clock expiry derived from the token response's `expires_in`,
     /// which RFC 6749 makes optional; the token's own `exp` claim and /me
     /// are the authorities on expiry, so absence is not an error.
     pub expiry: Option<String>,
+}
+
+impl fmt::Debug for Credential {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Credential")
+            .field("token", &"***")
+            .field("expiry", &self.expiry)
+            .finish()
+    }
 }
 
 // The device flow never touches the authorization endpoint, so the client
@@ -727,6 +737,22 @@ mod tests {
     use uuid::Uuid;
 
     use super::*;
+
+    #[test]
+    fn credential_debug_redacts_token() {
+        let credential = Credential {
+            token: "synthetic-token".to_string(),
+            expiry: Some("2026-08-13T12:00:00Z".to_string()),
+        };
+
+        assert_eq!(format!("{credential:#?}"), indoc! {r#"
+                Credential {
+                    token: "***",
+                    expiry: Some(
+                        "2026-08-13T12:00:00Z",
+                    ),
+                }"#});
+    }
 
     struct EventsClientReset(Option<EventsClient>);
 

--- a/cli/floxhub-client/src/auth/token/floxhub_token.rs
+++ b/cli/floxhub-client/src/auth/token/floxhub_token.rs
@@ -10,6 +10,7 @@
 //! [`BareToken`]: crate::auth::token::BareToken
 //! [`AuthContext::new_from_token`]: crate::auth::AuthContext::new_from_token
 
+use std::fmt;
 use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
@@ -34,12 +35,21 @@ struct FloxTokenClaims {
 
 /// A token authenticating a user with FloxHub, identifying its owner
 /// locally through the Auth0 tenant's handle claim.
-#[derive(Debug, Clone, DeserializeFromStr)]
+#[derive(Clone, DeserializeFromStr)]
 pub struct FloxhubToken {
     /// The entire token as a string
     token: String,
     /// Assertions about the identity of the token's owner
     token_data: FloxTokenClaims,
+}
+
+impl fmt::Debug for FloxhubToken {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FloxhubToken")
+            .field("token", &"***")
+            .field("token_data", &self.token_data)
+            .finish()
+    }
 }
 
 impl FloxhubToken {
@@ -194,6 +204,16 @@ mod tests {
     use super::test_helpers::*;
     use super::*;
     use crate::auth::token::test_helpers::FAKE_TOKEN_NO_HANDLE;
+
+    #[test]
+    fn floxhub_token_debug_redacts_secret() {
+        let token = FloxhubToken::new(FAKE_TOKEN.to_string()).expect("synthetic token parses");
+
+        assert_eq!(
+            format!("{token:?}"),
+            "FloxhubToken { token: \"***\", token_data: FloxTokenClaims { handle: \"test\", exp: 9999999999, sub: None } }"
+        );
+    }
 
     #[test]
     fn auth0_shaped_jwt_answers_identity_locally() {


### PR DESCRIPTION
## Proposed Changes

- Replace the derived `Debug` implementation on the interactive-login credential with an implementation that redacts the token while retaining expiry metadata.
- Apply the same redaction to the parsed FloxHub token wrapper so future debug logging cannot expose its raw credential.
- Add regression tests using synthetic credentials to pin both formatter contracts.

The root cause was deriving `Debug` on types that directly store credential strings, combined with a verbose login log that formats one of those types.

[CLI-181](https://linear.app/floxdotdev/issue/CLI-181/flox-auth-derived-debug-on-credential-prints-the-floxhub-token-under)

## Release Notes

Fixed verbose authentication output so FloxHub credentials are redacted.

## Verification

- `nix develop -c cargo test -p flox -p floxhub-client debug_redacts -- --nocapture`
- Required pre-push checks: clippy, rustfmt, and treefmt.