### PR TITLE
fix(activate): export [vars] before sourcing profile.d scripts

### DIFF
--- a/assets/environment-interpreter/activate/activate
+++ b/assets/environment-interpreter/activate/activate
@@ -233,6 +233,10 @@ if [ "$_command_mode" = "false" ]; then
   $_jq -nS env > "$_start_env_json"
 fi
 
+# Set static environment variables from the manifest before sourcing
+# profile.d scripts so that plugin scripts can read [vars] entries.
+set_manifest_vars "$_FLOX_ENV"
+
 case "$_FLOX_ENV_ACTIVATION_MODE" in
   dev)
     # shellcheck disable=SC1090 # from rendered environment
@@ -251,9 +255,6 @@ case "$_FLOX_ENV_ACTIVATION_MODE" in
     exit 1
     ;;
 esac
-
-# Set static environment variables from the manifest.
-set_manifest_vars "$_FLOX_ENV"
 
 if [ "$_skip_hook_on_activate" = "false" ]; then
   # Source the hook-on-activate script if it exists.

--- a/assets/environment-interpreter/activate/activate
+++ b/assets/environment-interpreter/activate/activate
@@ -170,11 +170,12 @@ if [ -z "${_FLOX_ENV:-}" ]; then
   exit 1
 fi
 
-# Source profile.d scripts from the rendered environment rather than the
-# interpreter package so that scripts provided by installed packages are
-# processed in addition to the interpreter's own scripts, which are
-# symlinked into the environment as it is built.
+# The rendered environment's profile.d merges the interpreter's own
+# scripts with scripts provided by installed packages (plugins). The
+# interpreter's scripts are sourced from the interpreter package below;
+# the rendered directory is used for the plugin scripts.
 _profile_d="$_FLOX_ENV/etc/profile.d"
+_interpreter_profile_d="__OUT__/etc/profile.d"
 
 # Convert the provided command string into an array of arguments in "$@".
 # Henceforth in the script it is assumed that these are the arguments to be
@@ -233,22 +234,18 @@ if [ "$_command_mode" = "false" ]; then
   $_jq -nS env > "$_start_env_json"
 fi
 
-# Set static environment variables from the manifest before sourcing
-# profile.d scripts so that plugin scripts can read [vars] entries.
-set_manifest_vars "$_FLOX_ENV"
-
 case "$_FLOX_ENV_ACTIVATION_MODE" in
   dev)
-    # shellcheck disable=SC1090 # from rendered environment
-    source_profile_d "$_profile_d" "prepend" "$FLOX_ENV_DIRS"
+    # shellcheck disable=SC1090 # from interpreter package
+    source_profile_d "$_interpreter_profile_d" "prepend" "$FLOX_ENV_DIRS"
     ;;
   run)
-    # shellcheck disable=SC1091 # from rendered environment
-    source "$_profile_d/0100_common-run-mode-paths.sh"
+    # shellcheck disable=SC1091 # from interpreter package
+    source "$_interpreter_profile_d/0100_common-run-mode-paths.sh"
     ;;
   build)
-    # shellcheck disable=SC1090 # from rendered environment
-    source_profile_d "$_profile_d" "set" "$FLOX_ENV_DIRS"
+    # shellcheck disable=SC1090 # from interpreter package
+    source_profile_d "$_interpreter_profile_d" "set" "$FLOX_ENV_DIRS"
     ;;
   *)
     echo "Invalid activation mode: $_FLOX_ENV_ACTIVATION_MODE" >&2
@@ -256,9 +253,18 @@ case "$_FLOX_ENV_ACTIVATION_MODE" in
     ;;
 esac
 
-# Re-export [vars] so that they take precedence over same-named variables
-# exported by profile.d scripts.
+# Set static environment variables from the manifest: after the
+# interpreter's profile.d scripts so that [vars] can override variables
+# they set, and before plugin scripts so that plugins can read [vars]
+# entries. A variable exported by a plugin script therefore wins over a
+# same-named [vars] entry.
 set_manifest_vars "$_FLOX_ENV"
+
+# Plugin scripts do not run in run mode, matching the interpreter
+# scripts, of which run mode only sources the PATH setup above.
+if [ "$_FLOX_ENV_ACTIVATION_MODE" != "run" ]; then
+  source_plugin_profile_d "$_profile_d" "$_interpreter_profile_d"
+fi
 
 if [ "$_skip_hook_on_activate" = "false" ]; then
   # Source the hook-on-activate script if it exists.

