### PR TITLE
feat(metrics): report activation invocation type

### DIFF
--- a/cli/flox-events/src/lib.rs
+++ b/cli/flox-events/src/lib.rs
@@ -495,6 +495,14 @@ pub struct CliEnvironmentActivatePayload {
     manifest_version: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     shell: Option<String>,
+    /// How the activation was invoked: `interactive`, `inplace`,
+    /// `shellcommand`, or `execcommand`. The caller supplies the
+    /// `InvocationKind` projection of the activation's invocation type
+    /// (`flox-core`), so the command a user passed to `-c` or `--` never
+    /// travels with it. Rides the same emit as `shell`, so the two
+    /// cross-tabulate without a join.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    invocation_type: Option<String>,
 }
 
 impl CliEnvironmentActivatePayload {
@@ -509,6 +517,7 @@ impl CliEnvironmentActivatePayload {
             lockfile_version: None,
             manifest_version: None,
             shell: None,
+            invocation_type: None,
         }
     }
 
@@ -539,6 +548,11 @@ impl CliEnvironmentActivatePayload {
 
     pub fn with_shell(mut self, value: impl Into<String>) -> Self {
         self.shell = Some(value.into());
+        self
+    }
+
+    pub fn with_invocation_type(mut self, value: impl Into<String>) -> Self {
+        self.invocation_type = Some(value.into());
         self
     }
 }
@@ -1265,7 +1279,8 @@ mod tests {
         let payload = CliEnvironmentActivatePayload::new(env_detail("path", "myenv"))
             .with_lockfile_version("1")
             .with_manifest_version("1")
-            .with_shell("bash");
+            .with_shell("bash")
+            .with_invocation_type("interactive");
         let value = serde_json::to_value(fixed_event(EventKind::CliEnvironmentActivate(payload)))
             .expect("event serializes");
         let expected = activate_envelope_json(json!({
@@ -1274,6 +1289,7 @@ mod tests {
             "lockfile_version": "1",
             "manifest_version": "1",
             "shell": "bash",
+            "invocation_type": "interactive",
         }));
         assert_eq!(value, expected);
     }

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -586,13 +586,22 @@ impl ActivateOptions {
         } else {
             detect_shell_for_subshell()
         };
-        subcommand_metric!("activate", "shell" = shell.to_string());
+        // `InvocationType`'s Display projects through `InvocationKind`, so the
+        // command behind `-c` / `--` is dropped rather than reported.
+        let invocation_kind = invocation_type.to_string();
+        subcommand_metric!(
+            "activate",
+            "shell" = shell.to_string(),
+            "invocation_type" = invocation_kind.clone()
+        );
 
         // Runs before `command.exec()`, so the buffered event is flushed
         // synchronously by the pre-exec emit + flush block below
         // (spec AC #5).
         if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentActivate(
-            CliEnvironmentActivatePayload::new(v2_env_detail.clone()).with_shell(shell.to_string()),
+            CliEnvironmentActivatePayload::new(v2_env_detail.clone())
+                .with_shell(shell.to_string())
+                .with_invocation_type(invocation_kind),
         )) {
             debug!(error = %err, "Failed to record v2 event");
         }


### PR DESCRIPTION
- **feat(metrics): report activation invocation type**
  The activate payload carried `shell`, `mode`, `start_services`,
  `has_includes` and the lockfile/manifest versions, but nothing said
  whether an activation was interactive, in-place, or driven by a
  command. That distinction drives how the activation behaves, so it is
  worth being able to segment on.
  
  Ride the existing `shell` emit rather than adding a fifth one:
  `invocation_type` is already a parameter of `ActivateOptions::activate`
  and in scope there, and sharing a row lets shell and invocation type
  cross-tabulate without a join.
  
  Report the `InvocationKind` projection via `InvocationType`'s Display,
  which drops the command wrapped by `ShellCommand`/`ExecCommand`, so the
  field is four fixed values and never carries a user's command line.
  
  Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
  