### PR TITLE
ci: move CI to Blacksmith runners with persistent /nix sticky disks

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,7 @@
+self-hosted-runner:
+  # Blacksmith (https://docs.blacksmith.sh/blacksmith-runners/overview)
+  labels:
+    - "blacksmith-2vcpu-ubuntu-2404"
+    - "blacksmith-4vcpu-ubuntu-2404"
+    - "blacksmith-8vcpu-ubuntu-2204"
+    - "blacksmith-12vcpu-macos-15"

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   add-label:
-    runs-on: ubuntu-latest
+    runs-on: "blacksmith-2vcpu-ubuntu-2404"
     permissions:
       pull-requests: write
       issues: write

--- a/.github/workflows/build-examples-tests.yml
+++ b/.github/workflows/build-examples-tests.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   run-manifest-build-examples:
     name: "Build manifest build examples"
-    runs-on: "ubuntu-latest"
+    runs-on: "blacksmith-2vcpu-ubuntu-2404"
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
   # request on a status-check timeout.
   scope:
     name: "Scope"
-    runs-on: "ubuntu-latest"
+    runs-on: "blacksmith-2vcpu-ubuntu-2404"
     timeout-minutes: 10
 
     # Only `pull_request` and `merge_group` can be scoped down at all; the
@@ -157,8 +157,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - "ubuntu-22.04-8core"
-          - "macos-14-xlarge"
+          - "blacksmith-8vcpu-ubuntu-2204"
+          - "blacksmith-12vcpu-macos-15"
 
     # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
     permissions:
@@ -169,6 +169,19 @@ jobs:
     steps:
       - name: "Checkout"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: "Create Nix store mount point"
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          sudo mkdir -p /nix/store
+          sudo chmod -R 777 /nix
+
+      - name: "Mount Nix store"
+        if: ${{ runner.os == 'Linux' }}
+        uses: useblacksmith/stickydisk@74f3f01ab1392726dd6ee06904f0452b0ec1e151 # v1
+        with:
+          key: "${{ github.repository }}-nix-${{ runner.arch }}"
+          path: "/nix"
 
       - name: "Setup upterm session"
         if: ${{ (true == inputs.enableUpterm) && (inputs.breakOnJob == github.job) }}
@@ -204,7 +217,7 @@ jobs:
     # checks, so this doesn't hit the branch-protection issue `scope` guards
     # against.
     if: ${{ !(github.event_name == 'push' && github.ref == 'refs/heads/main') }}
-    runs-on: "ubuntu-22.04-8core"
+    runs-on: "blacksmith-8vcpu-ubuntu-2204"
     timeout-minutes: 15 # eval only tests should be plenty fast
 
     permissions:
@@ -213,6 +226,19 @@ jobs:
     steps:
       - name: "Checkout"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: "Create Nix store mount point"
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          sudo mkdir -p /nix/store
+          sudo chmod -R 777 /nix
+
+      - name: "Mount Nix store"
+        if: ${{ runner.os == 'Linux' }}
+        uses: useblacksmith/stickydisk@74f3f01ab1392726dd6ee06904f0452b0ec1e151 # v1
+        with:
+          key: "${{ github.repository }}-nix-${{ runner.arch }}"
+          path: "/nix"
 
       - name: "Setup upterm session"
         if: ${{ (true == inputs.enableUpterm) && (inputs.breakOnJob == github.job) }}
@@ -264,12 +290,25 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - "ubuntu-22.04-8core"
-          - "macos-14-xlarge"
+          - "blacksmith-8vcpu-ubuntu-2204"
+          - "blacksmith-12vcpu-macos-15"
 
     steps:
       - name: "Checkout"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: "Create Nix store mount point"
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          sudo mkdir -p /nix/store
+          sudo chmod -R 777 /nix
+
+      - name: "Mount Nix store"
+        if: ${{ runner.os == 'Linux' }}
+        uses: useblacksmith/stickydisk@74f3f01ab1392726dd6ee06904f0452b0ec1e151 # v1
+        with:
+          key: "${{ github.repository }}-nix-${{ runner.arch }}"
+          path: "/nix"
 
       - name: "Setup upterm session"
         if: ${{ (true == inputs.enableUpterm) && (inputs.breakOnJob == github.job) }}
