### PR TITLE
fix(tests): give the services waits room to be slow

### DIFF
--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -30,6 +30,25 @@ project_teardown() {
 
 # ---------------------------------------------------------------------------- #
 
+# How long the polls below wait before giving up.
+#
+# They return as soon as the content appears, so this only bounds how long a
+# genuine failure takes to report. The bound has to hold on a healthy machine
+# carrying the suite's own `--jobs 4` load, not just an idle one: the
+# executive's cleanup (event delivery, `process-compose down`, removing the
+# activation state) takes ~0.5s idle, but 1s expired on darwin runners whose
+# median test was 574ms — the fastest machines in the failing set, not slow
+# ones — pushing a 1.4s test to 5.7s.
+#
+# 10s matches `wait_for_activations`, which is what observed cleanup completing
+# on those same runs. Keeping the two equal means a cleanup that really is
+# stuck fails here, with the file's contents, rather than surviving this poll
+# and failing in teardown with a less useful message.
+#
+# Exported because "services stop after auto-activated environment is
+# deactivated" runs the poll inside a `bash -c`.
+export WAIT_FOR_FILE_CONTENT_TIMEOUT="10s"
+
 # Wait, with a poll and timeout, for a file to match some contents.
 #
 # This can be used to prevent race conditions where we expect something to
@@ -38,7 +57,7 @@ wait_for_file_content() {
   file="${1?}"
   expected="${2?}"
 
-  run timeout 1s bash -c "
+  run timeout "$WAIT_FOR_FILE_CONTENT_TIMEOUT" bash -c "
     while [ \"\$(cat \"$file\")\" != \"$expected\" ]; do
       sleep 0.1s
     done
@@ -51,11 +70,22 @@ wait_for_partial_file_content() {
   file="${1?}"
   expected="${2?}"
 
-  timeout 1s bash -c "
+  if timeout "$WAIT_FOR_FILE_CONTENT_TIMEOUT" bash -c "
     while ! grep -q \"$expected\" \"$file\"; do
       sleep 0.1s
     done
-  "
+  "; then
+    return 0
+  fi
+
+  # Without this the caller only sees status 124 and has to guess how far the
+  # file got.
+  {
+    echo "wait_for_partial_file_content: '$expected' did not appear in $file within $WAIT_FOR_FILE_CONTENT_TIMEOUT"
+    echo "contents of $file:"
+    cat "$file"
+  } >&2
+  return 1
 }
 
 setup() {
@@ -64,6 +94,13 @@ setup() {
   project_setup
 
   export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/empty.yaml"
+
+  # Starting services waits this long for process-compose to create its socket.
+  # The 2s default is a reasonable thing to make a user wait but is not enough
+  # for a healthy CI runner that is also running the rest of the suite, where it
+  # surfaced as "Failed to start services: process-compose socket not ready"
+  # (CLI-73). Tests that assert on the timeout itself override this.
+  export _FLOX_SERVICES_ACTIVATE_TIMEOUT=10
 }
 
 teardown() {
@@ -1642,12 +1679,12 @@ EOF
   run "$FLOX_BIN" activate -s -- bash <(cat <<'EOF'
     set -euxo pipefail
 
-    timeout 2 bash -c 'set -x; while [ ! -e "$(pwd)/pidfile" ]; do sleep .1; done'
+    timeout 10 bash -c 'set -x; while [ ! -e "$(pwd)/pidfile" ]; do sleep .1; done'
 
     "$FLOX_BIN" services status
     "$FLOX_BIN" services stop
 
-    timeout 2 bash -c 'set -x; while kill -0 "$(cat "$(pwd)/pidfile")"; do sleep .1; done'
+    timeout 10 bash -c 'set -x; while kill -0 "$(cat "$(pwd)/pidfile")"; do sleep .1; done'
 EOF
   )
   assert_success
@@ -1695,7 +1732,7 @@ EOF
   # Wait for 2nd activation to start before tearing down the 1st
   # otherwise services might get stopped
   TEARDOWN_FIFO="$PROJECT_DIR/finished_2"
-  timeout 2 cat finished_1
+  timeout 10 cat finished_1
   run cat output
   assert_output --partial "! Skipped starting services, services are already running"
 
@@ -1709,9 +1746,7 @@ EOF
   wait_for_partial_file_content "$executive_log" "finished cleanup"
 
   # Make sure services have stopped
-  timeout 1s bash -c '
-    "${TESTS_DIR}"/services/wait_for_service_status.sh one:Stopped two:Stopped
-  '
+  "${TESTS_DIR}"/services/wait_for_service_status.sh one:Stopped two:Stopped
 }
 
 # bats test_tags=services:auto-deactivate
@@ -1854,7 +1889,7 @@ EOF
     echo > "$TEARDOWN_FIFO"
 EOF
   ) &
-  timeout 2 cat started
+  timeout 10 cat started
 
   "${TESTS_DIR}"/services/wait_for_service_status.sh initial:Completed
   run cat initial_values

--- a/cli/tests/services/wait_for_service_status.sh
+++ b/cli/tests/services/wait_for_service_status.sh
@@ -28,4 +28,10 @@ check_status() {
 }
 
 export -f check_status
-timeout 1s bash -c "while ! check_status ${*}; do sleep 0.1; done"
+# Polling stops as soon as every service reports the expected status, so the
+# budget only bounds how long a genuine failure takes to report. 1s was under
+# what a healthy CI runner needs to move a service between states while it is
+# also running the rest of the suite, which showed up as "status
+# current=Stopped, expected=Completed" on runs where the service did reach the
+# expected status a moment later.
+timeout 10s bash -c "while ! check_status ${*}; do sleep 0.1; done"


### PR DESCRIPTION
- **fix(tests): give the services waits room to be slow (CLI-73)**
  Every content poll in the services suite gave up after a second, which is
  enough on an idle machine and not enough on a healthy CI runner that is
  also running the rest of the suite:
  
  - `wait_for_partial_file_content` expiring on "finished cleanup" with
    status 124, the single most common flaky-test signature in the merge
    queue. The executive's cleanup — event delivery, `process-compose
    down`, removing the activation state — takes ~0.5s idle. The same runs
    then show cleanup completing, via teardown's `wait_for_activations`.
  - `wait_for_file_content`, which shares the bound and expired the same
    way on an activation writing to a file.
  - `wait_for_service_status.sh` reporting "status current=Stopped,
    expected=Completed" for a service that reaches the expected status a
    moment later.
  - "Failed to start services: process-compose socket not ready", which is
    `flox services start` giving process-compose 2s to create its socket.
  
  Raise all of them to 10s. Polling returns as soon as the condition holds,
  so this only changes how long a genuine failure takes to report. 10s
  because `wait_for_activations` already allows that much, and it is
  `wait_for_activations` that observed cleanup finishing on the runs where
  these polls expired — holding the two equal means a stuck cleanup fails
  at the poll, with the file's contents attached, instead of clearing the
  poll and failing later in teardown with a vaguer message.
  
  The socket wait is raised through `_FLOX_SERVICES_ACTIVATE_TIMEOUT`
  rather than by changing the default: 2s is a reasonable thing to make a
  user wait, and the tests that assert on the timeout still set their own.
  
  Separately, three waits in this file used `timeout 2` where every
  comparable wait around them already used 8-10s: two polls in "kills
  daemon process" waiting on process-compose to create and then kill a
  service's pidfile, and two blocking fifo reads served by an activation's
  hook. None of the measurements below covers those — they are simply the
  outliers in a file that had otherwise settled on 8-10s.
  
  Also report the file's contents when a content poll gives up. Until now
  the only evidence a failure left behind was the status 124.
  
  This is test work rather than fleet work because loaded is not the same
  as degraded. Measuring machine speed from passing tests only — suite wall
  time is circular, since an expired wait *is* time spent — every job in
  this cluster ran on a healthy builder, each inside its platform's normal
  band and finishing the whole suite in 6-8 minutes against a 30-minute
  budget:
  
    90551717799  aarch64-darwin   776 ms median  1096 s  suite in 7m44
    90451564350  aarch64-darwin   692 ms median  1009 s  suite in 7m30
    90448782760  aarch64-darwin   574 ms median   888 s  suite in 6m38
    90024100602  x86_64-darwin   1132 ms median   698 s  suite in 6m23
    90004919646  x86_64-darwin   1241 ms median   800 s  suite in 6m55
  
  A degraded builder looks nothing like these: 90335744819 had a comparable
  790 ms median but 1921 test-seconds and 29 failures at a uniform ~19s,
  and 90586220235 — the source of the worst number on record, a 7256 ms
  cleanup — ran four times slower than its siblings at a 2880 ms median.
  Neither sizes anything here; a degraded builder should fail.
  
  Nor were the healthy machines slow at the moment the wait expired. In
  90024100602 the failing test took 2282 ms against a neighbour median of
  2206 ms, and the usual victim passed in that same job in 2206 ms. On
  aarch64-darwin the failing test does run long — 4883 ms and 5699 ms
  against neighbour medians of 897 ms and 1274 ms — but the tests either
  side of it stay ordinary, which puts the latency in the cleanup rather
  than the machine. The load these waits have to survive is the suite's
  own: bats runs `--jobs 4`, so four tests contend by design, and a 1s
  bound on an operation that takes ~0.5s leaves under 2x of margin.
  