### PR TITLE
docs(metrics): document the v2 events wire contract and add a skill

### DIFF
--- a/.claude/skills/adding-beta-subcommand/SKILL.md
+++ b/.claude/skills/adding-beta-subcommand/SKILL.md
@@ -79,9 +79,18 @@ Two modules are involved, by design:
 - Beta commands may freely depend on `flox-rust-sdk`, but when adding beta commands, strive to leave `flox-rust-sdk` code unchanged. Any code in the beta module doesn't need to be reviewed for stability, but any code changes in other crates will require more thorough review which will make it slower to add the beta command.
 - Reaching into the rest of the `flox` crate (`crate::utils::message`,
   `crate::utils::events`, …) is fine and needs no factoring out. Prefer
-  it over duplicating a helper inside `beta/`. For telemetry, use the
-  v2 events pipeline (see the `adding-metrics-events` skill) — don't
-  add new `subcommand_metric!` calls.
+  it over duplicating a helper inside `beta/`.
+- Telemetry: beta commands go through the normal dispatcher, so
+  `cli.command_run` and `cli.command_completed` are emitted for free —
+  most beta commands need no instrumentation of their own. Add a
+  bespoke v2 event (see the `adding-metrics-events` skill) only when
+  there is domain data worth reporting; that touches `cli/flox-events`
+  and is reviewed as a wire-contract change, so the
+  keep-`flox-rust-sdk`-unchanged guidance above doesn't make it free.
+  Don't add new `subcommand_metric!` calls — the existing beta
+  commands that use the macro predate the v2 pipeline; don't copy
+  them. Event names are frozen once a release that can emit them
+  ships, gated or not.
 - Don't put beta-only logic in `commands/`, elsewhere in `flox`, or in
   `flox-rust-sdk`; keep it in the `beta` module.
 - Integration tests are not required for beta commands while they

--- a/.claude/skills/adding-beta-subcommand/SKILL.md
+++ b/.claude/skills/adding-beta-subcommand/SKILL.md
@@ -78,8 +78,10 @@ Two modules are involved, by design:
 
 - Beta commands may freely depend on `flox-rust-sdk`, but when adding beta commands, strive to leave `flox-rust-sdk` code unchanged. Any code in the beta module doesn't need to be reviewed for stability, but any code changes in other crates will require more thorough review which will make it slower to add the beta command.
 - Reaching into the rest of the `flox` crate (`crate::utils::message`,
-  `crate::subcommand_metric!`, …) is fine and needs no factoring out. Prefer
-  it over duplicating a helper inside `beta/`.
+  `crate::utils::events`, …) is fine and needs no factoring out. Prefer
+  it over duplicating a helper inside `beta/`. For telemetry, use the
+  v2 events pipeline (see the `adding-metrics-events` skill) — don't
+  add new `subcommand_metric!` calls.
 - Don't put beta-only logic in `commands/`, elsewhere in `flox`, or in
   `flox-rust-sdk`; keep it in the `beta` module.
 - Integration tests are not required for beta commands while they

--- a/.claude/skills/adding-metrics-events/SKILL.md
+++ b/.claude/skills/adding-metrics-events/SKILL.md
@@ -41,10 +41,12 @@ Answer these, and put the answers in the PR description:
    the invocation's `cli.command_run` row, don't emit it), caps with
    true counts, faithful values at every emit site.
 3. **Name and privacy**, per the README's "Naming" and "Privacy"