--- a/assets/environment-interpreter/activate/activate
+++ b/assets/environment-interpreter/activate/activate
@@ -256,6 +256,10 @@ case "$_FLOX_ENV_ACTIVATION_MODE" in
     ;;
 esac
 
+# Re-export [vars] so that they take precedence over same-named variables
+# exported by profile.d scripts.
+set_manifest_vars "$_FLOX_ENV"
+
 if [ "$_skip_hook_on_activate" = "false" ]; then
   # Source the hook-on-activate script if it exists.
   if [ -e "$_FLOX_ENV/activate.d/hook-on-activate" ]; then

--- a/assets/environment-interpreter/common/activate.d/helpers.bash
+++ b/assets/environment-interpreter/common/activate.d/helpers.bash
@@ -71,6 +71,40 @@ function source_profile_d {
   unset -f setup_cmake
 }
 
+# source_plugin_profile_d <env profile.d directory> <interpreter profile.d directory>
+#
+# Source the profile.d scripts provided by installed packages (plugins):
+# the scripts in the environment's merged profile.d that the interpreter
+# does not itself provide. The interpreter's own scripts are sourced
+# separately from the interpreter package, before [vars] are exported,
+# so that [vars] can override their variables while remaining readable
+# by plugin scripts.
+function source_plugin_profile_d {
+  local _profile_d="${1?}"
+  shift
+  local _interpreter_profile_d="${1?}"
+  shift
+
+  # make sure the directory exists
+  [ -d "$_profile_d" ] || {
+    echo "'$_profile_d' is not a directory" >&2
+    return 1
+  }
+
+  declare -a _profile_scripts
+  read -r -a _profile_scripts < <(
+    cd "$_profile_d" || exit
+    shopt -s nullglob
+    echo *.sh
+  )
+  for profile_script in "${_profile_scripts[@]}"; do
+    if [ ! -e "$_interpreter_profile_d/$profile_script" ]; then
+      # shellcheck disable=SC1090 # from rendered environment
+      source "$_profile_d/$profile_script"
+    fi
+  done
+}
+
 # set_manifest_vars <flox_env>
 #
 # Set static environment variables from the manifest.

--- a/assets/environment-interpreter/wrapper/wrapper
+++ b/assets/environment-interpreter/wrapper/wrapper
@@ -113,28 +113,29 @@ if [ -z "${FLOX_ENV-}" ]; then
   exit 1
 fi
 
-# Source profile.d scripts from the rendered environment rather than the
-# interpreter package so that scripts provided by installed packages are
-# processed in addition to the interpreter's own scripts, which are
-# symlinked into the environment as it is built.
+# The rendered environment's profile.d merges the interpreter's own
+# scripts with scripts provided by installed packages (plugins). The
+# interpreter's scripts are sourced from the wrapper package below; the
+# rendered directory is used for the plugin scripts.
 _profile_d="$FLOX_ENV/etc/profile.d"
+_interpreter_profile_d="__OUT__/etc/profile.d"
 
 # prepend path
 export PATH="$FLOX_ENV/bin:$FLOX_ENV/sbin:$PATH"
 
+# source the interpreter's profile.d scripts
+source_profile_d "$_interpreter_profile_d" "set" ""
+
 if [ "${SET_VARS-}" = "1" ]; then
- # Set static environment variables from the manifest.
+ # Set static environment variables from the manifest: after the
+ # interpreter's profile.d scripts so that [vars] can override variables
+ # they set, and before plugin scripts so that plugins can read [vars]
+ # entries.
  set_manifest_vars "$FLOX_ENV"
 fi
 
-# source profile.d scripts
-source_profile_d "$_profile_d" "set" ""
-
-if [ "${SET_VARS-}" = "1" ]; then
- # Re-export [vars] so that they take precedence over same-named variables
- # exported by profile.d scripts.
- set_manifest_vars "$FLOX_ENV"
-fi
+# source plugin-provided profile.d scripts
+source_plugin_profile_d "$_profile_d" "$_interpreter_profile_d"
 
 "$_flox_activate_tracer" "${BASH_SOURCE[0]}" "$@" END
 

--- a/assets/environment-interpreter/wrapper/wrapper
+++ b/assets/environment-interpreter/wrapper/wrapper
@@ -130,6 +130,12 @@ fi
 # source profile.d scripts
 source_profile_d "$_profile_d" "set" ""
 
