### PR TITLE
chore(catalog-api): refresh by-command client from DEV-180 schema

### DIFF
--- a/cli/catalog-api-v1/openapi.json
+++ b/cli/catalog-api-v1/openapi.json
@@ -108,7 +108,7 @@
           "catalog"
         ],
         "summary": "Find packages that provide a command",
-        "description": "Reverse lookup: which package(s) provide the given command name.\n\nRequired Query Parameters:\n- **system**: The system architecture to search for (e.g., x86_64-linux)\n- **name**: The command name to look up (e.g., readelf, rg, gcc-13)\n\nReturns:\n- **ByCommandResult**: Providers of the command and total count\n\nNote: first pass returns a hardcoded mock so the OpenAPI contract can\nfreeze before the command_index table lands. No database query yet.",
+        "description": "Reverse lookup: which package(s) provide the given command name.\n\nRequired Query Parameters:\n- **system**: The system architecture to search for (e.g., x86_64-linux)\n- **name**: The command name to look up (e.g., readelf, rg, gcc-13)\n\nOptional Query Parameters:\n- **page**: Page number for pagination (default: 0)\n- **pageSize**: Page size for pagination (default: 10)\n\nReturns:\n- **ByCommandResult**: Providers of the command and total count",
         "operationId": "by_command_api_v1_catalog_by_command_get",
         "security": [
           {
@@ -136,6 +136,26 @@
               "minLength": 2,
               "maxLength": 200,
               "title": "Name"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "title": "Page"
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 10,
+              "title": "Pagesize"
             }
           }
         ],
@@ -3071,7 +3091,8 @@
           "unfree",
           "insecure",
           "broken",
-          "version_not_found"
+          "version_not_found",
+          "archived"
         ],
         "title": "MessageType"
       },

--- a/cli/catalog-api-v1/src/client.rs
+++ b/cli/catalog-api-v1/src/client.rs
@@ -5794,11 +5794,12 @@ Required Query Parameters:
 - **system**: The system architecture to search for (e.g., x86_64-linux)
 - **name**: The command name to look up (e.g., readelf, rg, gcc-13)
 
+Optional Query Parameters:
+- **page**: Page number for pagination (default: 0)
+- **pageSize**: Page size for pagination (default: 10)
+
 Returns:
 - **ByCommandResult**: Providers of the command and total count
-
-Note: first pass returns a hardcoded mock so the OpenAPI contract can
-freeze before the command_index table lands. No database query yet.
 
 Sends a `GET` request to `/api/v1/catalog/by-command`
 
@@ -5806,6 +5807,8 @@ Sends a `GET` request to `/api/v1/catalog/by-command`
     pub async fn by_command_api_v1_catalog_by_command_get<'a>(
         &'a self,
         name: &'a types::Name,
+        page: Option<i64>,
+        page_size: Option<i64>,
         system: types::PackageSystem,
     ) -> Result<ResponseValue<types::ByCommandResult>, Error<types::ErrorResponse>> {
         let url = format!("{}/api/v1/catalog/by-command", self.baseurl);
@@ -5824,6 +5827,8 @@ Sends a `GET` request to `/api/v1/catalog/by-command`
                 ::reqwest::header::HeaderValue::from_static("application/json"),
             )
             .query(&progenitor_client::QueryParam::new("name", &name))
+            .query(&progenitor_client::QueryParam::new("page", &page))
+            .query(&progenitor_client::QueryParam::new("pageSize", &page_size))
             .query(&progenitor_client::QueryParam::new("system", &system))
             .headers(header_map)
             .build()?;

--- a/cli/floxhub-client/src/client.rs
+++ b/cli/floxhub-client/src/client.rs
@@ -445,7 +445,7 @@ impl CatalogClientTrait for FloxhubClient {
 
         let response = self
             .catalog
-            .by_command_api_v1_catalog_by_command_get(&command_name, system)
+            .by_command_api_v1_catalog_by_command_get(&command_name, None, None, system)
             .await
             .map_api_error()
             .await?;


### PR DESCRIPTION
## Summary

- Refreshes `cli/catalog-api-v1/openapi.json` from the floxhub DEV-180 schema (PR #2232)
- Regenerates `cli/catalog-api-v1/src/client.rs` via progenitor — adds `page: Option<i64>` and `page_size: Option<i64>` to `by_command_api_v1_catalog_by_command_get`
- Updates the single call site in `cli/floxhub-client/src/client.rs` to pass `None, None` for the new optional params, preserving existing behavior

No trait or mock changes needed — pagination is transparent to callers of `CatalogClientTrait::by_command`.

## Test plan

- [ ] `cargo build -p floxhub-client` compiles clean
- [ ] No behavior change for existing `by_command` callers (None defaults to server-side page=0, pageSize=10)

---
*Via Forge (interactive) • 2c57c440*