### PR TITLE
fix: don't special case services environment

### DIFF
--- a/cli/flox-activations/src/attach_diff/mod.rs
+++ b/cli/flox-activations/src/attach_diff/mod.rs
@@ -72,14 +72,13 @@ pub struct AttachDiff {
     ///    This ensures we re-apply these variables after they could have been
     ///    changed, particularly if user RC files contain flox activations
     double_sets: EnvDiff,
-    /// Pre-encoded diff string for _FLOX_HOOK_DIFF. None if snapshot unavailable.
-    encoded_diff: Option<String>,
+    /// Pre-encoded diff string for _FLOX_HOOK_DIFF.
+    encoded_diff: String,
 }
 
 impl AttachDiff {
     /// Assemble all environment variable sets and unsets needed for
-    /// activation, and compute the activation diff if a pre-activation
-    /// snapshot is available.
+    /// activation, and compute the activation diff.
     pub fn new(
         context: &AttachCtx,
         project: Option<&AttachProjectCtx>,
@@ -89,7 +88,7 @@ impl AttachDiff {
         is_in_place: bool,
     ) -> Result<Self> {
         // Extract the pre-activation snapshot before consuming vars_from_env.
-        let full_env = vars_from_env.full_env.take();
+        let full_env = std::mem::take(&mut vars_from_env.full_env);
 
         let single_sets: HashMap<String, String> = single_set_envs(context)
             .into_iter()
@@ -116,8 +115,7 @@ impl AttachDiff {
             .deletions
             .extend(start_diff.deletions().iter().cloned());
 
-        // Compute the activation diff if we have a pre-activation snapshot.
-        let encoded_diff = if let Some(ref current_env) = full_env {
+        let encoded_diff = {
             let mut intended_sets = if is_in_place {
                 // These variables are computed by set-env-dirs and fix-paths,
                 // for which values must be computed dynamically at runtime.
@@ -138,7 +136,7 @@ impl AttachDiff {
             intended_sets.extend(double_sets.additions.keys().cloned());
             let intended_removals: HashSet<String> =
                 double_sets.deletions.iter().cloned().collect();
-            let diff = diff_env(current_env, &intended_sets, &intended_removals);
+            let diff = diff_env(&full_env, &intended_sets, &intended_removals);
             let encoded = diff.encode()?;
             debug!(
                 "captured activation diff: {} added, {} modified, {} removed ({} bytes encoded)",
@@ -147,9 +145,7 @@ impl AttachDiff {
                 diff.removed.len(),
                 encoded.len(),
             );
-            Some(encoded)
-        } else {
-            None
+            encoded
         };
 
         Ok(Self {
@@ -160,17 +156,16 @@ impl AttachDiff {
         })
     }
 
-    /// The encoded `_FLOX_HOOK_DIFF` string, if a pre-activation snapshot
-    /// was available when this `AttachDiff` was constructed.
+    /// The encoded `_FLOX_HOOK_DIFF` string.
     #[cfg(test)]
-    pub fn encoded_diff(&self) -> Option<&str> {
-        self.encoded_diff.as_deref()
+    pub fn encoded_diff(&self) -> &str {
+        &self.encoded_diff
     }
 
     /// Apply the activation environment to a Command.
     ///
     /// Sets all accumulated variables, removes all accumulated unsets,
-    /// and sets the _FLOX_HOOK_DIFF env var if a diff was computed.
+    /// and sets the _FLOX_HOOK_DIFF env var.
     pub fn apply_to_command(&self, command: &mut Command) {
         command.envs(&self.non_in_place_sets);
         command.envs(&self.single_sets);
@@ -181,9 +176,7 @@ impl AttachDiff {
         for var in &self.double_sets.deletions {
             command.env_remove(var);
         }
-        if let Some(ref encoded) = self.encoded_diff {
-            command.env(FLOX_HOOK_DIFF_VAR, encoded);
-        }
+        command.env(FLOX_HOOK_DIFF_VAR, &self.encoded_diff);
     }
 
     /// Generate statements that apply the environment in a gen_rc script
@@ -198,9 +191,10 @@ impl AttachDiff {
             for (k, v) in self.single_sets.iter().sorted_by_key(|(k, _)| *k) {
                 stmts.push(set_exported_unexpanded(k, v));
             }
-            if let Some(ref encoded) = self.encoded_diff {
-                stmts.push(set_exported_unexpanded(FLOX_HOOK_DIFF_VAR, encoded));
-            }
+            stmts.push(set_exported_unexpanded(
+                FLOX_HOOK_DIFF_VAR,
+                &self.encoded_diff,
+            ));
         }
         // double_sets includes user variables which we want to override
         // single_sets, so set them after single_sets.

--- a/cli/flox-activations/src/cli/activate.rs
+++ b/cli/flox-activations/src/cli/activate.rs
@@ -116,7 +116,7 @@ impl ActivateArgs {
 
         // Capture env snapshot *before* modifying the process environment so
         // the diff reflects the true pre-activation state.
-        let vars_from_env = VarsFromEnvironment::get_with_snapshot()?;
+        let vars_from_env = VarsFromEnvironment::get()?;
 
         // Unset FLOX_SHELL to detect the parent shell anew with each flox invocation.
         unsafe { std::env::remove_var("FLOX_SHELL") };

--- a/cli/flox-activations/src/gen_rc/mod.rs
+++ b/cli/flox-activations/src/gen_rc/mod.rs
@@ -197,7 +197,7 @@ pub(crate) mod test_helpers {
             sbin_env_dirs: None,
             path: None,
             manpath: None,
-            full_env: Some(full_env),
+            full_env,
         };
         let rc_path = Some(PathBuf::from("/path/to/rc/file"));
         startup_ctx(
@@ -222,11 +222,7 @@ pub(crate) mod test_helpers {
     /// have captured.
     pub fn test_deactivate_ctx(shell: ShellWithPath, is_in_place: bool) -> DeactivateCtx {
         let startup = test_startup_ctx(shell, is_in_place);
-        let encoded_diff = startup
-            .attach_diff
-            .encoded_diff()
-            .expect("test_startup_ctx should produce an encoded diff")
-            .to_string();
+        let encoded_diff = startup.attach_diff.encoded_diff().to_string();
         let restore_diff =
             DiffSerializer::decode(&encoded_diff).expect("encoded diff should decode successfully");
         DeactivateCtx {

--- a/cli/flox-activations/src/vars_from_env.rs
+++ b/cli/flox-activations/src/vars_from_env.rs
@@ -13,33 +13,19 @@ pub struct VarsFromEnvironment {
     pub sbin_env_dirs: Option<String>,
     pub path: Option<String>,
     pub manpath: Option<String>,
-    /// Full environment snapshot for activation diff computation.
-    /// Populated by [`VarsFromEnvironment::get_with_snapshot`].
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub full_env: Option<HashMap<String, String>>,
+    /// The environment as it stood before this activation applied anything,
+    /// which is the baseline the `_FLOX_HOOK_DIFF` restored by
+    /// `flox deactivate` is measured against.
+    // TODO: should we drop the individual fields and just keep this one?
+    pub full_env: HashMap<String, String>,
 }
 
 impl VarsFromEnvironment {
+    /// Capture the pre-activation environment.
+    ///
+    /// Call this before mutating the process environment, so that the
+    /// snapshot reflects the true pre-activation state.
     pub fn get() -> Result<Self> {
-        let flox_env_dirs = std::env::var(FLOX_ENV_DIRS_VAR).ok();
-        let sbin_env_dirs = std::env::var(FLOX_ENV_DIRS_ADD_SBIN_VAR).ok();
-        let path = std::env::var("PATH").ok();
-        let manpath = std::env::var("MANPATH").ok();
-
-        Ok(Self {
-            flox_env_dirs,
-            sbin_env_dirs,
-            path,
-            manpath,
-            full_env: None,
-        })
-    }
-
-    /// Capture path-related vars plus full env snapshot.
-    /// Used on activation so the diff can restore the full environment on
-    /// deactivation; [`VarsFromEnvironment::get`] captures only the
-    /// path-related vars.
-    pub fn get_with_snapshot() -> Result<Self> {
         // TODO(performance): is it faster to copy the entirety of env, or just get every environment variable we need?
         let all_vars: HashMap<String, String> = std::env::vars().collect();
         Ok(Self {
@@ -47,7 +33,7 @@ impl VarsFromEnvironment {
             sbin_env_dirs: all_vars.get(FLOX_ENV_DIRS_ADD_SBIN_VAR).cloned(),
             path: all_vars.get("PATH").cloned(),
             manpath: all_vars.get("MANPATH").cloned(),
-            full_env: Some(all_vars),
+            full_env: all_vars,
         })
     }
 }


### PR DESCRIPTION
Snapshotting the full environment served as a proxy for the auto
activate feature flag, but we neglected to catch that we never swapped
the activation environment for services to capture the full environment.
We don't technically need `_FLOX_HOOK_DIFF` in the services environment,
which is the only behavioral outcome, but we should try to keep that environment
as consistent as possible with the activation environment.

And dropping the special casing allows us to drop some code.