+if [ "${SET_VARS-}" = "1" ]; then
+ # Re-export [vars] so that they take precedence over same-named variables
+ # exported by profile.d scripts.
+ set_manifest_vars "$FLOX_ENV"
+fi
+
 "$_flox_activate_tracer" "${BASH_SOURCE[0]}" "$@" END
 
 # exec the command

--- a/assets/environment-interpreter/wrapper/wrapper
+++ b/assets/environment-interpreter/wrapper/wrapper
@@ -124,7 +124,7 @@ export PATH="$FLOX_ENV/bin:$FLOX_ENV/sbin:$PATH"
 
 if [ "${SET_VARS-}" = "1" ]; then
  # Set static environment variables from the manifest.
- set_vars "$FLOX_ENV"
+ set_manifest_vars "$FLOX_ENV"
 fi
 
 # source profile.d scripts

--- a/cli/flox/doc/manifest.toml.md
+++ b/cli/flox/doc/manifest.toml.md
@@ -876,6 +876,8 @@ Flox plugins work by convention:
 - Plugins have access to the entire manifest.
   By convention, plugins should only access data under `[plugins.<plugin name>]`,
   but Flox does not enforce this.
+- Plugin scripts run with the variables from `[vars]` already exported,
+  so a plugin may also be configured via `[vars]`.
 
 
 # SEE ALSO

--- a/cli/flox/doc/manifest.toml.md
+++ b/cli/flox/doc/manifest.toml.md
@@ -878,9 +878,9 @@ Flox plugins work by convention:
   but Flox does not enforce this.
 - Plugin scripts run with the variables from `[vars]` already exported,
   so a plugin may also be configured via `[vars]`.
-  The `[vars]` entries are exported again after plugin scripts run,
-  so if a plugin script exports a variable with the same name,
-  the value from `[vars]` wins.
+  If a plugin script exports a variable with the same name as a `[vars]`
+  entry, the plugin's value wins;
+  use the `hook.on-activate` script to override variables set by a plugin.
 
 
 # SEE ALSO

--- a/cli/flox/doc/manifest.toml.md
+++ b/cli/flox/doc/manifest.toml.md
@@ -878,6 +878,9 @@ Flox plugins work by convention:
   but Flox does not enforce this.
 - Plugin scripts run with the variables from `[vars]` already exported,
   so a plugin may also be configured via `[vars]`.
+  The `[vars]` entries are exported again after plugin scripts run,
+  so if a plugin script exports a variable with the same name,
+  the value from `[vars]` wins.
 
 
 # SEE ALSO

--- a/cli/flox/src/commands/activate-architecture.mmd
+++ b/cli/flox/src/commands/activate-architecture.mmd
@@ -93,9 +93,9 @@ flowchart TB
   end
  subgraph activate["activate (bash)"]
         n7["cmd mode?"]
-        n6["source etc-profiles"]
+        n6["source interpreter profile.d"]
         nd["set_manifest_vars"]
-        nd2["set_manifest_vars (again — [vars] win)"]
+        nd2["source plugin profile.d"]
         n171["hook.on-activate"]
         n63[["Capture end.env.json"]]
         n167["Capture start.env.json"]
@@ -190,7 +190,7 @@ flowchart TB
     match_activation_mode -- "flox activate -- cmd args" --> apply_activation_env_exec
     match_activation_mode -- interactive --> apply_activation_env_interactive
     apply_activation_env_exec --> exec_cmd
-    n6 --> nd2
+    nd --> nd2
     nd2 --> n173
     A(["Parent PID<br>flox activate<br>"]) -- fork() &amp;&amp; exec(flox) --> n88
     n88 --> n89
@@ -221,8 +221,8 @@ flowchart TB
     apply_activation_env_interactive --> n37
     n7 -- no --> n167
     n7 -- yes --> n172
-    n167 --> nd
-    nd --> n6
+    n167 --> n6
+    n6 --> nd
     n160(["Container entrypoint"]) --> Start
     n36 --> Start
     n63 ~~~ LockAfterHooks
@@ -233,7 +233,7 @@ flowchart TB
     ny --> n164
     n110 ~~~ n165
     n166(["flox-build.mk"]) -- "activate -- cmd args<br>activate -c 'cmd &amp;&amp; args'" --> activate
-    n170 --> nd
+    n170 --> n6
     n172 --> n170
     n173 --> n174 & n171
     n174 -- no --> n63

