### PR TITLE
feat(auth): warn unauthenticated users at the catalog /resolve call site

### DIFF
--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -593,6 +593,7 @@ pub mod test_helpers {
             // change (see the Justfile `gen-unit-data-no-publish` comment
             // for the full atomic flip checklist).
             stability: None,
+            on_unauthenticated_resolve: None,
         };
         FloxhubClient::new(catalog_config).expect("failed to create catalog client")
     }
@@ -690,6 +691,7 @@ pub mod test_helpers {
             // since nothing mutates `_FLOX_RESOLVE_STABILITY` mid-process, the
             // record and replay runs read the same value.
             stability: FloxhubClientConfig::stability_from_env(),
+            on_unauthenticated_resolve: None,
         };
         let mut client =
             FloxhubClient::new(catalog_config).expect("failed to create catalog client");
@@ -868,6 +870,7 @@ pub mod test_helpers {
             auth_context: AuthContext::Auth0(Some(admin_token)),
             user_agent: None,
             stability: None,
+            on_unauthenticated_resolve: None,
         };
         let admin_client =
             FloxhubClient::new(admin_config).expect("failed to create admin catalog client");

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -61,6 +61,7 @@ use flox_rust_sdk::models::environment::{
     find_dot_flox,
     open_path,
 };
+use floxhub_client::UnauthenticatedResolveHook;
 use indoc::{formatdoc, indoc};
 use tempfile::TempDir;
 use thiserror::Error;
@@ -82,9 +83,9 @@ use crate::utils::dialog::{Dialog, Select};
 use crate::utils::errors::display_chain;
 use crate::utils::events::{build_events_client, resolve_invocation_id};
 use crate::utils::init::init_floxhub_client;
-use crate::utils::message;
 use crate::utils::metrics::{AWSDatalakeConnection, Client, Hub, read_metrics_uuid};
 use crate::utils::update_notifications::UpdateNotification;
+use crate::utils::{auth_warning, message};
 
 pub(crate) const SHELL_COMPLETION_DIR: ShellComp = ShellComp::Dir { mask: None };
 const SHELL_COMPLETION_FILE: ShellComp = ShellComp::File { mask: None };