-   sections: `cli.<entity>.<verb>`, bare snake_case payload fields
-   (`event_type` is the namespace), `success`/`failure` outcomes; and
-   a value domain structurally unable to carry user data — plan the
-   projection now (an enum's `Display`, a `strum` slug), not a scrub.
+   sections: `cli.<entity>.<verb>` when there is an entity, `cli.<verb>`
+   for CLI-level actions with none (`cli.build`, `cli.update_prompted`);
+   bare snake_case payload fields (`event_type` is the namespace),
+   `success`/`failure` outcomes; and a value domain structurally unable
+   to carry user data — plan the projection now (an enum's `Display`, a
+   `strum` slug), not a scrub.
 
 For anything beyond a straightforward additive field, share the
 proposed shape (fields, sources, deliberate exclusions — ~10 lines)
@@ -91,7 +93,8 @@ Model: commit `0eec48c2a` (added `cli.authenticated` and
 
 1. **Add the variant** to `EventKind` in
    `cli/flox-events/src/lib.rs` with the dotted name on
-   `#[serde(rename = "cli.<entity>.<verb>")]`. That rename string is
+   `#[serde(rename = "...")]` — `cli.<entity>.<verb>` when there is an
+   entity, `cli.<verb>` when there is none. That rename string is
    the single source of truth for the wire name — no `Display`, no
    `as_str`, no string literals at call sites.
 2. **Pick the payload type.** Reuse an existing payload struct when
@@ -131,10 +134,10 @@ Model: commit `0eec48c2a` (added `cli.authenticated` and
    `json!({...})` literal, using the `fixed_event` fixture. Plus one
    absent-optional golden if the payload has optionals.
 5. **Add a call-site test** if the emit logic has branches worth
-   pinning: install the `MockHub` harness (see
-   `cli/flox/src/commands/upgrade.rs`), run the handler, filter
-   `sent_batches` by `EventKind`. Mark it
-   `#[serial(global_events_client)]`.
+   pinning: copy the `MockHub` pattern from
+   `cli/flox/src/commands/upgrade.rs` (a private test struct, not an
+   importable helper), run the handler, filter `sent_batches` by
+   `EventKind`. Mark it `#[serial(global_events_client)]`.
 
 ## Verify
 
@@ -157,18 +160,21 @@ that silently produce no output (wrong override var, buffering,
 `flox --version`). Inspect the NDJSON for each branch that matters:
 success, a typed failure, a non-1 exit code, and any exec/hand-off
 path. Confirm the field carries the real value on each, and is absent
-(not `null`, not `""`) where unknown.
+(not `null`, not `""`) where unknown. For every string field, read its
+actual emitted value and name the closed value set it belongs to — if
+you cannot name the set, the field can leak user data and needs
+redesign, not shipping.
 
 ## Red flags — stop and re-read the README
 
 | Thought | Reality |
 |---|---|
-| "I'll just rename this field/event to something better" | Renames break nothing locally and silently produce empty data downstream forever. Shipped names are frozen; an incompatible shape is a new event type. |
-| "The golden test fails — I'll update the expected JSON" | A failing golden means the contract moved. Update it only for the intentional addition you made; if it fails for a rename/retype, that's the signal working. |
+| "I'll just rename this field/event to something better" | Shipped names are frozen — a rename silently yields empty data downstream forever. An incompatible shape is a new event type. |
+| "The golden test fails — I'll update the expected JSON" | A failing golden is the signal working. Update it only for the intentional change you made. |
 | "The spec / the legacy stream did it this way" | Specs and legacy precedent are inputs to challenge. Parity with a legacy mistake is a chance to fix it, not a justification. |
 | "I'll hardcode this value here; it's always 1 anyway" | A stand-in value at one emit site poisons the data for every consumer. Plumb the real value. |
 | "The consumer could compute this, but emitting it is convenient" | Don't. Derived fields at the producer drift; consumers join to `cli.command_run` on `invocation_id`. |
 | "I'll scrub the string before emitting" | Denylists are unsound by construction. Redesign so user data is structurally absent (type-derived slug, closed-set projection). |
 | "I'll add the field now and populate it in a follow-up" | Every PR is a complete vertical slice: defined → populated → tested → verifiable in the same PR. No builders without call sites. |
 | "It compiled and unit tests pass, so it works" | The consumer is not in the test loop. Run the local-collector check and look at the bytes. |
-| "I'll note in the PR which internal system/dashboard needs this" | This is a public repo. PR text, commits, and comments describe the events and fields on their own technical terms — never name or link internal systems, tools, or trackers. |
+| "I'll note in the PR which internal system/dashboard needs this" | Public repo — PR text describes events and fields on their own terms. See the README's "Coordinating changes" section. |

--- a/.claude/skills/adding-metrics-events/SKILL.md
+++ b/.claude/skills/adding-metrics-events/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: adding-metrics-events
+description: Use when adding or changing CLI telemetry/metrics - a new metric value (payload field) on an existing v2 event, a new metric message (event type), a new emit site, or any change to what the flox CLI reports. Also use when a *_envelope_golden test fails, or when tempted to rename an event or payload field.
+---
+
+# Adding a v2 metrics event or field
+
+All new telemetry goes through the v2 events pipeline: the
+`cli/flox-events` crate (types, buffering, sending) plus the
+integration layer in `cli/flox/src/utils/events.rs`. The contract
+rules — wire format, naming, stability, privacy — live in
+`cli/flox-events/README.md`. **Read it before starting**; this skill
+is the procedure, that file is the law.
+
+The events are consumed by ingestion outside this repository with no
+compile-time link back here. Nothing breaks locally when the contract
+moves, so the discipline below is the only protection.
+
+## When not to use this skill
+
+- Adding to the legacy `subcommand_metric!` stream
+  (`cli/flox/src/utils/metrics.rs`) — don't add new instrumentation
+  there. Touch it only when an emit site you're riding already uses
+  it.
+- Server-side or non-CLI telemetry — out of scope for this repo.
+
+## Step 0: decide the shape before writing code
+
+Answer these, and put the answers in the PR description:
+
+1. **New field or new event?** A new fact about an existing action is
+   a field on that action's payload, preferably riding an existing
+   emit so fields cross-tabulate without a join (see the
+   `invocation_type` example below). A new *action* is a new event
+   type. An incompatible change to an existing shape is a **new event
+   type** — never an in-place edit.
+2. **The README's design questions**, answered one line each
+   (`cli/flox-events/README.md` § "Designing a new event or field"):
+   durable identity, structure preserved, the 12-month consumer,
+   derivability (if a consumer can compute it from the same event or
+   the invocation's `cli.command_run` row, don't emit it), caps with
+   true counts, faithful values at every emit site.
+3. **Name and privacy**, per the README's "Naming" and "Privacy"
+   sections: `cli.<entity>.<verb>`, bare snake_case payload fields
+   (`event_type` is the namespace), `success`/`failure` outcomes; and
+   a value domain structurally unable to carry user data — plan the
+   projection now (an enum's `Display`, a `strum` slug), not a scrub.
+
+For anything beyond a straightforward additive field, share the
+proposed shape (fields, sources, deliberate exclusions — ~10 lines)
+with the maintainers **before** implementing. A reviewer reading a
+finished diff anchors on "is this implemented correctly", not "is
+this the right shape".
+
+## Path A: add a field to an existing event
+
+Model: commit `be060afd5` (`feat(metrics): report activation
+invocation type`) — two files, ~28 lines.
+
+1. **Add the field** to the payload struct in
+   `cli/flox-events/src/lib.rs`:
+   - `#[serde(skip_serializing_if = "Option::is_none")]` for optional
+     fields. That alone is correct: it keeps the key off the wire when
+     absent, and a missing key already deserializes to `None`. (Some
+     existing fields also carry `default`, which is redundant on
+     `Option` fields — don't add it to new ones, and don't churn-fix
+     the old ones.)
+   - Doc comment stating the value domain and why it cannot carry
+     user data.
+   - Initialize to `None` in `new()`; add a
+     `with_<field>(mut self, value: …) -> Self` builder, matching the
+     existing builders in the same struct. For fields that must only
+     ever hold compile-time slugs, take `&'static str` (see
+     `CliBuildPayload::with_error_kind`).
+2. **Populate it at the emit site(s)** in `cli/flox/src/commands/`.
+   Grep for every constructor of that payload
+   (`grep -rn 'PayloadName::new' cli/flox/src/`) and decide per site:
+   populate with the **real** value, or leave absent. Never a
+   hardcoded stand-in — if the real value lives in a type the emit
+   site doesn't read, plumb it through.
+3. **Update the golden tests** in `cli/flox-events/src/lib.rs`:
+   extend the event's canonical `*_envelope_golden` with the new
+   field, and keep (or add) one golden pinning that the key is
+   omitted when absent. Do not add per-variant serde string
+   assertions — one canonical shape test per contract.
+
+## Path B: add a new event type
+
+Model: commit `0eec48c2a` (added `cli.authenticated` and
+`cli.update_prompted`).
+
+1. **Add the variant** to `EventKind` in
+   `cli/flox-events/src/lib.rs` with the dotted name on
+   `#[serde(rename = "cli.<entity>.<verb>")]`. That rename string is
+   the single source of truth for the wire name — no `Display`, no
+   `as_str`, no string literals at call sites.
+2. **Pick the payload type.** Reuse an existing payload struct when
+   the shape is identical (most environment events share
+   `CliEnvironmentPayload`) — the variant is the discriminant, so
+   don't clone a struct just to rename it. A payload-less event is a
+   unit-braces variant (`CliAuthenticated {}` → `"payload": {}`).
+   A new payload struct keeps fields private, takes required data in
+   `new()`, and adds `with_*` builders for optionals.
+3. **Emit it** where the action happens:
+
+   ```rust
+   if let Err(err) = EventsHub::global().record_event(EventKind::CliFoo(payload)) {
+       debug!(error = %err, "Failed to record v2 event");
+   }
+   ```
+
+   - Telemetry never fails a command: always the
+     `if let Err … debug!` wrapper.
+   - For environment events, build `EnvDetail` with
+     `env_detail_from_concrete(&flox, &env)` (or
+     `…_without_lineage(&env)` before the environment is locked or
+     trusted) from `cli/flox/src/utils/events.rs`.
+   - Wrap payload-only expensive work (git/lockfile reads) in
+     `EventsHub::global().when_client_set(…)`.
+   - **Check reachability:** the emit must run on every branch that
+     should count — early exits, error paths, and before any
+     `exec()` (code after `exec()` never runs in the parent; see the
+     pre-exec emit + flush in `activate.rs`). An outcome event with
+     no outcome emits nothing.
+   - If the path spawns flox subprocesses, set `FLOX_INVOCATION_ID`
+     on the child's `Command` from `current_invocation_id()`
+     (`cli/flox/src/utils/events.rs`) — propagation is explicit per
+     spawn site, deliberately never via the exported environment.
+4. **Add the golden test:** one canonical `<event>_envelope_golden`
+   asserting the **entire** envelope JSON with `assert_eq!` against a
+   `json!({...})` literal, using the `fixed_event` fixture. Plus one
+   absent-optional golden if the payload has optionals.
+5. **Add a call-site test** if the emit logic has branches worth
+   pinning: install the `MockHub` harness (see
+   `cli/flox/src/commands/upgrade.rs`), run the handler, filter
+   `sent_batches` by `EventKind`. Mark it
+   `#[serial(global_events_client)]`.
+
+## Verify
+
+Run the tests (inside `nix develop`, or prefix with
+`nix develop -c`):
+
+```bash
+just ut envelope_golden    # wire-shape goldens, skips the full build
+just unit-tests            # full workspace, before the PR
+```
+
+The name filter catches most canonical tests but not all (the
+`command_run` and `authenticated` pins use other names), so the full
+run before the PR is not optional.
+
+Then verify the real bytes with the local-collector recipe in
+`cli/flox-events/README.md` § "Verifying what is actually sent" —
+reading the code is not evidence, and that section lists the traps
+that silently produce no output (wrong override var, buffering,
+`flox --version`). Inspect the NDJSON for each branch that matters:
+success, a typed failure, a non-1 exit code, and any exec/hand-off
+path. Confirm the field carries the real value on each, and is absent
+(not `null`, not `""`) where unknown.
+
+## Red flags — stop and re-read the README
+
+| Thought | Reality |
+|---|---|
+| "I'll just rename this field/event to something better" | Renames break nothing locally and silently produce empty data downstream forever. Shipped names are frozen; an incompatible shape is a new event type. |
+| "The golden test fails — I'll update the expected JSON" | A failing golden means the contract moved. Update it only for the intentional addition you made; if it fails for a rename/retype, that's the signal working. |
+| "The spec / the legacy stream did it this way" | Specs and legacy precedent are inputs to challenge. Parity with a legacy mistake is a chance to fix it, not a justification. |
+| "I'll hardcode this value here; it's always 1 anyway" | A stand-in value at one emit site poisons the data for every consumer. Plumb the real value. |
+| "The consumer could compute this, but emitting it is convenient" | Don't. Derived fields at the producer drift; consumers join to `cli.command_run` on `invocation_id`. |
+| "I'll scrub the string before emitting" | Denylists are unsound by construction. Redesign so user data is structurally absent (type-derived slug, closed-set projection). |
+| "I'll add the field now and populate it in a follow-up" | Every PR is a complete vertical slice: defined → populated → tested → verifiable in the same PR. No builders without call sites. |
+| "It compiled and unit tests pass, so it works" | The consumer is not in the test loop. Run the local-collector check and look at the bytes. |
+| "I'll note in the PR which internal system/dashboard needs this" | This is a public repo. PR text, commits, and comments describe the events and fields on their own technical terms — never name or link internal systems, tools, or trackers. |

--- a/.github/scripts/classify-ci-scope.sh
+++ b/.github/scripts/classify-ci-scope.sh
@@ -94,6 +94,13 @@ is_inert() {
     # inside a nix `src`.
     cli/flox/doc/*) return 1 ;;
 
+    # Read at test time by
+    # `cli/flox-events/src/lib.rs::readme_lists_every_event_type`, which pins
+    # the event inventory in the README to the `EventKind` wire names.
+    # Without this arm, editing the README would skip `cli-unit` — the job
+    # containing the very test that guards it.
+    cli/flox-events/README.md) return 1 ;;
+
     *.md) return 0 ;;
     docs/*) return 0 ;;
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,6 +153,18 @@ eval "`flox activate`"   # correct
 eval `flox activate`     # WRONG — output is word-split and brace-expanded
 ```
 
+## Metrics / telemetry
+
+All new CLI telemetry goes through the v2 events pipeline
+(`cli/flox-events`); do not add to the legacy `subcommand_metric!`
+stream. The wire contract — envelope shape, naming, stability and
+privacy rules — is documented in `cli/flox-events/README.md`, and the
+step-by-step procedure for adding an event or field is the
+`adding-metrics-events` skill. Event and field names are frozen once
+shipped: renames and type changes break downstream consumers silently.
+A failing golden test in that crate is a contract signal — read the
+README before touching the expected JSON.
+
 ## Pull Requests
 
 Always follow `CONTRIBUTING.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,7 @@ pre-commit run -a              # Run all linters
 | `flox-rust-sdk` | Core SDK: data structures, models, providers |
 | `flox-core` | Low-level utilities (activations, paths, versions) |
 | `flox-activations` | Environment activation binaries and process monitoring |
+| `flox-events` | v2 telemetry events: envelope types, buffering, sending |
 | `catalog-api-v1` | Catalog API client (generated from OpenAPI) |
 | `flox-test-utils` | Shared test helpers |
 | `mk_data` | Test data generator |
@@ -160,7 +161,8 @@ All new CLI telemetry goes through the v2 events pipeline
 stream. The wire contract — envelope shape, naming, stability and
 privacy rules — is documented in `cli/flox-events/README.md`, and the
 step-by-step procedure for adding an event or field is the
-`adding-metrics-events` skill. Event and field names are frozen once
+`adding-metrics-events` skill
+(`.claude/skills/adding-metrics-events/SKILL.md`). Event and field names are frozen once
 shipped: renames and type changes break downstream consumers silently.
 A failing golden test in that crate is a contract signal — read the
 README before touching the expected JSON.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -303,7 +303,9 @@ The CLI emits telemetry events through the `cli/flox-events` crate.
 If your change adds or modifies an event or one of its fields, read
 [`cli/flox-events/README.md`](cli/flox-events/README.md) first — it
 documents the wire contract, naming and stability rules, and how to
-verify what is actually emitted. Event and field names are frozen once
+verify what is actually emitted — and see
+[`.claude/skills/adding-metrics-events/SKILL.md`](.claude/skills/adding-metrics-events/SKILL.md)
+for the step-by-step procedure. Event and field names are frozen once
 shipped, and the golden tests in that crate pin the wire shape; a
 failing golden is a contract signal — read the README before touching
 the expected JSON.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -297,6 +297,17 @@ nix build
 FLOX_ACTIVATE_TRACE=1 result/bin/flox activate [args]
 ```
 
+### Metrics / telemetry
+
+The CLI emits telemetry events through the `cli/flox-events` crate.
+If your change adds or modifies an event or one of its fields, read
+[`cli/flox-events/README.md`](cli/flox-events/README.md) first — it
+documents the wire contract, naming and stability rules, and how to
+verify what is actually emitted. Event and field names are frozen once
+shipped, and the golden tests in that crate pin the wire shape; a
+failing golden is a contract signal — read the README before touching
+the expected JSON.
+
 ## Testing
 
 ### Running all tests

--- a/cli/flox-events/README.md
+++ b/cli/flox-events/README.md
@@ -129,8 +129,8 @@ an event means adding its row here.
 | `cli.command_completed` | `CliCommandCompletedPayload` — exit code, duration, `error_kind` |
 | `cli.environment.activate` | `CliEnvironmentActivatePayload` |
 | `cli.environment.create`, `cli.environment.delete`, `cli.environment.push`, `cli.environment.pull`, `cli.environment.containerize`, `cli.environment.install`, `cli.environment.uninstall`, `cli.environment.upgrade`, `cli.environment.include.upgrade`, `cli.environment.list` | `CliEnvironmentPayload` — env detail only; the variant is the discriminant |
-| `cli.environment.edit` | `CliEnvironmentEditPayload` |
-| `cli.environment.publish` | `CliEnvironmentPublishPayload` |
+| `cli.environment.edit` | `CliEnvironmentEditPayload` — **two rows per invocation**, see Sparse merge |
+| `cli.environment.publish` | `CliEnvironmentPublishPayload` — **two rows per invocation**, see Sparse merge |
 | `cli.environment.services.start`, `cli.environment.services.stop`, `cli.environment.services.restart`, `cli.environment.services.status`, `cli.environment.services.logs`, `cli.environment.services.persist` | `CliEnvironmentPayload` |
 | `cli.environment.generations.history`, `cli.environment.generations.rollback`, `cli.environment.generations.switch` | `CliEnvironmentPayload` |
 | `cli.environment.generations.list` | `CliEnvironmentGenerationsListPayload` |
@@ -234,7 +234,8 @@ not be allowed. They are frozen as-is and are **not precedents**:
 |---|---|---|
 | `search_term` | `cli.search` | The search text verbatim (legacy parity). |
 | `env_ref_or_name` | `cli.environment.*` | `owner/name` for managed/remote environments — the owner segment is a FloxHub handle; the environment name for path environments. |
-| `package` | `cli.package.*` | The coordinate as written: a catalog path, a store path (canonicalized under `/nix/store`), or a flake URL — which can embed a hostname or a local path. |
+| `package` | `cli.package.install`, `cli.package.upgrade` | The coordinate as written: a catalog path, a store path (canonicalized under `/nix/store`), or a flake URL — which can embed a hostname or a local path. |
+| `package` | `cli.package.uninstall` | The manifest **install id**, not a coordinate — so the field is not one identity space across the three events, and install and uninstall rows do not join on it. |
 | `install_id` | `cli.package.upgrade` | The user-chosen manifest install id. |
 | `invocation_sources` | `cli.command_run` | Launcher tokens, including any supplied via `FLOX_INVOCATION_SOURCE` — an open set by design. |
 
@@ -368,6 +369,38 @@ into every `cli.environment.*` payload — serializes as `env_kind`
 `local_environment_id` for path environments and `generation_number`
 for managed/remote ones (path environments structurally cannot carry a
 generation number), plus an optional `package_count`.
+
+## Sparse merge: two rows for one action
+
+Two events are emitted from **two call sites** in the same invocation
+rather than one:
+
+| Event | Eager row | Result-known row |
+|---|---|---|
+| `cli.environment.edit` | env detail only | adds `edited_includes` |
+| `cli.environment.publish` | env detail only | adds the publish result fields |
+
+Both rows share their `EventKind` and their `invocation_id`, and each
+populates only what it knows at its call site; a consumer coalesces
+them. Every result field on those payloads is therefore `Option` and is
+absent on the eager row.
+
+Two consequences worth stating, because neither is visible from the
+payload type alone:
+
+- Counting rows for one of these event types gives **twice** the
+  invocation count.
+- Reading a result field off a single row yields `None` about half the
+  time. Coalesce across the invocation instead.
+
+For `cli.environment.edit`, `env_detail` is the **pre-edit** snapshot on
+both rows so the two agree on lineage, while the result row's
+`manifest_version` describes the post-edit manifest. Those are
+deliberately different epochs, not one snapshot.
+
+If you add a second emission site to an existing event, say so on the
+payload type and add the row count here — a consumer has no other way
+to learn it.
 
 ## Verifying what is actually sent
 

--- a/cli/flox-events/README.md
+++ b/cli/flox-events/README.md
@@ -116,6 +116,30 @@ Rules the envelope encodes:
 - Keep names neutral and technical, matching the vocabulary already in
   this crate. When unsure, choose the most boring, descriptive name.
 
+## Event inventory
+
+The full set of shipped event types. The
+`readme_lists_every_event_type` test in [`src/lib.rs`](src/lib.rs)
+fails if an `EventKind` wire name is missing from this file, so adding
+an event means adding its row here.
+
+| Event type | Payload |
+|---|---|
+| `cli.command_run` | `CliCommandRunPayload` — subcommand plus machine context |
+| `cli.command_completed` | `CliCommandCompletedPayload` — exit code, duration, `error_kind` |
+| `cli.environment.activate` | `CliEnvironmentActivatePayload` |
+| `cli.environment.create`, `cli.environment.delete`, `cli.environment.push`, `cli.environment.pull`, `cli.environment.containerize`, `cli.environment.install`, `cli.environment.uninstall`, `cli.environment.upgrade`, `cli.environment.include.upgrade`, `cli.environment.list` | `CliEnvironmentPayload` — env detail only; the variant is the discriminant |
+| `cli.environment.edit` | `CliEnvironmentEditPayload` |
+| `cli.environment.publish` | `CliEnvironmentPublishPayload` |
+| `cli.environment.services.start`, `cli.environment.services.stop`, `cli.environment.services.restart`, `cli.environment.services.status`, `cli.environment.services.logs`, `cli.environment.services.persist` | `CliEnvironmentPayload` |
+| `cli.environment.generations.history`, `cli.environment.generations.rollback`, `cli.environment.generations.switch` | `CliEnvironmentPayload` |
+| `cli.environment.generations.list` | `CliEnvironmentGenerationsListPayload` |
+| `cli.package.install`, `cli.package.uninstall` | `CliPackagePayload` — one event per package |
+| `cli.package.upgrade` | `CliPackageUpgradePayload` — one event per package |
+| `cli.build` | `CliBuildPayload` |
+| `cli.search` | `CliSearchPayload` |
+| `cli.authenticated`, `cli.update_prompted` | payload-less (`{}`) |
+
 ## Stability: what is safe and what is breaking
 
 The consumers of these events live outside this repository and have

--- a/cli/flox-events/README.md
+++ b/cli/flox-events/README.md
@@ -1,0 +1,359 @@
+# flox-events: v2 CLI telemetry events
+
+This crate defines the v2 telemetry events the Flox CLI emits and the
+self-contained pipeline that buffers and sends them. It is the single
+place where the event wire format is defined; everything else in the
+repo either constructs events through this crate's types or stays out
+of the way.
+
+This document is the contract reference for anyone adding or changing
+an event ("metrics message") or a field on one ("metric value"). The
+step-by-step procedure lives in the repo skill
+`.claude/skills/adding-metrics-events/SKILL.md`; this file explains
+the rules that procedure enforces and why they exist.
+
+Telemetry can be disabled entirely with
+`flox config --set disable_metrics true` (or `FLOX_DISABLE_METRICS=true`).
+When disabled, no events are constructed and nothing is sent — the
+global hub stays dormant. See `flox config --help` and the first-run
+notice for the user-facing description of what is collected.
+
+## The two streams
+
+The CLI currently emits two telemetry streams in parallel:
+
+- **Legacy (v1):** the `subcommand_metric!` macros in
+  `cli/flox/src/utils/metrics.rs`. Do not add new instrumentation
+  here.
+- **v2 (this crate):** typed events recorded through
+  `EventsHub::global().record_event(...)`, integrated via
+  `cli/flox/src/utils/events.rs`. All new instrumentation goes here.
+
+The two stacks share no code and write separate on-disk buffers.
+`disable_metrics` silences both.
+
+## The wire contract
+
+Events are serialized as JSON objects and sent as **NDJSON — one JSON
+object per line, never a JSON array**. Each object has this envelope
+shape:
+
+```jsonc
+{
+  "event_id":         "b6e2…",         // UUID, unique per event
+  "event_timestamp":  1733600000000,   // integer ms since Unix epoch
+  "source":           "cli",           // constant for this producer
+  "invocation_id":    "aa10…",         // UUID, one per CLI invocation
+  "device_id":        "9f42…",         // UUID, stable per installation
+  "auth_subject":     "github|123",    // optional; pseudonymous only
+  "producer_version": "1.16.0",        // optional; the CLI version
+  "event_type":       "cli.environment.activate",
+  "payload":          { }              // object, typed per event_type
+}
+```
+
+The Rust source of truth is the `Event` struct and `EventKind` enum in
+[`src/lib.rs`](src/lib.rs). `EventKind` is tagged with
+`#[serde(tag = "event_type", content = "payload")]`, and the dotted
+wire name on each variant's `#[serde(rename)]` attribute is the single
+source of truth for that event's name. Call sites construct the
+variant explicitly and never pass a string literal.
+
+Rules the envelope encodes:
+
+- `event_timestamp` is an **integer millisecond count** since the Unix
+  epoch. Not RFC 3339, not seconds, not nanoseconds, not a float.
+- `event_id` is fresh per event; downstream consumers de-duplicate on
+  it. `invocation_id` correlates every event from one CLI invocation
+  and is inherited by child processes via `FLOX_INVOCATION_ID`.
+- Optional fields are **omitted when absent** — never serialized as
+  `null` or `""`. Downstream, an explicit empty value is
+  indistinguishable from a missing one, so sending it destroys the
+  absent/empty distinction. Use
+  `#[serde(skip_serializing_if = "Option::is_none")]` — that alone is
+  enough; a missing key already deserializes to `None` without
+  `#[serde(default)]`. (The legacy machine-context fields on
+  `CommandPayload` — `os_family`, `os_family_release`, `os`,
+  `os_version` — predate this rule and serialize as `null` when
+  absent. They are frozen as shipped: don't imitate them, and don't
+  "fix" them, since removing a shipped key is itself a breaking
+  change.)
+- The set of top-level envelope keys is **closed**. Consumers drop
+  unknown envelope keys silently, so adding one is a coordinated
+  change (see "Coordinating changes" below). New data goes in
+  `payload`, where additions are safe.
+- `payload` is always a JSON object. Payload-less events serialize as
+  `"payload": {}`.
+
+## Naming
+
+- Event names are dotted, lowercase, `snake_case` within a segment:
+  `cli.command_run`, `cli.environment.activate`,
+  `cli.environment.generations.switch`. No camelCase, no hyphens.
+- **Every CLI event starts with `cli.`** — consumers select this
+  producer's events by that prefix, so an event named outside it is
+  invisible to them.
+- Group by the **entity**, not the caller: `cli.environment.install`
+  (the environment is what changed), so a whole domain can be selected
+  by prefix.
+- Payload field names are **bare**, discriminated by `event_type`:
+  `outcome`, `duration_ms`, `error_kind` — not `build_outcome`,
+  `build_duration_ms`. Shared meanings keep shared names across
+  events; the event type is the namespace.
+- Use one vocabulary for shared concepts. Outcomes are `success` /
+  `failure` (the `Outcome` enum), not `succeeded` / `failed`.
+- Keep names neutral and technical, matching the vocabulary already in
+  this crate. When unsure, choose the most boring, descriptive name.
+
+## Stability: what is safe and what is breaking
+
+The consumers of these events live outside this repository and have
+**no compile-time link back to this crate**. Nothing here breaks
+locally when the contract moves — which is exactly why these rules
+exist.
+
+Safe, no coordination needed:
+
+- Adding a new `cli.*` event type.
+- Adding a new **optional** payload field to an existing event.
+
+Breaking — never do these without coordination (see below):
+
+- Renaming a shipped event type or payload field. A rename does not
+  fail loudly anywhere; it silently produces empty data downstream
+  from the release forward.
+- Changing the JSON type of an existing field, including
+  optional↔required, or a value's unit or encoding.
+- Removing a field or event.
+- Adding, renaming, or retyping a **top-level envelope** field.
+- Changing the meaning of an existing field while keeping its name.
+
+When an event's shape needs to change incompatibly, mint a **new
+event type** rather than editing the old one in place — the
+`event_type` string is the version discriminator.
+
+Enum-like string values are part of the contract too. `error_kind`
+slugs are derived from Rust error type names via `strum`, so renaming
+a Rust error variant silently renames a wire value — and only a few
+sample slugs are pinned by tests (the `error_kind_tests` module in
+`cli/flox/src/main.rs` and the build-slug test in `flox-rust-sdk`), so
+most renames trip nothing. Treat any rename of a variant on a
+slug-bearing error enum as a wire change, even when every test stays
+green.
+
+## How the contract is enforced: golden tests
+
+The golden tests in [`src/lib.rs`](src/lib.rs) — most named
+`*_envelope_golden` — pin the serialized wire shape: the whole
+envelope, as JSON, compared with `assert_eq!`. They are **the only
+machine-checkable signal** that the contract moved:
+
+> A failing golden means the contract moved and the consumer needs a
+> migration. Update the expected JSON once that is arranged, not to
+> make the test pass.
+
+Test discipline:
+
+- Every new event gets **one canonical test** asserting the full
+  envelope, exercising the `#[serde(rename)]` through a real value.
+  Most are named `*_envelope_golden`, but not all
+  (`command_run_serializes_to_v2_envelope`,
+  `authenticated_serializes_with_empty_payload`), and shape-identical
+  variants sharing a payload struct may share coverage — so a
+  name-filtered test run is not the whole contract.
+- Optional fields additionally get one "absent key omits the field"
+  pin (e.g. `cli_environment_activate_without_manifest_version_envelope_golden`).
+- Do not add per-variant string assertions that only prove serde obeys
+  its own rename attribute — that tests the library, and it duplicates
+  the rename table. One canonical shape test per contract.
+
+## Privacy: data is structurally absent, not scrubbed
+
+The standing rule: **prefer designs where user data cannot reach the
+wire, rather than designs that filter it out.** A denylist or regex
+scrub is safe only against the leak shapes someone thought to
+enumerate; a closed set of compile-time values is safe by
+construction.
+
+Never on the wire:
+
+- Email addresses, usernames, or handles.
+- Tokens or any token bytes.
+- Filesystem paths and hostnames.
+- Free-form user text: error messages, descriptions, command lines.
+
+One shipped exception: `cli.search`'s `search_term` carries the user's
+search text verbatim, for parity with the legacy stream. It is frozen
+into the contract and is not a precedent — new fields don't get to
+cite it.
+
+Patterns that make this structural:
+
+- `error_kind` carries a slug derived from the error's **type**, never
+  its rendered message — user data enters an error only through
+  interpolated parameters, and the type name contains none of them.
+  There is deliberately no `error_message` field.
+- `CliBuildPayload::with_error_kind` takes `&'static str` instead of
+  `impl Into<String>`, so only compile-time slugs can populate it; a
+  runtime-rendered string is a compile error.
+- `invocation_type` reports a four-value projection of the invocation,
+  dropping the command the user passed to `-c` / `--`.
+- `auth_subject` carries only the opaque OIDC/JWT `sub` claim —
+  pseudonymous by contract, never an email or handle.
+
+When you add a string field, its doc comment must state the value
+domain and why it cannot carry personal data. If the honest answer is
+"it can", redesign the field before shipping it.
+
+Instrumentation must also stay within its scope: report what the
+command already computes, and don't reach into data the code path
+didn't already touch.
+
+## Designing a new event or field
+
+Get the shape right before implementing — shape mistakes are cheap to
+fix before a release ships them and nearly impossible after. Questions
+to answer (and to include in the PR description):
+
+1. **Identity.** For each entity in the payload, is the identifying
+   field a durable coordinate (stays meaningful as the system grows)
+   or a convenience label? Prefer the coordinate.
+2. **What does this emission destroy?** Emission is the last chance to
+   keep structure. Prefer emitting structure and letting consumers
+   flatten; a producer that pre-aggregates throws away the signal.
+3. **The 12-month consumer.** Name the questions someone will ask of
+   this data in a year. A producer change requires a release users
+   must adopt; a downstream query change does not. Bias toward shapes
+   that push future change downstream.
+4. **Can it be derived?** If a consumer can compute the value from
+   fields already on the same event — or from the same invocation's
+   `cli.command_run` row via `invocation_id` — don't emit it. A
+   derived field at the producer is a drift liability. (Domain events
+   deliberately carry no `subcommand` and no machine context for this
+   reason: consumers join to `cli.command_run`.)
+5. **Caps and truncation.** If you bound a list, emit the true count
+   alongside it, so truncation is distinguishable from genuinely
+   short.
+6. **Faithful values at every emit site.** Enumerate every site that
+   constructs this payload and confirm each populates the real value.
+   If the real value lives in a type the emit site doesn't read, the
+   fix is plumbing it through — never a hardcoded stand-in.
+
+"An existing spec said so" and "the legacy stream did it this way" are
+not answers to these questions. Parity with a legacy mistake is a
+chance to fix the mistake, not a reason to carry it forward.
+
+## Emission mechanics
+
+Call sites record events through the global hub and never construct
+transport-level shapes themselves:
+
+```rust
+use flox_events::{CliEnvironmentPayload, EventKind, EventsHub};
+
+if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentDelete(
+    CliEnvironmentPayload::new(env_detail_from_concrete(&flox, &concrete_environment)),
+)) {
+    debug!(error = %err, "Failed to record v2 event");
+}
+```
+
+- **Telemetry never fails a command.** Every `record_event` call is
+  wrapped in `if let Err(err) = … { debug!(…) }`.
+- The hub is dormant until `cli/flox/src/commands/mod.rs` installs a
+  client, and no client is installed when metrics are disabled — so
+  the opt-out is honored at every call site automatically.
+- Wrap expensive payload-only work (git or lockfile reads that exist
+  only to fill a payload) in `EventsHub::global().when_client_set(…)`
+  so opted-out users don't pay for it.
+- Events are buffered on disk (`events-v2.json` in the data dir, one
+  JSON object per line) and sent in batches of 100 once the buffer is
+  older than two minutes, from a flush-on-drop guard in `main`. A
+  failed send keeps events buffered for a later retry.
+- Lifecycle placement matters. `flox activate` replaces the process
+  with `exec()`: anything recorded after that line is dead code in the
+  parent, which is why `activate.rs` records completion and flushes
+  before exec'ing. When instrumenting a new path, confirm the
+  emission is reached on every branch — including early exits and
+  hand-off paths.
+- Propagating `invocation_id` to child flox processes is explicit,
+  per spawn site: set `FLOX_INVOCATION_ID` on the child's `Command`
+  from `current_invocation_id()` (`cli/flox/src/utils/events.rs`), so
+  one user action doesn't appear as several uncorrelated invocations.
+  The id is deliberately kept out of the process environment so that
+  commands run inside an activated shell count as fresh invocations —
+  never export it; set it on the specific spawn.
+
+The integration layer in `cli/flox/src/utils/events.rs` provides
+`env_detail_from_concrete` / `env_detail_from_concrete_without_lineage`
+for building the shared `EnvDetail` payload half, and
+`build_events_client` for client construction.
+
+## Verifying what is actually sent
+
+Reading the code is not enough — exercise the instrumented path and
+inspect the emitted JSON. Three gotchas silently produce no output:
+
+1. Use `_FLOX_METRICS_URL_V2_OVERRIDE` (and
+   `_FLOX_METRICS_API_KEY_V2_OVERRIDE`) to point the v2 stream at a
+   local collector. The unsuffixed `_FLOX_METRICS_URL_OVERRIDE`
+   redirects only the **legacy** stream.
+2. Set `_FLOX_FORCE_FLUSH_METRICS=true`. Without it a single command
+   sends nothing — the buffer flushes on expiry and in batches.
+3. Use a real dispatched subcommand. `flox --version` returns before
+   the events client is installed and emits nothing by construction.
+
+```bash
+# terminal 1: a local collector that acknowledges each send
+while true; do printf 'HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n' | nc -l 8080; done
+
+# terminal 2
+_FLOX_METRICS_URL_V2_OVERRIDE=http://localhost:8080 \
+_FLOX_METRICS_API_KEY_V2_OVERRIDE=dummy \
+_FLOX_FORCE_FLUSH_METRICS=true \
+  ./target/debug/flox envs
+```
+
+The collector must answer with a 2xx: a send that gets no response
+fails after a short timeout and the events stay buffered for retry, so
+a bare one-shot `nc -l` makes every rerun re-send all earlier events
+first — and BSD `nc` (the macOS default) exits after one connection
+anyway. The loop above acknowledges each request, so each run prints
+only its own events.
+
+Check the branches that matter: a success, a typed failure, a non-1
+exit code, and (for activate) the exec hand-off path. A test that
+asserts a constant you hardcoded is a claim, not evidence.
+
+In unit tests, install a mock-backed client on the global hub and
+assert on the sent events — see the `MockHub` harness in
+`cli/flox/src/commands/upgrade.rs`. Any test touching the global hub
+must be marked `#[serial(global_events_client)]`.
+
+## Coordinating changes
+
+The events emitted here are ingested by systems maintained outside
+this repository. Before merging any change from the "breaking" list
+above — or when a new field needs to show up in downstream reporting
+rather than just being recorded — raise it with the Flox maintainers
+on the PR first. Include:
+
+- The exact event type string(s) affected.
+- Each new or changed payload key: name, JSON type, optional or not,
+  and whether absent-vs-empty is meaningful.
+- Every emit site, and confirmation each carries a real value.
+- For enumerated values, the full value set and whether it grows.
+- The first CLI version that emits it. Data a producer never sent
+  cannot be reconstructed later, so the field's history starts at
+  that release.
+
+Additive changes (new `cli.*` events, new optional payload fields)
+don't need prior coordination to be safe on the wire — but flag them
+in the PR description regardless, so the downstream side knows they
+exist.
+
+This is a public repository. Code, comments, commit messages, and PR
+text describe the change on its own technical terms — the events and
+fields themselves. Don't name or link internal systems, tools,
+dashboards, or issue trackers, and don't explain which internal report
+a field powers.

--- a/cli/flox-events/README.md
+++ b/cli/flox-events/README.md
@@ -14,9 +14,13 @@ the rules that procedure enforces and why they exist.
 
 Telemetry can be disabled entirely with
 `flox config --set disable_metrics true` (or `FLOX_DISABLE_METRICS=true`).
-When disabled, no events are constructed and nothing is sent — the
-global hub stays dormant. See `flox config --help` and the first-run
-notice for the user-facing description of what is collected.
+When disabled, no client is installed, no `Event` envelope is created,
+and nothing is sent — but payload construction at a call site still
+happens, since the payload is built as the `record_event` argument.
+That is why expensive payload-only work must go behind
+`when_client_set` (see Emission mechanics). Telemetry is on by
+default with a first-run notice; see `flox config --help` for the
+user-facing description of what is collected.
 
 ## The two streams
 
@@ -93,9 +97,16 @@ Rules the envelope encodes:
 - **Every CLI event starts with `cli.`** — consumers select this
   producer's events by that prefix, so an event named outside it is
   invisible to them.
-- Group by the **entity**, not the caller: `cli.environment.install`
-  (the environment is what changed), so a whole domain can be selected
-  by prefix.
+- The template is `cli.<entity>.<verb>` when there is an entity, and
+  `cli.<verb>` for CLI-level actions with none (`cli.build`,
+  `cli.search`, `cli.authenticated`, `cli.update_prompted`). Group by
+  the **entity**, not the caller: `cli.environment.install` (the
+  environment is what changed), so a whole domain can be selected by
+  prefix.
+- `cli.environment.install` and `cli.package.install` are different
+  **grains**, not competing names: the environment event is one row
+  per invocation, the package events one row per package. Pick the
+  grain that matches what a consumer counts.
 - Payload field names are **bare**, discriminated by `event_type`:
   `outcome`, `duration_ms`, `error_kind` — not `build_outcome`,
   `build_duration_ms`. Shared meanings keep shared names across
@@ -110,7 +121,10 @@ Rules the envelope encodes:
 The consumers of these events live outside this repository and have
 **no compile-time link back to this crate**. Nothing here breaks
 locally when the contract moves — which is exactly why these rules
-exist.
+exist. Statements here about downstream behavior (unknown envelope
+keys dropped, de-duplication on `event_id`, no backfill of data never
+sent) are the ingestion side's contract, asserted for producers rather
+than verifiable from this repo.
 
 Safe, no coordination needed:
 
@@ -175,17 +189,30 @@ scrub is safe only against the leak shapes someone thought to
 enumerate; a closed set of compile-time values is safe by
 construction.
 
-Never on the wire:
+Three buckets govern what a field may carry:
 
-- Email addresses, usernames, or handles.
-- Tokens or any token bytes.
-- Filesystem paths and hostnames.
-- Free-form user text: error messages, descriptions, command lines.
+- **Never in a new field:** email addresses, tokens or token bytes,
+  filesystem paths, hostnames, and free-form user text (error
+  messages, descriptions, command lines).
+- **Allowed, and often the point:** low-cardinality identifiers the
+  user chose that *are* the usage signal — package coordinates,
+  environment names, manifest install ids, subcommand and flag names.
+  These are identifiers, not prose: a field in this bucket must not
+  be able to carry arbitrary sentences, paths, or secrets.
+- **Pseudonymous, handled carefully:** `auth_subject` (the opaque
+  OIDC/JWT `sub` claim) and `device_id`. Never substitute an email or
+  handle for either.
 
-One shipped exception: `cli.search`'s `search_term` carries the user's
-search text verbatim, for parity with the legacy stream. It is frozen
-into the contract and is not a precedent — new fields don't get to
-cite it.
+Some shipped fields carry user-controlled text that a new field would
+not be allowed. They are frozen as-is and are **not precedents**:
+
+| Field | Events | What it carries |
+|---|---|---|
+| `search_term` | `cli.search` | The search text verbatim (legacy parity). |
+| `env_ref_or_name` | `cli.environment.*` | `owner/name` for managed/remote environments — the owner segment is a FloxHub handle; the environment name for path environments. |
+| `package` | `cli.package.*` | The coordinate as written: a catalog path, a store path (canonicalized under `/nix/store`), or a flake URL — which can embed a hostname or a local path. |
+| `install_id` | `cli.package.upgrade` | The user-chosen manifest install id. |
+| `invocation_sources` | `cli.command_run` | Launcher tokens, including any supplied via `FLOX_INVOCATION_SOURCE` — an open set by design. |
 
 Patterns that make this structural:
 
@@ -245,8 +272,9 @@ chance to fix the mistake, not a reason to carry it forward.
 
 ## Emission mechanics
 
-Call sites record events through the global hub and never construct
-transport-level shapes themselves:
+Call sites record events through the global hub — with one sanctioned
+exception noted below — and never construct transport-level shapes
+themselves:
 
 ```rust
 use flox_events::{CliEnvironmentPayload, EventKind, EventsHub};
@@ -269,13 +297,36 @@ if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentDele
 - Events are buffered on disk (`events-v2.json` in the data dir, one
   JSON object per line) and sent in batches of 100 once the buffer is
   older than two minutes, from a flush-on-drop guard in `main`. A
-  failed send keeps events buffered for a later retry.
+  failed send keeps events buffered for a later retry. Two buffer
+  consequences shape the contract: the buffer caps at 1000 events with
+  oldest-first eviction, so a domain or completion row can outlive the
+  `cli.command_run` row it would join to — the join consumers are told
+  to design around is best-effort, and they must tolerate its absence.
+  And lines the running binary cannot parse (events from a newer flox
+  sharing the data dir) are kept verbatim and sent only once a binary
+  that understands them runs — so on a machine with several flox
+  versions, an event can land later than the release that minted it.
 - Lifecycle placement matters. `flox activate` replaces the process
   with `exec()`: anything recorded after that line is dead code in the
-  parent, which is why `activate.rs` records completion and flushes
-  before exec'ing. When instrumenting a new path, confirm the
-  emission is reached on every branch — including early exits and
-  hand-off paths.
+  parent, which is why `activate.rs` records completion and requests a
+  flush before exec'ing. (An unforced flush still waits for buffer
+  expiry — events not yet due are delivered by a later invocation.)
+  When instrumenting a new path, confirm the emission is reached on
+  every branch — including early exits and hand-off paths.
+- `record_command_completed` is single-shot per client install: the
+  first recorder wins and later calls are silently dropped, so the
+  pre-exec emit and the dispatcher cannot double-count. Over-emission
+  is as real a hazard as under-emission — the first writer must carry
+  the richest payload it can.
+- One sanctioned exception to "always through the hub": the
+  no-subcommand welcome path in `cli/flox/src/commands/mod.rs` builds
+  a client directly with `build_events_client`, because it returns
+  before dispatch installs the global client. Events recorded that way
+  are buffered and drained by a later invocation. Don't copy this
+  shape onto paths the dispatcher reaches.
+- `record_event_with_auth_subject` exists for the login flow, where
+  the authenticated subject becomes known mid-invocation and the
+  client's snapshot is stale by construction.
 - Propagating `invocation_id` to child flox processes is explicit,
   per spawn site: set `FLOX_INVOCATION_ID` on the child's `Command`
   from `current_invocation_id()` (`cli/flox/src/utils/events.rs`), so
@@ -287,21 +338,38 @@ if let Err(err) = EventsHub::global().record_event(EventKind::CliEnvironmentDele
 The integration layer in `cli/flox/src/utils/events.rs` provides
 `env_detail_from_concrete` / `env_detail_from_concrete_without_lineage`
 for building the shared `EnvDetail` payload half, and
-`build_events_client` for client construction.
+`build_events_client` for client construction. `EnvDetail` — flattened
+into every `cli.environment.*` payload — serializes as `env_kind`
+(`path`, `managed`, or `remote`) plus `env_ref_or_name`, with
+`local_environment_id` for path environments and `generation_number`
+for managed/remote ones (path environments structurally cannot carry a
+generation number), plus an optional `package_count`.
 
 ## Verifying what is actually sent
 
 Reading the code is not enough — exercise the instrumented path and
-inspect the emitted JSON. Three gotchas silently produce no output:
+inspect the emitted JSON. Build first (`just build-cli`, inside
+`nix develop` — the endpoint and key defaults are compiled in and the
+build tools are not on bare PATH). Four gotchas leave your collector
+silent:
 
 1. Use `_FLOX_METRICS_URL_V2_OVERRIDE` (and
    `_FLOX_METRICS_API_KEY_V2_OVERRIDE`) to point the v2 stream at a
    local collector. The unsuffixed `_FLOX_METRICS_URL_OVERRIDE`
-   redirects only the **legacy** stream.
+   redirects only the **legacy** stream — with only it set, your
+   collector stays quiet while your test events go to the production
+   endpoint, which is worse than no output.
 2. Set `_FLOX_FORCE_FLUSH_METRICS=true`. Without it a single command
    sends nothing — the buffer flushes on expiry and in batches.
 3. Use a real dispatched subcommand. `flox --version` returns before
    the events client is installed and emits nothing by construction.
+4. Check that metrics aren't disabled (`flox config --get
+   disable_metrics`, `FLOX_DISABLE_METRICS`) — many developers have
+   the opt-out set, and with it on no client is installed and nothing
+   is sent, with no error. Also look in the right buffer: the v2
+   stream buffers to `events-v2.json` in the data dir; the
+   similarly-named `metrics-events-v2.json` in the cache dir belongs
+   to the legacy stream.
 
 ```bash
 # terminal 1: a local collector that acknowledges each send
@@ -321,14 +389,22 @@ first — and BSD `nc` (the macOS default) exits after one connection
 anyway. The loop above acknowledges each request, so each run prints
 only its own events.
 
+Set the override variables per command, as above — never export them
+from a shell profile, `.envrc`, or CI config. An exported override
+silently redirects that machine's real telemetry to whatever the value
+says, over plain HTTP if the URL does. And `nc -l` listens on all
+interfaces, so stop the loop when you're done.
+
 Check the branches that matter: a success, a typed failure, a non-1
 exit code, and (for activate) the exec hand-off path. A test that
 asserts a constant you hardcoded is a claim, not evidence.
 
 In unit tests, install a mock-backed client on the global hub and
-assert on the sent events — see the `MockHub` harness in
-`cli/flox/src/commands/upgrade.rs`. Any test touching the global hub
-must be marked `#[serial(global_events_client)]`.
+assert on the sent events — copy the `MockHub` pattern from
+`cli/flox/src/commands/upgrade.rs` (it also appears in
+`commands/init/mod.rs`; it is a private test struct, not an importable
+helper). Any test touching the global hub must be marked
+`#[serial(global_events_client)]`.
 
 ## Coordinating changes
 
@@ -356,4 +432,6 @@ This is a public repository. Code, comments, commit messages, and PR
 text describe the change on its own technical terms — the events and
 fields themselves. Don't name or link internal systems, tools,
 dashboards, or issue trackers, and don't explain which internal report
-a field powers.
+a field powers. (A few pre-existing comments in this crate name
+specific downstream systems; they are grandfathered, not license for
+new text.)

--- a/cli/flox-events/src/lib.rs
+++ b/cli/flox-events/src/lib.rs
@@ -3,6 +3,10 @@
 //! This crate contains the v2 event envelope and the self-contained
 //! pipeline for buffering and sending `cli.*` events. The global hub is dormant
 //! until a client is installed by the CLI.
+//!
+//! The contributor-facing contract reference — wire shape, naming and
+//! stability rules, and the procedure for adding an event or field — is
+//! this crate's `README.md`.
 
 mod buffer;
 mod client;

--- a/cli/flox-events/src/lib.rs
+++ b/cli/flox-events/src/lib.rs
@@ -874,6 +874,66 @@ mod tests {
     // consumer needs a migration. Update the expected JSON once that is
     // arranged, not to make the test pass.
 
+    /// Wire names scraped from this file's `#[serde(rename = "cli...")]`
+    /// attributes — that pattern is unique to [`EventKind`] variants.
+    /// Scraped from source rather than enumerated at runtime because the
+    /// variants carry payloads, so there is no cheap way to iterate them.
+    fn event_kind_wire_names() -> Vec<&'static str> {
+        const SOURCE: &str = include_str!("lib.rs");
+        let names: Vec<_> = SOURCE
+            .lines()
+            .filter_map(|line| line.trim().strip_prefix(r#"#[serde(rename = ""#))
+            .filter_map(|rest| rest.split('"').next())
+            .filter(|name| name.starts_with("cli."))
+            .collect();
+        assert!(!names.is_empty(), "found no EventKind rename attributes");
+        names
+    }
+
+    #[test]
+    fn event_wire_names_follow_the_naming_grammar() {
+        for name in event_kind_wire_names() {
+            let mut segments = name.split('.');
+            assert_eq!(
+                segments.next(),
+                Some("cli"),
+                "{name}: every event type starts with the `cli.` namespace"
+            );
+            let mut trailing_segments = 0;
+            for segment in segments {
+                trailing_segments += 1;
+                assert!(
+                    !segment.is_empty()
+                        && segment
+                            .chars()
+                            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_'),
+                    "{name}: segment {segment:?} must be lowercase snake_case"
+                );
+            }
+            assert!(
+                trailing_segments >= 1,
+                "{name}: needs a segment after `cli.`"
+            );
+        }
+    }
+
+    // The README is the contributor-facing contract reference and carries an
+    // inventory of every event type; a variant added or renamed without a
+    // matching README update must fail here, since nothing else links them.
+    #[test]
+    fn readme_lists_every_event_type() {
+        const README: &str = include_str!("../README.md");
+        let missing: Vec<_> = event_kind_wire_names()
+            .into_iter()
+            .filter(|name| !README.contains(name))
+            .collect();
+        assert_eq!(
+            missing,
+            Vec::<&str>::new(),
+            "event types missing from cli/flox-events/README.md"
+        );
+    }
+
     /// The wire form of `OffsetDateTime::from_unix_timestamp(0)` under
     /// `TimestampMilliSeconds<i64>` — milliseconds since the Unix
     /// epoch, where 1970-01-01T00:00:00Z is exactly 0.


### PR DESCRIPTION
## What

- Adds `cli/flox-events/README.md` — the contributor-facing contract reference for v2 telemetry events: the NDJSON envelope shape, event/field naming rules, what is additive-safe vs. breaking, the privacy model (user data structurally absent, never scrubbed), how the golden tests enforce the contract, emission mechanics, and a working local-collector recipe for verifying what is actually sent.
- Adds the `adding-metrics-events` Claude skill — a step-by-step procedure for adding a payload field or a new event type, with a red-flags table for the common mistakes.
- Points at both from `AGENTS.md` and `CONTRIBUTING.md`.
- Updates the `adding-beta-subcommand` skill to direct new telemetry at the v2 pipeline instead of the legacy `subcommand_metric!` stream.
- Adds a test pinning the README's event inventory to the `EventKind` wire names (plus a naming-grammar test), and a CI-classifier arm so edits to that README run `cli-unit` instead of classifying as inert.

## Why

The v2 events pipeline had no prose documentation; the contract lived in doc comments and golden tests. Contributors adding a metric had no single place stating the rules that keep the wire format stable (frozen names, omit-don't-null optionals, additive-only changes) or the verification workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)