--- a/cli/flox/src/commands/activate-architecture.mmd
+++ b/cli/flox/src/commands/activate-architecture.mmd
@@ -189,7 +189,7 @@ flowchart TB
     match_activation_mode -- "flox activate -- cmd args" --> apply_activation_env_exec
     match_activation_mode -- interactive --> apply_activation_env_interactive
     apply_activation_env_exec --> exec_cmd
-    nd --> n173
+    n6 --> n173
     A(["Parent PID<br>flox activate<br>"]) -- fork() &amp;&amp; exec(flox) --> n88
     n88 --> n89
     n89 --> n36
@@ -219,8 +219,8 @@ flowchart TB
     apply_activation_env_interactive --> n37
     n7 -- no --> n167
     n7 -- yes --> n172
-    n167 --> n6
-    n6 --> nd
+    n167 --> nd
+    nd --> n6
     n160(["Container entrypoint"]) --> Start
     n36 --> Start
     n63 ~~~ LockAfterHooks
@@ -231,7 +231,7 @@ flowchart TB
     ny --> n164
     n110 ~~~ n165
     n166(["flox-build.mk"]) -- "activate -- cmd args<br>activate -c 'cmd &amp;&amp; args'" --> activate
-    n170 --> n6
+    n170 --> nd
     n172 --> n170
     n173 --> n174 & n171
     n174 -- no --> n63

--- a/cli/flox/src/commands/activate-architecture.mmd
+++ b/cli/flox/src/commands/activate-architecture.mmd
@@ -95,6 +95,7 @@ flowchart TB
         n7["cmd mode?"]
         n6["source etc-profiles"]
         nd["set_manifest_vars"]
+        nd2["set_manifest_vars (again — [vars] win)"]
         n171["hook.on-activate"]
         n63[["Capture end.env.json"]]
         n167["Capture start.env.json"]
@@ -189,7 +190,8 @@ flowchart TB
     match_activation_mode -- "flox activate -- cmd args" --> apply_activation_env_exec
     match_activation_mode -- interactive --> apply_activation_env_interactive
     apply_activation_env_exec --> exec_cmd
-    n6 --> n173
+    n6 --> nd2
+    nd2 --> n173
     A(["Parent PID<br>flox activate<br>"]) -- fork() &amp;&amp; exec(flox) --> n88
     n88 --> n89
     n89 --> n36
@@ -276,6 +278,7 @@ flowchart TB
     style n7 fill:#BBDEFB
     style n6 fill:#BBDEFB
     style nd fill:#BBDEFB
+    style nd2 fill:#BBDEFB
     style n171 fill:#BBDEFB
     style n63 fill:#BBDEFB
     style n167 fill:#BBDEFB

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -2888,7 +2888,7 @@ EOF
 }
 
 # bats test_tags=activate,activate:plugins
-@test "plugins: [vars] win over same-named variables exported by plugin scripts" {
+@test "plugins: variables exported by plugin scripts win over same-named [vars]" {
   project_setup
 
   mkdir -p "$BATS_TEST_TMPDIR/clobber-plugin/etc/profile.d"
@@ -2914,7 +2914,7 @@ EOF
   run "$FLOX_BIN" activate -c \
     "bash -c 'echo plugin saw: \${TEST_PLUGIN_SEES_VAR:-unset}, final: \${MY_VAR:-unset}'"
   assert_success
-  assert_output --partial 'plugin saw: user-value, final: user-value'
+  assert_output --partial 'plugin saw: user-value, final: plugin-value'
 }
 
 # bats test_tags=activate,activate:plugins

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -2859,6 +2859,35 @@ EOF
 }
 
 # bats test_tags=activate,activate:plugins
