### PR TITLE
fix(executive): downgrade StateFileRemoved send failure to debug

### DIFF
--- a/cli/flox-activations/src/cli/executive/event_coordinator.rs
+++ b/cli/flox-activations/src/cli/executive/event_coordinator.rs
@@ -213,7 +213,12 @@ impl EventCoordinator {
                     if !owned_state_json_path.exists() {
                         debug!(?event, "state.json is gone, sending removal event to main loop");
                         if sender.send(ExecutiveEvent::StateFileRemoved).is_err() {
-                            error!("failed to send StateFileRemoved event, channel closed");
+                            // Cleanup removes the very directory this watcher
+                            // is watching, so a removal event racing the main
+                            // loop's exit is the normal shutdown, not a failure.
+                            debug!(
+                                "failed to send StateFileRemoved event, channel closed during shutdown"
+                            );
                         }
                         return;
                     }


### PR DESCRIPTION
The state.json watcher logs at `error!` when it can't send
`StateFileRemoved`, which sends the message to Sentry. That channel only
closes once the main loop's receiver is dropped, which happens when the
executive exits — and the executive's own cleanup renames and removes the
activation state directory that this watcher is watching. The removal
event it generates therefore races the shutdown by design, so a failed
send is expected teardown ordering rather than a failure.

Downgrade it to `debug!`, matching the sibling `StateFileChanged` send
(CLI-154) and the sanity check thread, which already exits silently when
the channel is closed. The genuine `file watcher error` path is
untouched.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
