### PR TITLE
feat(publish): add hidden --no-cascade-update flag (ECO-225)

### DIFF
--- a/cli/catalog-api-v1/openapi.json
+++ b/cli/catalog-api-v1/openapi.json
@@ -3398,6 +3398,11 @@
               "$ref": "#/components/schemas/LockedInputEntry"
             },
             "type": "object"
+          },
+          "cascade_update": {
+            "type": "boolean",
+            "title": "Cascade Update",
+            "default": false
           }
         },
         "type": "object",

--- a/cli/catalog-api-v1/src/client.rs
+++ b/cli/catalog-api-v1/src/client.rs
@@ -2633,6 +2633,11 @@ catalog) or '<owner>.<pkgset>.*' (package set) — e.g. 'brantley.*'
     ///        "null"
     ///      ]
     ///    },
+    ///    "cascade_update": {
+    ///      "title": "Cascade Update",
+    ///      "default": false,
+    ///      "type": "boolean"
+    ///    },
     ///    "derivation": {
     ///      "$ref": "#/components/schemas/PackageDerivation"
     ///    },
@@ -2715,6 +2720,8 @@ catalog) or '<owner>.<pkgset>.*' (package set) — e.g. 'brantley.*'
         pub build_type: ::std::option::Option<BuildType>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub cache_uri: ::std::option::Option<::std::string::String>,
+        #[serde(default)]
+        pub cascade_update: bool,
         pub derivation: PackageDerivation,
         #[serde(default = "defaults::package_build_with_nar_info_dot_flox_dir")]
         pub dot_flox_dir: ::std::string::String,

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -123,6 +123,16 @@ pub enum PublishError {
     UnsupportedSystem(String),
 }
 
+/// Behavior of a single publish, as selected by the user on the command line.
+#[derive(Clone, Copy, Debug)]
+pub struct PublishOptions {
+    /// Publish only the metadata of the package, without uploading the
+    /// artifact itself.
+    pub metadata_only: bool,
+    /// Whether the hub should rebuild the packages that depend on this one.
+    pub cascade_update: bool,
+}
+
 /// The `Publish` trait describes the high level behavior of publishing a package to a catalog.
 /// Authentication, upload, builds etc, are implementation details of the specific provider.
 /// Modeling the behavior as a trait allows us to swap out the provider, e.g. a mock for testing.
