### PR TITLE
feat(run): DEV-182 optional `-p`, `--reselect`, and `run_preferences`…

### DIFF
--- a/cli/flox-config/src/config.rs
+++ b/cli/flox-config/src/config.rs
@@ -166,6 +166,17 @@ pub struct FloxConfig {
     #[serde(default)]
     pub auto_activate_environments: HashMap<PathBuf, AutoActivationPreference>,
 
+    /// Remembered package choices for `flox run`.
+    /// Maps a command name (`vi`) to the attr-path of the package the user
+    /// chose to provide it (`vim`, `python311Packages.pip`).
+    ///
+    /// Only selections made at the interactive disambiguation prompt are
+    /// stored. A command that resolves to exactly one package is never
+    /// recorded, so an absent entry means "nothing to remember", not
+    /// "not yet resolved".
+    #[serde(default)]
+    pub run_preferences: HashMap<String, String>,
+
     /// Don't setup the Flox prompt hook as part of activation.
     /// This disables auto-activation as well as features like `flox deactivate`
     /// without `--print-script` (default: false)

--- a/cli/flox/doc/flox-run.md
+++ b/cli/flox/doc/flox-run.md
@@ -14,6 +14,9 @@ flox-run - run a command from a Flox Catalog package
 flox [<general-options>] run
      -p <package>
      -- <command> [<arguments>]
+
+flox [<general-options>] run
+     --reselect <command>
 ```
 
 # DESCRIPTION
@@ -52,9 +55,9 @@ flox run -p curl -- curl http://example.com
 
 Without `--`, flags that look like options could be claimed by the
 wrong side of the boundary — for example, `flox run -p curl curl
--sL http://example.com` passes `-sL` to `curl`, but
-`flox run curl -p curl -- curl ...` would fail because `-p` is
-consumed by `curl`, leaving flox without a package.
+-sL http://example.com` passes `-sL` to `curl`, but in
+`flox run curl -p curl -- curl ...` the `-p` is consumed by `curl`,
+leaving flox without a package of its own.
 
 **`--version` caveat:**
 Flox intercepts `--version` from the full argument list before parsing.
@@ -99,6 +102,12 @@ Repeated invocations of the same package skip the download step.
     Accepts plain package names only (e.g. `curl`, `ripgrep`).
     Version constraints (`@`), output selectors (`^`), and custom
     catalogs (`/`) are not supported in this release.
+
+`--reselect <command>`
+:   Forget the saved package preference for `<command>` and exit without
+    running anything.
+    Cannot be combined with a command to run.
+    Clearing a command that has no saved preference is not an error.
 
 `-- <command> [<arguments>]`
 :   The command to run and any arguments to pass to it.

--- a/cli/flox/src/commands/general.rs
+++ b/cli/flox/src/commands/general.rs
@@ -174,6 +174,27 @@ pub(super) fn update_config_with_query<V: Serialize>(
     Ok(())
 }
 
+/// Like [`update_config_with_query`], but removes the key and reports whether
+/// there was anything to remove.
+///
+/// Absence is `Ok(false)`, not an error. [`Config::write_to`]'s removal branch
+/// raises `ReadWriteError::NotAUserValue` exactly when the key is missing —
+/// that is the only place in `flox-config` which constructs the variant — so
+/// mapping it to `false` cannot mask an unrelated failure. Genuine failures,
+/// including an unreadable or malformed config, still propagate.
+pub(super) fn remove_config_key_with_query(config_dir: &Path, query: &[Key]) -> Result<bool> {
+    let config_file_path = config_dir.join(FLOX_CONFIG_FILE);
+
+    match Config::write_to_in(config_file_path, query, None::<()>) {
+        Ok(()) => Ok(true),
+        Err(ReadWriteError::NotAUserValue(_)) => Ok(false),
+        Err(err @ ReadWriteError::ReadConfig(_)) => Err(err).context(
+            "Could not read current config file.\nPlease verify the format or reset using `flox config --reset`",
+        ),
+        Err(err) => Err(err.into()),
+    }
+}
+
 /// Parse a TOML key from a string, quoting any segments where necessary, so
 /// that a user doesn't need to understand the intricacies of TOML.
 fn parse_toml_key(key: &str) -> Result<Vec<Key>, TomlError> {

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -837,7 +837,7 @@ impl UseCommands {
         match self {
             UseCommands::Activate(args) => args.handle(config, flox).await,
             UseCommands::Deactivate(args) => args.handle(config, flox),
-            UseCommands::Run(args) => args.handle(flox).await,
+            UseCommands::Run(args) => args.handle(config, flox).await,
             UseCommands::Services(args) => args.handle(config, flox).await,
         }
     }

--- a/cli/flox/src/commands/run.rs
+++ b/cli/flox/src/commands/run.rs
@@ -23,6 +23,7 @@ use std::str::FromStr;
 
 use anyhow::Result;
 use bpaf::Bpaf;
+use flox_config::Config;
 use flox_manifest::raw::{CatalogPackage, RawManifestError};
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::providers::buildenv::{
@@ -43,9 +44,12 @@ use floxhub_client::{
 };
 use indoc::indoc;
 use thiserror::Error;
+use toml_edit::Key;
 use tracing::{debug, info_span};
 
+use crate::commands::general::{remove_config_key_with_query, update_config_with_query};
 use crate::subcommand_metric;
+use crate::utils::message;
 
 // ---------------------------------------------------------------------------
 // Error types
@@ -78,6 +82,24 @@ pub enum RunError {
     /// The value passed to `-p`/`--package` was not valid UTF-8.
     #[error("Package specs must be valid UTF-8.")]
     PackageSpecNotUtf8,
+
+    /// `--reselect` appeared without a value.
+    #[error(
+        "Missing value for '--reselect'.\n\
+         Use '--reselect <COMMAND>' to clear the saved package preference for a command."
+    )]
+    MissingReselectValue,
+
+    /// The value passed to `--reselect` was not valid UTF-8.
+    #[error("Command names must be valid UTF-8.")]
+    CommandNameNotUtf8,
+
+    /// `--reselect` was combined with a command to run.
+    #[error(
+        "'--reselect' cannot be combined with a command to run.\n\
+         Run 'flox run --reselect <COMMAND>' on its own to clear a saved package preference."
+    )]
+    ReselectWithCommand,
 
     /// `CatalogPackage::from_str` failed.
     #[error(
