### PR TITLE
feat(auth): discover the login issuer from the configured FloxHub

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -280,7 +280,6 @@ gen-unit-data-for-publish floxhub_repo_path force="": (reset-floxhub-db floxhub_
 
     # Grab configuration variables from the FloxHub repo's environment
     # (Only needed if you want to use Auth0 instead of the test users)
-    # export _FLOX_OAUTH_AUTH_URL="$(flox activate -d "{{ floxhub_repo_path }}" -- bash -c 'echo $_FLOX_OAUTH_AUTH_URL')"
     # export _FLOX_OAUTH_TOKEN_URL="$(flox activate -d "{{ floxhub_repo_path }}" -- bash -c 'echo $_FLOX_OAUTH_TOKEN_URL')"
     # export _FLOX_OAUTH_DEVICE_AUTH_URL="$(flox activate -d "{{ floxhub_repo_path }}" -- bash -c 'echo $_FLOX_OAUTH_DEVICE_AUTH_URL')"
     # export _FLOX_OAUTH_CLIENT_ID="$(flox activate -d "{{ floxhub_repo_path }}" -- bash -c 'echo $_FLOX_OAUTH_CLIENT_ID')"

--- a/cli/flox-rust-sdk/src/flox.rs
+++ b/cli/flox-rust-sdk/src/flox.rs
@@ -5,14 +5,7 @@ use std::sync::LazyLock;
 use flox_core::features::Features;
 use flox_core::floxhub::Floxhub;
 use flox_core::vars::FLOX_VERSION_STRING;
-pub use floxhub_client::{
-    AccessToken,
-    AuthContext,
-    AuthFailure,
-    FloxhubToken,
-    FloxhubTokenError,
-    UserIdentity,
-};
+pub use floxhub_client::{AccessToken, AuthContext, AuthFailure, FloxhubToken, UserIdentity};
 use floxhub_client::{FloxhubClient, FloxhubClientError, IdentityError};
 use url::Url;
 use uuid::Uuid;
@@ -96,9 +89,10 @@ impl Flox {
     }
 
     /// The identity behind the current credential — the one uniform way to
-    /// answer "who is authenticated": JWT claims for Auth0, `GET
-    /// /api/v1/accounts/me` for a personal access token (a successful
-    /// resolution is cached for the process), and the principal for
+    /// answer "who is authenticated": JWT claims for an Auth0-shaped token,
+    /// `GET /api/v1/accounts/me` for any credential that doesn't identify
+    /// its owner — a bare JWT or an opaque access token (a successful
+    /// resolution is cached for the process) — and the principal for
     /// Kerberos.
     ///
     /// - `Ok(Some(identity))` — authenticated. Expiry is reported *in* the
@@ -120,8 +114,22 @@ impl Flox {
                 expires_at: Some(token.expires_at()),
             })),
             AuthContext::Auth0(None) => Err(AuthFailure::NotLoggedIn),
+            // A bare token resolves from /me like an opaque access token.
+            // Its own exp claim wins over the server's expires_at — /me
+            // describes stored credentials like PATs, while a JWT carries
+            // its expiry with it.
+            AuthContext::Bare(token) => {
+                match self.floxhub_client.resolve_identity(token.secret()).await {
+                    Ok(identity) => Ok(Some(UserIdentity {
+                        expires_at: token.expires_at().or(identity.expires_at),
+                        ..identity
+                    })),
+                    Err(IdentityError::Unauthorized) => Err(AuthFailure::TokenExpired),
+                    Err(_) => Ok(None),
+                }
+            },
             AuthContext::AccessToken(token) => {
-                match self.floxhub_client.resolve_identity(token).await {
+                match self.floxhub_client.resolve_identity(token.secret()).await {
                     Ok(identity) => Ok(Some(identity)),
                     Err(IdentityError::Unauthorized) => Err(AuthFailure::TokenExpired),
                     Err(_) => Ok(None),
@@ -275,7 +283,7 @@ pub mod test_helpers {
             Url::from_directory_path(mock_floxhub_git_dir).unwrap()
         });
 
-        let auth_context = AuthContext::new_from_token(None).expect("no token to parse");
+        let auth_context = AuthContext::new_from_token(None);
 
         let flox = Flox {
             system: env!("NIX_TARGET_SYSTEM").to_string(),
@@ -308,21 +316,25 @@ pub mod test_helpers {
 
 #[cfg(test)]
 pub mod tests {
-    use floxhub_client::test_helpers::{FAKE_EXPIRED_TOKEN, FAKE_TOKEN};
+    use floxhub_client::test_helpers::{
+        FAKE_EXPIRED_TOKEN,
+        FAKE_TOKEN,
+        FAKE_TOKEN_NO_HANDLE,
+        test_bare_token,
+    };
 
     use super::test_helpers::flox_instance;
     use super::*;
 
     #[tokio::test]
     async fn test_get_username() {
-        let token = FloxhubToken::new(FAKE_TOKEN.to_string()).unwrap();
+        let token = FloxhubToken::new(FAKE_TOKEN.to_string()).expect("token parses");
         assert_eq!(token.handle(), "test");
     }
 
     #[tokio::test]
     async fn test_detect_expired() {
-        let token =
-            FloxhubToken::new(FAKE_EXPIRED_TOKEN.to_string()).expect("Expired token should parse");
+        let token = FloxhubToken::new(FAKE_EXPIRED_TOKEN.to_string()).expect("token parses");
         assert!(token.is_expired(), "Token should be marked as expired");
         assert_eq!(token.handle(), "test", "Handle should still be accessible");
         assert!(
@@ -366,5 +378,71 @@ pub mod tests {
         let identity = flox.get_identity().await.unwrap().unwrap();
         assert_eq!(identity.handle, "test");
         assert!(identity.is_expired(), "expiry is data, not an error");
+    }
+
+    /// A bare token (an issuer other than the Auth0 tenant) resolves its
+    /// identity from /me, with the token's own exp claim carried into the
+    /// identity over the server's null.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn get_identity_resolves_bare_token_via_me() {
+        let server = httpmock::MockServer::start();
+        server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path("/accounts/api/v1/accounts/me")
+                .header("authorization", format!("bearer {FAKE_TOKEN_NO_HANDLE}"));
+            then.status(200).json_body(serde_json::json!({
+                "user_id": "oidc|dexter",
+                "handle": "dexter",
+                "expires_at": null,
+            }));
+        });
+
+        let (mut flox, _temp_dir) = flox_instance();
+        flox.floxhub_client = FloxhubClient::new(
+            floxhub_client::client::test_helpers::client_config(&server.base_url()),
+        )
+        .unwrap();
+        let AuthContext::Bare(token) = AuthContext::new_from_token(Some(FAKE_TOKEN_NO_HANDLE))
+        else {
+            panic!("a claim-less JWT routes to Bare");
+        };
+        let expires_at = token.expires_at();
+        assert!(expires_at.is_some(), "test premise: the token carries exp");
+        let _ = flox.set_auth_context(AuthContext::Bare(token));
+
+        assert_eq!(
+            flox.get_identity().await.unwrap(),
+            Some(UserIdentity {
+                handle: "dexter".to_string(),
+                expires_at,
+            })
+        );
+    }
+
+    /// The server rejecting a claim-less token is affirmative: the login is
+    /// expired or revoked, not merely unverifiable.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn get_identity_maps_401_for_bare_token_to_token_expired() {
+        let server = httpmock::MockServer::start();
+        server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path("/accounts/api/v1/accounts/me");
+            then.status(401);
+        });
+
+        let (mut flox, _temp_dir) = flox_instance();
+        flox.floxhub_client = FloxhubClient::new(
+            floxhub_client::client::test_helpers::client_config(&server.base_url()),
+        )
+        .unwrap();
+        // A unique sub keeps the token's secret unique: the process-wide
+        // identity cache would otherwise satisfy the resolve after another
+        // test cached this token.
+        let _ = flox.set_auth_context(AuthContext::Bare(test_bare_token("identity-401-test")));
+
+        assert!(matches!(
+            flox.get_identity().await,
+            Err(AuthFailure::TokenExpired)
+        ));
     }
 }

--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -619,7 +619,7 @@ pub mod test_helpers {
             base_url: "https://not_used".to_string(),
             extra_headers: Default::default(),
             mock_mode: FloxhubMockMode::Replay(path.as_ref().to_path_buf()),
-            auth_context: AuthContext::new_from_token(None).expect("no token to parse"),
+            auth_context: AuthContext::new_from_token(None),
             user_agent: None,
             // Replays the mk_data-generated cassette store
             // (test_data/generated/resolve/*.yaml), recorded without a

--- a/cli/flox-rust-sdk/src/providers/git_auth.rs
+++ b/cli/flox-rust-sdk/src/providers/git_auth.rs
@@ -45,6 +45,20 @@ impl GitCommandOptionsExt for GitCommandOptions {
                     ),
                 );
             },