@@ -146,7 +156,7 @@ pub trait Publisher {
         package_created: PackageCreatedGuard,
         build_metadata: &CheckedBuildMetadata,
         key_file: Option<PathBuf>,
-        metadata_only: bool,
+        options: PublishOptions,
     ) -> Result<bool, PublishError>;
     async fn wait_for_publish_completion(
         &self,
@@ -631,7 +641,7 @@ where
         _package_created: PackageCreatedGuard,
         build_metadata: &CheckedBuildMetadata,
         key_file: Option<PathBuf>,
-        metadata_only: bool,
+        options: PublishOptions,
     ) -> Result<bool, PublishError> {
         // Step 2 hit /publish
         // Catalogs are configured with their "store".
@@ -647,7 +657,7 @@ where
             .map_err(PublishError::CatalogError)?;
 
         let catalog_store_config = get_client_side_catalog_store_config(
-            metadata_only,
+            options.metadata_only,
             key_file,
             &self.auth,
             publish_response,
@@ -685,6 +695,11 @@ where
             // map when the build resolved none. Older CLIs that omit the field
             // are coalesced to empty server-side (floxhub#1791).
             locked_inputs: Some(build_metadata.direct_catalog_inputs.clone()),
+            // Whether the hub should rebuild dependents of this package.
+            // Always sent explicitly: the server default is `false`, so an
+            // omitted field would silently disable cascading rather than
+            // fall back to the CLI's default of cascading.
+            cascade_update: options.cascade_update,
             base_catalog_rev_count: None,
             base_catalog_rev_date: None,
             url: self.env_metadata.build_repo_meta.url.to_string(),
@@ -1978,7 +1993,10 @@ pub mod tests {
                 package_created,
                 &build_metadata,
                 None,
-                false,
+                PublishOptions {
+                    metadata_only: false,
+                    cascade_update: true,
+                },
             )
             .await;
 
@@ -2261,7 +2279,10 @@ pub mod tests {
                 package_created,
                 &build_metadata,
                 None,
-                false,
+                PublishOptions {
+                    metadata_only: false,
+                    cascade_update: true,
+                },
             )
             .await;
 
@@ -2426,7 +2447,10 @@ pub mod tests {
                 package_created,
                 &build_metadata,
                 cache.local_signing_key_path(),
-                false,
+                PublishOptions {
+                    metadata_only: false,
+                    cascade_update: true,
+                },
             )
             .await
             .unwrap();
@@ -2705,7 +2729,10 @@ pub mod tests {
                 None,
                 // Server returns meta-only store config; narinfo collected
                 // from FIXED_TEST_STORE_PATH in the local daemon store.
-                false,
+                PublishOptions {
+                    metadata_only: false,
+                    cascade_update: true,
+                },
             )
             .await
             .expect("failed to do publish");
@@ -2745,7 +2772,10 @@ pub mod tests {
                 None,
                 // Server returns meta-only store config; narinfo collected
                 // from FIXED_TEST_STORE_PATH in the local daemon store.
-                false,
+                PublishOptions {
+                    metadata_only: false,
+                    cascade_update: true,
+                },
             )
             .await
             .expect("failed to do publish");
@@ -2812,7 +2842,10 @@ pub mod tests {
                 None,
                 // Server returns meta-only store config; narinfo collected
                 // from FIXED_TEST_STORE_PATH in the local daemon store.
-                false,
+                PublishOptions {
+                    metadata_only: false,
+                    cascade_update: true,
+                },
             )
             .await
             .expect("failed to do publish");
@@ -2827,7 +2860,10 @@ pub mod tests {
                 None,
                 // Server returns meta-only store config; narinfo collected
                 // from FIXED_TEST_STORE_PATH in the local daemon store.
-                false,
+                PublishOptions {
+                    metadata_only: false,
+                    cascade_update: true,
+                },
             )
             .await
             .expect("failed to do publish");
@@ -2861,7 +2897,10 @@ pub mod tests {
                 None,
                 // Server returns meta-only store config; narinfo collected
                 // from FIXED_TEST_STORE_PATH in the local daemon store.
-                false,
+                PublishOptions {
+                    metadata_only: false,
+                    cascade_update: true,
+                },
             )
             .await
             .unwrap_err();

--- a/cli/flox/src/commands/publish.rs
+++ b/cli/flox/src/commands/publish.rs
@@ -10,6 +10,7 @@ use flox_rust_sdk::models::environment::{ConcreteEnvironment, Environment};
 use flox_rust_sdk::providers::build::{COMMON_NIXPKGS_URL, CatalogLock, PackageTarget};
 use flox_rust_sdk::providers::nix_auth::NixAuth;
 use flox_rust_sdk::providers::publish::{
+    PublishOptions,
     PublishProvider,
     Publisher,
     build_repo_err,
@@ -89,6 +90,10 @@ pub struct Publish {
     #[bpaf(long, hide)]
     metadata_only: bool,
 
+    /// Do not rebuild packages that depend on the published package.
+    #[bpaf(long, hide)]
+    no_cascade_update: bool,
+
     #[bpaf(external(base_catalog_url_select), optional)]
     base_catalog_url_select: Option<BaseCatalogUrlSelect>,
 
@@ -129,7 +134,7 @@ struct PublishTarget {
 /// Configuration options for the publish command
 #[derive(Debug, Clone)]
 struct PublishConfig {
-    metadata_only: bool,
+    options: PublishOptions,
     cache_args: CacheArgs,
     base_catalog_url_select: Option<BaseCatalogUrlSelect>,
     system_override: SystemOverride,
@@ -148,7 +153,13 @@ impl Publish {
         }
 
         let publish_config = PublishConfig {
-            metadata_only: self.metadata_only,
+            options: PublishOptions {
+                metadata_only: self.metadata_only,
+                // The flag suppresses; the wire field enables. Invert here so
+                // the rest of the publish path only deals with the wire
+                // polarity.
+                cascade_update: !self.no_cascade_update,
+            },
             cache_args: self.cache,
             base_catalog_url_select: self.base_catalog_url_select,
             system_override: self.system_override,
@@ -432,7 +443,7 @@ impl Publish {
                 package_created,
                 &build_metadata,
                 key_file,
-                publish_config.metadata_only,
+                publish_config.options,
             )
             .await
         {

--- a/cli/floxhub-client/src/client.rs
+++ b/cli/floxhub-client/src/client.rs
@@ -1668,4 +1668,92 @@ pub mod tests {
         mock.assert();
         assert!(result.is_err(), "expected Err from 5xx, got: {result:?}");
     }
+    // ---------------------------------------------------------------------------
+    // publish_build — cascade_update is always on the wire
+    // ---------------------------------------------------------------------------
+
+    const PUBLISH_BUILD_PATH: &str = "/api/v1/catalog/catalogs/myorg/packages/mypkg/builds";
+
+    /// The smallest build payload the endpoint accepts, so the tests below
+    /// assert on `cascade_update` and nothing else.
+    fn minimal_build_info(cascade_update: bool) -> UserBuildPublish {
+        use catalog_api_v1::types as api_types;
+
+        UserBuildPublish {
+            cascade_update,
+            derivation: api_types::PackageDerivation {
+                broken: None,
+                description: None,
+                drv_path: "/nix/store/aaa-mypkg.drv".to_string(),
+                license: None,
+                licenses: None,
+                name: "mypkg".to_string(),
+                outputs: api_types::PackageOutputs(vec![]),
+                outputs_to_install: None,
+                pname: None,
+                system: api_types::PackageSystem::X8664Linux,
+                unfree: None,
+                version: None,
+            },
+            url: "https://example.com/repo".to_string(),
+            rev: "deadbeef".to_string(),
+            rev_count: 1,
+            rev_date: "2024-01-01T00:00:00Z".parse().unwrap(),
+            base_catalog_rev_count: None,
+            base_catalog_rev_date: None,
+            build_type: None,
+            cache_uri: None,
+            dot_flox_dir: ".flox".to_string(),
+            locked_base_catalog_url: None,
+            locked_inputs: None,
+            narinfos: None,
+            narinfos_source_url: None,
+            narinfos_source_version: None,
+            ref_: None,
+        }
+    }
+
+    /// A publish that should cascade sends `cascade_update: true` explicitly.
+    /// The server defaults the field to `false`, so omitting it would disable
+    /// cascading rather than fall back to the CLI's default.
+    #[tokio::test]
+    async fn publish_build_sends_cascade_update_true() {
+        let server = MockServer::start_async().await;
+        let mock = server.mock(|when, then| {
+            when.method("POST")
+                .path(PUBLISH_BUILD_PATH)
+                .json_body_includes(json!({ "cascade_update": true }).to_string());
+            then.status(200).json_body(json!({}));
+        });
+
+        let client = FloxhubClient::new(client_config(server.base_url().as_str())).unwrap();
+
+        let result = client
+            .publish_build("myorg", "mypkg", &minimal_build_info(true))
+            .await;
+
+        mock.assert();
+        assert!(result.is_ok(), "expected Ok, got: {result:?}");
+    }
+
+    /// `flox publish --no-cascade-update` sends `cascade_update: false`.
+    #[tokio::test]
+    async fn publish_build_sends_cascade_update_false() {
+        let server = MockServer::start_async().await;
+        let mock = server.mock(|when, then| {
+            when.method("POST")
+                .path(PUBLISH_BUILD_PATH)
+                .json_body_includes(json!({ "cascade_update": false }).to_string());
+            then.status(200).json_body(json!({}));
+        });
+
+        let client = FloxhubClient::new(client_config(server.base_url().as_str())).unwrap();
+
+        let result = client
+            .publish_build("myorg", "mypkg", &minimal_build_info(false))
+            .await;
+
+        mock.assert();
+        assert!(result.is_ok(), "expected Ok, got: {result:?}");
+    }
 }


### PR DESCRIPTION
Cascading rebuilds need a way for a publish to say whether the hub should rebuild the packages that depend on it. Factory-originated builds must be able to say no, or a cascading rebuild triggers another cascade. Nothing on the CLI side can express that today: `flox publish` has no such flag, and the publish wire payload has no such field.

## Proposed Changes

Add a hidden `--no-cascade-update` flag to `flox publish` and thread it through to the `cascade_update` field on the publish wire payload. The build coordinator will set it on factory-originated builds; that side is ECO-226 and lands separately.

**The flag is negative, the wire field is positive.** The value is inverted once at the CLI boundary so the rest of the publish path only deals with the wire polarity.

**The value is always sent explicitly, in both directions.** Omitting the field is not equivalent to sending `true`: the server defaults it to `false`, so an omitted field would silently disable cascading rather than fall back to the CLI's default of cascading. This follows the `locked_inputs` precedent, which is always sent for the same reason.

**The publish flags are grouped into `PublishOptions`.** Adding a seventh parameter pushed `Publisher::publish` over clippy's `too_many_arguments` limit, which is a hard failure under this repo's `-D warnings`. Rather than an `#[allow]`, `metadata_only` and `cascade_update` move into a struct. That clears the lint and stops the two flags from being adjacent positional bools at every call site, where transposing them would compile silently.

**The first commit is provisional and should not reach `main` as-is.** `cascade_update` is defined on `PackageBuildWithNarInfo` by ECO-222, still open as flox/floxhub#2219. `UserBuildPublish` aliases the generated `catalog_api_v1::types::PackageBuildWithNarInfo`, so the struct literal in `providers/publish.rs` does not compile until the vendored OpenAPI spec carries the property. That commit takes the property from the ECO-222 branch so this work can be written and tested now. It is byte-identical to what the branch carries, verified by copying `catalog_server_oas302.json` from it wholesale and confirming the regenerated `client.rs` matched exactly. The property normally arrives through the automated "build: Update catalog API schema and client" PR, which only fires on pushes to floxhub's `main`. Once ECO-222 merges, drop the commit in favour of that bump rather than resolving a conflict against it. The automated bump will be a superset — it also carries the unrelated `MessageType.Archived` variant this repo's vendored spec currently lacks, which is inert here because `build.rs` replaces the generated `MessageType` with the hand-written `crate::error::MessageType`.

**That commit does not compile standalone**, since a Rust struct literal must name every field: the spec change and its first consumer have to land together. This only matters for per-commit CI or bisects, not for the squashed merge.

**No docs, no bats, no cassette re-recording.** Hidden flags are undocumented by convention here — `--metadata-only` appears nowhere in `docs/` either. No integration test invokes `flox publish`. The four publish cassettes match with `json_body_includes`, which is inclusive subset matching, so an added request field does not break replay; the cassette tests passing on this branch confirms it rather than assuming it.

**Verification.** `just unit-tests publish` green (54 tests, including the four publish cassette-replay tests). `cargo test -p floxhub-client` green (100). Two new `httpmock` tests assert `cascade_update` reaches the wire in both polarities, modelled on the existing `check_build_sends_locked_inputs`; the `false` case is the load-bearing one, since it is what a future `skip_serializing_if` on the generated field would break. The eight existing SDK `publish()` call sites are updated for the new signature. `cargo clippy --all --all-targets -- -D warnings` and `cargo fmt --check` clean. Verified manually that the flag is hidden from `flox publish --help` and still parses.

**Do not merge before ECO-222**, or the CLI sends a field the server does not model. That gate is cheap to clear, though: ECO-222 carries no database migration — it is pydantic models, tests and the regenerated schema — so it can merge early and be reverted later if the rebuild algorithm changes shape. Separately, and outside what either repo enforces: do not deploy an ECO-226 build coordinator that emits `--no-cascade-update` until a flox containing this change is published into the `flox/factory-build` FloxHub environment. Build pods take their toolchain from that environment rather than a pinned image tag, so an unknown argument would fail every factory build, not only rebuilds.

Fixes [ECO-225](https://linear.app/floxdotdev/issue/ECO-225)

Blocked by [ECO-222](https://linear.app/floxdotdev/issue/ECO-222) (flox/floxhub#2219). Pairs with [ECO-226](https://linear.app/floxdotdev/issue/ECO-226).

## Release Notes

N/A. The flag is hidden and has no effect until the build coordinator starts setting it.