+@test "plugins: plugin scripts can read variables from [vars]" {
+  project_setup
+
+  mkdir -p "$BATS_TEST_TMPDIR/vars-plugin/etc/profile.d"
+  cat > "$BATS_TEST_TMPDIR/vars-plugin/etc/profile.d/0900_vars-plugin.sh" <<'EOF'
+# shellcheck shell=bash
+export TEST_PLUGIN_SEES_VAR="${MY_VAR:-unset}"
+EOF
+  pkg_store_path="$(nix --extra-experimental-features nix-command \
+    store add --name vars-plugin "$BATS_TEST_TMPDIR/vars-plugin")"
+
+  # The init template already declares a [vars] table, so write a complete
+  # manifest rather than appending a duplicate one.
+  "$FLOX_BIN" edit -f - <<< "$(with_latest_schema "$(cat <<EOF
+[install]
+vars-plugin.store-path = "$pkg_store_path"
+
+[vars]
+MY_VAR = "from-vars"
+EOF
+  )")"
+
+  run "$FLOX_BIN" activate -c \
+    "bash -c 'echo TEST_PLUGIN_SEES_VAR is: \${TEST_PLUGIN_SEES_VAR:-unset}'"
+  assert_success
+  assert_output --partial 'TEST_PLUGIN_SEES_VAR is: from-vars'
+}
+
+# bats test_tags=activate,activate:plugins
 @test "plugins: a failing plugin script blocks activation" {
   project_setup
   setup_test_plugin

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -2888,6 +2888,36 @@ EOF
 }
 
 # bats test_tags=activate,activate:plugins
+@test "plugins: [vars] win over same-named variables exported by plugin scripts" {
+  project_setup
+
+  mkdir -p "$BATS_TEST_TMPDIR/clobber-plugin/etc/profile.d"
+  cat > "$BATS_TEST_TMPDIR/clobber-plugin/etc/profile.d/0900_clobber-plugin.sh" <<'EOF'
+# shellcheck shell=bash
+export TEST_PLUGIN_SEES_VAR="${MY_VAR:-unset}"
+export MY_VAR="plugin-value"
+EOF
+  pkg_store_path="$(nix --extra-experimental-features nix-command \
+    store add --name clobber-plugin "$BATS_TEST_TMPDIR/clobber-plugin")"
+
+  # The init template already declares a [vars] table, so write a complete
+  # manifest rather than appending a duplicate one.
+  "$FLOX_BIN" edit -f - <<< "$(with_latest_schema "$(cat <<EOF
+[install]
+clobber-plugin.store-path = "$pkg_store_path"
+
+[vars]
+MY_VAR = "user-value"
+EOF
+  )")"
+
+  run "$FLOX_BIN" activate -c \
+    "bash -c 'echo plugin saw: \${TEST_PLUGIN_SEES_VAR:-unset}, final: \${MY_VAR:-unset}'"
+  assert_success
+  assert_output --partial 'plugin saw: user-value, final: user-value'
+}
+
+# bats test_tags=activate,activate:plugins
 @test "plugins: a failing plugin script blocks activation" {
   project_setup
   setup_test_plugin


### PR DESCRIPTION
Fixes [DEV-260](https://linear.app/floxdotdev/issue/DEV-260/plugins-cant-read-vars).

Plugin scripts — `etc/profile.d` scripts shipped by installed packages — were sourced before `set_manifest_vars` exported the `[vars]` section, so a plugin could not read user-provided configuration from `[vars]`.

Per the review discussion, activation now runs in three phases instead of one merged profile.d pass:

1. The interpreter's own profile.d scripts, sourced directly from the interpreter package
2. `[vars]` exported — so users can override variables set by Flox's scripts
3. Plugin-provided profile.d scripts, sourced from the rendered environment — so plugins can read `[vars]`

On a name collision, a plugin's export wins over the same-named `[vars]` entry: you opted into the plugin, and `hook.on-activate` remains the way to override it. Each script is sourced exactly once, so there is no double expansion of self-referencing `[vars]` values.

Also included:
- New helper `source_plugin_profile_d` in `helpers.bash`: sources scripts in the environment's merged `etc/profile.d` whose basename is not provided by the interpreter package.
- Fix the build-executable wrapper calling `set_vars`, a function that no longer exists after its rename to `set_manifest_vars` (dormant: nothing passes `--set-vars` yet). The wrapper follows the same three-phase order.
- Update the activation architecture diagram and the `[plugins]` section of `manifest.toml.md`.
- Integration tests: a plugin script reads a `[vars]` variable; a plugin's export wins over a same-named `[vars]` entry.

Known caveat: a `[vars]` value referencing a variable exported by a *plugin* script (undocumented — the docs only promise references between `[vars]` entries) now fails under `set -u`, since `[vars]` are exported before plugin scripts run. References to variables set by the interpreter's scripts and to ambient shell variables still resolve.

## Release Notes

- Plugin scripts can now read variables set in the manifest's `[vars]` section: activation sources Flox's own profile.d scripts first, then exports `[vars]`, then sources plugin-provided profile.d scripts. A variable exported by a plugin script takes precedence over a same-named `[vars]` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)