@@ -425,10 +426,22 @@ impl FloxArgs {
             .then(|| read_metrics_uuid(&config).ok())
             .flatten();
 
+        // Warn when the catalog is actually contacted for resolution while
+        // unauthenticated (see `FloxhubClient::resolve`). Rate limiting lives
+        // in `warn_unauthenticated_resolve`; like other advisory messages the
+        // warning is suppressed for the prompt-hook flow.
+        let on_unauthenticated_resolve = (!self.is_prompt_hook_flow()).then(|| {
+            let cache_dir = config.flox.cache_dir.clone();
+            UnauthenticatedResolveHook::new(move || {
+                auth_warning::warn_unauthenticated_resolve(&cache_dir)
+            })
+        });
+
         let floxhub_client = init_floxhub_client(
             floxhub.api_url_str(),
             credential.clone(),
             metrics_device_uuid,
+            on_unauthenticated_resolve,
         )?;
 
         // we already make sure $USER corresponds to **euid** earlier on in the process.

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -428,9 +428,20 @@ impl FloxArgs {
 
         // Warn when the catalog is actually contacted for resolution while
         // unauthenticated (see `FloxhubClient::resolve`). Rate limiting lives
-        // in `warn_unauthenticated_resolve`; like other advisory messages the
-        // warning is suppressed for the prompt-hook flow.
-        let on_unauthenticated_resolve = (!self.is_prompt_hook_flow()).then(|| {
+        // in `warn_unauthenticated_resolve`. The hook is not installed for
+        // the prompt-hook flow (like other advisory messages) or under `-q`:
+        // installing-but-silencing would still write the 8-hour stamp and
+        // mute the next interactive warning the user never saw.
+        //
+        // This deliberately coexists with the once-per-shell-session
+        // logged-out reminder from `resolve_auth_context`: the reminder
+        // reports current status on every command, while this warning fires
+        // only on the resolve that will start failing once catalog auth
+        // gating is enforced — at which point it becomes an error (or an
+        // interactive login prompt) and the overlap gets revisited.
+        let install_resolve_warning =
+            !self.is_prompt_hook_flow() && !matches!(self.verbosity, Verbosity::Quiet);
+        let on_unauthenticated_resolve = install_resolve_warning.then(|| {
             let cache_dir = config.flox.cache_dir.clone();
             UnauthenticatedResolveHook::new(move || {
                 auth_warning::warn_unauthenticated_resolve(&cache_dir)

--- a/cli/flox/src/utils/auth_warning.rs
+++ b/cli/flox/src/utils/auth_warning.rs
@@ -1,0 +1,159 @@
+//! Rate-limited warning for unauthenticated catalog resolution.
+//!
+//! [`FloxhubClient::resolve`](floxhub_client::FloxhubClient::resolve) invokes
+//! the hook built here when it is about to contact the catalog `/resolve`
+//! endpoint without authentication material — the exact call that will fail
+//! once catalog auth gating is enforced server-side. Warning at that point
+//! (rather than per command) means users see the warning precisely where they
+//! will later see the failure: a fully locked environment resolves nothing
+//! and stays quiet, while the first lock of an environment warns regardless
+//! of which command triggered it.
+
+use std::path::Path;
+use std::{fs, io};
+
+use serde::{Deserialize, Serialize};
+use time::{Duration, OffsetDateTime};
+use tracing::debug;
+
+use crate::utils::message;
+
+const RESOLVE_AUTH_WARNING_FILE_NAME: &str = "resolve-auth-warning-timestamp.json";
+const RESOLVE_AUTH_WARNING_EXPIRY: Duration = Duration::hours(8);
+
+// TODO(DEV-200): append the docs URL explaining the auth transition once the
+// explainer page exists.
+const RESOLVE_AUTH_WARNING: &str = "Resolving packages will require authentication to FloxHub in an upcoming release.\nRun 'flox auth login' to authenticate now.";
+
+/// Timestamp serialized to a file to track when the user was last warned.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct LastResolveAuthWarning {
+    #[serde(with = "time::serde::iso8601")]
+    last_warning: OffsetDateTime,
+}
+
+/// Warn that resolution will require authentication, at most once per
+/// [`RESOLVE_AUTH_WARNING_EXPIRY`] per user (tracked by a timestamp file in
+/// the cache directory).
+///
+/// Emitted via [`message::warning`], so `-q` silences it through the logger
+/// filter and it lands on stderr like every other advisory message.
+pub(crate) fn warn_unauthenticated_resolve(cache_dir: impl AsRef<Path>) {
+    let stamp_file = cache_dir.as_ref().join(RESOLVE_AUTH_WARNING_FILE_NAME);
+    let now = OffsetDateTime::now_utc();
+    if !should_warn(&stamp_file, now) {
+        return;
+    }
+    message::warning(RESOLVE_AUTH_WARNING);
+    record_warning(&stamp_file, now);
+}
+
+/// True when the stamp file is absent, unreadable, invalid, or older than
+/// [`RESOLVE_AUTH_WARNING_EXPIRY`]. Failures count as "warn": losing the
+/// stamp only repeats the warning.
+fn should_warn(stamp_file: &Path, now: OffsetDateTime) -> bool {
+    let contents = match fs::read_to_string(stamp_file) {
+        Ok(contents) => contents,
+        Err(err) => {
+            if err.kind() != io::ErrorKind::NotFound {
+                debug!(%err, "failed to read resolve-auth-warning stamp");
+            }
+            return true;
+        },
+    };
+    match serde_json::from_str::<LastResolveAuthWarning>(&contents) {
+        Ok(stamp) => now - stamp.last_warning >= RESOLVE_AUTH_WARNING_EXPIRY,
+        Err(err) => {
+            debug!(%err, "invalid resolve-auth-warning stamp");
+            true
+        },
+    }
+}
+
+/// Best-effort write of the stamp file; failure only means the warning may
+/// repeat sooner than the expiry.
+fn record_warning(stamp_file: &Path, now: OffsetDateTime) {
+    let stamp = LastResolveAuthWarning { last_warning: now };
+    let contents = match serde_json::to_string(&stamp) {
+        Ok(contents) => contents,
+        Err(err) => {
+            debug!(%err, "failed to serialize resolve-auth-warning stamp");
+            return;
+        },
+    };
+    if let Err(err) = fs::write(stamp_file, contents) {
+        debug!(%err, "failed to write resolve-auth-warning stamp");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stamp_in(dir: &Path) -> std::path::PathBuf {
+        dir.join(RESOLVE_AUTH_WARNING_FILE_NAME)
+    }
+
+    /// The backdated stamp written by catalog-auth-warnings.bats must parse
+    /// as a valid, expired timestamp — not fall into the invalid-stamp path.
+    #[test]
+    fn bats_backdated_stamp_parses_as_expired() {
+        let dir = tempfile::tempdir().unwrap();
+        let stamp_file = stamp_in(dir.path());
+        fs::write(&stamp_file, r#"{"last_warning":"2020-01-01T00:00:00Z"}"#).unwrap();
+        let stamp: LastResolveAuthWarning =
+            serde_json::from_str(&fs::read_to_string(&stamp_file).unwrap())
+                .expect("bats fixture timestamp must parse");
+        assert_eq!(stamp.last_warning.year(), 2020);
+        assert!(should_warn(&stamp_file, OffsetDateTime::now_utc()));
+    }
+
+    #[test]
+    fn warns_when_stamp_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(should_warn(
+            &stamp_in(dir.path()),
+            OffsetDateTime::now_utc()
+        ));
+    }
+
+    #[test]
+    fn does_not_warn_within_expiry() {
+        let dir = tempfile::tempdir().unwrap();
+        let stamp_file = stamp_in(dir.path());
+        let now = OffsetDateTime::now_utc();
+        record_warning(&stamp_file, now);
+        assert!(!should_warn(&stamp_file, now));
+        assert!(!should_warn(
+            &stamp_file,
+            now + RESOLVE_AUTH_WARNING_EXPIRY - Duration::seconds(1)
+        ));
+    }
+
+    #[test]
+    fn warns_again_after_expiry() {
+        let dir = tempfile::tempdir().unwrap();
+        let stamp_file = stamp_in(dir.path());
+        let now = OffsetDateTime::now_utc();
+        record_warning(&stamp_file, now);
+        assert!(should_warn(&stamp_file, now + RESOLVE_AUTH_WARNING_EXPIRY));
+    }
+
+    #[test]
+    fn warns_when_stamp_invalid() {
+        let dir = tempfile::tempdir().unwrap();
+        let stamp_file = stamp_in(dir.path());
+        fs::write(&stamp_file, "not json").unwrap();
+        assert!(should_warn(&stamp_file, OffsetDateTime::now_utc()));
+    }
+
+    #[test]
+    fn warn_unauthenticated_resolve_writes_stamp() {
+        let dir = tempfile::tempdir().unwrap();
+        warn_unauthenticated_resolve(dir.path());
+        assert!(!should_warn(
+            &stamp_in(dir.path()),
+            OffsetDateTime::now_utc()
+        ));
+    }
+}

--- a/cli/flox/src/utils/auth_warning.rs
+++ b/cli/flox/src/utils/auth_warning.rs
@@ -12,6 +12,7 @@
 use std::path::Path;
 use std::{fs, io};
 
+use indoc::indoc;
 use serde::{Deserialize, Serialize};
 use time::{Duration, OffsetDateTime};
 use tracing::debug;
@@ -23,7 +24,10 @@ const RESOLVE_AUTH_WARNING_EXPIRY: Duration = Duration::hours(8);
 
 // TODO(DEV-200): append the docs URL explaining the auth transition once the
 // explainer page exists.
-const RESOLVE_AUTH_WARNING: &str = "Resolving packages will require authentication to FloxHub in an upcoming release.\nRun 'flox auth login' to authenticate now.";
+const RESOLVE_AUTH_WARNING: &str = indoc! {"
+    Resolving packages will require authentication to FloxHub in an upcoming release.
+    Run 'flox auth login' to authenticate now.\
+"};
 
 /// Timestamp serialized to a file to track when the user was last warned.
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -36,8 +40,11 @@ struct LastResolveAuthWarning {
 /// [`RESOLVE_AUTH_WARNING_EXPIRY`] per user (tracked by a timestamp file in
 /// the cache directory).
 ///
-/// Emitted via [`message::warning`], so `-q` silences it through the logger
-/// filter and it lands on stderr like every other advisory message.
+/// Emitted via [`message::warning`], landing on stderr like every other
+/// advisory message. The stamp is only written when the warning is actually
+/// emitted: invocations that suppress it (`-q`, the prompt-hook flow) never
+/// install the hook that calls this (see `FloxArgs::handle`), so they cannot
+/// consume the 8-hour window.
 pub(crate) fn warn_unauthenticated_resolve(cache_dir: impl AsRef<Path>) {
     let stamp_file = cache_dir.as_ref().join(RESOLVE_AUTH_WARNING_FILE_NAME);
     let now = OffsetDateTime::now_utc();

--- a/cli/flox/src/utils/init/floxhub_client.rs
+++ b/cli/flox/src/utils/init/floxhub_client.rs
@@ -2,7 +2,13 @@ use std::collections::BTreeMap;
 
 use flox_rust_sdk::flox::FLOX_VERSION;
 use flox_rust_sdk::utils::{HEADER_DEVICE_UUID, INVOCATION_SOURCES};
-use floxhub_client::{AuthContext, FloxhubClient, FloxhubClientConfig, FloxhubMockMode};
+use floxhub_client::{
+    AuthContext,
+    FloxhubClient,
+    FloxhubClientConfig,
+    FloxhubMockMode,
+    UnauthenticatedResolveHook,
+};
 use tracing::debug;
 use uuid::Uuid;
 
@@ -21,6 +27,7 @@ pub fn init_floxhub_client(
     base_url: String,
     auth_context: AuthContext,
     metrics_device_uuid: Option<Uuid>,
+    on_unauthenticated_resolve: Option<UnauthenticatedResolveHook>,
 ) -> Result<FloxhubClient, anyhow::Error> {
     let mut extra_headers = BTreeMap::new();
 
@@ -44,6 +51,7 @@ pub fn init_floxhub_client(
         auth_context,
         user_agent: Some(format!("flox-cli/{}", &*FLOX_VERSION)),
         stability: FloxhubClientConfig::stability_from_env(),
+        on_unauthenticated_resolve,
     };
 
     debug!("using catalog client with url: {}", client_config.base_url);

--- a/cli/flox/src/utils/mod.rs
+++ b/cli/flox/src/utils/mod.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 use flox_core::util::default_nix_env_vars;
 
 pub mod active_environments;
+pub mod auth_warning;
 pub mod colors;
 pub mod credential_store;
 pub mod detect_shell;

--- a/cli/floxhub-client/src/auth/auth_context.rs
+++ b/cli/floxhub-client/src/auth/auth_context.rs
@@ -150,10 +150,10 @@ impl AuthContext {
     /// Returns true when no authentication material is available and a
     /// future catalog-auth-gated call would fail.
     ///
-    /// Currently only `Auth0(None)` (not logged in via the default flow) is
-    /// considered unauthenticated for the purpose of Milestone 1 deprecation
-    /// warnings. `Kerberos(None)`, `AccessToken`, and `Auth0(Some(expired))`
-    /// are outside the scope of this milestone.
+    /// Only `Auth0(None)` (not logged in via the default flow) counts.
+    /// `Kerberos(..)` does not require a FloxHub login, `AccessToken` carries
+    /// its own material, and `Auth0(Some(expired))` is still validated
+    /// server-side, so none of them are treated as unauthenticated here.
     pub fn is_unauthenticated(&self) -> bool {
         matches!(self, AuthContext::Auth0(None))
     }

--- a/cli/floxhub-client/src/auth/auth_context.rs
+++ b/cli/floxhub-client/src/auth/auth_context.rs
@@ -147,15 +147,20 @@ impl AuthContext {
         }
     }
 
-    /// Returns true when no authentication material is available and a
+    /// Returns true when no valid authentication material is available and a
     /// future catalog-auth-gated call would fail.
     ///
-    /// Only `Auth0(None)` (not logged in via the default flow) counts.
-    /// `Kerberos(..)` does not require a FloxHub login, `AccessToken` carries
-    /// its own material, and `Auth0(Some(expired))` is still validated
-    /// server-side, so none of them are treated as unauthenticated here.
+    /// `Auth0(None)` (not logged in) and `Auth0(Some(expired))` both count —
+    /// neither carries a credential that will pass once gating is enforced.
+    /// `Kerberos(..)` does not require a FloxHub login, and `AccessToken` is
+    /// opaque (validity unknown until resolved via /me), so neither is
+    /// treated as unauthenticated here.
     pub fn is_unauthenticated(&self) -> bool {
-        matches!(self, AuthContext::Auth0(None))
+        match self {
+            AuthContext::Auth0(None) => true,
+            AuthContext::Auth0(Some(token)) => token.is_expired(),
+            AuthContext::AccessToken(_) | AuthContext::Kerberos(_) => false,
+        }
     }
 
     /// Create a Kerberos [`AuthContext`]: resolves the principal and embeds
@@ -221,6 +226,19 @@ mod tests {
         assert_eq!(AuthContext::Auth0(Some(token)).user_subject(), None);
         assert_eq!(AuthContext::Auth0(None).user_subject(), None);
         assert_eq!(AuthContext::Kerberos(None).user_subject(), None);
+    }
+
+    #[test]
+    fn is_unauthenticated_covers_missing_and_expired_auth0_tokens() {
+        let valid = FloxhubToken::from_str(FAKE_TOKEN).expect("token parses");
+        let expired = FloxhubToken::from_str(FAKE_EXPIRED_TOKEN_WITH_SUB).expect("token parses");
+        assert!(expired.is_expired(), "test premise: token is expired");
+
+        assert!(AuthContext::Auth0(None).is_unauthenticated());
+        assert!(AuthContext::Auth0(Some(expired)).is_unauthenticated());
+        assert!(!AuthContext::Auth0(Some(valid)).is_unauthenticated());
+        assert!(!pat_unresolved().is_unauthenticated());
+        assert!(!AuthContext::Kerberos(None).is_unauthenticated());
     }
 
     fn pat_unresolved() -> AuthContext {

--- a/cli/floxhub-client/src/client.rs
+++ b/cli/floxhub-client/src/client.rs
@@ -317,6 +317,16 @@ impl CatalogClientTrait for FloxhubClient {
         package_groups: Vec<PackageGroup>,
     ) -> Result<Vec<ResolvedPackageGroup>, ResolveError> {
         tracing::debug!(n_groups = package_groups.len(), "resolving package groups");
+
+        // This is the call that will require authentication once catalog auth
+        // gating is enforced server-side, so an unauthenticated request is
+        // reported here — not per command — via the configured hook.
+        if self.config.auth_context.is_unauthenticated()
+            && let Some(hook) = &self.config.on_unauthenticated_resolve
+        {
+            hook.call();
+        }
+
         let package_groups = api_types::PackageGroups {
             items: package_groups
                 .into_iter()
@@ -926,6 +936,7 @@ pub mod test_helpers {
             auth_context: AuthContext::new_from_token(None).expect("no token to parse"),
             user_agent: None,
             stability: None,
+            on_unauthenticated_resolve: None,
         }
     }
 
@@ -956,6 +967,7 @@ pub mod tests {
 
     use super::test_helpers::client_config;
     use super::*;
+    use crate::config::UnauthenticatedResolveHook;
     const SENTRY_TRACE_HEADER: &str = "sentry-trace";
 
     #[tokio::test(flavor = "multi_thread")]
@@ -1138,6 +1150,67 @@ pub mod tests {
             .await
             .unwrap();
         mock.assert();
+    }
+
+    /// `resolve()` fires `on_unauthenticated_resolve` before contacting the
+    /// server when no authentication material is available.
+    #[tokio::test]
+    async fn resolve_fires_unauthenticated_hook_when_logged_out() {
+        let server = MockServer::start_async().await;
+        let mock = server.mock(|when, then| {
+            when.method("POST").path("/api/v1/catalog/resolve");
+            then.status(200).json_body(json!({"items": []}));
+        });
+
+        let fired = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let fired_in_hook = std::sync::Arc::clone(&fired);
+        let config = FloxhubClientConfig {
+            on_unauthenticated_resolve: Some(UnauthenticatedResolveHook::new(move || {
+                fired_in_hook.store(true, std::sync::atomic::Ordering::SeqCst);
+            })),
+            ..client_config(&server.base_url())
+        };
+        let client = FloxhubClient::new(config).unwrap();
+        client
+            .resolve(vec![PackageGroup {
+                name: "group".to_string(),
+                descriptors: vec![],
+            }])
+            .await
+            .unwrap();
+        mock.assert();
+        assert!(fired.load(std::sync::atomic::Ordering::SeqCst));
+    }
+
+    /// `resolve()` does not fire `on_unauthenticated_resolve` when the client
+    /// carries authentication material.
+    #[tokio::test]
+    async fn resolve_skips_unauthenticated_hook_when_authenticated() {
+        let server = MockServer::start_async().await;
+        let mock = server.mock(|when, then| {
+            when.method("POST").path("/api/v1/catalog/resolve");
+            then.status(200).json_body(json!({"items": []}));
+        });
+
+        let fired = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let fired_in_hook = std::sync::Arc::clone(&fired);
+        let config = FloxhubClientConfig {
+            auth_context: AuthContext::new_from_token(Some("flox_pat_test")).unwrap(),
+            on_unauthenticated_resolve: Some(UnauthenticatedResolveHook::new(move || {
+                fired_in_hook.store(true, std::sync::atomic::Ordering::SeqCst);
+            })),
+            ..client_config(&server.base_url())
+        };
+        let client = FloxhubClient::new(config).unwrap();
+        client
+            .resolve(vec![PackageGroup {
+                name: "group".to_string(),
+                descriptors: vec![],
+            }])
+            .await
+            .unwrap();
+        mock.assert();
+        assert!(!fired.load(std::sync::atomic::Ordering::SeqCst));
     }
 
     #[tokio::test]

--- a/cli/floxhub-client/src/config.rs
+++ b/cli/floxhub-client/src/config.rs
@@ -2,8 +2,38 @@
 
 use std::collections::BTreeMap;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use crate::AuthContext;
+
+/// Hook invoked by [`crate::FloxhubClient::resolve`] just before it contacts
+/// the catalog `/resolve` endpoint without authentication material (see
+/// [`AuthContext::is_unauthenticated`]).
+///
+/// The CLI installs a hook that warns that resolution will require
+/// authentication in an upcoming release; rate limiting and output routing
+/// live in that hook, not here. Consumers with no user to warn (tests, batch
+/// tools) leave the config field unset. This call site is also where an
+/// interactive "log in now?" prompt will live once catalog auth gating is
+/// enforced server-side.
+#[derive(Clone)]
+pub struct UnauthenticatedResolveHook(Arc<dyn Fn() + Send + Sync>);
+
+impl UnauthenticatedResolveHook {
+    pub fn new(hook: impl Fn() + Send + Sync + 'static) -> Self {
+        Self(Arc::new(hook))
+    }
+
+    pub fn call(&self) {
+        (self.0)()
+    }
+}
+
+impl std::fmt::Debug for UnauthenticatedResolveHook {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("UnauthenticatedResolveHook")
+    }
+}
 
 /// Configuration for FloxHub client construction.
 ///
@@ -24,6 +54,9 @@ pub struct FloxhubClientConfig {
     /// `resolve()`. Test/regen-only — not a user-facing interface. See
     /// [`crate::FLOX_RESOLVE_STABILITY_VAR`] and [`Self::stability_from_env`].
     pub stability: Option<String>,
+    /// Invoked when `resolve()` is called without authentication material;
+    /// `None` disables the unauthenticated-resolve warning.
+    pub on_unauthenticated_resolve: Option<UnauthenticatedResolveHook>,
 }
 
 impl FloxhubClientConfig {

--- a/cli/floxhub-client/src/lib.rs
+++ b/cli/floxhub-client/src/lib.rs
@@ -25,6 +25,7 @@
 //!     auth_context: AuthContext::new_from_token(floxhub_token)?,
 //!     user_agent: Some("flox-cli/1.0".to_string()),
 //!     stability: FloxhubClientConfig::stability_from_env(),
+//!     on_unauthenticated_resolve: None,
 //! };
 //!
 //! let client = FloxhubClient::new(config)?;
@@ -71,7 +72,7 @@ pub use client::{
     str_to_catalog_name,
     str_to_package_name,
 };
-pub use config::{FloxhubClientConfig, FloxhubMockMode};
+pub use config::{FloxhubClientConfig, FloxhubMockMode, UnauthenticatedResolveHook};
 // Errors
 pub use error::*;
 // Re-export factory types so consumers depend only on floxhub-client.

--- a/cli/nef-lock-catalog/src/bin/lock.rs
+++ b/cli/nef-lock-catalog/src/bin/lock.rs
@@ -227,6 +227,7 @@ fn build_client(config: &Config, floxhub_token: Option<String>) -> Result<Floxhu
         // `--stability` flag targets a different endpoint entirely, so it
         // does not participate in the `_FLOX_RESOLVE_STABILITY` mechanism.
         stability: None,
+        on_unauthenticated_resolve: None,
     };
 
     Ok(FloxhubClient::new(config)?)

--- a/cli/tests/catalog-auth-warnings.bats
+++ b/cli/tests/catalog-auth-warnings.bats
@@ -1,0 +1,127 @@
+#! /usr/bin/env bats
+# -*- mode: bats; -*-
+# ============================================================================ #
+#
+# Tests for DEV-199: warn unauthenticated users at the point of contacting the
+# catalog /resolve endpoint — the call that will require authentication once
+# catalog auth gating is enforced server-side.
+#
+# Commands that never resolve (fully locked environments, empty manifests)
+# must stay quiet; any command that triggers a resolve warns, rate-limited to
+# once per 8 hours via a timestamp file in the cache directory.
+#
+# bats file_tags=catalog-auth-warnings
+#
+# ---------------------------------------------------------------------------- #
+
+load test_support.bash
+
+# ---------------------------------------------------------------------------- #
+
+RESOLVE_AUTH_WARNING="Resolving packages will require authentication to FloxHub in an upcoming release."
+STAMP_FILE_NAME="resolve-auth-warning-timestamp.json"
+
+project_setup() {
+  export PROJECT_NAME="test"
+  export PROJECT_DIR="${BATS_TEST_TMPDIR?}/$PROJECT_NAME"
+  rm -rf "$PROJECT_DIR"
+  mkdir -p "$PROJECT_DIR"
+  pushd "$PROJECT_DIR" > /dev/null || return
+}
+
+project_teardown() {
+  popd > /dev/null || return
+  rm -rf "${PROJECT_DIR?}"
+  unset PROJECT_DIR
+}
+
+setup() {
+  common_test_setup
+  setup_isolated_flox
+  project_setup
+  export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/resolve/hello.yaml"
+}
+
+teardown() {
+  project_teardown
+  common_test_teardown
+}
+
+# ---------------------------------------------------------------------------- #
+# Warn on resolve
+# ---------------------------------------------------------------------------- #
+
+@test "resolving while logged out prints the auth warning" {
+  # The suite runs "logged in" by default; this test needs the logged-out state.
+  unset FLOX_FLOXHUB_TOKEN
+  flox_init_pinned
+  run "$FLOX_BIN" install hello
+  assert_success
+  assert_output --partial "$RESOLVE_AUTH_WARNING"
+}
+
+@test "resolving while logged in does NOT print the auth warning" {
+  flox_init_pinned
+  run "$FLOX_BIN" install hello
+  assert_success
+  refute_output --partial "$RESOLVE_AUTH_WARNING"
+}
+
+@test "'-q' suppresses the auth warning" {
+  unset FLOX_FLOXHUB_TOKEN
+  flox_init_pinned
+  run "$FLOX_BIN" -q install hello
+  assert_success
+  refute_output --partial "$RESOLVE_AUTH_WARNING"
+}
+
+# ---------------------------------------------------------------------------- #
+# No resolve, no warning
+# ---------------------------------------------------------------------------- #
+
+@test "'flox init' with nothing to resolve does NOT print the auth warning" {
+  unset FLOX_FLOXHUB_TOKEN
+  run "$FLOX_BIN" init
+  assert_success
+  refute_output --partial "$RESOLVE_AUTH_WARNING"
+}
+
+@test "'flox activate' with existing lockfile does NOT print the auth warning" {
+  # Lock the environment while logged in, then activate logged out: the
+  # lockfile means no resolve happens, so no warning — the case that must
+  # stay quiet for `flox activate` in shell rc files.
+  flox_init_pinned
+  "$FLOX_BIN" install hello
+  unset FLOX_FLOXHUB_TOKEN
+  run "$FLOX_BIN" activate -- true
+  assert_success
+  refute_output --partial "$RESOLVE_AUTH_WARNING"
+}
+
+# ---------------------------------------------------------------------------- #
+# Rate limiting
+# ---------------------------------------------------------------------------- #
+
+@test "a second resolve within the rate-limit window does NOT warn again" {
+  unset FLOX_FLOXHUB_TOKEN
+  flox_init_pinned
+  run "$FLOX_BIN" install hello
+  assert_output --partial "$RESOLVE_AUTH_WARNING"
+  # Force a fresh resolve by removing the lockfile.
+  rm .flox/env/manifest.lock
+  run "$FLOX_BIN" list
+  assert_success
+  refute_output --partial "$RESOLVE_AUTH_WARNING"
+}
+
+@test "a resolve after the rate-limit window expires warns again" {
+  unset FLOX_FLOXHUB_TOKEN
+  flox_init_pinned
+  "$FLOX_BIN" install hello
+  # Backdate the stamp beyond the 8 hour window.
+  echo '{"last_warning":"2020-01-01T00:00:00Z"}' > "$FLOX_CACHE_DIR/$STAMP_FILE_NAME"
+  rm .flox/env/manifest.lock
+  run "$FLOX_BIN" list
+  assert_success
+  assert_output --partial "$RESOLVE_AUTH_WARNING"
+}

--- a/cli/tests/catalog-auth-warnings.bats
+++ b/cli/tests/catalog-auth-warnings.bats
@@ -75,6 +75,28 @@ teardown() {
   refute_output --partial "$RESOLVE_AUTH_WARNING"
 }
 
+@test "'-q' does not consume the rate-limit window" {
+  unset FLOX_FLOXHUB_TOKEN
+  flox_init_pinned
+  run "$FLOX_BIN" -q install hello
+  refute_output --partial "$RESOLVE_AUTH_WARNING"
+  # The quiet invocation must not have written the stamp: the next
+  # interactive resolve still warns.
+  rm .flox/env/manifest.lock
+  run "$FLOX_BIN" list
+  assert_success
+  assert_output --partial "$RESOLVE_AUTH_WARNING"
+}
+
+@test "resolving with an expired token prints the auth warning" {
+  # Same shape as the suite token but with exp in the past (2001-09-09).
+  export FLOX_FLOXHUB_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3guZGV2L2hhbmRsZSI6InRlc3QiLCJleHAiOjEwMDAwMDAwMDB9.6-nbzFzQEjEX7dfWZFLE-I_qW2N_-9W2HFzzfsquI74"
+  flox_init_pinned
+  run "$FLOX_BIN" install hello
+  assert_success
+  assert_output --partial "$RESOLVE_AUTH_WARNING"
+}
+
 # ---------------------------------------------------------------------------- #
 # No resolve, no warning
 # ---------------------------------------------------------------------------- #


### PR DESCRIPTION
## Proposed Changes

Reworks Milestone 1 of catalog auth gating (DEV-199). The per-command
deprecation warnings (added in #4573 / #4594, removed in #4605) warned in
places that will never fail once auth gating is enforced — and stayed silent
in places that will. This PR moves the warning to the exact point the CLI
contacts the catalog `/resolve` endpoint, so users see the warning precisely
where they will later see the failure:

- A fully locked environment resolves nothing, so `flox activate` with a
  lockfile (including shell-rc auto-activation) and `flox init` with an empty
  manifest never warn.
- Any command that triggers a resolve — the first lock, an install, an
  upgrade — warns, regardless of which command it was, with no per-command
  wrapping to maintain.

Implementation:

- `FloxhubClient::resolve` fires a new `on_unauthenticated_resolve` hook when
  `AuthContext::is_unauthenticated()`. Kerberos and `flox_pat_` access tokens
  are excluded, so deployments that do not log in to FloxHub never warn.
- The CLI installs the hook: rate-limited to once per 8 hours via a timestamp
  file in the cache directory (same pattern as update notifications), emitted
  on stderr via `message::warning`, silenced by `-q` through the existing
  logger filter, and suppressed for the prompt-hook flow like other advisory
  messages.
- The hook call site is where the interactive "log in now?" prompt will live
  once gating is enforced server-side, and where the warning becomes an error
  for non-interactive invocations.

The warning text intentionally ships without a docs URL; the DEV-200
explainer link can be appended when the page exists.

Covered by unit tests (hook firing, rate-limit stamp handling) and a new
`catalog-auth-warnings.bats` (warns on resolve when logged out; quiet when
logged in, with `-q`, with a lockfile, and within the 8-hour window; warns
again after expiry).

## Release Notes

Unauthenticated users now see a warning when a command resolves packages
against the Flox Catalog, noting that resolution will require authentication
in an upcoming release. The warning appears at most once per 8 hours, is
suppressed by `-q`, and does not apply to Kerberos deployments or commands
that use an existing lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)