### PR TITLE
fix(lock_manifest): hint to add system to options.systems on lock failure

### DIFF
--- a/cli/flox-rust-sdk/src/providers/lock_manifest.rs
+++ b/cli/flox-rust-sdk/src/providers/lock_manifest.rs
@@ -79,7 +79,7 @@ pub enum ResolveError {
     // todo: this should probably part of some validation logic of the manifest file
     //       rather than occurring during the locking process creation
     #[error(
-        "'{install_id}' specifies disabled or unknown system '{system}' (enabled systems: {enabled_systems})",
+        "'{install_id}' specifies disabled or unknown system '{system}' (enabled systems: {enabled_systems}).\n\nAdd '{system}' to 'options.systems' in manifest.toml",
         enabled_systems=enabled_systems.join(", ")
     )]
     SystemUnavailableInManifest {


### PR DESCRIPTION
## Summary

- Amends the `SystemUnavailableInManifest` error to include actionable guidance when a package's `{install_id}.systems` names a system absent from `options.systems`
- Interpolates the offending `{system}` field (already present on the variant) rather than hardcoding `x86_64-darwin`
- Follows the same `\n\nAdd ...` style used by the adjacent `LicenseNotAllowed`, `BrokenNotAllowed`, and `UnfreeNotAllowed` variants

**Before:**
```
'my-pkg' specifies disabled or unknown system 'x86_64-darwin' (enabled systems: aarch64-linux)
```

**After:**
```
'my-pkg' specifies disabled or unknown system 'x86_64-darwin' (enabled systems: aarch64-linux).

Add 'x86_64-darwin' to 'options.systems' in manifest.toml
```

Closes DEV-265.

## Test plan

- [ ] `cargo build -p flox-rust-sdk` passes
- [ ] Set `options.systems = ["aarch64-linux"]` and add a package with `systems = ["x86_64-darwin"]`; confirm the new guidance line appears on `flox install` / `flox upgrade`

🤖 Generated with [Claude Code](https://claude.com/claude-code)