@@ -343,7 +382,7 @@ jobs:
     # See `scope`: `!cancelled()` keeps the pre-existing fork condition as the
     # *only* reason this job is ever skipped.
     if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
-    runs-on: "ubuntu-latest"
+    runs-on: "blacksmith-4vcpu-ubuntu-2404"
     timeout-minutes: 120
 
     needs:
@@ -437,7 +476,7 @@ jobs:
   trigger-flox-installers-workflow:
     name: "Build installers"
     if: ${{ (github.base_ref == 'refs/heads/main' || github.ref == 'refs/heads/main') && github.event_name == 'push' }}
-    runs-on: "ubuntu-latest"
+    runs-on: "blacksmith-2vcpu-ubuntu-2404"
     timeout-minutes: 120
 
     needs:
@@ -490,7 +529,7 @@ jobs:
 
   report-failure:
     name: "Report Failure"
-    runs-on: "ubuntu-latest"
+    runs-on: "blacksmith-2vcpu-ubuntu-2404"
     timeout-minutes: 30
 
     if: ${{ failure() && (github.base_ref == 'refs/heads/main' || github.ref == 'refs/heads/main') && github.event_name == 'push' }}
@@ -526,7 +565,7 @@ jobs:
 
   nix-build-bats-tests:
     name: "remote"
-    runs-on: "ubuntu-latest"
+    runs-on: "blacksmith-2vcpu-ubuntu-2404"
     timeout-minutes: 90
 
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,15 @@ jobs:
         if: ${{ needs.scope.outputs.heavy != 'false' }}
         run: nix develop -L --no-update-lock-file --command just test-nix-plugins
 
+      # The sticky-disk post step must unmount /nix to commit the
+      # snapshot; the multi-user nix-daemon keeps the mount busy, so
+      # stop it as the job's last act.
+      - name: "Stop nix-daemon for sticky disk commit"
+        if: ${{ always() && runner.os == 'Linux' }}
+        run: |
+          sudo systemctl stop nix-daemon.socket nix-daemon.service 2>/dev/null || true
+          sudo pkill -9 nix-daemon 2>/dev/null || true
+
   nef-dev:
     name: "Nix expression tests"
     # Skip on push to main; already run in the merge queue. Safe as a job-level
@@ -263,6 +272,15 @@ jobs:
 
       - name: "Test buildenvLib"
         run: nix develop -L --no-update-lock-file --command just test-buildenvLib
+
+      # The sticky-disk post step must unmount /nix to commit the
+      # snapshot; the multi-user nix-daemon keeps the mount busy, so
+      # stop it as the job's last act.
+      - name: "Stop nix-daemon for sticky disk commit"
+        if: ${{ always() && runner.os == 'Linux' }}
+        run: |
+          sudo systemctl stop nix-daemon.socket nix-daemon.service 2>/dev/null || true
+          sudo pkill -9 nix-daemon 2>/dev/null || true
 
   cli-unit:
     name: "unit"
@@ -371,6 +389,15 @@ jobs:
             git diff
             exit 1
           fi
+
+      # The sticky-disk post step must unmount /nix to commit the
+      # snapshot; the multi-user nix-daemon keeps the mount busy, so
+      # stop it as the job's last act.
+      - name: "Stop nix-daemon for sticky disk commit"
+        if: ${{ always() && runner.os == 'Linux' }}
+        run: |
+          sudo systemctl stop nix-daemon.socket nix-daemon.service 2>/dev/null || true
+          sudo pkill -9 nix-daemon 2>/dev/null || true
 
   nix-build:
     name: "Nix build"

--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -17,7 +17,7 @@ jobs:
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-    runs-on: ubuntu-latest
+    runs-on: "blacksmith-4vcpu-ubuntu-2404"
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -28,7 +28,7 @@ jobs:
     # Skip on fork PRs: the review needs CLAUDE_CODE_OAUTH_TOKEN, which isn't
     # available to pull_request runs from forks, so it only fails.
     if: ${{ !github.event.pull_request.draft && github.event.pull_request.head.repo.full_name == github.repository }}
-    runs-on: ubuntu-latest
+    runs-on: "blacksmith-4vcpu-ubuntu-2404"
     permissions:
       contents: read
       pull-requests: write # Required to post reviews