@@ -162,6 +184,9 @@ pub enum RunError {
 pub enum ParsedArgs {
     /// `-h`/`--help` was seen before the first positional or `--`.
     Help,
+    /// `--reselect <COMMAND>` was seen; clear that command's saved preference
+    /// and run nothing.
+    Reselect(String),
     /// A fully-specified run invocation.
     Run(RunArgs),
 }
@@ -169,8 +194,11 @@ pub enum ParsedArgs {
 /// Validated arguments produced by the POSIX state machine.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RunArgs {
-    /// Package spec from `-p`/`--package` (required, plain form only).
-    pub package: String,
+    /// Package spec from `-p`/`--package` (plain form only).
+    ///
+    /// `None` when no `-p` was given. Parsing accepts that; [`exec_run`]
+    /// rejects it, because it is the only consumer that needs a package.
+    pub package: Option<String>,
     /// Command name (first positional argument).
     pub executable: OsString,
     /// Remaining arguments forwarded verbatim to the command.
@@ -194,7 +222,7 @@ pub struct Run {
 impl Run {
     /// Entry point: parse args with POSIX stop-at-first-positional semantics,
     /// then resolve, download, and exec.
-    pub async fn handle(self, flox: Flox) -> Result<()> {
+    pub async fn handle(self, config: Config, flox: Flox) -> Result<()> {
         subcommand_metric!("run");
 
         // Re-read raw OS args. bpaf has already consumed the first `--`, so
@@ -216,9 +244,57 @@ impl Run {
                 print_help();
                 Ok(())
             },
+            ParsedArgs::Reselect(command) => {
+                subcommand_metric!("run::reselect");
+                let cleared = clear_run_preference(&config.flox.config_dir, &command)?;
+                if cleared {
+                    message::updated(format!(
+                        "Cleared the saved package preference for '{command}'."
+                    ));
+                } else {
+                    message::updated(format!("No saved package preference for '{command}'."));
+                }
+                Ok(())
+            },
             ParsedArgs::Run(run_args) => exec_run(run_args, &flox).await,
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// run_preferences config helpers
+// ---------------------------------------------------------------------------
+
+/// Build the `run_preferences.<command>` key path.
+///
+/// Both segments are `Key::new`, never `Key::parse`: a command name can
+/// contain `.`, and dotted-key parsing would shatter it into nested tables
+/// instead of writing one literal key. `flox-config`'s
+/// `writing_auto_activate_preference_for_path_with_dot` in `src/write.rs` is
+/// the regression test for the equivalent hazard on the auto-activation path.
+fn run_preference_query(command: &str) -> [Key; 2] {
+    [Key::new("run_preferences"), Key::new(command)]
+}
+
+/// Record the package the user chose to provide `command`.
+///
+/// Only the interactive disambiguation prompt calls this; see
+/// [`flox_config::FloxConfig::run_preferences`]. That prompt does not exist
+/// yet, so nothing but the tests calls this today — the writer ships with the
+/// config field so the two stay in step.
+#[allow(dead_code)]
+pub fn write_run_preference(config_dir: &Path, command: &str, attr_path: &str) -> Result<()> {
+    update_config_with_query(config_dir, &run_preference_query(command), Some(attr_path))?;
+    Ok(())
+}
+
+/// Forget the package the user chose to provide `command`.
+///
+/// Returns whether an entry was actually removed. Clearing an absent
+/// preference is a success, not an error: the caller asked to be prompted
+/// again next time, and that is already true.
+pub fn clear_run_preference(config_dir: &Path, command: &str) -> Result<bool> {
+    remove_config_key_with_query(config_dir, &run_preference_query(command))
 }
 
 // ---------------------------------------------------------------------------
@@ -233,14 +309,17 @@ impl Run {
 /// - `-p` / `--package` (space form only) → consume next arg as package spec
 /// - `-p=…` / `--package=…` / bundled forms → `UnknownFlag`
 /// - `--` → force positional mode; next arg is the command even if it starts with `-`
+/// - `--reselect` (space form only) → consume next arg as a command name
 /// - any other `"-…"` → `UnknownFlag`
 ///
 /// After the first positional (or after `--`), everything is forwarded
 /// verbatim including any literal `--`.
 ///
-/// After the loop: missing `-p` is reported before missing command.
+/// A missing `-p` is not an error here — [`RunArgs::package`] is optional and
+/// [`exec_run`] enforces it. Only a missing command is rejected.
 pub fn parse_run_args(args: Vec<OsString>) -> Result<ParsedArgs, RunError> {
     let mut package: Option<String> = None;
+    let mut reselect: Option<String> = None;
     let mut executable: Option<OsString> = None;
     let mut passthrough: Vec<OsString> = Vec::new();
 
@@ -274,6 +353,13 @@ pub fn parse_run_args(args: Vec<OsString>) -> Result<ParsedArgs, RunError> {
                     .map_err(|_| RunError::PackageSpecNotUtf8)?;
                 package = Some(value);
             },
+            Some("--reselect") => {
+                let value_os = iter.next().ok_or(RunError::MissingReselectValue)?;
+                let value = value_os
+                    .into_string()
+                    .map_err(|_| RunError::CommandNameNotUtf8)?;
+                reselect = Some(value);
+            },
             Some(s) if s.starts_with('-') => {
                 return Err(RunError::UnknownFlag(s.to_owned()));
             },
@@ -287,8 +373,15 @@ pub fn parse_run_args(args: Vec<OsString>) -> Result<ParsedArgs, RunError> {
         }
     }
 
-    // Report missing package before missing command.
-    let package = package.ok_or(RunError::MissingPackage)?;
+    // `--reselect` is a one-shot config edit, so it cannot also name a command
+    // to run.
+    if let Some(command) = reselect {
+        if executable.is_some() {
+            return Err(RunError::ReselectWithCommand);
+        }
+        return Ok(ParsedArgs::Reselect(command));
+    }
+
     let executable = executable.ok_or(RunError::NoExecutable)?;
 
     Ok(ParsedArgs::Run(RunArgs {
@@ -381,7 +474,7 @@ async fn download_custom_catalog_package(
 
 /// Resolve, download, and exec the requested command.
 async fn exec_run(run_args: RunArgs, flox: &Flox) -> Result<()> {
-    let pkg_spec = run_args.package.clone();
+    let pkg_spec = run_args.package.clone().ok_or(RunError::MissingPackage)?;
 
     // 1. Parse the package spec and reject unsupported syntax.
     let catalog_pkg = CatalogPackage::from_str(&pkg_spec)
@@ -854,9 +947,11 @@ pub fn print_help() {
         Run a command from a Flox Catalog package
 
         Usage: flox run -p <PACKAGE> -- <COMMAND> [ARGS...]
+               flox run --reselect <COMMAND>
 
         Options:
           -p, --package <PACKAGE>   Package that provides the command (required)
+              --reselect <COMMAND>  Forget the saved package preference for a command
           -h, --help                Print this help
 
         Always use '--' to separate flox flags from the command and its arguments.
@@ -871,7 +966,7 @@ pub fn print_help() {
 
         Limitations:
           Version constraints (@) and output selectors (^) are not supported.
-          The -p flag is always required.
+          The -p flag is always required to run a command.
 
         Caching:
           Downloaded store paths are registered as GC roots under
@@ -891,6 +986,8 @@ mod tests {
     use std::ffi::OsString;
     #[cfg(unix)]
     use std::os::unix::ffi::OsStringExt;
+
+    use flox_config::FLOX_CONFIG_FILE;
 
     use super::*;
 
@@ -913,7 +1010,7 @@ mod tests {
         assert_eq!(
             result,
             ParsedArgs::Run(RunArgs {
-                package: "binutils".to_string(),
+                package: Some("binutils".to_string()),
                 executable: os("readelf"),
                 args: os_vec(&["-a", "/bin/ls"]),
             })
@@ -926,7 +1023,7 @@ mod tests {
         assert_eq!(
             result,
             ParsedArgs::Run(RunArgs {
-                package: "binutils".to_string(),
+                package: Some("binutils".to_string()),
                 executable: os("readelf"),
                 args: vec![],
             })
@@ -939,7 +1036,7 @@ mod tests {
         assert_eq!(
             result,
             ParsedArgs::Run(RunArgs {
-                package: "somepkg".to_string(),
+                package: Some("somepkg".to_string()),
                 executable: os("-weirdname"),
                 args: vec![],
             })
@@ -953,7 +1050,7 @@ mod tests {
         assert_eq!(
             result,
             ParsedArgs::Run(RunArgs {
-                package: "x".to_string(),
+                package: Some("x".to_string()),
                 executable: os("cmd"),
                 args: os_vec(&["--", "-z"]),
             })
@@ -961,24 +1058,40 @@ mod tests {
     }
 
     #[test]
-    fn no_args_returns_missing_package_error() {
+    fn no_args_returns_no_executable_error() {
+        // Parsing no longer rejects a missing -p, so the command name is the
+        // only thing left to complain about.
         let result = parse_run_args(vec![]);
-        assert!(matches!(result, Err(RunError::MissingPackage)));
+        assert!(matches!(result, Err(RunError::NoExecutable)));
     }
 
     #[test]
-    fn no_package_flag_returns_missing_package() {
-        // A bare command with no -p/--package must report MissingPackage.
-        let result = parse_run_args(os_vec(&["curl", "http://example.com"]));
-        assert!(matches!(result, Err(RunError::MissingPackage)));
+    fn no_package_flag_parses_with_none_package() {
+        // A bare command with no -p/--package parses; exec_run rejects it.
+        let result = parse_run_args(os_vec(&["curl", "http://example.com"])).unwrap();
+        assert_eq!(
+            result,
+            ParsedArgs::Run(RunArgs {
+                package: None,
+                executable: os("curl"),
+                args: os_vec(&["http://example.com"]),
+            })
+        );
     }
 
     #[test]
     fn posix_order_dependence_curl_minus_p_curl() {
-        // After the first positional `curl`, -p belongs to curl (not flox).
-        // The absence of a flox -p flag should yield MissingPackage.
-        let result = parse_run_args(os_vec(&["curl", "-p", "curl"]));
-        assert!(matches!(result, Err(RunError::MissingPackage)));
+        // After the first positional `curl`, -p belongs to curl (not flox),
+        // so flox is left with no package of its own.
+        let result = parse_run_args(os_vec(&["curl", "-p", "curl"])).unwrap();
+        assert_eq!(
+            result,
+            ParsedArgs::Run(RunArgs {
+                package: None,
+                executable: os("curl"),
+                args: os_vec(&["-p", "curl"]),
+            })
+        );
     }
 
     #[test]
@@ -1031,7 +1144,7 @@ mod tests {
         assert_eq!(
             result,
             ParsedArgs::Run(RunArgs {
-                package: "curl".to_string(),
+                package: Some("curl".to_string()),
                 executable: os("curl"),
                 args: os_vec(&["--help"]),
             })
@@ -1045,7 +1158,7 @@ mod tests {
         assert_eq!(
             result,
             ParsedArgs::Run(RunArgs {
-                package: "hello".to_string(),
+                package: Some("hello".to_string()),
                 executable: os("hello"),
                 args: os_vec(&["--help"]),
             })
@@ -1064,6 +1177,54 @@ mod tests {
         assert!(matches!(result, Err(RunError::MissingPackageValue(_))));
     }
 
+    #[test]
+    fn reselect_parses_to_reselect() {
+        let result = parse_run_args(os_vec(&["--reselect", "vi"])).unwrap();
+        assert_eq!(result, ParsedArgs::Reselect("vi".to_string()));
+    }
+
+    #[test]
+    fn reselect_without_value_rejected() {
+        let result = parse_run_args(os_vec(&["--reselect"]));
+        assert!(matches!(result, Err(RunError::MissingReselectValue)));
+    }
+
+    #[test]
+    fn reselect_with_command_rejected() {
+        let result = parse_run_args(os_vec(&["--reselect", "vi", "vim"]));
+        assert!(matches!(result, Err(RunError::ReselectWithCommand)));
+    }
+
+    #[test]
+    fn reselect_equals_form_rejected() {
+        let result = parse_run_args(os_vec(&["--reselect=vi"]));
+        assert!(matches!(result, Err(RunError::UnknownFlag(_))));
+    }
+
+    #[test]
+    fn reselect_after_command_stays_in_passthrough() {
+        // `flox run vi --reselect foo` — after the first positional,
+        // `--reselect` belongs to the command, not to flox.
+        let result = parse_run_args(os_vec(&["-p", "vim", "vi", "--reselect", "foo"])).unwrap();
+        assert_eq!(
+            result,
+            ParsedArgs::Run(RunArgs {
+                package: Some("vim".to_string()),
+                executable: os("vi"),
+                args: os_vec(&["--reselect", "foo"]),
+            })
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn non_utf8_reselect_value() {
+        let bad = OsString::from_vec(vec![0xff]);
+        let args = vec![os("--reselect"), bad];
+        let result = parse_run_args(args);
+        assert!(matches!(result, Err(RunError::CommandNameNotUtf8)));
+    }
+
     #[cfg(unix)]
     #[test]
     fn non_utf8_package_value() {
@@ -1071,6 +1232,101 @@ mod tests {
         let args = vec![os("-p"), bad, os("cmd")];
         let result = parse_run_args(args);
         assert!(matches!(result, Err(RunError::PackageSpecNotUtf8)));
+    }
+
+    // -----------------------------------------------------------------------
+    // run_preferences config helper tests
+    // -----------------------------------------------------------------------
+
+    fn config_contents(config_dir: &Path) -> String {
+        std::fs::read_to_string(config_dir.join(FLOX_CONFIG_FILE)).unwrap()
+    }
+
+    /// Read back the `[run_preferences]` table.
+    ///
+    /// `FloxConfig` cannot be deserialized from the user config file alone —
+    /// it carries resolved fields like `cache_dir` that only the full config
+    /// assembly supplies — so assert against the TOML directly.
+    fn run_preferences_table(config_dir: &Path) -> toml::Table {
+        let document: toml::Table = toml::from_str(&config_contents(config_dir)).unwrap();
+        document
+            .get("run_preferences")
+            .and_then(|value| value.as_table())
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    #[test]
+    fn write_run_preference_writes_command_as_one_literal_key() {
+        let dir = tempfile::tempdir().unwrap();
+        // A dotted command name must land as a single quoted key rather than
+        // being shattered into `[run_preferences.my]` / `tool`.
+        write_run_preference(dir.path(), "my.tool", "python311Packages.pip").unwrap();
+
+        let contents = config_contents(dir.path());
+        assert!(
+            contents.contains(r#""my.tool" = "python311Packages.pip""#),
+            "expected one literal key, got:\n{contents}"
+        );
+    }
+
+    #[test]
+    fn write_run_preference_round_trips_dotted_attr_path() {
+        let dir = tempfile::tempdir().unwrap();
+        write_run_preference(dir.path(), "pip", "python311Packages.pip").unwrap();
+
+        let expected: toml::Table = toml::from_str(r#"pip = "python311Packages.pip""#).unwrap();
+        assert_eq!(run_preferences_table(dir.path()), expected);
+    }
+
+    #[test]
+    fn clear_run_preference_removes_existing_key() {
+        let dir = tempfile::tempdir().unwrap();
+        write_run_preference(dir.path(), "vi", "vim").unwrap();
+
+        assert!(clear_run_preference(dir.path(), "vi").unwrap());
+
+        // Clearing the last entry leaves an empty `[run_preferences]` table
+        // behind. `auto_activate_environments` behaves the same way; the
+        // contents are what matters.
+        assert_eq!(run_preferences_table(dir.path()), toml::Table::new());
+    }
+
+    #[test]
+    fn clear_run_preference_absent_key_in_existing_table_is_ok_false() {
+        let dir = tempfile::tempdir().unwrap();
+        // `[run_preferences]` exists but holds a different command, so the
+        // parent-segment walk in `write_to` succeeds and only the leaf is
+        // missing.
+        write_run_preference(dir.path(), "vi", "vim").unwrap();
+
+        assert!(!clear_run_preference(dir.path(), "emacs").unwrap());
+    }
+
+    #[test]
+    fn clear_run_preference_absent_table_is_ok_false() {
+        let dir = tempfile::tempdir().unwrap();
+        // No config file at all: `write_to` creates the `[run_preferences]`
+        // table on the way down, then fails to find the leaf. Nothing reaches
+        // disk on that path.
+        assert!(!clear_run_preference(dir.path(), "vi").unwrap());
+        assert!(!dir.path().join(FLOX_CONFIG_FILE).exists());
+    }
+
+    #[test]
+    fn remove_config_key_with_query_propagates_read_failures() {
+        let dir = tempfile::tempdir().unwrap();
+        // A directory where the config file belongs makes the read fail with
+        // something other than NotFound, which must not be flattened into
+        // `Ok(false)`.
+        std::fs::create_dir(dir.path().join(FLOX_CONFIG_FILE)).unwrap();
+
+        let err = clear_run_preference(dir.path(), "vi").unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("Could not read current config file"),
+            "unexpected error: {err}"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/cli/tests/run.bats
+++ b/cli/tests/run.bats
@@ -48,10 +48,10 @@ teardown() {
 # Required-flag errors (no network or store required)
 # ---------------------------------------------------------------------------- #
 
-@test "'flox run' with no args reports missing package" {
+@test "'flox run' with no args reports missing command" {
   run "$FLOX_BIN" run
   assert_failure
-  assert_output --partial "No package specified"
+  assert_output --partial "No command specified"
 }
 
 @test "'flox run <command>' without -p reports missing package" {
@@ -64,6 +64,59 @@ teardown() {
   run "$FLOX_BIN" run -p
   assert_failure
   assert_output --partial "Missing value"
+}
+
+# ---------------------------------------------------------------------------- #
+# --reselect (config state, no network or store required)
+# ---------------------------------------------------------------------------- #
+
+@test "'flox run --reselect' clears a saved preference" {
+  mkdir -p "$FLOX_CONFIG_DIR"
+  cat > "$FLOX_CONFIG_DIR/flox.toml" <<'EOF'
+[run_preferences]
+vi = "vim"
+EOF
+
+  run "$FLOX_BIN" run --reselect vi
+  assert_success
+  assert_output --partial "Cleared the saved package preference for 'vi'."
+
+  run cat "$FLOX_CONFIG_DIR/flox.toml"
+  refute_output --partial "vim"
+}
+
+@test "'flox run --reselect' on an absent preference succeeds" {
+  run "$FLOX_BIN" run --reselect vi
+  assert_success
+  assert_output --partial "No saved package preference for 'vi'."
+}
+
+@test "'flox run --reselect' leaves other preferences untouched" {
+  mkdir -p "$FLOX_CONFIG_DIR"
+  cat > "$FLOX_CONFIG_DIR/flox.toml" <<'EOF'
+[run_preferences]
+vi = "vim"
+pip = "python311Packages.pip"
+EOF
+
+  run "$FLOX_BIN" run --reselect vi
+  assert_success
+
+  run cat "$FLOX_CONFIG_DIR/flox.toml"
+  refute_output --partial "vim"
+  assert_output --partial 'pip = "python311Packages.pip"'
+}
+
+@test "'flox run --reselect' with a command is rejected" {
+  run "$FLOX_BIN" run --reselect vi vim
+  assert_failure
+  assert_output --partial "cannot be combined with a command"
+}
+
+@test "'flox run --reselect' without a value is rejected" {
+  run "$FLOX_BIN" run --reselect
+  assert_failure
+  assert_output --partial "Missing value for '--reselect'"
 }
 
 # ---------------------------------------------------------------------------- #


### PR DESCRIPTION
## Proposed Changes
Wires up the CLI argument surface and config store that the `flox run` command resolver ([DEV-184](https://linear.app/floxdotdev/issue/DEV-184)) will sit on top of, and ships one user-facing behavior along the way: `flox run --reselect <COMMAND>` forgets a remembered package choice.

[DEV-182](https://linear.app/floxdotdev/issue/DEV-182/flox-run-t5-cli-arg-surface-run-preferences-config)

**Argument surface.** `RunArgs.package` becomes `Option<String>`. `parse_run_args` no longer rejects a missing `-p`; that rejection moves to `exec_run`, its only consumer. This is what lets DEV-184 insert a resolver between parsing and execution without touching either side. A new `--reselect <COMMAND>` flag is parsed in the same hand-rolled POSIX state machine, before the first positional, so `flox run vi --reselect foo` still passes `--reselect foo` through to `vi`.

**Config store.** New `run_preferences: HashMap<String, String>` on `FloxConfig`, keyed by command name with the chosen attr-path as the value, marked `#[serde(default)]` so older configs load unchanged and older CLIs ignore the new key. `write_run_preference` and `clear_run_preference` in `run.rs` build the key path with `Key::new`, never `Key::parse`, so a command name containing a dot lands as a single literal TOML key instead of shattering into nested tables — the same hazard `writing_auto_activate_preference_for_path_with_dot` already pins for the auto-activation path.

**Config writes stay in one funnel.** New `remove_config_key_with_query` sits beside `update_config_with_query` in `general.rs` rather than having `run.rs` reach past it to `Config::write_to_in`.

**Dispatch.** `Run::handle` now receives `Config`, matching `Activate` and `Services` on the same dispatch block.

**One behavior changes.** `flox run` with no arguments now reports `No command specified` instead of `No package specified`. With `-p` no longer required at parse time, the missing command is the only thing left to report, and this is the correct end state once the resolver lands. Every other currently-valid invocation is unchanged — same result, same exit code, same message. `flox run <command>` without `-p` still reports `No package specified`, now raised from `exec_run`.

**This does not depend on DEV-181.** `grep -r by_command cli/` returns nothing on this branch. Nothing here calls the catalog client, makes a network request, or touches catalog code, so this can be reviewed and merged in parallel with #4624 rather than queued behind it. DEV-182's `blockedBy: DEV-181` relation in Linear was inherited from a blanket "every Subsystem 4 task needs `by_command` to compile" note in the design and does not apply to this ticket.

Notes for reviewers:
- **Clearing an absent preference is a success, not an error.** `--reselect` means "prompt me again next time", which is already true when nothing is stored. This needed building deliberately: `Config::write_to`'s removal branch raises `ReadWriteError::NotAUserValue` when the key is missing, so a naive implementation would fail on every `--reselect` until the disambiguation prompt starts writing preferences. `remove_config_key_with_query` maps that one variant to `Ok(false)`. That variant is constructed in exactly one place in all of `flox-config` — the removal branch — so the mapping cannot mask an unrelated failure, and read failures still propagate.
- **`write_run_preference` is currently unused outside tests** and carries `#[allow(dead_code)]`. Its only caller will be the interactive disambiguation prompt in DEV-185. It ships here so the writer and the config field it writes to land together.
- **Nothing in this PR writes a preference.** Until that prompt exists, `--reselect` clears entries that can only arrive by hand-editing `flox.toml`. The behavior is real and tested end to end; the user value arrives with the prompt.
- **Known wart, pre-existing.** Clearing the last entry leaves an empty `[run_preferences]` table in `flox.toml`. `auto_activate_environments` behaves identically today. Not addressed here.
- **Open question.** `flox run --reselect vi -p vim` silently drops the `-p`. The ticket specifies mutual exclusion with a *command* only, so that is what was built. Happy to fold `-p` into the same error if reviewers would rather it be rejected.

### Verification

Run inside `nix develop`:

```
$ cargo clippy --all --all-targets
    Finished `dev` profile [unoptimized + debuginfo] target(s)

$ just unit-tests
     Summary [77.727s] 1699 tests run: 1699 passed (4 slow), 4 skipped

$ just integ-tests run.bats
     24 tests, 0 failures
```

New coverage: 12 unit tests over `--reselect` parsing (value, missing value, combined with a command, `=` form rejected, passthrough after the first positional, non-UTF-8 value), the two `RunArgs` cases that now parse instead of erroring, dotted command names surviving as one literal key, dotted attr-paths round-tripping as values, clearing present and absent keys, and read failures propagating rather than being flattened to `Ok(false)`. Five new `run.bats` cases assert config file state before and after `--reselect`, including that other preferences are left untouched. One existing `run.bats` case was updated for the behavior change above.

## Release Notes
`flox run` now accepts `--reselect <COMMAND>`, which clears the remembered package choice for a command so a selection made by mistake can be corrected without hand-editing `flox.toml`.