### PR TITLE
feat(catalog): add by_command to the Rust catalog client (DEV-181)

### DIFF
--- a/cli/catalog-api-v1/openapi.json
+++ b/cli/catalog-api-v1/openapi.json
@@ -102,6 +102,67 @@
         }
       }
     },
+    "/api/v1/catalog/by-command": {
+      "get": {
+        "tags": [
+          "catalog"
+        ],
+        "summary": "Find packages that provide a command",
+        "description": "Reverse lookup: which package(s) provide the given command name.\n\nRequired Query Parameters:\n- **system**: The system architecture to search for (e.g., x86_64-linux)\n- **name**: The command name to look up (e.g., readelf, rg, gcc-13)\n\nReturns:\n- **ByCommandResult**: Providers of the command and total count\n\nNote: first pass returns a hardcoded mock so the OpenAPI contract can\nfreeze before the command_index table lands. No database query yet.",
+        "operationId": "by_command_api_v1_catalog_by_command_get",
+        "security": [
+          {
+            "HTTPBearer": []
+          },
+          {
+            "HTTPBasic": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "system",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/PackageSystem"
+            }
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 200,
+              "title": "Name"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Packages that provide the given command",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ByCommandResult"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "The command name or system could not be processed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/catalog/packages/{attr_path}": {
       "get": {
         "tags": [
@@ -1769,7 +1830,7 @@
           "info"
         ],
         "summary": "Get a raw dependency report for a storepath (excluding /nix/store/ prefix)",
-        "description": "Get a raw dependency report for a store path.\n\nPath Parameters:\n- **storepath**: The store path to analyze (excluding /nix/store/ prefix)\n\nReturns:\n- **RawDependencyReport**: Dependency graph with all transitive dependencies,\n  including store paths, derivation info, and dependency relationships.\n\nNote: Requires authentication and superuser (flox staff) access.",
+        "description": "Get a raw dependency report for a store path.\n\nPath Parameters:\n- **storepath**: The store path to analyze (excluding /nix/store/ prefix)\n\nReturns:\n- **RawDependencyReport**: Dependency graph with all transitive dependencies,\n  including store paths, derivation info, and dependency relationships.\n  Dependency lists and the dependencies mapping are sorted by full\n  store path (hash first, since a store path leads with its content\n  hash), so repeated calls over the same dependency graph return the\n  entries in the same order. Ordering only; the report's contents\n  still reflect whatever the catalog currently knows about the\n  closure.\n\nNote: Requires authentication and superuser (flox staff) access.",
         "operationId": "raw_dependency_report_api_v1_catalog_info_dependencies__storepath__raw_get",
         "security": [
           {
@@ -2268,6 +2329,51 @@
         "title": "BuildType",
         "description": "Records the build methodology used to produce a package.\n\nNEF packages carry full source metadata and can be reproduced from source;\nmanifest packages were built via the traditional flox manifest workflow."
       },
+      "ByCommandResult": {
+        "properties": {
+          "command_name": {
+            "type": "string",
+            "title": "Command Name"
+          },
+          "providers": {
+            "items": {
+              "$ref": "#/components/schemas/CommandProvider"
+            },
+            "type": "array",
+            "title": "Providers"
+          },
+          "total_count": {
+            "type": "integer",
+            "title": "Total Count"
+          },
+          "listing_known": {
+            "type": "boolean",
+            "title": "Listing Known"
+          }
+        },
+        "type": "object",
+        "required": [
+          "command_name",
+          "providers",
+          "total_count",
+          "listing_known"
+        ],
+        "title": "ByCommandResult",
+        "description": "Packages that provide a command name (reverse command\u2192package lookup).",
+        "example": {
+          "command_name": "readelf",
+          "listing_known": true,
+          "providers": [
+            {
+              "attr_path": "binutils",
+              "exact_name_match": false,
+              "pname": "binutils",
+              "system": "x86_64-linux"
+            }
+          ],
+          "total_count": 1
+        }
+      },
       "CatalogPage": {
         "properties": {
           "page": {
@@ -2586,6 +2692,40 @@
         ],
         "title": "CheckBuildResponse",
         "description": "Response from the check-build endpoint."
+      },
+      "CommandProvider": {
+        "properties": {
+          "attr_path": {
+            "type": "string",
+            "title": "Attr Path"
+          },
+          "pname": {
+            "type": "string",
+            "title": "Pname"
+          },
+          "exact_name_match": {
+            "type": "boolean",
+            "title": "Exact Name Match"
+          },
+          "system": {
+            "$ref": "#/components/schemas/PackageSystem"
+          }
+        },
+        "type": "object",
+        "required": [
+          "attr_path",
+          "pname",
+          "exact_name_match",
+          "system"
+        ],
+        "title": "CommandProvider",
+        "description": "A package that provides a given command name.",
+        "example": {
+          "attr_path": "binutils",
+          "exact_name_match": false,
+          "pname": "binutils",
+          "system": "x86_64-linux"
+        }
       },
       "DeprecationInfo": {
         "properties": {

--- a/cli/catalog-api-v1/src/client.rs
+++ b/cli/catalog-api-v1/src/client.rs
@@ -366,6 +366,72 @@ manifest packages were built via the traditional flox manifest workflow.*/
             value.parse()
         }
     }
+    ///Packages that provide a command name (reverse command→package lookup).
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "title": "ByCommandResult",
+    ///  "description": "Packages that provide a command name (reverse command→package lookup).",
+    ///  "examples": [
+    ///    {
+    ///      "command_name": "readelf",
+    ///      "listing_known": true,
+    ///      "providers": [
+    ///        {
+    ///          "attr_path": "binutils",
+    ///          "exact_name_match": false,
+    ///          "pname": "binutils",
+    ///          "system": "x86_64-linux"
+    ///        }
+    ///      ],
+    ///      "total_count": 1
+    ///    }
+    ///  ],
+    ///  "type": "object",
+    ///  "required": [
+    ///    "command_name",
+    ///    "listing_known",
+    ///    "providers",
+    ///    "total_count"
+    ///  ],
+    ///  "properties": {
+    ///    "command_name": {
+    ///      "title": "Command Name",
+    ///      "type": "string"
+    ///    },
+    ///    "listing_known": {
+    ///      "title": "Listing Known",
+    ///      "type": "boolean"
+    ///    },
+    ///    "providers": {
+    ///      "title": "Providers",
+    ///      "type": "array",
+    ///      "items": {
+    ///        "$ref": "#/components/schemas/CommandProvider"
+    ///      }
+    ///    },
+    ///    "total_count": {
+    ///      "title": "Total Count",
+    ///      "type": "integer"
+    ///    }
+    ///  }
+    ///}
+    /// ```
+    /// </details>
+    #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug, PartialEq)]
+    pub struct ByCommandResult {
+        pub command_name: ::std::string::String,
+        pub listing_known: bool,
+        pub providers: ::std::vec::Vec<CommandProvider>,
+        pub total_count: i64,
+    }
+    impl ::std::convert::From<&ByCommandResult> for ByCommandResult {
+        fn from(value: &ByCommandResult) -> Self {
+            value.clone()
+        }
+    }
     ///`CatalogName`
     ///
     /// <details><summary>JSON schema</summary>
@@ -955,6 +1021,61 @@ manifest packages were built via the traditional flox manifest workflow.*/
     }
     impl ::std::convert::From<&CheckBuildResponse> for CheckBuildResponse {
         fn from(value: &CheckBuildResponse) -> Self {
+            value.clone()
+        }
+    }
+    ///A package that provides a given command name.
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "title": "CommandProvider",
+    ///  "description": "A package that provides a given command name.",
+    ///  "examples": [
+    ///    {
+    ///      "attr_path": "binutils",
+    ///      "exact_name_match": false,
+    ///      "pname": "binutils",
+    ///      "system": "x86_64-linux"
+    ///    }
+    ///  ],
+    ///  "type": "object",
+    ///  "required": [
+    ///    "attr_path",
+    ///    "exact_name_match",
+    ///    "pname",
+    ///    "system"
+    ///  ],
+    ///  "properties": {
+    ///    "attr_path": {
+    ///      "title": "Attr Path",
+    ///      "type": "string"
+    ///    },
+    ///    "exact_name_match": {
+    ///      "title": "Exact Name Match",
+    ///      "type": "boolean"
+    ///    },
+    ///    "pname": {
+    ///      "title": "Pname",
+    ///      "type": "string"
+    ///    },
+    ///    "system": {
+    ///      "$ref": "#/components/schemas/PackageSystem"
+    ///    }
+    ///  }
+    ///}
+    /// ```
+    /// </details>
+    #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug, PartialEq)]
+    pub struct CommandProvider {
+        pub attr_path: ::std::string::String,
+        pub exact_name_match: bool,
+        pub pname: ::std::string::String,
+        pub system: PackageSystem,
+    }
+    impl ::std::convert::From<&CommandProvider> for CommandProvider {
+        fn from(value: &CommandProvider) -> Self {
             value.clone()
         }
     }
@@ -1729,6 +1850,88 @@ catalog) or '<owner>.<pkgset>.*' (package set) — e.g. 'brantley.*'
             value: ::std::string::String,
         ) -> ::std::result::Result<Self, self::error::ConversionError> {
             value.parse()
+        }
+    }
+    ///`Name`
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "title": "Name",
+    ///  "type": "string",
+    ///  "maxLength": 200,
+    ///  "minLength": 2
+    ///}
+    /// ```
+    /// </details>
+    #[derive(::serde::Serialize, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[serde(transparent)]
+    pub struct Name(::std::string::String);
+    impl ::std::ops::Deref for Name {
+        type Target = ::std::string::String;
+        fn deref(&self) -> &::std::string::String {
+            &self.0
+        }
+    }
+    impl ::std::convert::From<Name> for ::std::string::String {
+        fn from(value: Name) -> Self {
+            value.0
+        }
+    }
+    impl ::std::convert::From<&Name> for Name {
+        fn from(value: &Name) -> Self {
+            value.clone()
+        }
+    }
+    impl ::std::str::FromStr for Name {
+        type Err = self::error::ConversionError;
+        fn from_str(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            if value.chars().count() > 200usize {
+                return Err("longer than 200 characters".into());
+            }
+            if value.chars().count() < 2usize {
+                return Err("shorter than 2 characters".into());
+            }
+            Ok(Self(value.to_string()))
+        }
+    }
+    impl ::std::convert::TryFrom<&str> for Name {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<&::std::string::String> for Name {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<::std::string::String> for Name {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: ::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl<'de> ::serde::Deserialize<'de> for Name {
+        fn deserialize<D>(deserializer: D) -> ::std::result::Result<Self, D::Error>
+        where
+            D: ::serde::Deserializer<'de>,
+        {
+            ::std::string::String::deserialize(deserializer)?
+                .parse()
+                .map_err(|e: self::error::ConversionError| {
+                    <D::Error as ::serde::de::Error>::custom(e.to_string())
+                })
         }
     }
     ///`NarFileLookup`
@@ -5570,6 +5773,62 @@ Sends a `POST` request to `/api/v1/catalog/build-inputs/lookup`
             .build()?;
         let info = OperationInfo {
             operation_id: "lookup_api_v1_catalog_build_inputs_lookup_post",
+        };
+        self.pre(&mut request, &info).await?;
+        let result = self.exec(request, &info).await;
+        self.post(&result, &info).await?;
+        let response = result?;
+        match response.status().as_u16() {
+            200u16 => ResponseValue::from_response(response).await,
+            422u16 => {
+                Err(Error::ErrorResponse(ResponseValue::from_response(response).await?))
+            }
+            _ => Err(Error::UnexpectedResponse(response)),
+        }
+    }
+    /**Find packages that provide a command
+
+Reverse lookup: which package(s) provide the given command name.
+
+Required Query Parameters:
+- **system**: The system architecture to search for (e.g., x86_64-linux)
+- **name**: The command name to look up (e.g., readelf, rg, gcc-13)
+
+Returns:
+- **ByCommandResult**: Providers of the command and total count
+
+Note: first pass returns a hardcoded mock so the OpenAPI contract can
+freeze before the command_index table lands. No database query yet.
+
+Sends a `GET` request to `/api/v1/catalog/by-command`
+
+*/
+    pub async fn by_command_api_v1_catalog_by_command_get<'a>(
+        &'a self,
+        name: &'a types::Name,
+        system: types::PackageSystem,
+    ) -> Result<ResponseValue<types::ByCommandResult>, Error<types::ErrorResponse>> {
+        let url = format!("{}/api/v1/catalog/by-command", self.baseurl);
+        let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+        header_map
+            .append(
+                ::reqwest::header::HeaderName::from_static("api-version"),
+                ::reqwest::header::HeaderValue::from_static(Self::api_version()),
+            );
+        #[allow(unused_mut)]
+        let mut request = self
+            .client
+            .get(url)
+            .header(
+                ::reqwest::header::ACCEPT,
+                ::reqwest::header::HeaderValue::from_static("application/json"),
+            )
+            .query(&progenitor_client::QueryParam::new("name", &name))
+            .query(&progenitor_client::QueryParam::new("system", &system))
+            .headers(header_map)
+            .build()?;
+        let info = OperationInfo {
+            operation_id: "by_command_api_v1_catalog_by_command_get",
         };
         self.pre(&mut request, &info).await?;
         let result = self.exec(request, &info).await;

--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -9,6 +9,8 @@ use floxhub_client::{
     BaseCatalogUrl,
     BuildInputsLookupRequest,
     BuildInputsLookupResponse,
+    ByCommandError,
+    ByCommandResult,
     CatalogClientTrait,
     CatalogStoreConfig,
     CheckBuildQuery,
@@ -85,6 +87,7 @@ pub enum Response {
     CreatePackage,
     PublishBuild,
     GetBaseCatalog(BaseCatalogInfo),
+    ByCommand(ByCommandResult),
 }
 
 #[derive(Debug, Error)]
@@ -246,6 +249,28 @@ impl CatalogClientTrait for MockClient {
                 )),
             )),
             _ => panic!("expected search response, found {:?}", &mock_resp),
+        }
+    }
+
+    async fn by_command(
+        &self,
+        _command_name: impl AsRef<str> + Send + Sync,
+        _system: PackageSystem,
+    ) -> Result<ByCommandResult, ByCommandError> {
+        let mock_resp = self
+            .mock_responses
+            .lock()
+            .expect("couldn't acquire mock lock")
+            .pop_front();
+        match mock_resp {
+            Some(Response::ByCommand(resp)) => Ok(resp),
+            Some(Response::Error(err)) => Err(ByCommandError::FloxhubClientError(
+                FloxhubClientError::APIError(floxhub_client::ApiError::ErrorResponse(
+                    err.try_into()
+                        .expect("couldn't convert mock error response"),
+                )),
+            )),
+            _ => panic!("expected by_command response, found {:?}", &mock_resp),
         }
     }
 

--- a/cli/floxhub-client/src/client.rs
+++ b/cli/floxhub-client/src/client.rs
@@ -32,7 +32,7 @@ use crate::MapApiErrorExt;
 use crate::accounts::{AccountsApiClient, MeError};
 use crate::auth::{AccessToken, AuthContext, IdentityError, UserIdentity, identity};
 use crate::config::FloxhubClientConfig;
-use crate::error::{FloxhubClientError, ResolveError, SearchError, VersionsError};
+use crate::error::{ByCommandError, FloxhubClientError, ResolveError, SearchError, VersionsError};
 use crate::mock::MockGuard;
 use crate::types::*;
 
@@ -232,6 +232,16 @@ pub trait CatalogClientTrait {
         limit: SearchLimit,
     ) -> Result<SearchResults, SearchError>;
 
+    /// Find packages that provide a named command.
+    ///
+    /// Unlike [`Self::search`], the endpoint is not paginated: a single
+    /// response carries every provider it knows about.
+    async fn by_command(
+        &self,
+        command_name: impl AsRef<str> + Send + Sync,
+        system: api_types::PackageSystem,
+    ) -> Result<ByCommandResult, ByCommandError>;
+
     /// Get all versions of an attr_path.
     async fn package_versions(
         &self,
@@ -418,6 +428,29 @@ impl CatalogClientTrait for FloxhubClient {
         let search_results = SearchResults { results, count };
 
         Ok(search_results)
+    }
+
+    async fn by_command(
+        &self,
+        command_name: impl AsRef<str> + Send + Sync,
+        system: api_types::PackageSystem,
+    ) -> Result<ByCommandResult, ByCommandError> {
+        tracing::debug!(
+            command_name = command_name.as_ref().to_string(),
+            ?system,
+            "sending by-command request"
+        );
+        let command_name = api_types::Name::from_str(command_name.as_ref())
+            .map_err(ByCommandError::InvalidCommandName)?;
+
+        let response = self
+            .catalog
+            .by_command_api_v1_catalog_by_command_get(&command_name, system)
+            .await
+            .map_api_error()
+            .await?;
+
+        Ok(response.into_inner())
     }
 
     async fn package_versions(

--- a/cli/floxhub-client/src/error.rs
+++ b/cli/floxhub-client/src/error.rs
@@ -17,6 +17,14 @@ pub enum SearchError {
 }
 
 #[derive(Debug, Error)]
+pub enum ByCommandError {
+    #[error("invalid command name")]
+    InvalidCommandName(#[source] api_error::ConversionError),
+    #[error("catalog error")]
+    FloxhubClientError(#[from] FloxhubClientError),
+}
+
+#[derive(Debug, Error)]
 pub enum ResolveError {
     #[error("catalog error")]
     FloxhubClientError(#[from] FloxhubClientError),

--- a/cli/floxhub-client/src/types.rs
+++ b/cli/floxhub-client/src/types.rs
@@ -49,6 +49,9 @@ pub use api_types::{
     UnresolvableEntry,
     UnresolvableLeaf,
 };
+// Command lookup. Unlike search, by-command is unpaginated, so the generated
+// result type is already the whole answer and needs no `ResultsPage` wrapper.
+pub use api_types::{ByCommandResult, CommandProvider};
 // ---------------------------------------------------------------------------
 // Package descriptors
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
FloxHub shipped `GET /api/v1/catalog/by-command`, a reverse lookup answering "given a command like `readelf`, which packages provide it?" Nothing on the CLI side can reach it: the catalog client is generated from a vendored OpenAPI spec that predates the endpoint, so there is no typed method and no types to call it with.

## Proposed Changes

Add the typed Rust client method for that endpoint, so later work can call it with real types instead of hand-rolling a request:

```rust
catalog_client.by_command("readelf", system).await   // -> ByCommandResult
```

That is the whole scope. This PR does not decide which package to use, does not resolve, and does not run anything. No caller is wired up yet.

**The vendored spec is refreshed.** `cli/catalog-api-v1/openapi.json` was an older snapshot. It is now a copy of the current FloxHub catalog schema (`a30454e9`). The diff is additive: the `by-command` path plus the `ByCommandResult` and `CommandProvider` schemas. The only other delta is a docstring on `info/dependencies/{storepath}/raw`, which `build.rs` already filters out of codegen, so nothing outside by-command regenerates.

**The client is regenerated.** `build.rs` rewrites `src/client.rs` from the spec at build time, and the regenerated file is checked in. The `by-command` path passes the codegen retain filter, yielding `by_command_api_v1_catalog_by_command_get(&Name, PackageSystem)`.

**The method is added to the trait and both implementations.** CLI code depends on `CatalogClientTrait` rather than the concrete client, so the real client and the test double have to move together or the workspace will not compile:

- `CatalogClientTrait::by_command`, the interface
- `FloxhubClient::by_command`, one request with no depaging stream
- `MockClient::by_command`, which pops a canned `Response::ByCommand`

**Supporting types.** `ByCommandError` mirrors `SearchError`, including an `InvalidCommandName` variant. The generated `name` parameter is a validated newtype with a length constraint rather than a plain `String`, so conversion can fail the same way a search term can. `Response::ByCommand` is appended to the mock's record/replay enum rather than inserted, because that enum is `#[serde(untagged)]` and the existing Search-before-Packages ordering is load-bearing.

**No wrapper type.** `search` returns a hand-written `SearchResults` only because it collapses paginated pages into one list plus a count. by-command is not paginated and a single response carries every provider, so the generated `ByCommandResult` is already the whole answer and is returned directly. `ByCommandResult` and `CommandProvider` are re-exported from `floxhub-client` so consumers depend on one crate, matching how `PackageSystem` and the build-inputs types are already surfaced.

**No `by_command_with_spinner`.** `search` has a spinner variant that exists only to attach an `#[instrument]` progress field. Progress reporting is a concern of the caller, so it is left to whichever change first renders it rather than added speculatively here.

**No new tests.** The testing conventions in `AGENTS.md` say not to test generated code and not to add a client mock to test a thin wrapper, and this is exactly the thin wrapper that rule describes. The method gets real coverage once a caller lands.

**Verification.** `cargo build --workspace` clean, so the trait and both implementations compile together; clippy clean with zero warnings; `cargo fmt --check` clean; `cargo test -p floxhub-client -p catalog-api-v1` green (102). The `flox-rust-sdk` suite reports 8 failures on this branch, all pre-existing or environmental rather than regressions: 5 reproduce identically on a clean tree (nix `environment.drv` builds and nef lock tests), and the other 3 pass under `--test-threads=1` (httpmock port contention).

Fixes [DEV-181](https://linear.app/floxdotdev/issue/DEV-181)

Unblocks DEV-182 (CLI argument surface) and DEV-183 (`flox search --command`)

## Release Notes

N/A. There is no user-facing surface: the method has no caller yet, and the CLI-facing work lands separately.