+            AuthContext::Bare(token) => {
+                if token.is_expired() {
+                    tracing::debug!("bare FloxHub token is expired, sending for identification");
+                } else {
+                    tracing::debug!("using bare FloxHub token");
+                }
+                self.add_env_var(FLOXHUB_TOKEN_ENV_VAR, token.secret());
+                self.add_config_flag(
+                    &format!("credential.{git_url}.helper"),
+                    format!(
+                        r#"!f(){{ echo "username=oauth"; echo "password=${FLOXHUB_TOKEN_ENV_VAR}"; }}; f"#
+                    ),
+                );
+            },
             AuthContext::AccessToken(token) => {
                 tracing::debug!("using FloxHub personal access token");
                 self.add_env_var(FLOXHUB_TOKEN_ENV_VAR, token.secret());

--- a/cli/flox-rust-sdk/src/providers/nix_auth.rs
+++ b/cli/flox-rust-sdk/src/providers/nix_auth.rs
@@ -93,7 +93,7 @@ impl NixAuth {
     /// Construct a new auth provider from a Flox instance
     pub fn from_flox(flox: &Flox) -> Result<Self, AuthError> {
         let netrc_tempdir = match &flox.auth_context {
-            AuthContext::Auth0(_) | AuthContext::AccessToken(_) => {
+            AuthContext::Auth0(_) | AuthContext::Bare(_) | AuthContext::AccessToken(_) => {
                 Some(tempdir_in(&flox.temp_dir).map_err(AuthError::CreateTempDir)?)
             },
             AuthContext::Kerberos(_) => None,
@@ -180,7 +180,7 @@ mod tests {
     use crate::flox::FloxhubToken;
 
     fn test_auth() -> NixAuth {
-        let token = FloxhubToken::new(FAKE_TOKEN.to_string()).unwrap();
+        let token = FloxhubToken::new(FAKE_TOKEN.to_string()).expect("token parses");
         NixAuth::from_tempdir_and_context(tempdir().unwrap(), AuthContext::Auth0(Some(token)))
     }
 

--- a/cli/flox/src/commands/auth.rs
+++ b/cli/flox/src/commands/auth.rs
@@ -7,7 +7,7 @@ use chrono::offset::Utc;
 use chrono::{DateTime, Duration};
 use flox_config::{Config, FLOX_CONFIG_FILE, TokenStorageMode};
 use flox_events::{EventKind, EventsHub};
-use flox_rust_sdk::flox::{FLOX_VERSION, Flox, FloxhubToken};
+use flox_rust_sdk::flox::{FLOX_VERSION, Flox};
 use floxhub_client::{AuthContext, AuthFailure};
 use indoc::{formatdoc, indoc};
 use oauth2::basic::{
@@ -413,7 +413,7 @@ impl Auth {
 ///
 /// * updates the config file with the received token
 /// * updates the floxhub_token field in the config struct
-// TODO: `flox auth login` is currently Auth0-specific. It should be abstracted
+// TODO: `flox auth login` is currently OAuth-specific. It should be abstracted
 // to handle different auth methods — for Kerberos, it should print a warning
 // that login is not needed (Kerberos authentication is handled externally via
 // `kinit`).
@@ -429,17 +429,28 @@ pub async fn login_flox(
         .context("Could not authorize via oauth")?;
 
     debug!("Credentials received: {cred:#?}");
-    debug!("Writing token to config");
 
-    // set the token in the runtime config
-    let token = FloxhubToken::new(cred.token)?;
-    let handle = token.handle().to_string();
+    // Route by what the issuer minted: an Auth0-shaped JWT answers its
+    // handle locally, a bare JWT or opaque token resolves it from /me. An
+    // unresolvable identity fails the login — it exists to produce a usable
+    // credential, and every handle consumer needs the same server.
+    let auth_context = AuthContext::new_from_token(Some(&cred.token));
+    let _ = flox.set_auth_context(auth_context.clone());
+    let handle = match flox.get_identity().await {
+        Ok(Some(identity)) => identity.handle,
+        Ok(None) => bail!(indoc! {"
+            Could not reach FloxHub to verify the login.
+            Try again."
+        }),
+        Err(_) => bail!(indoc! {"
+            FloxHub rejected the login token.
+            Try again."
+        }),
+    };
 
-    // The OAuth flow always yields an Auth0 JWT, parsed above — no token
-    // routing or identity resolution applies.
     complete_login(
         flox,
-        AuthContext::Auth0(Some(token)),
+        auth_context,
         handle,
         insecure_storage,
         once,
@@ -562,14 +573,16 @@ fn print_login_success(handle: &str) {
 /// Log in non-interactively with a token read from a file, or from stdin if
 /// the path is `-`.
 ///
-/// * validates the token and rejects expired (or, for a personal access
-///   token, revoked) tokens
+/// * validates the token and rejects expired (or, for a server-verified
+///   token, revoked and invalid) tokens
 /// * stores the token like an interactive login (OS keyring, plaintext
 ///   fallback, or forced plaintext via `--insecure-storage`)
 /// * updates the auth context of the [Flox] instance
 ///
-/// The token may be an Auth0 JWT or a `flox_pat_` personal access token;
-/// [AuthContext::new_from_token] routes by the token's form.
+/// [AuthContext::new_from_token] routes by what the credential's claims
+/// answer locally: Auth0-shaped JWTs identify themselves, bare JWTs and
+/// opaque tokens resolve their identity via `/me`. No token is rejected
+/// locally — validity is the server's call.
 pub async fn login_with_token_file(
     flox: &mut Flox,
     token_file: &Path,
@@ -590,8 +603,7 @@ pub async fn login_with_token_file(
 
     let secret = contents.trim();
 
-    let auth_context = AuthContext::new_from_token(Some(secret))
-        .context("The provided token is not a valid FloxHub token.")?;
+    let auth_context = AuthContext::new_from_token(Some(secret));
     let _ = flox.set_auth_context(auth_context.clone());
 
     // Validates locally for a JWT; via /me for a personal access token,
@@ -611,9 +623,11 @@ pub async fn login_with_token_file(
             Could not reach FloxHub to verify the token.
             Try again."
         }),
-        // The server rejected the token — expired and revoked alike.
+        // The server rejected the token — invalid, expired, and revoked
+        // alike; nothing distinguishes them locally now that any string
+        // parses as a credential.
         Err(_) => bail!(indoc! {"
-            The provided token is expired.
+            FloxHub rejected the provided token: it is invalid, expired, or revoked.
             Obtain a fresh token from FloxHub and try again."
         }),
     };
@@ -634,6 +648,7 @@ mod tests {
 
     use flox_config::FLOX_CONFIG_FILE;
     use flox_events::{EventsBuffer, EventsClient, SharedMetadataTemplate};
+    use flox_rust_sdk::flox::FloxhubToken;
     use flox_rust_sdk::flox::test_helpers::{create_test_token, flox_instance};
     use floxhub_client::test_helpers::{FAKE_EXPIRED_TOKEN, FAKE_TOKEN_WITH_SUB};
     use httpmock::MockServer;
@@ -743,7 +758,7 @@ mod tests {
             .expect("Auth0 login completes");
             complete_login(
                 &mut flox,
-                AuthContext::new_from_token(Some("flox_pat_secret")).expect("PAT parses"),
+                AuthContext::new_from_token(Some("flox_pat_secret")),
                 "pat-user".to_string(),
                 false,
                 false,
@@ -802,9 +817,20 @@ mod tests {
         assert!(!flox.config_dir.join(FLOX_CONFIG_FILE).exists());
     }
 
-    #[tokio::test]
-    async fn login_with_token_file_rejects_malformed_token() {
+    /// A non-JWT token can no longer be rejected locally — it may be an
+    /// issuer's opaque access token — so it is verified via /me like a PAT,
+    /// and the server's rejection fails the login.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn login_with_token_file_rejects_opaque_token_the_server_rejects() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path("/accounts/api/v1/accounts/me");
+            then.status(401);
+        });
+
         let (mut flox, _temp_dir) = flox_instance();
+        override_client(&mut flox, &server);
         let token_file = flox.temp_dir.join("token");
         fs::write(&token_file, "not-a-jwt").unwrap();
 
@@ -820,7 +846,7 @@ mod tests {
 
         assert_eq!(
             err.to_string(),
-            "The provided token is not a valid FloxHub token."
+            "FloxHub rejected the provided token: it is invalid, expired, or revoked.\nObtain a fresh token from FloxHub and try again."
         );
         assert!(!flox.config_dir.join(FLOX_CONFIG_FILE).exists());
     }
@@ -926,7 +952,7 @@ mod tests {
 
         assert_eq!(
             err.to_string(),
-            "The provided token is expired.\nObtain a fresh token from FloxHub and try again."
+            "FloxHub rejected the provided token: it is invalid, expired, or revoked.\nObtain a fresh token from FloxHub and try again."
         );
         assert!(!flox.config_dir.join(FLOX_CONFIG_FILE).exists());
     }

--- a/cli/flox/src/commands/auth.rs
+++ b/cli/flox/src/commands/auth.rs
@@ -8,7 +8,7 @@ use chrono::{DateTime, Duration};
 use flox_config::{Config, FLOX_CONFIG_FILE, TokenStorageMode};
 use flox_events::{EventKind, EventsHub};
 use flox_rust_sdk::flox::{FLOX_VERSION, Flox};
-use floxhub_client::{AuthContext, AuthFailure};
+use floxhub_client::{AuthContext, AuthFailure, DiscoveredLoginConfig, discover_login_config};
 use indoc::{formatdoc, indoc};
 use oauth2::basic::{
     BasicClient,
@@ -18,7 +18,6 @@ use oauth2::basic::{
     BasicTokenResponse,
 };
 use oauth2::{
-    AuthUrl,
     ClientId,
     DeviceAuthorizationUrl,
     DeviceCodeErrorResponseType,
@@ -46,11 +45,16 @@ use crate::{Exit, subcommand_metric};
 #[derive(Debug, Default, Clone, Serialize)]
 pub struct Credential {
     pub token: String,
-    pub expiry: String,
+    /// Wall-clock expiry derived from the token response's `expires_in`,
+    /// which RFC 6749 makes optional; the token's own `exp` claim and /me
+    /// are the authorities on expiry, so absence is not an error.
+    pub expiry: Option<String>,
 }
 
+// The device flow never touches the authorization endpoint, so the client
+// carries no auth URL.
 type ConfiguredClient<
-    HasAuthUrl = EndpointSet,
+    HasAuthUrl = EndpointNotSet,
     HasDeviceAuthUrl = EndpointSet,
     HasIntrospectionUrl = EndpointNotSet,
     HasRevocationUrl = EndpointNotSet,
@@ -68,54 +72,100 @@ type ConfiguredClient<
     HasTokenUrl,
 >;
 
-/// construct an oauth client using compile time constants or environment variables
-///
-/// Environment variables can be used to override the compile time constants during testing.
-/// For use in production, the compile time constants should be used.
-/// For multitenancy, we will integrate with the config subsystem later.
-fn create_oauth_client() -> Result<ConfiguredClient> {
-    let auth_url = AuthUrl::new(
-        std::env::var("_FLOX_OAUTH_AUTH_URL").unwrap_or(env!("OAUTH_AUTH_URL").to_string()),
-    )
-    .context("Invalid auth url")?;
-    let token_url = TokenUrl::new(
-        std::env::var("_FLOX_OAUTH_TOKEN_URL").unwrap_or(env!("OAUTH_TOKEN_URL").to_string()),
-    )
-    .context("Invalid token url")?;
-    let device_auth_url = DeviceAuthorizationUrl::new(
-        std::env::var("_FLOX_OAUTH_DEVICE_AUTH_URL")
-            .unwrap_or(env!("OAUTH_DEVICE_AUTH_URL").to_string()),
-    )
-    .context("Invalid device auth url")?;
-    let client_id = ClientId::new(
-        std::env::var("_FLOX_OAUTH_CLIENT_ID").unwrap_or(env!("OAUTH_CLIENT_ID").to_string()),
-    );
-    let client = BasicClient::new(client_id)
-        .set_auth_uri(auth_url)
-        .set_token_uri(token_url)
-        .set_device_authorization_url(device_auth_url);
-    Ok(client)
+/// Audience sent with the device-code request when the deployment serves no
+/// login configuration — the value the SaaS Auth0 tenant expects, matching
+/// the compiled-in endpoints used on that same path.
+const FALLBACK_AUDIENCE: &str = "https://hub.flox.dev/api";
+
+/// Where `flox auth login` runs the device grant: endpoints, client id, and
+/// the audience to send (none when the deployment's document omits it).
+#[derive(Debug, Clone, PartialEq)]
+struct LoginConfig {
+    device_auth_url: DeviceAuthorizationUrl,
+    token_url: TokenUrl,
+    client_id: ClientId,
+    audience: Option<String>,
 }
 
-pub async fn authorize(client: ConfiguredClient, floxhub_url: &Url) -> Result<Credential> {
-    if !Dialog::can_prompt() {
-        bail!("Cannot prompt for user input")
+impl LoginConfig {
+    fn oauth_client(&self) -> ConfiguredClient {
+        BasicClient::new(self.client_id.clone())
+            .set_token_uri(self.token_url.clone())
+            .set_device_authorization_url(self.device_auth_url.clone())
     }
+}
 
+/// Resolve each login value by precedence: an explicit `_FLOX_OAUTH_*`
+/// environment override, then the deployment's discovered document, then the
+/// compiled-in constants. Env vars on top preserves the debugging escape
+/// hatch, at the accepted cost that a stale override silently beats a
+/// correct advertisement.
+///
+/// The audience has no override variable: a discovered document decides it
+/// (absent member means send none — Dex has no audience concept), and only
+/// the no-document path sends the compiled-in Auth0 value.
+fn merge_login_config(discovered: Option<DiscoveredLoginConfig>) -> Result<LoginConfig> {
+    let (device_endpoint, token_endpoint, client_id, audience) = match discovered {
+        Some(discovered) => (
+            Some(discovered.device_authorization_endpoint.to_string()),
+            Some(discovered.token_endpoint.to_string()),
+            Some(discovered.client_id),
+            discovered.audience,
+        ),
+        None => (None, None, None, Some(FALLBACK_AUDIENCE.to_string())),
+    };
+
+    let device_auth_url = DeviceAuthorizationUrl::new(
+        std::env::var("_FLOX_OAUTH_DEVICE_AUTH_URL")
+            .ok()
+            .or(device_endpoint)
+            .unwrap_or_else(|| env!("OAUTH_DEVICE_AUTH_URL").to_string()),
+    )
+    .context("Invalid device auth url")?;
+    let token_url = TokenUrl::new(
+        std::env::var("_FLOX_OAUTH_TOKEN_URL")
+            .ok()
+            .or(token_endpoint)
+            .unwrap_or_else(|| env!("OAUTH_TOKEN_URL").to_string()),
+    )
+    .context("Invalid token url")?;
+    let client_id = ClientId::new(
+        std::env::var("_FLOX_OAUTH_CLIENT_ID")
+            .ok()
+            .or(client_id)
+            .unwrap_or_else(|| env!("OAUTH_CLIENT_ID").to_string()),
+    );
+
+    Ok(LoginConfig {
+        device_auth_url,
+        token_url,
+        client_id,
+        audience,
+    })
+}
+
+pub async fn authorize(
+    client: ConfiguredClient,
+    audience: Option<&str>,
+    floxhub_url: &Url,
+) -> Result<Credential> {
     let http_client = reqwest::ClientBuilder::new()
         .redirect(redirect::Policy::none())
         .user_agent(format!("flox-cli/{}", &*FLOX_VERSION))
         .build()
         .expect("Failed to build OAuth HTTP client");
 
-    let details: StandardDeviceAuthorizationResponse = client
+    let mut request = client
         .exchange_device_code()
         .add_scope(Scope::new("openid".to_string()))
         .add_scope(Scope::new("profile".to_string()))
-        .add_extra_param(
-            "audience".to_string(),
-            "https://hub.flox.dev/api".to_string(),
-        )
+        .add_scope(Scope::new("email".to_string()));
+    // An Auth0 extension parameter; a document without the member — or a
+    // Dex issuer — gets a bare RFC 8628 request.
+    if let Some(audience) = audience {
+        request = request.add_extra_param("audience".to_string(), audience.to_string());
+    }
+    let details: StandardDeviceAuthorizationResponse = request
         .request_async(&http_client)
         .await
         .context("Could not request device code")?;
@@ -219,7 +269,9 @@ pub async fn authorize(client: ConfiguredClient, floxhub_url: &Url) -> Result<Cr
 
     Ok(Credential {
         token: token.access_token().secret().to_string(),
-        expiry: calculate_expiry(token.expires_in().unwrap().as_secs() as i64),
+        expiry: token
+            .expires_in()
+            .map(|expires_in| calculate_expiry(expires_in.as_secs() as i64)),
     })
 }
 
@@ -423,10 +475,26 @@ pub async fn login_flox(
     once: bool,
     storage_pref: TokenStorageMode,
 ) -> Result<String> {
-    let client = create_oauth_client()?;
-    let cred = authorize(client, flox.floxhub.base_url())
+    // Checked before discovery so a non-interactive invocation fails fast
+    // instead of probing the network first.
+    if !Dialog::can_prompt() {
+        bail!("Cannot prompt for user input")
+    }
+
+    let floxhub_url = flox.floxhub.base_url();
+    let discovered = discover_login_config(floxhub_url)
         .await
-        .context("Could not authorize via oauth")?;
+        .with_context(|| format!("Could not discover the login configuration for {floxhub_url}"))?;
+    let login_config = merge_login_config(discovered)?;
+    debug!(?login_config, "resolved login configuration");
+
+    let cred = authorize(
+        login_config.oauth_client(),
+        login_config.audience.as_deref(),
+        floxhub_url,
+    )
+    .await
+    .context("Could not authorize via oauth")?;
 
     debug!("Credentials received: {cred:#?}");
 
@@ -698,6 +766,108 @@ mod tests {
             floxhub_client::client::test_helpers::client_config(&server.base_url()),
         )
         .unwrap();
+    }
+
+    const OAUTH_OVERRIDE_VARS: [&str; 3] = [
+        "_FLOX_OAUTH_DEVICE_AUTH_URL",
+        "_FLOX_OAUTH_TOKEN_URL",
+        "_FLOX_OAUTH_CLIENT_ID",
+    ];
+
+    /// Run `f` with every `_FLOX_OAUTH_*` override unset.
+    fn without_oauth_overrides<R>(f: impl FnOnce() -> R) -> R {
+        temp_env::with_vars(OAUTH_OVERRIDE_VARS.map(|var| (var, None::<&str>)), f)
+    }
+
+    fn discovered_dex_config() -> DiscoveredLoginConfig {
+        DiscoveredLoginConfig {
+            client_id: "floxhub-cli".to_string(),
+            audience: None,
+            device_authorization_endpoint: "https://floxhub.example/dex/device/code"
+                .parse()
+                .unwrap(),
+            token_endpoint: "https://floxhub.example/dex/token".parse().unwrap(),
+        }
+    }
+
+    #[test]
+    fn merge_login_config_falls_back_to_compiled_constants() {
+        without_oauth_overrides(|| {
+            let config = merge_login_config(None).unwrap();
+            assert_eq!(config, LoginConfig {
+                device_auth_url: DeviceAuthorizationUrl::new(
+                    env!("OAUTH_DEVICE_AUTH_URL").to_string()
+                )
+                .unwrap(),
+                token_url: TokenUrl::new(env!("OAUTH_TOKEN_URL").to_string()).unwrap(),
+                client_id: ClientId::new(env!("OAUTH_CLIENT_ID").to_string()),
+                audience: Some(FALLBACK_AUDIENCE.to_string()),
+            });
+        });
+    }
+
+    /// A discovered document supplies every value, and its missing audience
+    /// member means "send none" — not the compiled-in Auth0 audience.
+    #[test]
+    fn merge_login_config_prefers_the_discovered_document() {
+        without_oauth_overrides(|| {
+            let config = merge_login_config(Some(discovered_dex_config())).unwrap();
+            assert_eq!(config, LoginConfig {
+                device_auth_url: DeviceAuthorizationUrl::new(
+                    "https://floxhub.example/dex/device/code".to_string()
+                )
+                .unwrap(),
+                token_url: TokenUrl::new("https://floxhub.example/dex/token".to_string()).unwrap(),
+                client_id: ClientId::new("floxhub-cli".to_string()),
+                audience: None,
+            });
+        });
+    }
+
+    #[test]
+    fn merge_login_config_carries_the_document_audience() {
+        without_oauth_overrides(|| {
+            let discovered = DiscoveredLoginConfig {
+                audience: Some("https://hub.preview.example/api".to_string()),
+                ..discovered_dex_config()
+            };
+            let config = merge_login_config(Some(discovered)).unwrap();
+            assert_eq!(
+                config.audience,
+                Some("https://hub.preview.example/api".to_string())
+            );
+        });
+    }
+
+    #[test]
+    fn merge_login_config_prefers_env_overrides_over_the_document() {
+        temp_env::with_vars(
+            [
+                (
+                    "_FLOX_OAUTH_DEVICE_AUTH_URL",
+                    Some("https://override.example/device"),
+                ),
+                (
+                    "_FLOX_OAUTH_TOKEN_URL",
+                    Some("https://override.example/token"),
+                ),
+                ("_FLOX_OAUTH_CLIENT_ID", Some("override-client")),
+            ],
+            || {
+                let config = merge_login_config(Some(discovered_dex_config())).unwrap();
+                assert_eq!(config, LoginConfig {
+                    device_auth_url: DeviceAuthorizationUrl::new(
+                        "https://override.example/device".to_string()
+                    )
+                    .unwrap(),
+                    token_url: TokenUrl::new("https://override.example/token".to_string()).unwrap(),
+                    client_id: ClientId::new("override-client".to_string()),
+                    // The audience has no override variable; the document
+                    // still decides it.
+                    audience: None,
+                });
+            },
+        );
     }
 
     /// A token-file login persists through the credential stores like an

--- a/cli/flox/src/commands/auth.rs
+++ b/cli/flox/src/commands/auth.rs
@@ -449,12 +449,15 @@ impl Auth {
                 let span = tracing::info_span!("token");
                 let _guard = span.enter();
 
-                let AuthContext::Auth0(Some(token)) = flox.auth_context else {
+                // Any bearer credential prints — Auth0-shaped, bare, or
+                // opaque alike. Kerberos carries no token, so it reports
+                // as not logged in here.
+                let Some(secret) = flox.auth_context.token_secret() else {
                     message::warning("You are not currently logged in to FloxHub.");
                     return Err(Exit(1).into());
                 };
 
-                println!("{}", token.secret());
+                println!("{secret}");
                 Ok(())
             },
         }

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -44,7 +44,7 @@ use flox_core::vars::FLOX_DISABLE_METRICS_VAR;
 use flox_events::{EventKind, EventsHub};
 use flox_manifest::interfaces::AsLatestSchema;
 use flox_manifest::{Manifest, TypedOnly};
-use flox_rust_sdk::flox::{AuthContext, FLOX_VERSION, Flox, FloxhubTokenError};
+use flox_rust_sdk::flox::{AuthContext, FLOX_VERSION, Flox};
 use flox_rust_sdk::models::env_registry;
 use flox_rust_sdk::models::env_registry::{ENV_REGISTRY_FILENAME, EnvRegistry};
 use flox_rust_sdk::models::environment::generations::GenerationId;
@@ -390,7 +390,7 @@ impl FloxArgs {
             }
         }
 
-        let credential = self.resolve_auth_context(&config, &stores);
+        let credential = self.resolve_auth_context(&config);
 
         if let Some(events_client) = build_events_client(
             &config,
@@ -587,26 +587,27 @@ impl FloxArgs {
         )
     }
 
-    /// Parse and validate the configured `floxhub_token`, building the
-    /// [AuthContext] and emitting any user-facing warnings as a side effect.
+    /// Build the [AuthContext] from the configured `floxhub_token`, emitting
+    /// any user-facing warnings as a side effect.
     ///
-    /// A user who is not logged in — no token, or a parsed token that has
-    /// expired — is reminded to run 'flox auth login'. The reminder is
+    /// A user who is not logged in — no token, or a token whose `exp` claim
+    /// has passed — is reminded to run 'flox auth login'. The reminder is
     /// suppressed for `flox auth` subcommands, the prompt-hook flow,
     /// invocations nested inside an activation, and when the
     /// `auth_notifications` config key is set to `false`.
     ///
     /// The token is not consumed when the configured authn mode does not use
-    /// it (e.g. Kerberos) — construction cannot fail there, so warning about
-    /// the token's state — or rewriting the user's config — never happens.
+    /// it (e.g. Kerberos), so warning about the token's state never happens
+    /// there.
     ///
     /// For `flox hook-env` the token state is reported by the next
     /// user-invoked command instead; see [Self::is_prompt_hook_flow].
     ///
-    /// A `flox_pat_` token is opaque: it is never parsed, never wiped as
-    /// invalid, and its expiry is unknown until it is lazily resolved via
-    /// /me — so it counts as logged in and no startup warning applies to it.
-    fn resolve_auth_context(&self, config: &Config, stores: &CredentialStores) -> AuthContext {
+    /// No token can be rejected locally: a `flox_pat_` token is opaque by
+    /// design, and any other string may be an issuer's opaque access token,
+    /// so both count as logged in until the server says otherwise. Expiry is
+    /// only known locally for a token carrying the `exp` claim.
+    fn resolve_auth_context(&self, config: &Config) -> AuthContext {
         // Kerberos does not use FloxHub tokens; the stored token is not
         // consumed (and none of the token warnings below apply).
         if let Some(flox_config::AuthnMode::Kerberos) = config.flox.floxhub_authn_mode {
@@ -619,58 +620,39 @@ impl FloxArgs {
             .as_deref()
             .filter(|s| !s.is_empty());
 
-        match AuthContext::new_from_token(raw) {
-            Err(FloxhubTokenError::InvalidToken(token_error)) => {
-                // The prompt hook must neither print nor rewrite the user's
-                // config; the next user-invoked command surfaces and removes
-                // the invalid token.
-                if self.is_prompt_hook_flow() {
-                    return AuthContext::Auth0(None);
-                }
-                message::error(formatdoc! {"
-                    Your FloxHub token is invalid: {token_error}
-                    You may need to log in again.
-                "});
-                // Clear the invalid token only from the store that supplied it
-                // (probed here). An invalid `FLOX_FLOXHUB_TOKEN` or system-config
-                // token must not delete the user's saved keyring/plaintext
-                // credential.
-                let source = stores.probe_source(config);
-                stores.clear_invalid(source);
-                AuthContext::Auth0(None)
-            },
-            Ok(auth_context) => {
-                let logged_out = match &auth_context {
-                    AuthContext::Auth0(None) => true,
-                    AuthContext::Auth0(Some(token)) => token.is_expired(),
-                    _ => false,
-                };
-                if logged_out {
-                    // Every `flox auth` subcommand either logs the user in
-                    // (`login`) or already reports the logged-out state itself
-                    // (`status`, `logout`, `token`), so the reminder would be
-                    // redundant there.
-                    let is_auth_command =
-                        matches!(self.command, Some(Commands::Admin(AdminCommands::Auth(_))));
-                    // The logged-out state is account-global, so the reminder only
-                    // needs to appear once per shell session. The outermost activation
-                    // surfaces it; any `flox` invocation already running inside an
-                    // activation — a nested `flox activate`, or a command in an
-                    // activated shell whose rc re-activates an environment — stays
-                    // quiet. Activations export `_FLOX_ACTIVE_ENVIRONMENTS` into the
-                    // shell, including in-place `eval "$(flox activate)"` ones, so
-                    // it is a reliable signal even across the parent shell.
-                    let nested = activated_environments().last_active().is_some();
-                    let quieted = !config.flox.auth_notifications.unwrap_or(true);
-                    if !is_auth_command && !self.is_prompt_hook_flow() && !nested && !quieted {
-                        message::warning(
-                            "You are not logged in to FloxHub. Run 'flox auth login' to log in.",
-                        );
-                    }
-                }
-                auth_context
-            },
+        let auth_context = AuthContext::new_from_token(raw);
+        let logged_out = match &auth_context {
+            AuthContext::Auth0(None) => true,
+            AuthContext::Auth0(Some(token)) => token.is_expired(),
+            // A bare token's expiry is known locally only when it carries
+            // the exp claim; an opaque token's never is (like a PAT's).
+            AuthContext::Bare(token) => token.is_expired(),
+            _ => false,
+        };
+        if logged_out {
+            // Every `flox auth` subcommand either logs the user in
+            // (`login`) or already reports the logged-out state itself
+            // (`status`, `logout`, `token`), so the reminder would be
+            // redundant there.
+            let is_auth_command =
+                matches!(self.command, Some(Commands::Admin(AdminCommands::Auth(_))));
+            // The logged-out state is account-global, so the reminder only
+            // needs to appear once per shell session. The outermost activation
+            // surfaces it; any `flox` invocation already running inside an
+            // activation — a nested `flox activate`, or a command in an
+            // activated shell whose rc re-activates an environment — stays
+            // quiet. Activations export `_FLOX_ACTIVE_ENVIRONMENTS` into the
+            // shell, including in-place `eval "$(flox activate)"` ones, so
+            // it is a reliable signal even across the parent shell.
+            let nested = activated_environments().last_active().is_some();
+            let quieted = !config.flox.auth_notifications.unwrap_or(true);
+            if !is_auth_command && !self.is_prompt_hook_flow() && !nested && !quieted {
+                message::warning(
+                    "You are not logged in to FloxHub. Run 'flox auth login' to log in.",
+                );
+            }
         }
+        auth_context
     }
 }
 

--- a/cli/flox/src/utils/credential_store/mod.rs
+++ b/cli/flox/src/utils/credential_store/mod.rs
@@ -242,8 +242,8 @@ impl CredentialStores {
     /// already did). A non-empty merged token that differs from the keyring
     /// entry is not being read from the keyring at all — it came from
     /// `/etc/flox.toml` — and must report `SystemConfig` even when the keyring
-    /// also holds an unrelated entry, so an invalid system token never routes
-    /// [Self::clear_invalid] to the user's saved keyring credential.
+    /// also holds an unrelated entry, so messaging about a system-supplied
+    /// token never points at the user's saved keyring credential.
     pub fn probe_source(&self, config: &Config) -> CredentialSource {
         let env_token = std::env::var(FLOXHUB_TOKEN_ENV_VAR).ok();
         if env_token.is_some_and(|t| !t.is_empty()) {
@@ -420,40 +420,6 @@ impl CredentialStores {
         }
 
         ResolveOutcome::Unchanged
-    }
-
-    /// Remove an invalid FloxHub credential from the store that actually
-    /// supplied it, identified by `source`.
-    ///
-    /// The startup resolver discovers an invalid token only after it has been
-    /// merged into the config, so the bad token may come from any source. Only
-    /// clear a store we own and that actually provided the token:
-    /// - [CredentialSource::Keyring] → clear the keyring.
-    /// - [CredentialSource::UserConfigPlaintext] → clear the plaintext file.
-    /// - [CredentialSource::Env] / [CredentialSource::SystemConfig] /
-    ///   [CredentialSource::None] → clear nothing. The invalid value came from
-    ///   `FLOX_FLOXHUB_TOKEN` or `/etc/flox.toml` (or nowhere), so deleting a
-    ///   valid saved keyring/plaintext credential would force a needless re-login
-    ///   once the env/system value is corrected.
-    ///
-    /// Removals are idempotent, so this is safe regardless of provenance.
-    pub fn clear_invalid(&self, source: CredentialSource) {
-        match source {
-            CredentialSource::Keyring => {
-                if let Err(e) = self.keyring.remove() {
-                    tracing::debug!(error = %e, "could not remove invalid token from the keyring");
-                }
-            },
-            CredentialSource::UserConfigPlaintext => {
-                if let Err(e) = self.plaintext.remove() {
-                    tracing::debug!(error = %e, "could not remove invalid token from the plaintext file");
-                }
-            },
-            // The invalid value came from `FLOX_FLOXHUB_TOKEN`, `/etc/flox.toml`,
-            // or nowhere — none of which we own. Leave any saved credential
-            // intact.
-            CredentialSource::Env | CredentialSource::SystemConfig | CredentialSource::None => {},
-        }
     }
 
     /// Remove the token from both stores, for logout.
@@ -688,7 +654,7 @@ mod tests {
 
     /// `/etc/flox.toml` supplies the merged token while the keyring holds a
     /// *different* credential: the probe must report `SystemConfig`, not
-    /// `Keyring`, so an invalid system token never routes `clear_invalid` to
+    /// `Keyring`, so messaging about a system-supplied token never points at
     /// the user's unrelated saved keyring credential.
     #[test]
     fn probe_reports_system_config_when_keyring_holds_different_token() {
@@ -705,11 +671,6 @@ mod tests {
 
             let source = stores.probe_source(&config);
             assert_eq!(source, CredentialSource::SystemConfig);
-
-            // The invalid-token cleanup routed by this source must preserve
-            // the keyring credential.
-            stores.clear_invalid(source);
-            assert_eq!(keyring.get().unwrap(), Some("keyring-token".to_string()));
         });
     }
 
@@ -1004,61 +965,6 @@ mod tests {
             assert_eq!(keyring.get().unwrap(), Some(TOKEN.to_string()));
             assert_eq!(plaintext.get().unwrap(), Some(TOKEN.to_string()));
         });
-    }
-
-    // --- CredentialStores::clear_invalid: invalid-token cleanup routing ---
-
-    /// A keyring-sourced invalid token is cleared from the keyring only; a
-    /// plaintext credential that did not supply it is left intact.
-    #[test]
-    fn clear_invalid_credential_removes_only_keyring_for_keyring_source() {
-        let keyring = CredentialStoreImpl::Mock(MockStore::new());
-        keyring.set(TOKEN).unwrap();
-        let dir = tempfile::tempdir().unwrap();
-        write_flox_toml(dir.path(), "floxhub_token = \"other-token\"\n");
-        let plaintext = CredentialStoreImpl::Plaintext(PlaintextStore::new(dir.path()));
-        let stores = CredentialStores::from_stores(keyring.clone(), plaintext.clone());
-
-        stores.clear_invalid(CredentialSource::Keyring);
-
-        assert_eq!(keyring.get().unwrap(), None);
-        assert_eq!(plaintext.get().unwrap(), Some("other-token".to_string()));
-    }
-
-    /// A plaintext-file-sourced invalid token is cleared from the file only; a
-    /// keyring credential that did not supply it is left intact.
-    #[test]
-    fn clear_invalid_credential_removes_only_plaintext_for_user_file_source() {
-        let keyring = CredentialStoreImpl::Mock(MockStore::new());
-        keyring.set("other-token").unwrap();
-        let dir = tempfile::tempdir().unwrap();
-        write_flox_toml(dir.path(), &format!("floxhub_token = \"{TOKEN}\"\n"));
-        let plaintext = CredentialStoreImpl::Plaintext(PlaintextStore::new(dir.path()));
-        let stores = CredentialStores::from_stores(keyring.clone(), plaintext.clone());
-
-        stores.clear_invalid(CredentialSource::UserConfigPlaintext);
-
-        assert_eq!(plaintext.get().unwrap(), None);
-        assert_eq!(keyring.get().unwrap(), Some("other-token".to_string()));
-    }
-
-    /// An invalid token from `FLOX_FLOXHUB_TOKEN` (or system config) must not
-    /// delete the user's saved keyring/plaintext credential — those did not
-    /// supply the bad token, and clearing them would force a needless re-login
-    /// once the env/system value is corrected.
-    #[test]
-    fn clear_invalid_credential_preserves_saved_stores_for_env_source() {
-        let keyring = CredentialStoreImpl::Mock(MockStore::new());
-        keyring.set(TOKEN).unwrap();
-        let dir = tempfile::tempdir().unwrap();
-        write_flox_toml(dir.path(), &format!("floxhub_token = \"{TOKEN}\"\n"));
-        let plaintext = CredentialStoreImpl::Plaintext(PlaintextStore::new(dir.path()));
-        let stores = CredentialStores::from_stores(keyring.clone(), plaintext.clone());
-
-        stores.clear_invalid(CredentialSource::Env);
-
-        assert_eq!(keyring.get().unwrap(), Some(TOKEN.to_string()));
-        assert_eq!(plaintext.get().unwrap(), Some(TOKEN.to_string()));
     }
 
     // --- CredentialStores::remove_all: logout removal ---

--- a/cli/floxhub-client/src/auth/auth_context.rs
+++ b/cli/floxhub-client/src/auth/auth_context.rs
@@ -1,9 +1,10 @@
 //! [`AuthContext`] — the credential threaded through the CLI.
 //!
 //! [`AuthContext`] is the central authentication type threaded through the CLI.
-//! It captures both the *kind* of authentication in use (Auth0 / PAT /
-//! Kerberos) and the authentication material available for that kind (which
-//! may be absent — e.g. no token yet, or no Kerberos ticket).
+//! It captures both the *kind* of credential in use — decided by what the
+//! credential answers locally: Auth0-shaped JWT, bare JWT, opaque token, or
+//! Kerberos — and the material available for that kind (which may be
+//! absent — e.g. no token yet, or no Kerberos ticket).
 //!
 //! Transport layers (HTTP catalog client, git credential helper) inspect the
 //! variant to decide how to authenticate requests. "No material" is an
@@ -13,7 +14,7 @@
 use url::Url;
 
 use crate::auth::kerberos::KerberosMaterial;
-use crate::auth::token::{ACCESS_TOKEN_PREFIX, AccessToken, FloxhubToken, FloxhubTokenError};
+use crate::auth::token::{ACCESS_TOKEN_PREFIX, AccessToken, BareToken, FloxhubToken};
 
 /// Describes why authentication failed.
 ///
@@ -42,12 +43,18 @@ pub struct AuthHeaderError(pub String);
 /// Each variant corresponds to a kind of authentication and wraps an
 /// `Option` of the material for that kind:
 ///
-/// - `Auth0(Some(token))` — logged in via Auth0, token may or may not be
-///   expired (checked lazily).
-/// - `Auth0(None)` — Auth0 mode but no token yet (not logged in).
-/// - `AccessToken(token)` — opaque access token (`flox_…`, e.g. a
-///   `flox_pat_` personal access token); identity is resolved at the point
-///   of use and cached process-wide.
+/// - `Auth0(Some(token))` — an Auth0-shaped JWT, identity answered from
+///   its claims; the token may or may not be expired (checked lazily).
+/// - `Auth0(None)` — interactive-login mode but no token yet (not logged
+///   in).
+/// - `Bare(token)` — a decodable JWT without the handle claim (an issuer
+///   other than the Auth0 tenant, e.g. a deployment's Dex); `exp` and
+///   `sub` read from the claims, identity resolved at the point of use
+///   and cached process-wide.
+/// - `AccessToken(token)` — not decodable at all: a `flox_`-prefixed
+///   token (e.g. a `flox_pat_` personal access token) or any opaque
+///   string an issuer mints; identity is resolved at the point of use
+///   and cached process-wide.
 /// - `Kerberos(Some(material))` — Kerberos mode with a resolved principal
 ///   and SPNEGO token generator.
 /// - `Kerberos(None)` — Kerberos mode but no ticket available (`kinit`
@@ -60,11 +67,18 @@ pub struct AuthHeaderError(pub String);
 /// no-op (kerberized git authenticates via the ccache directly).
 #[derive(Clone)]
 pub enum AuthContext {
-    /// Auth0 authentication — may or may not have a token.
+    /// Auth0-shaped JWT — identity answered locally from its claims.
+    /// May or may not have a token; the settled server-side direction is
+    /// that identity comes from accounts, so this is the shape being
+    /// retired as issuers stop emitting the handle claim.
     Auth0(Option<FloxhubToken>),
-    /// Opaque access token (`flox_…`) — identity is resolved lazily and
-    /// cached process-wide. No `Option`: "Auth0 mode with no token" remains
-    /// `Auth0(None)`.
+    /// Decodable JWT without the handle claim — identity resolved lazily
+    /// via /me and cached process-wide. No `Option`: "logged-in mode with
+    /// no token" remains `Auth0(None)`.
+    Bare(BareToken),
+    /// Opaque token (`flox_`-prefixed, or any string that doesn't decode
+    /// as a JWT) — identity is resolved lazily and cached process-wide.
+    /// No `Option`, as for `Bare`.
     AccessToken(AccessToken),
     /// Kerberos authentication — may or may not have a ticket/principal.
     Kerberos(Option<KerberosMaterial>),
@@ -72,13 +86,14 @@ pub enum AuthContext {
 
 impl AuthContext {
     /// Return the user's handle, when it is known locally: JWT claims, a
-    /// Kerberos principal, or an opaque token whose identity was already
-    /// resolved and cached. Never blocks and never touches the network —
-    /// for the resolved answer use `Flox::get_identity`.
+    /// Kerberos principal, or a token whose identity was already resolved
+    /// and cached. Never blocks and never touches the network — for the
+    /// resolved answer use `Flox::get_identity`.
     pub fn handle(&self) -> Option<String> {
         match self {
             AuthContext::Auth0(Some(token)) => Some(token.handle().to_string()),
             AuthContext::Auth0(None) => None,
+            AuthContext::Bare(token) => token.handle(),
             AuthContext::AccessToken(token) => token.handle(),
             AuthContext::Kerberos(Some(material)) => Some(material.principal.clone()),
             AuthContext::Kerberos(None) => None,
@@ -99,6 +114,7 @@ impl AuthContext {
         match self {
             AuthContext::Auth0(Some(token)) => token.sub(),
             AuthContext::Auth0(None) => None,
+            AuthContext::Bare(token) => token.sub(),
             // An opaque token carries no locally readable subject.
             AuthContext::AccessToken(_) => None,
             AuthContext::Kerberos(_) => None,
@@ -108,7 +124,7 @@ impl AuthContext {
     /// Produce the value for an HTTP Authorization header targeting the given URL.
     pub fn authorization_header(&self, url: &Url) -> Option<Result<String, AuthHeaderError>> {
         match self {
-            AuthContext::Auth0(_) | AuthContext::AccessToken(_) => self
+            AuthContext::Auth0(_) | AuthContext::Bare(_) | AuthContext::AccessToken(_) => self
                 .token_secret()
                 .map(|secret| Ok(format!("bearer {secret}"))),
             AuthContext::Kerberos(Some(material)) => {
@@ -125,25 +141,38 @@ impl AuthContext {
         match self {
             AuthContext::Auth0(Some(token)) => Some(token.secret()),
             AuthContext::Auth0(None) => None,
+            AuthContext::Bare(token) => Some(token.secret()),
             AuthContext::AccessToken(token) => Some(token.secret()),
             AuthContext::Kerberos(_) => None,
         }
     }
 
-    /// Create an [`AuthContext`] from a stored token, routing by the
-    /// token's form:
+    /// Create an [`AuthContext`] from a stored token, routing by what the
+    /// credential's claims answer locally:
     ///
-    /// - `flox_`-prefixed token: [`AuthContext::AccessToken`] — the token
-    ///   stays opaque; its identity is resolved at the point of use.
-    /// - Any other token: must decode as a JWT → [`AuthContext::Auth0`].
+    /// - `flox_`-prefixed token: [`AuthContext::AccessToken`] — opaque by
+    ///   fiat, never decoded.
+    /// - Auth0-shaped JWT (handle claim and expiry): [`AuthContext::Auth0`].
+    /// - Any other decodable JWT: [`AuthContext::Bare`].
+    /// - Anything else: [`AuthContext::AccessToken`] — an issuer may mint
+    ///   opaque access tokens.
     /// - No token: `Auth0(None)` (not logged in).
-    pub fn new_from_token(token: Option<&str>) -> Result<Self, FloxhubTokenError> {
-        match token {
-            Some(token) if token.starts_with(ACCESS_TOKEN_PREFIX) => Ok(AuthContext::AccessToken(
-                AccessToken::new(token.to_string()),
-            )),
-            Some(token) => Ok(AuthContext::Auth0(Some(token.parse()?))),
-            None => Ok(AuthContext::Auth0(None)),
+    ///
+    /// Routing is total: no local check can reject a token, and the
+    /// server's 401 is the authority on validity.
+    pub fn new_from_token(token: Option<&str>) -> Self {
+        let Some(token) = token else {
+            return AuthContext::Auth0(None);
+        };
+        if token.starts_with(ACCESS_TOKEN_PREFIX) {
+            return AuthContext::AccessToken(AccessToken::new(token.to_string()));
+        }
+        match FloxhubToken::new(token.to_string()) {
+            Ok(parsed) => AuthContext::Auth0(Some(parsed)),
+            Err(_) => match BareToken::new(token.to_string()) {
+                Ok(parsed) => AuthContext::Bare(parsed),
+                Err(_) => AuthContext::AccessToken(AccessToken::new(token.to_string())),
+            },
         }
     }
 
@@ -151,14 +180,17 @@ impl AuthContext {
     /// future catalog-auth-gated call would fail.
     ///
     /// `Auth0(None)` (not logged in) and `Auth0(Some(expired))` both count —
-    /// neither carries a credential that will pass once gating is enforced.
-    /// `Kerberos(..)` does not require a FloxHub login, and `AccessToken` is
-    /// opaque (validity unknown until resolved via /me), so neither is
+    /// neither carries a credential that will pass once gating is enforced —
+    /// and a bare token counts exactly when its exp claim has passed.
+    /// `Kerberos(..)` does not require a FloxHub login, `AccessToken` is
+    /// opaque (validity unknown until resolved via /me), and a bare token
+    /// without the exp claim is equally unknowable, so none of those are
     /// treated as unauthenticated here.
     pub fn is_unauthenticated(&self) -> bool {
         match self {
             AuthContext::Auth0(None) => true,
             AuthContext::Auth0(Some(token)) => token.is_expired(),
+            AuthContext::Bare(token) => token.is_expired(),
             AuthContext::AccessToken(_) | AuthContext::Kerberos(_) => false,
         }
     }
@@ -176,6 +208,7 @@ impl std::fmt::Debug for AuthContext {
         match self {
             AuthContext::Auth0(Some(_)) => f.debug_tuple("Auth0").field(&"<token>").finish(),
             AuthContext::Auth0(None) => f.write_str("Auth0(None)"),
+            AuthContext::Bare(token) => f.debug_tuple("Bare").field(&token).finish(),
             AuthContext::AccessToken(token) => f.debug_tuple("AccessToken").field(&token).finish(),
             AuthContext::Kerberos(Some(material)) => f
                 .debug_struct("Kerberos")
@@ -196,7 +229,9 @@ mod tests {
     use crate::auth::token::test_helpers::{
         FAKE_EXPIRED_TOKEN_WITH_SUB,
         FAKE_TOKEN,
+        FAKE_TOKEN_NO_HANDLE,
         FAKE_TOKEN_WITH_SUB,
+        test_bare_token,
     };
 
     #[test]
@@ -288,7 +323,7 @@ mod tests {
         // Any flox_-prefixed token is an opaque access token: personal
         // access tokens today, service account tokens to come.
         for secret in ["flox_pat_abc123", "flox_sat_abc123"] {
-            let auth = AuthContext::new_from_token(Some(secret)).unwrap();
+            let auth = AuthContext::new_from_token(Some(secret));
             let AuthContext::AccessToken(token) = auth else {
                 panic!("expected AccessToken, got {auth:?}");
             };
@@ -298,7 +333,7 @@ mod tests {
 
     #[test]
     fn new_from_token_routes_jwt_to_auth0() {
-        let auth = AuthContext::new_from_token(Some(FAKE_TOKEN)).unwrap();
+        let auth = AuthContext::new_from_token(Some(FAKE_TOKEN));
         let AuthContext::Auth0(Some(token)) = auth else {
             panic!("expected Auth0, got {auth:?}");
         };
@@ -307,12 +342,44 @@ mod tests {
 
     #[test]
     fn new_from_token_without_token_is_not_logged_in() {
-        let auth = AuthContext::new_from_token(None).unwrap();
+        let auth = AuthContext::new_from_token(None);
         assert!(matches!(auth, AuthContext::Auth0(None)));
     }
 
     #[test]
-    fn new_from_token_rejects_garbage() {
-        AuthContext::new_from_token(Some("not-a-token")).unwrap_err();
+    fn new_from_token_routes_claimless_jwt_to_bare() {
+        let auth = AuthContext::new_from_token(Some(FAKE_TOKEN_NO_HANDLE));
+        let AuthContext::Bare(token) = auth else {
+            panic!("expected Bare, got {auth:?}");
+        };
+        assert_eq!(token.secret(), FAKE_TOKEN_NO_HANDLE);
+    }
+
+    #[test]
+    fn new_from_token_carries_a_non_jwt_opaquely() {
+        // No local check can reject a token — an issuer may mint opaque
+        // access tokens, so a non-decodable string is a credential whose
+        // validity only the server can judge.
+        let auth = AuthContext::new_from_token(Some("not-a-jwt"));
+        let AuthContext::AccessToken(token) = auth else {
+            panic!("expected AccessToken, got {auth:?}");
+        };
+        assert_eq!(token.secret(), "not-a-jwt");
+    }
+
+    #[test]
+    fn bare_token_subject_and_cached_handle() {
+        // A bare token contributes its sub for telemetry, and its handle
+        // comes from the /me-filled cache, like an opaque token's.
+        let token = test_bare_token("context-bare-handle-test");
+        let auth = AuthContext::Bare(token.clone());
+        assert_eq!(auth.user_subject(), Some("context-bare-handle-test"));
+        assert_eq!(auth.handle(), None);
+
+        crate::auth::identity::cache_identity(token.secret(), &test_identity("dexter"));
+        assert_eq!(
+            AuthContext::Bare(token).handle(),
+            Some("dexter".to_string())
+        );
     }
 }

--- a/cli/floxhub-client/src/auth/discovery.rs
+++ b/cli/floxhub-client/src/auth/discovery.rs
@@ -1,0 +1,592 @@
+//! Per-deployment login discovery.
+//!
+//! A FloxHub deployment advertises where the CLI should log in: an
+//! unauthenticated RFC 9728 protected-resource metadata document at
+//! `{floxhub_url}/.well-known/oauth-protected-resource` names the
+//! deployment's OIDC issuer (`authorization_servers`, exactly one entry),
+//! the CLI's public client id (`client_id`, an extension member), and
+//! optionally the `audience` value to send with the device-code request
+//! (an Auth0 extension; absent on Dex deployments). The issuer's own
+//! OIDC discovery then supplies the device-authorization and token
+//! endpoints. FloxHub is not in the token path: after discovery the CLI
+//! speaks standard OIDC directly to the issuer.
+//!
+//! Deployments without the document — today's SaaS until it is deployed
+//! there, and forks that never serve it — answer the probe with a 404 or
+//! with the web UI's `index.html`, which [`discover_login_config`]
+//! reports as [`None`] so the caller can fall back to its compiled-in
+//! login configuration.
+
+use std::time::Duration;
+
+use serde::Deserialize;
+use thiserror::Error;
+use tracing::debug;
+use url::Url;
+
+/// RFC 8628 grant type identifier for the device authorization grant.
+const DEVICE_CODE_GRANT: &str = "urn:ietf:params:oauth:grant-type:device_code";
+
+/// Bound on each discovery request. Login is interactive, so a hung probe
+/// must fail rather than hang the prompt.
+const DISCOVERY_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// The login configuration a deployment advertises, fully resolved:
+/// members of the protected-resource document plus the endpoints from the
+/// issuer's OIDC discovery.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DiscoveredLoginConfig {
+    /// The CLI's public client id at this deployment's issuer.
+    pub client_id: String,
+    /// Auth0 `audience` parameter for the device-code request; sent
+    /// exactly when advertised.
+    pub audience: Option<String>,
+    pub device_authorization_endpoint: Url,
+    pub token_endpoint: Url,
+}
+
+/// Why discovery failed. Absence of the document is not a failure — see
+/// [`discover_login_config`] — so every variant means the deployment
+/// advertised a login configuration that could not be used.
+#[derive(Debug, Error)]
+pub enum LoginDiscoveryError {
+    #[error("could not fetch the login configuration from {url}")]
+    ProbeConnection {
+        url: Url,
+        #[source]
+        source: reqwest::Error,
+    },
+    #[error(
+        "the login configuration advertises {count} authorization servers; expected exactly one"
+    )]
+    NotExactlyOneAuthorizationServer { count: usize },
+    #[error("the login configuration does not name a client id")]
+    MissingClientId,
+    #[error("could not fetch OIDC discovery from {url}")]
+    OidcDiscovery {
+        url: String,
+        #[source]
+        source: reqwest::Error,
+    },
+    #[error(
+        "the OIDC issuer reports itself as '{reported}' but the login configuration advertises '{advertised}'"
+    )]
+    IssuerMismatch {
+        advertised: String,
+        reported: String,
+    },
+    #[error("the OIDC issuer '{issuer}' does not advertise the device authorization grant")]
+    DeviceGrantNotSupported { issuer: String },
+    #[error("the OIDC issuer '{issuer}' does not advertise a token endpoint")]
+    MissingTokenEndpoint { issuer: String },
+}
+
+/// The members of the protected-resource document the CLI consumes.
+/// `authorization_servers` doubles as the presence test: a 2xx body that
+/// deserializes with it present is the document, anything else is
+/// absence.
+#[derive(Debug, Deserialize)]
+struct ProtectedResourceMetadata {
+    authorization_servers: Vec<String>,
+    client_id: Option<String>,
+    audience: Option<String>,
+}
+
+/// The members of the issuer's OIDC discovery document the CLI consumes.
+#[derive(Debug, Deserialize)]
+struct OidcProviderMetadata {
+    issuer: String,
+    token_endpoint: Option<Url>,
+    device_authorization_endpoint: Option<Url>,
+    grant_types_supported: Option<Vec<String>>,
+}
+
+/// Discover where to log in against the deployment at `floxhub_url`.
+///
+/// Returns `Ok(None)` when the deployment does not advertise a login
+/// configuration: the probe answered with anything other than a 2xx
+/// protected-resource document (404, the web UI's SPA fallback, an error
+/// page). Only a connection-level failure of the probe is an error — a
+/// login against an unreachable FloxHub cannot complete anyway, because
+/// the handle resolves from the same server.
+///
+/// A present document that cannot be used — no client id, more than one
+/// authorization server, an issuer whose OIDC discovery fails or that
+/// does not offer the device grant — is an error rather than absence:
+/// falling back to the compiled-in configuration would silently log the
+/// user in against the wrong deployment's issuer.
+pub async fn discover_login_config(
+    floxhub_url: &Url,
+) -> Result<Option<DiscoveredLoginConfig>, LoginDiscoveryError> {
+    let client = reqwest::Client::builder()
+        .timeout(DISCOVERY_TIMEOUT)
+        .build()
+        .expect("failed to build discovery HTTP client");
+
+    let probe_url = append_path_segments(floxhub_url, &[".well-known", "oauth-protected-resource"]);
+    let response = client.get(probe_url.clone()).send().await.map_err(|err| {
+        LoginDiscoveryError::ProbeConnection {
+            url: probe_url.clone(),
+            source: err,
+        }
+    })?;
+
+    if !response.status().is_success() {
+        debug!(url = %probe_url, status = %response.status(), "no login configuration served");
+        return Ok(None);
+    }
+    let Ok(document) = response.json::<ProtectedResourceMetadata>().await else {
+        debug!(url = %probe_url, "response is not a login configuration document");
+        return Ok(None);
+    };
+    debug!(url = %probe_url, ?document, "fetched login configuration");
+
+    let [issuer] = document.authorization_servers.as_slice() else {
+        return Err(LoginDiscoveryError::NotExactlyOneAuthorizationServer {
+            count: document.authorization_servers.len(),
+        });
+    };
+    let client_id = document
+        .client_id
+        .ok_or(LoginDiscoveryError::MissingClientId)?;
+
+    // Append-form only (RFC 8414 path-insertion does not exist on a
+    // path-bearing issuer like Dex's `https://<host>/dex`).
+    let oidc_url = format!(
+        "{}/.well-known/openid-configuration",
+        issuer.trim_end_matches('/')
+    );
+    let oidc = async {
+        client
+            .get(&oidc_url)
+            .send()
+            .await?
+            .error_for_status()?
+            .json::<OidcProviderMetadata>()
+            .await
+    }
+    .await
+    .map_err(|err| LoginDiscoveryError::OidcDiscovery {
+        url: oidc_url.clone(),
+        source: err,
+    })?;
+    debug!(url = %oidc_url, ?oidc, "fetched OIDC provider metadata");
+
+    // The issuer must vouch for itself, modulo the trailing slash: Auth0
+    // self-reports with one, and the advertisement may carry either form.
+    if oidc.issuer.trim_end_matches('/') != issuer.trim_end_matches('/') {
+        return Err(LoginDiscoveryError::IssuerMismatch {
+            advertised: issuer.clone(),
+            reported: oidc.issuer,
+        });
+    }
+
+    // The endpoint's presence advertises the grant; grant_types_supported
+    // is only a veto because RFC 8414 makes the member optional (Auth0
+    // omits it while supporting the grant).
+    let device_grant_listed = oidc
+        .grant_types_supported
+        .is_none_or(|grants| grants.iter().any(|grant| grant == DEVICE_CODE_GRANT));
+    let device_authorization_endpoint = match oidc.device_authorization_endpoint {
+        Some(endpoint) if device_grant_listed => endpoint,
+        _ => {
+            return Err(LoginDiscoveryError::DeviceGrantNotSupported {
+                issuer: issuer.clone(),
+            });
+        },
+    };
+    let token_endpoint =
+        oidc.token_endpoint
+            .ok_or_else(|| LoginDiscoveryError::MissingTokenEndpoint {
+                issuer: issuer.clone(),
+            })?;
+
+    Ok(Some(DiscoveredLoginConfig {
+        client_id,
+        audience: document.audience,
+        device_authorization_endpoint,
+        token_endpoint,
+    }))
+}
+
+/// Append `segments` to `base`'s path, preserving any existing path prefix
+/// (`https://host/floxhub` + `.well-known/x` → `https://host/floxhub/.well-known/x`).
+/// `Url::join` would instead replace the last segment.
+fn append_path_segments(base: &Url, segments: &[&str]) -> Url {
+    let mut url = base.clone();
+    url.path_segments_mut()
+        .expect("FloxHub URLs are http(s) and can be a base")
+        .pop_if_empty()
+        .extend(segments);
+    url
+}
+
+#[cfg(test)]
+mod tests {
+    use httpmock::MockServer;
+    use serde_json::json;
+
+    use super::*;
+
+    const PROBE_PATH: &str = "/.well-known/oauth-protected-resource";
+
+    /// Serve a document at `probe_path` advertising `issuer`, and the
+    /// issuer's OIDC discovery under the issuer's own path.
+    fn mock_deployment(
+        server: &MockServer,
+        document: serde_json::Value,
+        issuer_path: &str,
+        oidc_overrides: serde_json::Value,
+    ) {
+        server.mock(|when, then| {
+            when.method(httpmock::Method::GET).path(PROBE_PATH);
+            then.status(200).json_body(document);
+        });
+        let issuer = server.url(issuer_path);
+        let mut oidc = json!({
+            "issuer": issuer,
+            "token_endpoint": format!("{issuer}/token"),
+            "device_authorization_endpoint": format!("{issuer}/device/code"),
+        });
+        oidc.as_object_mut()
+            .unwrap()
+            .extend(oidc_overrides.as_object().unwrap().clone());
+        server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path(format!("{issuer_path}/.well-known/openid-configuration"));
+            then.status(200).json_body(oidc);
+        });
+    }
+
+    fn base_url(server: &MockServer) -> Url {
+        Url::parse(&server.base_url()).unwrap()
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn absent_on_404() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(httpmock::Method::GET).path(PROBE_PATH);
+            then.status(404);
+        });
+
+        let result = discover_login_config(&base_url(&server)).await.unwrap();
+        assert_eq!(result, None);
+    }
+
+    /// Deployments without the document fall through to the web UI, which
+    /// answers 200 with the SPA's index.html.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn absent_on_spa_fallback_html() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(httpmock::Method::GET).path(PROBE_PATH);
+            then.status(200)
+                .header("content-type", "text/html")
+                .body("<!doctype html><html><body>FloxHub</body></html>");
+        });
+
+        let result = discover_login_config(&base_url(&server)).await.unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn absent_on_json_that_is_not_the_document() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(httpmock::Method::GET).path(PROBE_PATH);
+            then.status(200).json_body(json!({"detail": "who dis"}));
+        });
+
+        let result = discover_login_config(&base_url(&server)).await.unwrap();
+        assert_eq!(result, None);
+    }
+
+    /// A non-2xx answer is absence even when the body looks like the
+    /// document: only a successful response advertises a configuration.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn absent_on_error_status_with_document_body() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(httpmock::Method::GET).path(PROBE_PATH);
+            then.status(500).json_body(json!({
+                "authorization_servers": ["https://issuer.example"],
+                "client_id": "cli",
+            }));
+        });
+
+        let result = discover_login_config(&base_url(&server)).await.unwrap();
+        assert_eq!(result, None);
+    }
+
+    /// A connection failure is an error, not absence: nothing was learned
+    /// about the deployment, and a login against an unreachable FloxHub
+    /// cannot complete anyway.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn errors_when_floxhub_is_unreachable() {
+        // Bind to learn a free port, then drop the listener so nothing
+        // answers on it.
+        let port = {
+            let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            listener.local_addr().unwrap().port()
+        };
+        let url = Url::parse(&format!("http://127.0.0.1:{port}")).unwrap();
+
+        let err = discover_login_config(&url).await.unwrap_err();
+        assert!(matches!(err, LoginDiscoveryError::ProbeConnection { .. }));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn errors_on_multiple_authorization_servers() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(httpmock::Method::GET).path(PROBE_PATH);
+            then.status(200).json_body(json!({
+                "authorization_servers": ["https://a.example", "https://b.example"],
+                "client_id": "cli",
+            }));
+        });
+
+        let err = discover_login_config(&base_url(&server)).await.unwrap_err();
+        assert!(matches!(
+            err,
+            LoginDiscoveryError::NotExactlyOneAuthorizationServer { count: 2 }
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn errors_on_empty_authorization_servers() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(httpmock::Method::GET).path(PROBE_PATH);
+            then.status(200).json_body(json!({
+                "authorization_servers": [],
+                "client_id": "cli",
+            }));
+        });
+
+        let err = discover_login_config(&base_url(&server)).await.unwrap_err();
+        assert!(matches!(
+            err,
+            LoginDiscoveryError::NotExactlyOneAuthorizationServer { count: 0 }
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn errors_on_missing_client_id() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(httpmock::Method::GET).path(PROBE_PATH);
+            then.status(200).json_body(json!({
+                "authorization_servers": ["https://issuer.example"],
+            }));
+        });
+
+        let err = discover_login_config(&base_url(&server)).await.unwrap_err();
+        assert!(matches!(err, LoginDiscoveryError::MissingClientId));
+    }
+
+    /// The Auth0-shaped happy path: root issuer self-reporting with a
+    /// trailing slash, audience advertised.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn discovers_auth0_shaped_deployment() {
+        let server = MockServer::start();
+        let issuer_with_slash = format!("{}/", server.base_url());
+        server.mock(|when, then| {
+            when.method(httpmock::Method::GET).path(PROBE_PATH);
+            then.status(200).json_body(json!({
+                "resource": "https://api.flox.example",
+                "authorization_servers": [issuer_with_slash],
+                "scopes_supported": ["openid", "profile", "email"],
+                "client_id": "auth0-cli-client",
+                "audience": "https://hub.flox.example/api",
+            }));
+        });
+        let issuer = server.base_url();
+        server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path("/.well-known/openid-configuration");
+            then.status(200).json_body(json!({
+                "issuer": format!("{issuer}/"),
+                "token_endpoint": format!("{issuer}/oauth/token"),
+                "device_authorization_endpoint": format!("{issuer}/oauth/device/code"),
+            }));
+        });
+
+        let config = discover_login_config(&base_url(&server))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(config, DiscoveredLoginConfig {
+            client_id: "auth0-cli-client".to_string(),
+            audience: Some("https://hub.flox.example/api".to_string()),
+            device_authorization_endpoint: Url::parse(&format!("{issuer}/oauth/device/code"))
+                .unwrap(),
+            token_endpoint: Url::parse(&format!("{issuer}/oauth/token")).unwrap(),
+        });
+    }
+
+    /// The Dex-shaped happy path: a path-bearing issuer (append-form
+    /// discovery URL), no audience, device grant listed explicitly.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn discovers_dex_shaped_deployment() {
+        let server = MockServer::start();
+        let issuer = server.url("/dex");
+        mock_deployment(
+            &server,
+            json!({
+                "resource": server.base_url(),
+                "authorization_servers": [issuer],
+                "client_id": "floxhub-cli",
+            }),
+            "/dex",
+            json!({
+                "grant_types_supported": ["authorization_code", DEVICE_CODE_GRANT],
+            }),
+        );
+
+        let config = discover_login_config(&base_url(&server))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(config, DiscoveredLoginConfig {
+            client_id: "floxhub-cli".to_string(),
+            audience: None,
+            device_authorization_endpoint: Url::parse(&format!("{issuer}/device/code")).unwrap(),
+            token_endpoint: Url::parse(&format!("{issuer}/token")).unwrap(),
+        });
+    }
+
+    /// The probe preserves a path prefix on the FloxHub URL, as an on-prem
+    /// deployment served under one may carry.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn probes_under_a_path_prefixed_floxhub_url() {
+        let server = MockServer::start();
+        let issuer = server.url("/dex");
+        server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path("/floxhub/.well-known/oauth-protected-resource");
+            then.status(200).json_body(json!({
+                "authorization_servers": [issuer],
+                "client_id": "floxhub-cli",
+            }));
+        });
+        server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path("/dex/.well-known/openid-configuration");
+            then.status(200).json_body(json!({
+                "issuer": issuer,
+                "token_endpoint": format!("{issuer}/token"),
+                "device_authorization_endpoint": format!("{issuer}/device/code"),
+            }));
+        });
+
+        let floxhub_url = Url::parse(&server.url("/floxhub")).unwrap();
+        let config = discover_login_config(&floxhub_url).await.unwrap().unwrap();
+        assert_eq!(config.client_id, "floxhub-cli");
+    }
+
+    /// Advertised without a trailing slash, self-reported with one (and
+    /// vice versa): both normalize to the same issuer.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn issuer_check_normalizes_the_trailing_slash() {
+        let server = MockServer::start();
+        let issuer = server.url("/dex");
+        mock_deployment(
+            &server,
+            json!({
+                "authorization_servers": [format!("{issuer}/")],
+                "client_id": "floxhub-cli",
+            }),
+            "/dex",
+            json!({}),
+        );
+
+        let config = discover_login_config(&base_url(&server)).await.unwrap();
+        assert!(config.is_some());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn errors_when_the_issuer_reports_a_different_identity() {
+        let server = MockServer::start();
+        mock_deployment(
+            &server,
+            json!({
+                "authorization_servers": [server.url("/dex")],
+                "client_id": "floxhub-cli",
+            }),
+            "/dex",
+            json!({"issuer": "https://impostor.example/dex"}),
+        );
+
+        let err = discover_login_config(&base_url(&server)).await.unwrap_err();
+        assert!(matches!(err, LoginDiscoveryError::IssuerMismatch { .. }));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn errors_when_the_issuer_omits_the_device_endpoint() {
+        let server = MockServer::start();
+        let issuer = server.url("/dex");
+        server.mock(|when, then| {
+            when.method(httpmock::Method::GET).path(PROBE_PATH);
+            then.status(200).json_body(json!({
+                "authorization_servers": [issuer],
+                "client_id": "floxhub-cli",
+            }));
+        });
+        server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path("/dex/.well-known/openid-configuration");
+            then.status(200).json_body(json!({
+                "issuer": issuer,
+                "token_endpoint": format!("{issuer}/token"),
+            }));
+        });
+
+        let err = discover_login_config(&base_url(&server)).await.unwrap_err();
+        assert!(matches!(
+            err,
+            LoginDiscoveryError::DeviceGrantNotSupported { .. }
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn errors_when_grant_types_exclude_the_device_grant() {
+        let server = MockServer::start();
+        mock_deployment(
+            &server,
+            json!({
+                "authorization_servers": [server.url("/dex")],
+                "client_id": "floxhub-cli",
+            }),
+            "/dex",
+            json!({"grant_types_supported": ["authorization_code"]}),
+        );
+
+        let err = discover_login_config(&base_url(&server)).await.unwrap_err();
+        assert!(matches!(
+            err,
+            LoginDiscoveryError::DeviceGrantNotSupported { .. }
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn errors_when_oidc_discovery_is_unavailable() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(httpmock::Method::GET).path(PROBE_PATH);
+            then.status(200).json_body(json!({
+                "authorization_servers": [server.url("/dex")],
+                "client_id": "floxhub-cli",
+            }));
+        });
+        server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path("/dex/.well-known/openid-configuration");
+            then.status(404);
+        });
+
+        let err = discover_login_config(&base_url(&server)).await.unwrap_err();
+        assert!(matches!(err, LoginDiscoveryError::OidcDiscovery { .. }));
+    }
+}

--- a/cli/floxhub-client/src/auth/mod.rs
+++ b/cli/floxhub-client/src/auth/mod.rs
@@ -13,9 +13,10 @@
 //! One file per type:
 //! - [`auth_context`]: [`AuthContext`] and its failure types
 //! - [`identity`]: [`UserIdentity`] and its resolution errors
-//! - [`token`]: [`FloxhubToken`] (decoded Auth0 JWT) and
-//!   [`AccessToken`] (opaque `flox_`-prefixed token with lazy identity
-//!   resolution)
+//! - [`token`]: one type per credential capability — [`FloxhubToken`]
+//!   (Auth0-shaped JWT, identity local), [`BareToken`] (JWT without the
+//!   handle claim, identity via /me), [`AccessToken`] (opaque, everything
+//!   via /me)
 //! - [`kerberos`]: [`KerberosMaterial`] and SPNEGO token generation
 
 mod auth_context;
@@ -26,7 +27,7 @@ mod token;
 pub use auth_context::{AuthContext, AuthFailure, AuthHeaderError};
 pub use identity::{IdentityError, UNKNOWN_HANDLE, UserIdentity};
 pub use kerberos::{KerberosMaterial, TokenGenerator};
-pub use token::{AccessToken, FloxhubToken, FloxhubTokenError};
+pub use token::{AccessToken, BareToken, FloxhubToken, InvalidTokenError};
 
 /// Test fixtures, re-exported from each type's own module.
 #[cfg(any(test, feature = "tests"))]

--- a/cli/floxhub-client/src/auth/mod.rs
+++ b/cli/floxhub-client/src/auth/mod.rs
@@ -12,6 +12,8 @@
 //!
 //! One file per type:
 //! - [`auth_context`]: [`AuthContext`] and its failure types
+//! - [`discovery`]: per-deployment login discovery
+//!   ([`discover_login_config`])
 //! - [`identity`]: [`UserIdentity`] and its resolution errors
 //! - [`token`]: one type per credential capability — [`FloxhubToken`]
 //!   (Auth0-shaped JWT, identity local), [`BareToken`] (JWT without the
@@ -20,11 +22,13 @@
 //! - [`kerberos`]: [`KerberosMaterial`] and SPNEGO token generation
 
 mod auth_context;
+mod discovery;
 pub(crate) mod identity;
 mod kerberos;
 mod token;
 
 pub use auth_context::{AuthContext, AuthFailure, AuthHeaderError};
+pub use discovery::{DiscoveredLoginConfig, LoginDiscoveryError, discover_login_config};
 pub use identity::{IdentityError, UNKNOWN_HANDLE, UserIdentity};
 pub use kerberos::{KerberosMaterial, TokenGenerator};
 pub use token::{AccessToken, BareToken, FloxhubToken, InvalidTokenError};

--- a/cli/floxhub-client/src/auth/token/bare_token.rs
+++ b/cli/floxhub-client/src/auth/token/bare_token.rs
@@ -1,0 +1,187 @@
+//! [`BareToken`] — a decodable JWT that does not identify its owner.
+//!
+//! Issuers other than the Auth0 tenant (a deployment's Dex) mint tokens
+//! without the FloxHub handle claim, and the settled server-side model
+//! trusts the provider for `sub` only, with the handle coming from
+//! accounts. A bare token therefore reads what its claims do carry —
+//! `exp` for the local expiry warning, `sub` for telemetry attribution —
+//! and resolves its identity from `/me` at the point of use, cached
+//! process-wide exactly like an opaque [`AccessToken`]'s.
+//!
+//! [`AccessToken`]: crate::auth::token::AccessToken
+
+use serde::Deserialize;
+
+use crate::auth::identity;
+use crate::auth::token::InvalidTokenError;
+
+/// The claims a bare token may carry; every one is optional — a JWT with
+/// none of them is still a valid credential.
+#[derive(Debug, Clone, Default, Deserialize)]
+struct BareTokenClaims {
+    /// The expiration time of the token (Unix timestamp)
+    exp: Option<usize>,
+    /// The OIDC subject identifier — an opaque, pseudonymous id stable
+    /// across the user's lifetime. Declaring the claim here means a
+    /// non-string `sub` fails the decode — deliberate, since OIDC
+    /// requires `sub` to be a string.
+    sub: Option<String>,
+}
+
+/// A bearer credential that is a JWT but carries no FloxHub identity;
+/// the identity resolves from `/me` and is cached, like an opaque
+/// token's.
+#[derive(Clone)]
+pub struct BareToken {
+    /// The entire token as a string
+    token: String,
+    claims: BareTokenClaims,
+}
+
+impl BareToken {
+    /// Decode a JWT without requiring any identity claims. Errors when
+    /// the string is not a decodable JWT at all — such a credential is
+    /// opaque, not bare.
+    pub fn new(token: String) -> Result<Self, InvalidTokenError> {
+        let decoded = jsonwebtoken::dangerous::insecure_decode::<BareTokenClaims>(&token)
+            .map_err(InvalidTokenError)?;
+
+        Ok(BareToken {
+            token,
+            claims: decoded.claims,
+        })
+    }
+
+    /// Return the token as a string
+    pub fn secret(&self) -> &str {
+        &self.token
+    }
+
+    /// Return the resolved handle; `None` until `/me` resolution has
+    /// succeeded. Reads the process-wide cache — never blocks, never
+    /// touches the network. For the resolved answer use
+    /// `Flox::get_identity`.
+    pub fn handle(&self) -> Option<String> {
+        identity::cached_identity(&self.token).map(|identity| identity.handle)
+    }
+
+    /// Return the OIDC `sub` claim, if present and non-empty. See
+    /// [`FloxhubToken::sub`](crate::auth::token::FloxhubToken::sub).
+    pub fn sub(&self) -> Option<&str> {
+        self.claims.sub.as_deref().filter(|s| !s.is_empty())
+    }
+
+    /// Returns whether the token has expired by checking the `exp` claim
+    /// against the current time. A token without the claim never expires
+    /// locally — the server's 401 is the authority.
+    pub fn is_expired(&self) -> bool {
+        let Some(exp) = self.claims.exp else {
+            return false;
+        };
+        let now = {
+            let start = std::time::SystemTime::now();
+            start
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("Time went backwards")
+                .as_secs() as usize
+        };
+        exp < now
+    }
+
+    /// The wall-clock expiry of the token, from the `exp` claim;
+    /// `None` when the token doesn't carry one.
+    pub fn expires_at(&self) -> Option<chrono::DateTime<chrono::Utc>> {
+        self.claims.exp.map(|exp| {
+            chrono::DateTime::from_timestamp(exp as i64, 0)
+                .expect("the exp claim is a valid unix timestamp")
+        })
+    }
+}
+
+impl std::fmt::Debug for BareToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BareToken")
+            .field("claims", &self.claims)
+            .field("identity", &identity::cached_identity(&self.token))
+            .finish_non_exhaustive()
+    }
+}
+
+/// Test fixtures for [BareToken].
+///
+/// Nothing here should be used in production code.
+#[cfg(any(test, feature = "tests"))]
+pub mod test_helpers {
+    use super::*;
+
+    /// A fake token shaped like a Dex-issued one: `sub` and `exp` but no
+    /// handle claim.
+    ///
+    /// {
+    ///  "typ": "JWT",
+    ///  "alg": "HS256"
+    /// }
+    /// .
+    /// {
+    ///   "exp": 9999999999,                // 2286-11-20T17:46:39+00:00
+    ///   "sub": "CiQwOGE4Njg0Yi1kYjg4LTRiNzMtOTBhOS0zY2QxNjYxZjU0NjYSBWxvY2Fs",
+    ///   "email": "dev@flox.dev",
+    ///   "name": "dexter"
+    /// }
+    /// .
+    /// AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+    pub const FAKE_TOKEN_NO_HANDLE: &str = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjk5OTk5OTk5OTksInN1YiI6IkNpUXdPR0U0TmpnMFlpMWtZamc0TFRSaU56TXRPVEJoT1MwelkyUXhOall4WmpVME5qWVNCV3h2WTJGcyIsImVtYWlsIjoiZGV2QGZsb3guZGV2IiwibmFtZSI6ImRleHRlciJ9.AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+    /// A bare token with a unique `sub`, for tests that touch the
+    /// process-wide identity cache and must not share a secret with any
+    /// other test.
+    pub fn test_bare_token(sub: &str) -> BareToken {
+        let claims = serde_json::json!({ "sub": sub, "exp": 9999999999_i64 });
+        let token = jsonwebtoken::encode(
+            &jsonwebtoken::Header::default(),
+            &claims,
+            &jsonwebtoken::EncodingKey::from_secret("secret".as_ref()),
+        )
+        .expect("encoding a test JWT succeeds");
+        BareToken::new(token).expect("a freshly encoded JWT decodes")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_helpers::*;
+    use super::*;
+    use crate::auth::identity::test_helpers::test_identity;
+
+    #[test]
+    fn dex_shaped_jwt_parses_with_claims_but_no_handle() {
+        let token = BareToken::new(FAKE_TOKEN_NO_HANDLE.to_string()).expect("token parses");
+        assert_eq!(token.handle(), None, "handle is unknown before resolution");
+        assert_eq!(
+            token.sub(),
+            Some("CiQwOGE4Njg0Yi1kYjg4LTRiNzMtOTBhOS0zY2QxNjYxZjU0NjYSBWxvY2Fs")
+        );
+        assert!(!token.is_expired());
+        assert!(token.expires_at().is_some());
+    }
+
+    #[test]
+    fn non_jwt_is_rejected() {
+        BareToken::new("not-a-jwt".to_string()).unwrap_err();
+    }
+
+    #[test]
+    fn handle_reads_the_identity_cache() {
+        let token = test_bare_token("bare-handle-cache-test");
+        assert_eq!(token.handle(), None, "handle is unknown before resolution");
+
+        identity::cache_identity(token.secret(), &test_identity("bareuser"));
+        assert_eq!(token.handle(), Some("bareuser".to_string()));
+    }
+
+    #[test]
+    fn debug_redacts_the_secret() {
+        let token = test_bare_token("bare-debug-test");
+        assert!(!format!("{token:?}").contains(token.secret()));
+    }
+}

--- a/cli/floxhub-client/src/auth/token/floxhub_token.rs
+++ b/cli/floxhub-client/src/auth/token/floxhub_token.rs
@@ -1,12 +1,21 @@
-//! [`FloxhubToken`] — a parsed Auth0 JWT that authenticates a user with
-//! FloxHub.  The token is decoded (without signature verification) at
-//! construction time so that the handle and expiration are available cheaply.
+//! [`FloxhubToken`] — the Auth0-shaped bearer credential: a JWT whose
+//! claims carry the FloxHub handle and expiry. The token is decoded
+//! (without signature verification) at construction time so that identity
+//! and expiry are answered locally, with no request to FloxHub.
+//!
+//! A JWT without these claims is not an error — it is a [`BareToken`],
+//! whose identity resolves from `/me` instead; [`AuthContext::new_from_token`]
+//! routes between the two.
+//!
+//! [`BareToken`]: crate::auth::token::BareToken
+//! [`AuthContext::new_from_token`]: crate::auth::AuthContext::new_from_token
 
 use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 use serde_with::DeserializeFromStr;
-use thiserror::Error;
+
+use crate::auth::token::InvalidTokenError;
 
 /// Assertions about the owner of this token
 #[derive(Debug, Clone, Deserialize)]
@@ -23,7 +32,8 @@ struct FloxTokenClaims {
     sub: Option<String>,
 }
 
-/// A token authenticating a user with FloxHub
+/// A token authenticating a user with FloxHub, identifying its owner
+/// locally through the Auth0 tenant's handle claim.
 #[derive(Debug, Clone, DeserializeFromStr)]
 pub struct FloxhubToken {
     /// The entire token as a string
@@ -33,9 +43,21 @@ pub struct FloxhubToken {
 }
 
 impl FloxhubToken {
-    /// Create a new floxhub token from a string
-    pub fn new(token: String) -> Result<Self, FloxhubTokenError> {
-        token.parse()
+    /// Decode an Auth0-shaped JWT: the handle claim and `exp` are
+    /// required. Errors for anything else — which may still be a valid
+    /// credential of another kind (bare or opaque); routing is
+    /// `AuthContext::new_from_token`'s job, not the caller's.
+    pub fn new(token: String) -> Result<Self, InvalidTokenError> {
+        // Client side we don't need to verify the signature,
+        // as all privileged access is guarded server side.
+        // We still decode the token to extract claims like handle and expiration.
+        let decoded = jsonwebtoken::dangerous::insecure_decode::<FloxTokenClaims>(&token)
+            .map_err(InvalidTokenError)?;
+
+        Ok(FloxhubToken {
+            token,
+            token_data: decoded.claims,
+        })
     }
 
     /// Return the token as a string
@@ -88,27 +110,11 @@ impl Serialize for FloxhubToken {
 }
 
 impl FromStr for FloxhubToken {
-    type Err = FloxhubTokenError;
+    type Err = InvalidTokenError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        // Client side we don't need to verify the signature,
-        // as all privileged access is guarded server side.
-        // We still decode the token to extract claims like handle and expiration.
-
-        let token = jsonwebtoken::dangerous::insecure_decode::<FloxTokenClaims>(s)
-            .map_err(FloxhubTokenError::InvalidToken)?;
-
-        Ok(FloxhubToken {
-            token: s.to_string(),
-            token_data: token.claims,
-        })
+        FloxhubToken::new(s.to_string())
     }
-}
-
-#[derive(Debug, Clone, Error, Eq, PartialEq)]
-pub enum FloxhubTokenError {
-    #[error("invalid token")]
-    InvalidToken(#[source] jsonwebtoken::errors::Error),
 }
 
 /// Test fixtures for [FloxhubToken].
@@ -181,4 +187,37 @@ pub mod test_helpers {
     /// .
     /// AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
     pub const FAKE_EXPIRED_TOKEN_WITH_SUB: &str = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3guZGV2L2hhbmRsZSI6InRlc3QiLCJleHAiOjE3MDQwNjM2MDAsInN1YiI6ImdpdGh1Ynw0MjQyNDIifQ.AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_helpers::*;
+    use super::*;
+    use crate::auth::token::test_helpers::FAKE_TOKEN_NO_HANDLE;
+
+    #[test]
+    fn auth0_shaped_jwt_answers_identity_locally() {
+        let token = FloxhubToken::new(FAKE_TOKEN.to_string()).expect("token parses");
+        assert_eq!(token.handle(), "test");
+        assert!(!token.is_expired());
+    }
+
+    /// A JWT without the handle claim is not an invalid FloxhubToken so
+    /// much as a different kind of credential — routing sends it to
+    /// [`BareToken`](crate::auth::token::BareToken).
+    #[test]
+    fn jwt_without_handle_claim_is_rejected() {
+        FloxhubToken::new(FAKE_TOKEN_NO_HANDLE.to_string()).unwrap_err();
+    }
+
+    #[test]
+    fn non_jwt_is_rejected() {
+        FloxhubToken::new("not-a-jwt".to_string()).unwrap_err();
+    }
+
+    #[test]
+    fn expired_jwt_reports_expiry() {
+        let token = FloxhubToken::new(FAKE_EXPIRED_TOKEN.to_string()).expect("token parses");
+        assert!(token.is_expired());
+    }
 }

--- a/cli/floxhub-client/src/auth/token/mod.rs
+++ b/cli/floxhub-client/src/auth/token/mod.rs
@@ -1,10 +1,36 @@
-//! FloxHub token types: a decoded Auth0 JWT and an opaque access token.
+//! FloxHub token types, one per capability class: what a credential's
+//! claims answer locally decides its type, and [`AuthContext::new_from_token`]
+//! routes between them.
+//!
+//! - [`FloxhubToken`]: an Auth0-shaped JWT — handle and expiry claims
+//!   present, identity answered locally.
+//! - [`BareToken`]: a decodable JWT without the handle claim — `exp` and
+//!   `sub` read opportunistically, identity resolved from `/me`.
+//! - [`AccessToken`]: not decodable at all (`flox_`-prefixed tokens, or
+//!   any opaque string an issuer mints) — everything resolved from `/me`.
+//!
+//! [`AuthContext::new_from_token`]: crate::auth::AuthContext::new_from_token
 
 mod access_token;
+mod bare_token;
 mod floxhub_token;
 
 pub(crate) use access_token::ACCESS_TOKEN_PREFIX;
 pub use access_token::AccessToken;
+pub use bare_token::BareToken;
+pub use floxhub_token::FloxhubToken;
+use thiserror::Error;
+
+/// The string does not decode as a JWT of the attempted shape. Not
+/// necessarily a bad credential — routing tries the next capability
+/// class, and the server is the only authority on validity.
+#[derive(Debug, Error)]
+#[error("invalid token")]
+pub struct InvalidTokenError(#[source] pub(crate) jsonwebtoken::errors::Error);
+
+/// Test fixtures, re-exported from each type's own module.
 #[cfg(any(test, feature = "tests"))]
-pub use floxhub_token::test_helpers;
-pub use floxhub_token::{FloxhubToken, FloxhubTokenError};
+pub mod test_helpers {
+    pub use super::bare_token::test_helpers::*;
+    pub use super::floxhub_token::test_helpers::*;
+}

--- a/cli/floxhub-client/src/client.rs
+++ b/cli/floxhub-client/src/client.rs
@@ -30,7 +30,7 @@ use url::Url;
 
 use crate::MapApiErrorExt;
 use crate::accounts::{AccountsApiClient, MeError};
-use crate::auth::{AccessToken, AuthContext, IdentityError, UserIdentity, identity};
+use crate::auth::{AuthContext, IdentityError, UserIdentity, identity};
 use crate::config::FloxhubClientConfig;
 use crate::error::{ByCommandError, FloxhubClientError, ResolveError, SearchError, VersionsError};
 use crate::mock::MockGuard;
@@ -819,35 +819,34 @@ where
 }
 
 // ---------------------------------------------------------------------------
-// PAT identity resolution
+// Opaque-credential identity resolution
 // ---------------------------------------------------------------------------
 
 impl FloxhubClient {
-    /// Resolve the identity behind a personal access token from
-    /// `GET /api/v1/accounts/me`. A successful resolution is cached for the
-    /// process; failures are returned but not cached, so a later call
+    /// Resolve the identity behind a bearer credential whose claims don't
+    /// carry it — a personal access token, or an interactive-login token
+    /// without the handle claim — from `GET /api/v1/accounts/me`. A
+    /// successful resolution is cached for the process, keyed by the
+    /// secret; failures are returned but not cached, so a later call
     /// retries.
     ///
     /// This is the only auth operation that needs a client; every other
     /// credential kind derives its identity locally. Callers holding a
     /// [`Flox`] should use its uniform `Flox::get_identity` instead.
-    pub async fn resolve_identity(
-        &self,
-        token: &AccessToken,
-    ) -> Result<UserIdentity, IdentityError> {
-        if let Some(identity) = identity::cached_identity(token.secret()) {
+    pub async fn resolve_identity(&self, secret: &str) -> Result<UserIdentity, IdentityError> {
+        if let Some(identity) = identity::cached_identity(secret) {
             return Ok(identity);
         }
         let identity = self
             .accounts()
-            .me(token.secret())
+            .me(secret)
             .await
             .map_err(|err| match err {
                 MeError::Unauthorized => IdentityError::Unauthorized,
                 other => IdentityError::Other(other.to_string()),
             })
             .inspect_err(|err| debug!(%err, "could not resolve identity"))?;
-        identity::cache_identity(token.secret(), &identity);
+        identity::cache_identity(secret, &identity);
         Ok(identity)
     }
 }
@@ -966,7 +965,7 @@ pub mod test_helpers {
             base_url: url.to_string(),
             extra_headers: Default::default(),
             mock_mode: Default::default(),
-            auth_context: AuthContext::new_from_token(None).expect("no token to parse"),
+            auth_context: AuthContext::new_from_token(None),
             user_agent: None,
             stability: None,
             on_unauthenticated_resolve: None,
@@ -1018,12 +1017,16 @@ pub mod tests {
         });
 
         let client = FloxhubClient::new(client_config(&server.base_url())).unwrap();
-        let token = AccessToken::new("flox_pat_client-cache-test".to_string());
-
-        let identity = client.resolve_identity(&token).await.unwrap();
+        let identity = client
+            .resolve_identity("flox_pat_client-cache-test")
+            .await
+            .unwrap();
         assert_eq!(identity.handle, "testuser");
         // A second resolve reads the cache instead of the server.
-        client.resolve_identity(&token).await.unwrap();
+        client
+            .resolve_identity("flox_pat_client-cache-test")
+            .await
+            .unwrap();
         mock.assert_calls(1);
     }
 
@@ -1038,10 +1041,8 @@ pub mod tests {
         });
 
         let client = FloxhubClient::new(client_config(&server.base_url())).unwrap();
-        let token = AccessToken::new("flox_pat_client-401-test".to_string());
-
         assert!(matches!(
-            client.resolve_identity(&token).await,
+            client.resolve_identity("flox_pat_client-401-test").await,
             Err(IdentityError::Unauthorized)
         ));
     }
@@ -1056,15 +1057,13 @@ pub mod tests {
         });
 
         let client = FloxhubClient::new(client_config(&server.base_url())).unwrap();
-        let token = AccessToken::new("flox_pat_client-500-test".to_string());
-
         assert!(matches!(
-            client.resolve_identity(&token).await,
+            client.resolve_identity("flox_pat_client-500-test").await,
             Err(IdentityError::Other(_))
         ));
         // The failure is not cached: a second resolve retries the server.
         assert!(matches!(
-            client.resolve_identity(&token).await,
+            client.resolve_identity("flox_pat_client-500-test").await,
             Err(IdentityError::Other(_))
         ));
         mock.assert_calls(2);
@@ -1228,7 +1227,7 @@ pub mod tests {
         let fired = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
         let fired_in_hook = std::sync::Arc::clone(&fired);
         let config = FloxhubClientConfig {
-            auth_context: AuthContext::new_from_token(Some("flox_pat_test")).unwrap(),
+            auth_context: AuthContext::new_from_token(Some("flox_pat_test")),
             on_unauthenticated_resolve: Some(UnauthenticatedResolveHook::new(move || {
                 fired_in_hook.store(true, std::sync::atomic::Ordering::SeqCst);
             })),

--- a/cli/floxhub-client/src/lib.rs
+++ b/cli/floxhub-client/src/lib.rs
@@ -22,7 +22,7 @@
 //!     base_url: "https://api.flox.dev".to_string(),
 //!     extra_headers: BTreeMap::new(),
 //!     mock_mode: FloxhubMockMode::None,
-//!     auth_context: AuthContext::new_from_token(floxhub_token)?,
+//!     auth_context: AuthContext::new_from_token(floxhub_token),
 //!     user_agent: Some("flox-cli/1.0".to_string()),
 //!     stability: FloxhubClientConfig::stability_from_env(),
 //!     on_unauthenticated_resolve: None,

--- a/cli/nef-lock-catalog/src/bin/lock.rs
+++ b/cli/nef-lock-catalog/src/bin/lock.rs
@@ -214,7 +214,7 @@ fn build_client(config: &Config, floxhub_token: Option<String>) -> Result<Floxhu
 
     let auth_context = match config.flox.floxhub_authn_mode {
         Some(flox_config::AuthnMode::Kerberos) => AuthContext::new_kerberos(),
-        _ => AuthContext::new_from_token(floxhub_token.as_deref())?,
+        _ => AuthContext::new_from_token(floxhub_token.as_deref()),
     };
 
     let config = FloxhubClientConfig {

--- a/cli/tests/auth-pat.bats
+++ b/cli/tests/auth-pat.bats
@@ -152,5 +152,5 @@ teardown() {
 
   run "$FLOX_BIN" auth login --token-file "$BATS_TEST_TMPDIR/token"
   assert_failure
-  assert_output --partial "The provided token is expired."
+  assert_output --partial "FloxHub rejected the provided token: it is invalid, expired, or revoked."
 }

--- a/cli/tests/auth.bats
+++ b/cli/tests/auth.bats
@@ -116,12 +116,30 @@ EXPIRED_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3guZGV2L2hh
 }
 
 # bats test_tags=auth,auth:login:token-file
-@test "auth login --token-file fails for a malformed token" {
+@test "auth login --token-file fails for a token the server rejects" {
+  # A non-JWT token cannot be rejected locally — it may be an issuer's
+  # opaque access token — so it is verified via /me, which answers 401 here.
+  export _FLOX_USE_CATALOG_MOCK="$MANUALLY_GENERATED/auth/me_revoked.yaml"
   echo "not-a-jwt" > "$PROJECT_DIR/token"
 
   run "$FLOX_BIN" auth login --token-file "$PROJECT_DIR/token"
   assert_failure
-  assert_output --partial "The provided token is not a valid FloxHub token."
+  assert_output --partial "FloxHub rejected the provided token: it is invalid, expired, or revoked."
+}
+
+# bats test_tags=auth
+@test "an opaque stored token is not discarded as invalid" {
+  # No token can be rejected locally — an issuer may mint opaque access
+  # tokens — so a non-JWT stored token is kept, counts as logged in like a
+  # flox_pat_ token, and the server stays the authority for its validity.
+  echo 'floxhub_token = "not-a-jwt"' >> "$FLOX_CONFIG_DIR/flox.toml"
+
+  run "$FLOX_BIN" config
+  assert_success
+  refute_output --partial "token is invalid"
+  refute_output --partial "not logged in to FloxHub"
+  run grep floxhub_token "$FLOX_CONFIG_DIR/flox.toml"
+  assert_success
 }
 
 # bats test_tags=auth,auth:login:token-file

--- a/cli/tests/hook.bats
+++ b/cli/tests/hook.bats
@@ -170,32 +170,6 @@ EXPIRED_FLOXHUB_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3gu
   assert_output ""
 }
 
-# An invalid token is normally surfaced and removed from the user's config;
-# both must be deferred to the next user-invoked command rather than printing
-# and rewriting config on every prompt.
-# bats test_tags=hook:hook-env
-@test "'flox hook-env' defers invalid token cleanup to user-invoked commands" {
-  # See the empty-cwd note in the first hook-env test.
-  cd "$BATS_TEST_TMPDIR"
-  # The suite-wide env token would shadow the invalid file token (env wins over
-  # the user config file), so drop it for this test.
-  unset FLOX_FLOXHUB_TOKEN
-  mkdir -p "$FLOX_CONFIG_DIR"
-  echo 'floxhub_token = "not-a-jwt"' >> "$FLOX_CONFIG_DIR/flox.toml"
-
-  run --separate-stderr "$FLOX_BIN" hook-env --shell bash --shell-pid "$$"
-  assert_success
-  assert_equal "$stderr" ""
-  run grep floxhub_token "$FLOX_CONFIG_DIR/flox.toml"
-  assert_success
-
-  run --separate-stderr "$FLOX_BIN" config
-  assert_success
-  assert_regex "$stderr" "Your FloxHub token is invalid"
-  run grep floxhub_token "$FLOX_CONFIG_DIR/flox.toml"
-  assert_failure
-}
-
 # 'flox deactivate' hands the deactivation off to the prompt hook, so its
 # preamble advisories are suppressed like hook-env's. Without an active
 # environment the command prints "No environment active!", but the advisories

--- a/pkgs/flox-cli/default.nix
+++ b/pkgs/flox-cli/default.nix
@@ -55,7 +55,6 @@ let
       # oauth client id
       OAUTH_CLIENT_ID = "fGrotHBfQr9X1PHGbFoifEWaDPyWZDmc";
       OAUTH_BASE_URL = "${auth0BaseUrl}";
-      OAUTH_AUTH_URL = "${auth0BaseUrl}/authorize";
       OAUTH_TOKEN_URL = "${auth0BaseUrl}/oauth/token";
       OAUTH_DEVICE_AUTH_URL = "${auth0BaseUrl}/oauth/device/code";
 


### PR DESCRIPTION
### Problem

`flox auth login` is Auth0-specific twice over. The device-grant endpoints and client id are compile-time constants naming the SaaS Auth0 tenant, so login ignores which FloxHub server `floxhub_url` points at. And `FloxhubToken` requires the tenant's custom `https://flox.dev/handle` claim, so a token minted by any other issuer is rejected as invalid the moment login hands it over. An on-prem deployment can therefore neither name its identity broker nor have its tokens accepted.

### What this ships

One commit per layer:

- **Token acceptance** — tokens are typed by what their claims answer locally: `FloxhubToken` keeps its strict Auth0 shape (handle and expiry claims, identity answered locally), the new `BareToken` covers any other decodable JWT (`exp` and `sub` read opportunistically, handle resolved from `/me` through the same lazy, process-cached resolution that personal access tokens already use), and `AccessToken` widens to any string that doesn't decode. Routing is total: no stored token can be rejected locally, so the startup path that wiped invalid stored tokens is gone and a garbage token surfaces as the server's 401.
- **Discovery** — `discover_login_config` (floxhub-client) fetches `{floxhub_url}/.well-known/oauth-protected-resource`, the RFC 9728 document every FloxHub deployment serves after flox/floxhub#2231. It then takes the device-authorization and token endpoints from the advertised issuer's own OIDC discovery. A response that is not the document, whether a 404 or the web UI's SPA fallback answering 200 with `index.html`, means the deployment advertises nothing, and login falls back to the compiled-in constants. A document that is present but unusable is an error rather than a fallback, because falling back would silently log the user in against the SaaS tenant.
- **Login wiring** — each login value resolves by precedence: an explicit `_FLOX_OAUTH_*` override, then the discovered document, then the compiled-in constants. The `audience` parameter is sent exactly when the document carries it, and the no-document path sends today's hardcoded SaaS value. The authorization-endpoint constant is gone, because the device flow never calls that endpoint.
- **Integration tests** — the cases that asserted a malformed token fails locally now assert that the server rejects it, against a mocked 401 from `/me`, and `auth.bats` and `auth-pat.bats` both expect the one message "FloxHub rejected the provided token: it is invalid, expired, or revoked." A new case holds the opposite: an opaque stored token stays in the config and still counts as logged in. The `hook.bats` case covering deferred invalid-token cleanup is deleted, because no token is invalid locally any more.

### Verified against the dev stack and production

With the floxhub dev stack serving the document (flox/floxhub#2231), `flox auth login` against `https://hub.local.flox.dev:8000` discovered the local Dex, ran the device grant with scopes `openid profile email` and no audience parameter, completed the login as the dev stack's static user, and received the token. The accounts service then rejected the token at `/me`, because it validates bearer JWTs against the Auth0 JWKS only. That rejection is the expected state today rather than a defect in this change: teaching the backends a deployment's issuer is ENT-184's server-side work, and login surfaced the rejection as "FloxHub rejected the login token." Against production `hub.flox.dev`, which serves no document today, login fell back to the compiled-in constants and obtained an Auth0 device code.

### Release Notes

`flox auth login` now asks the configured FloxHub server where to log in: a deployment serving auth discovery gets the device-grant login against its own identity provider, and a deployment without it keeps today's Auth0 login unchanged.

Closes ENT-196.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