--- a/.github/workflows/nix-managed-lints.yml
+++ b/.github/workflows/nix-managed-lints.yml
@@ -122,6 +122,15 @@ jobs:
               --from-ref "$( git rev-parse "target" )" \
               --to-ref   "$( git rev-parse "head" )";
 
+      # The sticky-disk post step must unmount /nix to commit the
+      # snapshot; the multi-user nix-daemon keeps the mount busy, so
+      # stop it as the job's last act.
+      - name: "Stop nix-daemon for sticky disk commit"
+        if: ${{ always() && runner.os == 'Linux' }}
+        run: |
+          sudo systemctl stop nix-daemon.socket nix-daemon.service 2>/dev/null || true
+          sudo pkill -9 nix-daemon 2>/dev/null || true
+
 # ---------------------------------------------------------------------------- #
 #
 #

--- a/.github/workflows/nix-managed-lints.yml
+++ b/.github/workflows/nix-managed-lints.yml
@@ -25,12 +25,23 @@ env:
 jobs:
   nix-git-hooks:
     name: "Nix Git Hooks"
-    runs-on: "ubuntu-latest"
+    runs-on: "blacksmith-4vcpu-ubuntu-2404"
     timeout-minutes: 30
 
     steps:
       - name: "Checkout"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: "Create Nix store mount point"
+        run: |
+          sudo mkdir -p /nix/store
+          sudo chmod -R 777 /nix
+
+      - name: "Mount Nix store"
+        uses: useblacksmith/stickydisk@74f3f01ab1392726dd6ee06904f0452b0ec1e151 # v1
+        with:
+          key: "${{ github.repository }}-nix-${{ runner.arch }}"
+          path: "/nix"
 
       - name: "Setup Nix"
         uses: "./.github/actions/common-setup"


### PR DESCRIPTION
## What

Same migration as [flox/floxenvs#10818](https://github.com/flox/floxenvs/pull/10818): all CI onto [Blacksmith](https://blacksmith.sh) runners, with a persistent `/nix` volume via [stickydisk](https://github.com/useblacksmith/stickydisk) where jobs do local Nix work. Measured on floxenvs: full-matrix wall clock 12m01s → 5m20s, `Install flox` fixed cost halved, sticky-disk mount ≤1s / snapshot 3–4s.

### Runner mapping

| Before | After | Jobs |
| ------ | ----- | ---- |
| `ubuntu-22.04-8core` | `blacksmith-8vcpu-ubuntu-2204` | nix-plugins-dev, nef-dev, cli-unit |
| `macos-14-xlarge` | `blacksmith-12vcpu-macos-15` (M4) | nix-plugins-dev, cli-unit |
| `ubuntu-latest` (orchestration) | `blacksmith-2vcpu-ubuntu-2404` | scope, installers trigger, report-failure, remote bats, build-examples, auto-label |
| `ubuntu-latest` (nix work) | `blacksmith-4vcpu-ubuntu-2404` | nix-build legs, nix-managed-lints, claude-mention/review |

### Nix integration

`nix-plugins-dev`, `nef-dev`, `cli-unit` (Linux legs), and `nix-managed-lints` mount a sticky disk (block-level snapshot volume, key `flox/flox-nix-<arch>`) at `/nix` before `common-setup`, so the dev-shell closure persists across runs instead of re-substituting from S3 every job. Guarded with `runner.os == 'Linux'` in matrix jobs — sticky disks are Linux-only; macOS legs keep cold stores.

Sticky-disk branch protection is enabled org-side, so only default-branch `push`/`schedule`/`workflow_dispatch` jobs commit new snapshots; PR jobs hydrate the warm store read-only.

### Notes

- `nix-build` and bats jobs execute on the Tailscale remote builders as before — runner swap only.
- Cargo cache stays on `actions/cache`; Blacksmith transparently serves it from colocated NVMe (~4× faster).
- OS drift to note: macOS 14 → 15 (Blacksmith has no macOS 14), Ubuntu 24.04 for former `ubuntu-latest` jobs; the 8core jobs stay on 22.04.
- `cachix/install-nix-action` vs a persisted `/nix`: first run per arch is cold and installs normally; if the warm second run trips the installer on the pre-existing store, the fallback is switching `common-setup` to `nix-quick-install-action` for Linux.
- stickydisk pinned by commit SHA (v1). Added `.github/actionlint.yaml` with the labels; remaining actionlint findings pre-date this PR (9 → 6).