### PR TITLE
chore(ci): add skill for investigating flakey tests

### DIFF
--- a/.claude/skills/investigating-merge-queue-failures/.flox/.gitattributes
+++ b/.claude/skills/investigating-merge-queue-failures/.flox/.gitattributes
@@ -1,0 +1,1 @@
+env/manifest.lock linguist-generated=true linguist-language=JSON

--- a/.claude/skills/investigating-merge-queue-failures/.flox/.gitignore
+++ b/.claude/skills/investigating-merge-queue-failures/.flox/.gitignore
@@ -1,0 +1,5 @@
+run/
+cache/
+lib/
+log/
+!env/

--- a/.claude/skills/investigating-merge-queue-failures/.flox/env.json
+++ b/.claude/skills/investigating-merge-queue-failures/.flox/env.json
@@ -1,0 +1,4 @@
+{
+  "name": "merge-queue-triage",
+  "version": 1
+}

--- a/.claude/skills/investigating-merge-queue-failures/.flox/env/manifest.lock
+++ b/.claude/skills/investigating-merge-queue-failures/.flox/env/manifest.lock
@@ -1,0 +1,431 @@
+{
+  "lockfile-version": 1,
+  "manifest": {
+    "version": 1,
+    "install": {
+      "coreutils": {
+        "pkg-path": "coreutils"
+      },
+      "gh": {
+        "pkg-path": "gh"
+      },
+      "jq": {
+        "pkg-path": "jq"
+      }
+    },
+    "hook": {},
+    "profile": {},
+    "options": {}
+  },
+  "packages": [
+    {
+      "attr_path": "coreutils",
+      "broken": false,
+      "derivation": "/nix/store/6qj2zcxknmx7m89xp3var5rvh8c4bpx1-coreutils-9.11.drv",
+      "description": "GNU Core Utilities",
+      "install_id": "coreutils",
+      "license": "GPL-3.0-or-later",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d407951447dcd00442e97087bf374aad70c04cea",
+      "name": "coreutils-9.11",
+      "pname": "coreutils",
+      "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+      "rev_count": 1027867,
+      "rev_date": "2026-07-05T04:06:12Z",
+      "scrape_date": "2026-07-06T03:12:55.258386Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "9.11",
+      "outputs_to_install": [
+        "out",
+        "out",
+        "out",
+        "out",
+        "out",
+        "out",
+        "out",
+        "out",
+        "out"
+      ],
+      "outputs": {
+        "info": "/nix/store/lv9640g9czilp4h0bzvaaa1pybkk7jjg-coreutils-9.11-info",
+        "out": "/nix/store/2pj9qd6qs9b5rk4xzbsj9l2nmm07cdaf-coreutils-9.11"
+      },
+      "system": "aarch64-darwin",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "coreutils",
+      "broken": false,
+      "derivation": "/nix/store/y7adjxihg95hrq74jjqxarkr3h2r7vz5-coreutils-9.11.drv",
+      "description": "GNU Core Utilities",
+      "install_id": "coreutils",
+      "license": "GPL-3.0-or-later",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d407951447dcd00442e97087bf374aad70c04cea",
+      "name": "coreutils-9.11",
+      "pname": "coreutils",
+      "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+      "rev_count": 1027867,
+      "rev_date": "2026-07-05T04:06:12Z",
+      "scrape_date": "2026-07-06T03:41:21.925224Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "9.11",
+      "outputs_to_install": [
+        "out",
+        "out",
+        "out",
+        "out"
+      ],
+      "outputs": {
+        "debug": "/nix/store/c9i9h5zarcllbifym9n5iqkz03pvdcbp-coreutils-9.11-debug",
+        "info": "/nix/store/jbj9dg06bmdr8jpg8i2r2kpczh81h7vk-coreutils-9.11-info",
+        "out": "/nix/store/xapdnwj438nw0drpnxpbr1yds0yqhngi-coreutils-9.11"
+      },
+      "system": "aarch64-linux",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "coreutils",
+      "broken": false,
+      "derivation": "/nix/store/a0dp57smwj4jgd90ak4kz3ciazrdxb0v-coreutils-9.11.drv",
+      "description": "GNU Core Utilities",
+      "install_id": "coreutils",
+      "license": "GPL-3.0-or-later",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d407951447dcd00442e97087bf374aad70c04cea",
+      "name": "coreutils-9.11",
+      "pname": "coreutils",
+      "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+      "rev_count": 1027867,
+      "rev_date": "2026-07-05T04:06:12Z",
+      "scrape_date": "2026-07-06T04:09:00.643516Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "9.11",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "info": "/nix/store/8jc9262zif5m5gh6h5n1kbs5yrv594xn-coreutils-9.11-info",
+        "out": "/nix/store/rg42k0h3hj1mwldhywll29n7m0kcpxq2-coreutils-9.11"
+      },
+      "system": "x86_64-darwin",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "coreutils",
+      "broken": false,
+      "derivation": "/nix/store/yzawmmja3azkam2gyf3b0z5a8aafja9m-coreutils-9.11.drv",
+      "description": "GNU Core Utilities",
+      "install_id": "coreutils",
+      "license": "GPL-3.0-or-later",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d407951447dcd00442e97087bf374aad70c04cea",
+      "name": "coreutils-9.11",
+      "pname": "coreutils",
+      "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+      "rev_count": 1027867,
+      "rev_date": "2026-07-05T04:06:12Z",
+      "scrape_date": "2026-07-06T04:40:24.577683Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "9.11",
+      "outputs_to_install": [
+        "out",
+        "out",
+        "out",
+        "out",
+        "out",
+        "out",
+        "out"
+      ],
+      "outputs": {
+        "debug": "/nix/store/wifadx5v4ps5nvf23cr22lswn3q70s6f-coreutils-9.11-debug",
+        "info": "/nix/store/zs5bzwnkhgzka1ccvzkhx0xzf1mlah2j-coreutils-9.11-info",
+        "out": "/nix/store/sr26flm2nkfa12dkrwj2630kqsfakky4-coreutils-9.11"
+      },
+      "system": "x86_64-linux",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "gh",
+      "broken": false,
+      "derivation": "/nix/store/knh1znqhi7kg50vj7wb7vyb8cxknv8jn-gh-2.96.0.drv",
+      "description": "GitHub CLI tool",
+      "install_id": "gh",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d407951447dcd00442e97087bf374aad70c04cea",
+      "name": "gh-2.96.0",
+      "pname": "gh",
+      "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+      "rev_count": 1027867,
+      "rev_date": "2026-07-05T04:06:12Z",
+      "scrape_date": "2026-07-06T03:12:56.060369Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "2.96.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/0370cakz5b3yf6dlr2r75ybxsrjpp5k3-gh-2.96.0"
+      },
+      "system": "aarch64-darwin",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "gh",
+      "broken": false,
+      "derivation": "/nix/store/7bia0bikhgg4bdm95pnfk71z02zb7hq6-gh-2.96.0.drv",
+      "description": "GitHub CLI tool",
+      "install_id": "gh",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d407951447dcd00442e97087bf374aad70c04cea",
+      "name": "gh-2.96.0",
+      "pname": "gh",
+      "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+      "rev_count": 1027867,
+      "rev_date": "2026-07-05T04:06:12Z",
+      "scrape_date": "2026-07-06T03:41:23.108736Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "2.96.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/nkm00gpkyg9dqlisnxffwjk647r4q81s-gh-2.96.0"
+      },
+      "system": "aarch64-linux",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "gh",
+      "broken": false,
+      "derivation": "/nix/store/3smfxxfn6mjw6nsf6aijvh9514h2kqlc-gh-2.96.0.drv",
+      "description": "GitHub CLI tool",
+      "install_id": "gh",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d407951447dcd00442e97087bf374aad70c04cea",
+      "name": "gh-2.96.0",
+      "pname": "gh",
+      "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+      "rev_count": 1027867,
+      "rev_date": "2026-07-05T04:06:12Z",
+      "scrape_date": "2026-07-06T04:09:01.575200Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "2.96.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/waa7fl1d466lkihg89p60iisjwynyfb7-gh-2.96.0"
+      },
+      "system": "x86_64-darwin",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "gh",
+      "broken": false,
+      "derivation": "/nix/store/wbhspnqh3z83s5gy4gfb97m58crvclqa-gh-2.96.0.drv",
+      "description": "GitHub CLI tool",
+      "install_id": "gh",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d407951447dcd00442e97087bf374aad70c04cea",
+      "name": "gh-2.96.0",
+      "pname": "gh",
+      "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+      "rev_count": 1027867,
+      "rev_date": "2026-07-05T04:06:12Z",
+      "scrape_date": "2026-07-06T04:40:25.881436Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "2.96.0",
+      "outputs_to_install": [
+        "out",
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/zmby710xkfnzpq1wq3zxgp044724zwwb-gh-2.96.0"
+      },
+      "system": "x86_64-linux",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "jq",
+      "broken": false,
+      "derivation": "/nix/store/mpxw23n62v0rkp5n468pk46srixprs54-jq-1.8.1.drv",
+      "description": "Lightweight and flexible command-line JSON processor",
+      "install_id": "jq",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d407951447dcd00442e97087bf374aad70c04cea",
+      "name": "jq-1.8.1",
+      "pname": "jq",
+      "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+      "rev_count": 1027867,
+      "rev_date": "2026-07-05T04:06:12Z",
+      "scrape_date": "2026-07-06T03:13:12.483661Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "1.8.1",
+      "outputs_to_install": [
+        "bin",
+        "bin",
+        "man"
+      ],
+      "outputs": {
+        "bin": "/nix/store/n9ri7m7j3l3ggx7ag8xm87cavjvcxycz-jq-1.8.1-bin",
+        "dev": "/nix/store/pfp4psnwxs2ygda5sq6sr95x2snn6yjl-jq-1.8.1-dev",
+        "doc": "/nix/store/6va29c6s0v4kqi0zvc5jhn7s31c9i4hd-jq-1.8.1-doc",
+        "man": "/nix/store/0l8f1i70kd15qadl45b4fvqlg2j7s5hn-jq-1.8.1-man",
+        "out": "/nix/store/phmsnvxjh6rmf7id4wahi3vllbj8fn4s-jq-1.8.1"
+      },
+      "system": "aarch64-darwin",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "jq",
+      "broken": false,
+      "derivation": "/nix/store/zxip019ljwma1b99d59gyd4y5d8qlnba-jq-1.8.1.drv",
+      "description": "Lightweight and flexible command-line JSON processor",
+      "install_id": "jq",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d407951447dcd00442e97087bf374aad70c04cea",
+      "name": "jq-1.8.1",
+      "pname": "jq",
+      "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+      "rev_count": 1027867,
+      "rev_date": "2026-07-05T04:06:12Z",
+      "scrape_date": "2026-07-06T03:41:44.221148Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "1.8.1",
+      "outputs_to_install": [
+        "bin",
+        "bin",
+        "bin",
+        "man"
+      ],
+      "outputs": {
+        "bin": "/nix/store/hmwz4mnhiwyy1zyrypbdk6xqrxrpv4jp-jq-1.8.1-bin",
+        "dev": "/nix/store/gkincbg9wkmasrxw36mmyvp08jyhcxxg-jq-1.8.1-dev",
+        "doc": "/nix/store/vh84k872pnn2xavlx9j551056k1h579f-jq-1.8.1-doc",
+        "man": "/nix/store/iy9j5qqv7bkf0fnwh6pddfbk5q93i3nh-jq-1.8.1-man",
+        "out": "/nix/store/cs80rizzqf70hsya9n2h60zj9rf23sr5-jq-1.8.1"
+      },
+      "system": "aarch64-linux",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "jq",
+      "broken": false,
+      "derivation": "/nix/store/0shj1l58q4p6g3kf20748vq91b6rvr0r-jq-1.8.1.drv",
+      "description": "Lightweight and flexible command-line JSON processor",
+      "install_id": "jq",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d407951447dcd00442e97087bf374aad70c04cea",
+      "name": "jq-1.8.1",
+      "pname": "jq",
+      "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+      "rev_count": 1027867,
+      "rev_date": "2026-07-05T04:06:12Z",
+      "scrape_date": "2026-07-06T04:09:22.080679Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "1.8.1",
+      "outputs_to_install": [
+        "bin",
+        "man"
+      ],
+      "outputs": {
+        "bin": "/nix/store/glj1kzrb6jm7x4r5z400mcmja8ws657q-jq-1.8.1-bin",
+        "dev": "/nix/store/akbah2c4a6xcgpx2l7xqqgfbxgi8anfj-jq-1.8.1-dev",
+        "doc": "/nix/store/jb2xgi4gjvzwifzfmf4kzkimbgrhsaav-jq-1.8.1-doc",
+        "man": "/nix/store/vpk901871j7kfmmb20i1vfxh5d8mhim2-jq-1.8.1-man",
+        "out": "/nix/store/l4i89frkjf4dly7gxwbksrcimcgr2x8f-jq-1.8.1"
+      },
+      "system": "x86_64-darwin",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "jq",
+      "broken": false,
+      "derivation": "/nix/store/n9cdsl2rnrzwh2c3kw6ib023vp9qfm9f-jq-1.8.1.drv",
+      "description": "Lightweight and flexible command-line JSON processor",
+      "install_id": "jq",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d407951447dcd00442e97087bf374aad70c04cea",
+      "name": "jq-1.8.1",
+      "pname": "jq",
+      "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+      "rev_count": 1027867,
+      "rev_date": "2026-07-05T04:06:12Z",
+      "scrape_date": "2026-07-06T04:40:47.719913Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "1.8.1",
+      "outputs_to_install": [
+        "bin",
+        "bin",
+        "bin",
+        "man"
+      ],
+      "outputs": {
+        "bin": "/nix/store/q0pj1dw2nr57y6b4pqljklf0hy20alfj-jq-1.8.1-bin",
+        "dev": "/nix/store/3vavalljj18drsycygl361zqz4rryygd-jq-1.8.1-dev",
+        "doc": "/nix/store/nzhykmz9qn2vrb9ki6ddrpipic7rfpfb-jq-1.8.1-doc",
+        "man": "/nix/store/d21dmfzxkgpa7jkn5ggr0balzfg0j269-jq-1.8.1-man",
+        "out": "/nix/store/bzm6nb8fx5p005bygrarn48i6qy1ir3a-jq-1.8.1"
+      },
+      "system": "x86_64-linux",
+      "group": "toplevel",
+      "priority": 5
+    }
+  ]
+}

--- a/.claude/skills/investigating-merge-queue-failures/.flox/env/manifest.toml
+++ b/.claude/skills/investigating-merge-queue-failures/.flox/env/manifest.toml
@@ -1,0 +1,106 @@
+## Flox Environment Manifest -----------------------------------------
+##
+##   _Everything_ you need to know about the _manifest_ is here:
+##
+##   https://flox.dev/docs/reference/command-reference/manifest.toml/
+##
+## -------------------------------------------------------------------
+# Flox manifest version managed by Flox CLI
+version = 1
+
+
+## Install Packages --------------------------------------------------
+##  $ flox install gum  <- puts a package in [install] section below
+##  $ flox search gum   <- search for a package
+##  $ flox show gum     <- show all versions of a package
+## -------------------------------------------------------------------
+[install]
+gh.pkg-path = "gh"
+jq.pkg-path = "jq"
+coreutils.pkg-path = "coreutils"
+# gum.pkg-path = "gum"
+# gum.version = "^0.14.5"
+
+
+## Environment Variables ---------------------------------------------
+##  ... available for use in the activated environment
+##      as well as [hook], [profile] scripts and [services] below.
+## -------------------------------------------------------------------
+[vars]
+# INTRO_MESSAGE = "It's gettin' Flox in here"
+
+
+## Activation Hook ---------------------------------------------------
+##  ... run by _bash_ shell when you run 'flox activate'.
+## -------------------------------------------------------------------
+[hook]
+# on-activate = '''
+#   # -> Set variables, create files and directories
+#   # -> Perform initialization steps, e.g. create a python venv
+#   # -> Useful environment variables:
+#   #      - FLOX_ENV_PROJECT=/home/user/example
+#   #      - FLOX_ENV=/home/user/example/.flox/run
+#   #      - FLOX_ENV_CACHE=/home/user/example/.flox/cache
+# '''
+
+
+## Profile script ----------------------------------------------------
+## ... sourced by _your shell_ when you run 'flox activate'.
+## -------------------------------------------------------------------
+[profile]
+# common = '''
+#   gum style \
+#   --foreground 212 --border-foreground 212 --border double \
+#   --align center --width 50 --margin "1 2" --padding "2 4" \
+#     $INTRO_MESSAGE
+# '''
+## Shell-specific customizations such as setting aliases go here:
+# bash = ...
+# zsh  = ...
+# fish = ...
+
+
+## Services ---------------------------------------------------------
+##  $ flox services start             <- Starts all services
+##  $ flox services status            <- Status of running services
+##  $ flox activate --start-services  <- Activates & starts all
+## ------------------------------------------------------------------
+[services]
+# myservice.command = "python3 -m http.server"
+
+
+## Include ----------------------------------------------------------
+## ... environments to create a composed environment
+## ------------------------------------------------------------------
+[include]
+# environments = [
+#     { dir = "../common" }
+# ]
+
+
+## Build and publish your own packages ------------------------------
+##  $ flox build
+##  $ flox publish
+## ------------------------------------------------------------------
+[build]
+# [build.myproject]
+# description = "The coolest project ever"
+# version = "0.0.1"
+# command = """
+#   mkdir -p $out/bin
+#   cargo build --release
+#   cp target/release/myproject $out/bin/myproject
+# """
+
+
+## Other Environment Options -----------------------------------------
+[options]
+# Systems that environment is compatible with
+# systems = [
+#   "aarch64-darwin",
+#   "aarch64-linux",
+#   "x86_64-darwin",
+#   "x86_64-linux",
+# ]
+# Uncomment to disable CUDA detection.
+# cuda-detection = false

--- a/.claude/skills/investigating-merge-queue-failures/SKILL.md
+++ b/.claude/skills/investigating-merge-queue-failures/SKILL.md
@@ -1,0 +1,262 @@
+---
+name: investigating-merge-queue-failures
+description: Use when investigating flaky CI in flox/flox — triaging failures in the GitHub merge queue, working out whether a CI failure is a flaky test, slow infrastructure, or a real break. Accepts an optional lookback window (defaults to 30 days). Examples - "/investigating-merge-queue-failures", "/investigating-merge-queue-failures 14d", "why is the merge queue red so often?"
+argument-hint: "[lookback window, e.g. 30d (default) or 7d]"
+---
+
+# Investigating merge queue failures
+
+A merge queue run tests the PR *as it would land*, on top of everything ahead of
+it. The PR's own CI already passed before it was queued, so a merge-queue
+failure is usually — but not always — a flake.
+
+The goal of this skill is to sort each failure into a category and, where the
+category is new, add it to `references/failure-categories.md`. **That reference
+is the durable output.** Do not write occurrence logs, per-run tallies, or dated
+findings to disk; those go in the chat reply and are thrown away.
+
+## Do not assume every merge-queue failure is flaky
+
+Two non-flaky things also fail here, and mislabelling them wastes real
+debugging time. Both exist because the queue tests something the PR's own CI
+never did:
+
+- **A genuine semantic conflict between PRs.** The queue builds the PR on top
+  of everything ahead of it in the group, so two PRs that each pass alone can
+  break when combined. This is the queue working as designed.
+- **A check that is deliberately stricter in the queue.** The commitizen hook
+  narrows its allowed commit prefixes when `IS_MERGE_QUEUE=1`, so a branch
+  carrying a `fixup!` commit passes PR CI and fails the queue every time. Any
+  check that reads `IS_MERGE_QUEUE` can do this.
+
+`references/failure-categories.md` has the signatures that separate these from
+flakes. Check it before concluding anything is flaky — and note that neither
+is identified by failing more than once. See the note on repeats in step 1.
+
+## Setup
+
+The skill ships a Flox environment providing `gh`, `jq`, and GNU `coreutils`.
+Use it — the timestamp arithmetic in step 4 needs GNU `date -d`, and `jq`'s
+`--arg` is not available through `gh api --jq`. Nothing here should assume the
+host has `jq`, `sed`, `awk`, `python3`, or `perl`.
+
+Steps 1–3 are mechanical, so they are scripted:
+
+```bash
+flox activate -d <skill dir> -- <skill dir>/scripts/collect.sh [since] [outdir]
+```
+
+`since` defaults to 30 days ago, `outdir` to `./merge-queue-triage`. It writes
+`jobs.tsv` — one row per failed job, giving the bats plan line (`1..N`, the
+total number of tests), the number of the last test that finished, the timeout
+gap in seconds, and whether a `124` appears anywhere — plus `conclusions.tsv`,
+the run counts by conclusion that step 6's denominator comes from. It leaves the
+raw logs in `logs/` for the judgement calls it deliberately does not make.
+
+**Read the warnings on stderr before trusting a count.** The script says
+`INCOMPLETE` when a fetch failed after retries and `WARNING: hit --limit` when
+the run list was capped; either means the numbers are undercounts, and the
+second is fixed by re-running with a larger `LIMIT`.
+
+**The script collects; it does not classify.** Read `jobs.tsv`, then work
+through step 4 with `references/failure-categories.md` in hand. The rest of
+this document explains what the script does and how to go further by hand when
+a job does not fit the mould.
+
+## Step 1: Collect failed runs
+
+```bash
+gh run list --repo flox/flox --event merge_group --status failure \
+  --created ">=<WINDOW_START>" --limit 1000 \
+  --json databaseId,workflowName,headBranch,createdAt \
+  --jq '.[] | "\(.databaseId)\t\(.createdAt)\t\(.workflowName)\t\(.headBranch)"'
+```
+
+`--event merge_group` is what restricts this to the queue; those runs have a
+`gh-readonly-queue/main/pr-<N>-<sha>` head branch. Substitute an ISO date for
+`<WINDOW_START>`.
+
+**Filter the window with `--created`, not with `jq`, and keep `--limit` well
+above the expected row count.** `--limit` bounds the reply, and `gh` truncates
+to it silently — filtering client-side instead throws away whatever the cap
+already cut. The queue runs roughly 170 times a month, so 30 days needs a limit
+in the high hundreds; if a query returns exactly the limit, it was truncated.
+
+Two things to note about the run list:
+
+- **Ignore `cancelled`.** When one run in a merge group fails, GitHub dequeues
+  the group and cancels its siblings. Those cancellations are bookkeeping, not
+  failures.
+- **Repeat failures on the same `pr-<N>-<sha>` prove nothing on their own.**
+  It is tempting to read "failed twice, therefore reproduces, therefore real",
+  but bogged-down infrastructure fails the same way on consecutive attempts,
+  and an established flaky test reproduces perfectly well. Group the repeats by
+  *signature* and classify that; the repetition itself is not evidence.
+
+For a denominator, count all merge-queue runs in the window — the same query
+with `--status failure` dropped, grouped by conclusion. A category is only worth
+chasing relative to how often the queue runs at all, so an undercounted
+denominator is worse than none: it silently inflates every rate in the report.
+`collect.sh` writes this to `conclusions.tsv`.
+
+## Step 2: Collect failed jobs and their logs
+
+A run has many jobs; only some failed.
+
+```bash
+gh api "repos/flox/flox/actions/runs/<RUN_ID>/jobs?per_page=100" \
+  --jq '.jobs[] | select(.conclusion=="failure" or .conclusion=="timed_out") | "\(.id)\t\(.name)\t\(.conclusion)"'
+```
+
+Then fetch each job's full log:
+
+```bash
+gh api "repos/flox/flox/actions/jobs/<JOB_ID>/logs" > <JOB_ID>.txt
+```
+
+Practical notes:
+
+- Write logs to the scratchpad directory, not the worktree. A month of
+  failures is a few MB.
+- Logs are retained ~90 days, so a 30-day window is always available.
+- Every line is prefixed with a 29-character ISO timestamp. Strip it with
+  `cut -c30-`.
+- `gh api --jq` does **not** accept `--arg`. Pipe to the environment's `jq`
+  instead of working around it.
+- Anchor any `1..N` search on the timestamp prefix
+  (`^[0-9T:.Z-]+ 1\.\.[0-9]+`). Unanchored, it matches unrelated ranges
+  elsewhere in the log and reports a plan the suite never had.
+
+## Step 3: Extract a signature
+
+**The `##[error]` line is almost never the signature.** The large majority of
+failed jobs report only `Process completed with exit code 1`. Get it for the
+exit code, then look deeper:
+
+```bash
+grep -a "##\[error\]" <JOB_ID>.txt | cut -c30- | sort -u
+```
+
+| Failure kind | What to grep for |
+|---|---|
+| bats test | `not ok <N> <name>`, then `grep -a -A 20` that line for the assertion |
+| bats suite shape | the plan line `1..<N>`, and the last `ok`/`not ok` line |
+| a timeout | the timestamp gap between the last log line and the `##[error]` |
+| cargo/nextest | `panicked at <file>:<line>`, `test result: FAILED` |
+| nix build | `error: builder for '/nix/store/...' failed`, and the `>`-prefixed build output |
+| network | `Could not resolve hostname (6)`, `Timeout was reached (28)` — curl exit codes |
+| — | check whether the line says `warning:` or `error:` before calling it the cause |
+| timeout inside a test | `failed with status 124`, `status : 124` |
+
+## Step 4: Classify — in this order
+
+Order matters, because the loudest symptom is usually downstream of the real
+cause. Work through `references/failure-categories.md`, but always:
+
+1. **For a timed-out job, measure the gap before calling it a hang.** Compare
+   the timestamp of the last log line to the `##[error]` line. Tens of minutes
+   means something genuinely hung. A few seconds means the suite was still
+   running when the 30-minute budget expired — that is slow infrastructure,
+   and there is no hung test to look for. Skipping this check invents hangs
+   that never happened.
+2. **Look for `124`, even in a job that timed out.** A `timeout` expiry inside
+   a test is the root cause; a job timeout that follows it is a symptom.
+3. **Check the plan line against the last test.** If a job hung and its plan is
+   `1..N` with last line `ok N`, every test ran and the *suite finished* — the
+   job hung afterwards. That is the FD 3 hang, not a hung test.
+4. **Check whether the same test failed on every platform in the run.** That is
+   the semantic-conflict signature, not a flake.
+5. **For infrastructure, identify the host before choosing a category.**
+   GitHub and `releases.nixos.org` are not ours — retry and exclude them
+   (section 2). Our builders, our cache, and the tailnet that reaches them are
+   (section 3). The response differs, so the report has to.
+6. Only then classify by the individual test signature (section 4).
+
+A job can belong to more than one category — a slow builder causing a 124,
+causing a failed test, causing an FD 3 hang, is one job with three symptoms.
+Tag per job and say so; don't force one label per run.
+
+If a test hung or was cut off mid-flight, its name was never printed. See
+"Naming a test that never printed" in the reference for how to recover it from
+a healthy run.
+
+## Step 5: Report and update the catalog
+
+Report in chat, and lead with the split that says what to prioritise:
+
+- **section 3 (builder instability)** vs **section 4 (flaky tests)** — this is
+  the whole point of the report. It answers whether the next block of effort
+  belongs in the fleet or in the test suite, which a single combined "flaky"
+  number cannot;
+- **section 1** separately, since it is not flakiness and needs a code fix;
+- **section 2** as a footnote, with a note that it is excluded from the
+  totals — counting outages we cannot fix only inflates the number.
+
+Then give the platforms each skews toward and which categories share a root
+cause. Name the specific tests inside a flaky cluster so they can be fixed, but
+keep run IDs and dates out of the reference file.
+
+If a signature matched nothing in the catalog, propose a new category —
+signature, what it means, and how to tell it apart from its neighbours — and
+add it to `references/failure-categories.md`. That is the only file in the
+repository this skill writes.
+
+**Only add a category the evidence supports.** A category earns its place by
+having failed something. Before adding one, confirm the signature appears as an
+`error:` and not merely a `warning:`, and that it was the reason a job failed
+rather than noise in a step that passed. A category invented from warnings
+sends every future reader hunting a problem that does not exist.
+
+## Step 6: Write an HTML report
+
+After classifying, write a standalone HTML file to `<outdir>/report.html` —
+self-contained, with the CSS inlined and no external requests, so it can be
+opened straight from disk or attached to an issue. The report is a snapshot,
+not state: it is regenerated per run, lives with the collected logs rather than
+in the repository, and nothing in it feeds back into the catalog.
+
+It must contain:
+
+- **The denominator, up front.** Failed runs over total merge-queue runs in the
+  window. "27 failures" means nothing without "out of 186 runs".
+- **A pie chart of the four categories**, with each slice's percentage and job
+  count. Four slices of a genuine part-to-whole is what a pie is for; keep it to
+  the four categories and do not split it further. Give each slice the same
+  colour that category's section uses, so identity holds down the page, and put
+  the names in a legend — never colour alone.
+- **The architecture split within categories 3 and 4**, as a percentage for
+  each, since where the failures land is most of the diagnosis. Use steps of the
+  owning category's colour rather than new hues, so the split reads as a
+  subdivision. Note that `macos-14-xlarge` runners are `macos-14-arm64`, so
+  those jobs are aarch64-darwin — reading the label as x86 miscounts the split.
+- **Sections 3 and 4 as the two headline numbers**, side by side and clearly
+  distinguished — builder instability versus flaky tests. This is the report's
+  entire reason for existing: it says whether the next block of effort should go
+  into the fleet or into the test suite. Do not merge them into one "flaky"
+  figure, which cannot answer that.
+- **Section 1 separately**, marked as needing a code fix rather than CI work.
+- **Section 2 as a footnote**, with its count stated and explicitly excluded
+  from the totals, so the exclusion is visible rather than silent.
+- **Named tests** inside each category-4 cluster, and named hosts or steps
+  inside each category-3 one. A category with no specifics in it cannot be
+  acted on.
+- **Root causes that span categories**, called out — most importantly that a
+  `124` in a category-4 job usually means the real fix is in category 3.
+- **Anything uncategorisable**, counted honestly rather than forced into the
+  nearest bucket, with the reason it could not be classified.
+
+**Never print an aggregate next to the breakdown that supersedes it.** "76% of
+failed jobs were darwin" is worth nothing once the per-category split is on the
+page, and repeating it as a headline figure buys prominence with no
+information. Where both would fit, keep the breakdown and delete the aggregate.
+
+Keep dates and run IDs to this report; they must not reach the catalog. Link
+each cluster to a failing job so a reader can check the evidence, and say
+plainly which findings rest on a single occurrence.
+
+The palette is chosen, not incidental: the category colours pass a
+colourblindness and contrast check in both light and dark, and the dark steps
+are separate values rather than a flip of the light ones. If you restyle the
+report, re-validate rather than picking new colours by eye — a teal that looks
+fine can sit under the chroma floor and read as grey, and dark steps drift
+above the dark lightness band easily.

--- a/.claude/skills/investigating-merge-queue-failures/references/failure-categories.md
+++ b/.claude/skills/investigating-merge-queue-failures/references/failure-categories.md
@@ -1,0 +1,450 @@
+# Merge-queue failure categories
+
+A catalog of *kinds* of failure and the signatures that identify them.
+Deliberately no dates, run IDs, or occurrence counts — those belong in a
+report, not here. Add a category when a signature matches nothing below.
+
+Categories are organised by **what we would do about it**, not by mechanism,
+because that is the decision the report has to support:
+
+| | | |
+|---|---|---|
+| **1** | Not flaky at all | Fix the code; never retry |
+| **2** | Flaky, not ours to fix | Retry, exclude from statistics |
+| **3** | Flaky, ours to fix — builder instability | Fleet work |
+| **4** | Flaky, ours to fix — tests written flakily | Test work |
+
+Sections 3 and 4 are the ones worth counting, and the split between them is
+what the report is for: it says whether the next block of effort should go into
+the fleet or into the test suite. A single combined "flaky" number cannot
+answer that, so it cannot change what anyone prioritises.
+
+"Section 5: diagnosing a 30-minute timeout" is not a category — it is a routing
+procedure, because that one symptom lands in three different categories above.
+
+---
+
+# 1. Not flaky — the queue doing its job
+
+The queue tests something the PR's own CI never did, so these are real and
+reproduce. **Fix the code. Retrying can never help.**
+
+## 1a. Semantic conflict between PRs
+
+**Signature:** the *same* test or build step fails identically on **every
+platform in the run**, with a missing-symbol shape:
+
+```
+`<helper>' failed with status 127
+<file>.bats: line <N>: <helper>: command not found
+```
+
+…or a compile error for a name that exists on neither side alone.
+
+The queue builds the PR on top of everything ahead of it in the group, so two
+PRs that each pass alone break when combined — typically one adds callers of a
+helper another adds, or removes something a third still uses.
+
+**Tell it apart from a flake:** **uniformity across platforms is the signal.**
+A flake is platform-skewed — darwin but not linux, one arch but not the other.
+This fails the same way everywhere at once.
+
+**Repetition is not the signal.** Do not conclude "it failed twice on the same
+head SHA, so it reproduces, so it is real." Both flaky categories repeat
+readily: when infrastructure is bogged down the same PR fails the same
+infrastructural way on consecutive attempts, and a well-established flaky test
+can fail identically on two runs in a row. Observed semantic conflicts have
+been caught on a *single* run.
+
+## 1b. A check that is stricter in the queue than on the PR
+
+**Signature:** `commit validation: failed!` in the `Nix Git Hooks` job, with:
+
+```
+commitizen-in-ci.........................................................Failed
+- hook id: commitizen-in-ci
+- exit code: 14
+```
+
+This is reachable *because the queue is deliberately stricter*.
+`pkgs/pre-commit-check/default.nix` narrows commitizen's allowed commit
+prefixes to `Revert` alone when `IS_MERGE_QUEUE=1`, where PR CI accepts
+commitizen's defaults (`Merge`, `fixup!`, `squash!`, …). A branch carrying a
+`fixup!` or `squash!` commit therefore passes its own CI by design and fails
+the queue by design.
+
+A `~/.netrc file owner ... does not match current user` warning often appears
+alongside and is a red herring — it is a warning, not the failure.
+
+**Action:** squash or reword the offending commits. When adding any check, note
+whether it behaves differently under `IS_MERGE_QUEUE`; that difference is the
+whole mechanism by which a queue-only, non-flaky failure exists.
+
+---
+
+# 2. Flaky, but not ours to fix
+
+Third-party outages and queue bookkeeping. **Retry, and exclude these from
+flake statistics** — counting them inflates the number without giving anyone
+something to do. Identify by hostname: `api.github.com`, `github.com`, and
+`releases.nixos.org` are not ours.
+
+## 2a. Merge-queue ref race
+
+Not instability at all — pure bookkeeping, filed here because the response is
+the same: ignore it.
+
+**Signature:** git exit code `128` with:
+
+```
+fatal: couldn't find remote ref refs/heads/gh-readonly-queue/main/pr-<N>-<sha>
+```
+
+The queue branch was deleted while the job was still checking it out — the
+group was dequeued underneath a job that had already started. It tells you
+nothing about the code and nothing about the fleet.
+
+## 2b. GitHub API and GitHub-hosted runners
+
+**Signature:** curl exit codes against `api.github.com` or `github.com`:
+
+```
+Could not resolve hostname (6)
+Timeout was reached (28)
+```
+
+Also covers failures on GitHub's own runner images (the `macos-14-xlarge`
+label and friends).
+
+## 2c. Upstream Nix distribution
+
+**Signature:** the Nix *installation* step fails or hangs, with curl verbose
+output against `releases.nixos.org` and no completion. The job dies before any
+test runs.
+
+---
+
+# 3. Flaky and ours to fix — builder instability
+
+Our own builders, cache, and tailnet. **A recurring one is a fleet problem, not
+bad luck.** This is where most infrastructure failures land.
+
+Ours means: `s3://flox-cache-public` (our substituter), the tailnet, and any
+machine drawn from `/etc/nix/machines` via `REMOTE_SERVER_ENTRY` — `hetzner-*`,
+`indigo-*`, `lhr-*-darwin-*`, `flox-aarch64-darwin`.
+
+## 3a. Slow builder — `timeout` expiry inside a test
+
+**Signature:** exit status `124` anywhere in the log:
+
+```
+`wait_for_partial_file_content "$executive_log" "<text>"' failed with status 124
+status : 124
+```
+
+`124` is what `timeout(1)` returns when it kills its child. Something did not
+happen inside a hard-coded budget — which is *either* a slow builder or a wait
+too tight to absorb normal variance.
+
+**A 124 does not by itself mean the builder was slow. Measure before you
+decide** — but measure the right thing.
+
+**Do not use suite wall time.** It is contaminated: an expired wait *is* time
+spent, so a job where twenty teardowns each burn ~19s on a bounded wait instead
+of ~0.5s inflates its own wall clock by six minutes. Concluding "slow builder"
+from that is circular — the timeouts caused the slowness you are citing as
+their cause.
+
+**Use the duration of the tests that passed.** Those are unaffected by whatever
+timed out:
+
+```
+grep -aE '^[0-9T:.Z-]+ ok [0-9]+ .* # in [0-9]+ ms' <log> \
+  | grep -oE '# in [0-9]+ ms' | grep -oE '[0-9]+' | sort -n
+```
+
+Take the median and the total, and compare two ways:
+
+| Comparison | Why |
+|---|---|
+| Against a **healthy run of the same job** | The obvious baseline, but weak on its own — a reference from another week may differ for reasons unrelated to health. |
+| Against the **other failed jobs on the same platform in the same period** | Much stronger. A builder problem makes one job an outlier among its peers; a systematically different baseline moves all of them together. |
+
+A job that is ~1.5× a stale baseline *along with every one of its siblings* is
+probably a baseline artefact. A job that is ~2× its own siblings, with several
+times their number of failing tests, is a degraded machine — category **3**.
+Everything else stays in category **4**.
+
+Reference passing-test medians, for orientation only:
+
+| Job | Tests | Median passing test |
+|---|---|---|
+| `remote (aarch64-darwin, !containerize)` | ~750 | ~505 ms |
+| `remote (x86_64-darwin, !containerize,!activate)` | ~435 | ~1200 ms |
+
+**Action when it is a tight wait:** make the wait poll a condition with a
+generous ceiling rather than sleep a fixed budget. Do not "fix" the behaviour
+being waited on — it was working.
+
+## 3b. Slow builder — suite exhausts the 30-minute job budget
+
+**Signature:** the bats timeout error with a **gap of seconds** between the
+last log line and the error, and a last finished test well short of the plan.
+Nothing hung — the suite was still making progress when the clock ran out. See
+section 5.
+
+Wall time is the right measure *here* — unlike in 3a — but only once you have
+confirmed the log contains no `124` and no bounded-wait failures. If it does,
+the suite inflated its own clock and you are back to 3a's method.
+
+**A partially-completed suite means the builder is slow. Full stop.** The
+budget is not marginal: a healthy `remote (aarch64-linux, !containerize)` run
+gets through all ~750 tests in **under eight minutes**, leaving more than
+twenty minutes of headroom. A run that fails to finish in thirty is several
+times slower than normal, not a suite that has outgrown its budget. Don't
+reach for "maybe the suite got too big" — check the healthy wall time and the
+ratio will be obvious.
+
+**Action:** treat as builder capacity. Worth recording which builder it landed
+on, as with 3d.
+
+## 3c. Tailscale setup failure
+
+**Signature:**
+
+```
+##[warning]Tailscale up attempt <N> failed: Error: Timeout
+##[error]Timeout
+```
+
+…usually with `logtail: dial "log.tailscale.com:443" failed` nearby. The job
+never reaches the build. The tailnet is how jobs reach our remote builders, so
+this is ours even though Tailscale is a vendor.
+
+## 3d. Toolchain crash on a remote builder
+
+**Signature:**
+
+```
+clang: error: linker command failed with exit code 139
+error: linking with `cc` failed: exit status: 1
+error: could not compile `<crate>`
+```
+
+`139` is `128 + 11` — the linker took SIGSEGV. Not a code error; the same
+source builds fine on retry. Check the `remote-builders:` line to see which
+machine it landed on; recurrence on one host is a fleet problem.
+
+The same instability also shows up **inside a bats test**, where it looks like
+a category-4 flake until you read the test's captured output:
+
+```
+not ok <N> 'flox init' sets up a local working <lang> module environment
+# SIGSEGV: segmentation violation
+# runtime.mallocgc(...)
+```
+
+A compiler crashing in its own allocator — Go's `runtime.mallocgc`, or clang
+similarly — is the builder, not the test. The distinguishing question is
+whether the crash is in the toolchain the test invoked or in `flox` itself;
+only the latter belongs in section 4. Both variants are the same fleet
+problem, so count them together when deciding whether a host is bad.
+
+## 3e. `podman machine start` hangs on darwin
+
+**Signature:** a `containerize` job on darwin whose log ends at:
+
+```
+Creating podman machine
+Starting podman machine
+```
+
+…followed by tens of minutes of nothing and then the job timeout. No test
+output at all, though the plan line was printed.
+
+`setup_file` in `cli/tests/containerize.bats` calls
+`create_and_start_podman_machine` on darwin. When healthy this takes on the
+order of ten seconds; when it hangs it never returns. The suite never reached
+test 1, so no test is implicated — this is infrastructure, not category 4.
+
+---
+
+# 4. Flaky and ours to fix — tests written flakily
+
+Genuinely intermittent, strongly darwin-skewed. Before landing anything here,
+rule out 1a (same failure on every platform). If the log contains a `124` or a
+failing bounded wait, also run 3a's check on the passing-test durations: a slow
+builder tripping a wait looks exactly like a flaky test, and "fixing" the test
+would be fixing the wrong thing.
+
+## 4a. Leaked background process holding FD 3
+
+The one category here whose symptom is a timeout rather than an assertion.
+
+**Signature:** plan is `1..N`, the last line is `ok N` for that same `N`, and
+the gap before the timeout is tens of minutes. Every test ran and the *suite
+finished*; the job then sat idle until the job timeout.
+
+bats keeps file descriptor 3 open for its own output. If a test backgrounds a
+process that inherits FD 3 and the test then fails without reaping it, the
+leaked process holds FD 3 open and bats never sees it close — so the run hangs.
+The hang may land right after the offending test or at the end of the whole
+suite; both have been observed.
+
+**The lead is the failing tests earlier in the same log**, not the timeout.
+
+**Action:** find the test that backgrounds a process without closing FD 3 —
+redirect its FD 3 (`3>&-` or `3>/dev/null`), or reap the child.
+
+## 4b. Services lifecycle
+
+Tests around starting, stopping, and reloading `process-compose` services:
+
+- `services stop after auto-activated environment is deactivated`
+- `start: shuts down process-compose started by imperative start`
+- `config reload: ...: picks up environment modifications ...`
+
+Frequently reached via a `124` on `wait_for_partial_file_content`. Check the
+suite wall time against 3a's baselines before blaming the fleet: these
+typically finish the whole suite in well under ten minutes, which means the
+wait had no headroom rather than the builder being slow. The fix is the wait —
+which lives in the test suite, so it stays category 4.
+
+## 4c. Auto-activation and re-activation
+
+Directory-transition behaviour, sensitive to timing and to leftover state:
+
+- `re-allowing a denied mid-stack env re-inserts it in ancestor order`
+- `bash: re-entering a project after leaving re-activates it`
+- `'flox deactivate' suppresses re-activation until the directory is left`
+
+## 4d. Activation hooks and shell integration
+
+Per-shell (bash/fish/tcsh/zsh) activation behaviour, usually failing across
+several shells at once when it goes:
+
+- `activate runs hook only once in nested activation`
+- `'flox activate' modifies the current shell (<shell>)`
+- `<shell>: ...: attach sets vars from profile`
+
+**Watch for failures in `teardown` rather than the test body:**
+
+```
+(from function `teardown' in test file activate.bats, line NN)
+  `wait_for_activations "$PROJECT_DIR" || return 1' failed
+```
+
+This is a bounded wait like 3a's `124`, just a different helper, and it fails
+the same way: the test body passed and cleanup did not finish inside its
+budget. The giveaway is a run where many of these fail at once with nearly
+identical durations (~19 s) against healthy times of a few hundred
+milliseconds — that uniformity is the ceiling, not the behaviour.
+
+## 4e. Containerize / podman
+
+Container build-and-run tests, on both linux and darwin:
+
+- `container can be run with 'podman run' with/without -i'`
+- `container is written to runtime when '--runtime <runtime>' is passed`
+- `cmd can run binary from activated environment`
+
+Distinct from 3e, which is the VM failing to start before any of these run.
+
+## 4f. Language end-to-end tests
+
+`flox init` scaffolding for a language toolchain, e.g.
+`'flox init' sets up a local working Go module environment`. These install real
+packages, so rule out sections 2 and 3 before calling one flaky.
+
+## 4g. Assertions that discard the cause
+
+Not a failure mode so much as a test-authoring defect that makes every other
+category impossible to diagnose:
+
+```
+test <name> has been running for over 60 seconds
+thread '<name>' panicked at <file>:<line>: assertion failed: result.is_ok()
+```
+
+The `Err` is thrown away, so the log records only that something failed slowly.
+A test like this **cannot be classified**. Do not guess a category for it from
+unrelated warnings elsewhere in the log — record it as uncategorisable and fix
+the assertion.
+
+**Action:** assert on the error value (`unwrap()`, `expect()`, or
+`assert!(matches!(...))` on the variant) so the next reader gets a cause
+instead of a boolean.
+
+**The trap this creates.** Wanting a cause, it is tempting to reach up the log
+for the nearest scary-looking line and treat it as the explanation. Nix logs
+substituter failures as `warning:` and then builds from source, so a burst of
+`unable to download ... Timeout was reached (28)` against our own cache is
+**not a failure at all** — it appears in green, collapsed steps of jobs that
+went on to succeed. Check whether a candidate cause is a `warning:` or an
+`error:` before attributing anything to it. Warnings are not causes, and a
+category built on them is a category that does not exist.
+
+---
+
+# 5. Diagnosing a 30-minute timeout
+
+**Signature:**
+
+```
+##[error]The action 'Run Bats Tests (./#flox-cli-tests)' has timed out after 30 minutes.
+```
+
+Not a category. This one symptom routes to three different categories, and the
+routing is mechanical:
+
+1. **Measure the gap** between the last log line and the `##[error]`.
+   - **Seconds** → nothing hung; the suite ran out of budget. **3b.** Do not go
+     looking for a hung test, there isn't one.
+   - **Tens of minutes** → something genuinely hung. Continue.
+2. **Compare the plan line `1..N` to the number of the last test that
+   finished.**
+   - Last number **equals** `N` → the suite finished and the job hung
+     afterwards. **4a**, FD 3.
+   - **No test output at all** → it hung in setup. On darwin `containerize`
+     that is **3e**, `podman machine start`; read the last few lines to confirm
+     which step stalled before assuming.
+
+Skipping step 1 invents hangs that never happened, and sends someone hunting a
+deadlock in a test that merely got cut off mid-run.
+
+---
+
+# Naming a test that never printed
+
+bats prints a test's name only *after* it completes, so a test that hangs — or
+that was mid-flight when the budget expired — is anonymous. You are left with
+the *number* of the last test that finished and nothing else.
+
+The number is the one bats prints in each result line — `ok 433 <name>` is test
+number 433 — counting up to the total in the plan line, `1..N`. So a log ending
+at `ok 433` tells you test 434 is the one that never reported, but not what
+test 434 is called.
+
+Get the name from a run where that test did finish:
+
+1. Find a **successful** run of the **same job name** from around the same
+   date (`gh run list --status success`, then match `.jobs[].name`).
+2. Download its log and check its plan line. **It must be the identical
+   `1..N`.** Test numbers shift whenever tests are added or removed, so a
+   different `N` means the numbering has moved — discard that run and try
+   another.
+3. Double-check by comparing the last few test names *before* the stall in both
+   logs. If they don't match, the numbering moved anyway; find another run.
+4. Look up the next number after the last one that finished. That is the test
+   that never reported.
+
+This works only because bats prints results in numerical order here, so "last
+was `ok N`" really does mean `N+1` is where it stopped. Confirm that before
+relying on it: the first dozen numbers in the reference log should climb
+strictly 1, 2, 3, …. If they jump around, the suite ran its tests in parallel,
+and the last number printed tells you nothing about where it stopped.
+
+The reference log also gives the test's **healthy duration**, which is worth
+reporting and is often decisive: a test that normally takes 100 ms is a very
+unlikely candidate to have hung for half an hour, and that mismatch is a signal
+the job belongs in 3b rather than 4a.

--- a/.claude/skills/investigating-merge-queue-failures/scripts/collect.sh
+++ b/.claude/skills/investigating-merge-queue-failures/scripts/collect.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Collect failed merge-queue jobs and summarise each one.
+#
+# Run inside the skill's flox environment, which provides gh, jq and GNU date:
+#   flox activate -d <skill dir> -- ./scripts/collect.sh [since] [outdir]
+#
+# Emits <outdir>/jobs.tsv, one row per failed job, and <outdir>/conclusions.tsv,
+# the run counts by conclusion that the report's denominator comes from. Leaves
+# the raw logs in <outdir>/logs/ for the judgement calls it does not make.
+set -uo pipefail
+
+REPO="${REPO:-flox/flox}"
+SINCE="${1:-$(date -d '30 days ago' +%Y-%m-%d)}"
+OUT="${2:-./merge-queue-triage}"
+# Only a bound on the reply, not the window: `--created` does the filtering
+# server-side. Raise it if the truncation warning below ever fires.
+LIMIT="${LIMIT:-1000}"
+
+# GNU `date -d` is what computes the default. Without it the substitution above
+# yields an empty string, which `--created '>='` accepts and answers with zero
+# runs — a wrong window that reads exactly like a quiet month.
+: "${SINCE:?empty window — run inside the flox environment this skill ships, which provides GNU date}"
+
+mkdir -p "$OUT/logs"
+
+# The GitHub API fails transiently often enough to matter here. Retry, and if
+# it still fails, say so loudly — a silently dropped run or log understates a
+# category, which is worse than no answer at all.
+try() { # try <destination> <command>...
+  local dest="$1"; shift
+  for attempt in 1 2 3; do
+    if "$@" > "$dest" 2>/dev/null && [ -s "$dest" ]; then return 0; fi
+    [ "$attempt" -lt 3 ] && sleep $(( attempt * 3 ))
+  done
+  return 1
+}
+
+try_api() { try "$2" gh api "$1"; }
+
+run_list() { # run_list <destination> <extra gh run list args>...
+  local dest="$1"; shift
+  try "$dest" gh run list --repo "$REPO" --event merge_group \
+    --created ">=$SINCE" --limit "$LIMIT" "$@" || return 1
+  # `gh` returns exactly `--limit` rows when it truncates and says nothing
+  # about it, so a capped query reads as a quiet month rather than an error.
+  if [ "$(jq 'length' < "$dest")" -ge "$LIMIT" ]; then
+    printf 'WARNING: hit --limit %s; older runs in the window are MISSING. Re-run with LIMIT=%s\n' \
+      "$LIMIT" "$(( LIMIT * 4 ))" >&2
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# The denominator, collected first because the rest is meaningless without it:
+# "27 failures" says nothing until it is "27 out of 168 runs".
+# ---------------------------------------------------------------------------
+if run_list "$OUT/.all.json" --json conclusion; then
+  jq -r 'group_by(.conclusion)[] | [ (.[0].conclusion // "pending"), length ] | @tsv' \
+    < "$OUT/.all.json" > "$OUT/conclusions.tsv"
+  printf 'merge-queue runs since %s: %s\n' "$SINCE" "$(jq 'length' < "$OUT/.all.json")" >&2
+  rm -f "$OUT/.all.json"
+else
+  : > "$OUT/conclusions.tsv"
+  printf 'WARNING: could not count all merge-queue runs — the report has NO denominator\n' >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Failed runs in the window. Only `failure` and `timed_out` matter: when one
+# run in a merge group fails, GitHub cancels its siblings, and those
+# cancellations are bookkeeping rather than failures.
+# ---------------------------------------------------------------------------
+if ! run_list "$OUT/.runs.json" --status failure \
+    --json databaseId,workflowName,headBranch,createdAt
+then
+  printf 'FATAL: could not list failed merge-queue runs after retries — nothing collected\n' >&2
+  exit 1
+fi
+
+jq -r '
+    .[]
+    | [ .databaseId,
+        .createdAt,
+        .workflowName,
+        ( .headBranch | capture("pr-(?<n>[0-9]+)") // {n:"?"} | .n )
+      ] | @tsv' < "$OUT/.runs.json" > "$OUT/runs.tsv"
+rm -f "$OUT/.runs.json"
+
+printf 'failed runs: %s\n' "$(wc -l < "$OUT/runs.tsv")" >&2
+
+# ---------------------------------------------------------------------------
+# Failed jobs within those runs, plus each job's full log.
+# ---------------------------------------------------------------------------
+: > "$OUT/jobs.raw"
+failures=0
+while IFS=$'\t' read -r rid created wf pr; do
+  if try_api "repos/$REPO/actions/runs/$rid/jobs?per_page=100" "$OUT/.jobs.json"; then
+    jq -r --arg rid "$rid" --arg created "$created" --arg wf "$wf" --arg pr "$pr" '
+        .jobs[]
+        | select(.conclusion=="failure" or .conclusion=="timed_out")
+        | [$rid, $created, $wf, $pr, (.id|tostring), .name, .conclusion] | @tsv' \
+      < "$OUT/.jobs.json" >> "$OUT/jobs.raw"
+  else
+    printf 'WARNING: could not list jobs for run %s — it is MISSING from the output\n' "$rid" >&2
+    failures=$((failures + 1))
+  fi
+done < "$OUT/runs.tsv"
+rm -f "$OUT/.jobs.json"
+
+while IFS=$'\t' read -r rid created wf pr jid jname concl; do
+  [ -s "$OUT/logs/$jid.txt" ] && continue
+  if ! try_api "repos/$REPO/actions/jobs/$jid/logs" "$OUT/logs/$jid.txt"; then
+    rm -f "$OUT/logs/$jid.txt"
+    printf 'WARNING: could not fetch log for job %s (%s) — its row will be blank\n' "$jid" "$jname" >&2
+    failures=$((failures + 1))
+  fi
+done < "$OUT/jobs.raw"
+
+printf 'failed jobs: %s\n' "$(wc -l < "$OUT/jobs.raw")" >&2
+if [ "$failures" -gt 0 ]; then
+  printf 'INCOMPLETE: %s fetch(es) failed after retries; re-run before trusting counts\n' \
+    "$failures" >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Summarise. Every field here is mechanical; classification is not, and is
+# left to the reader with references/failure-categories.md in hand.
+# ---------------------------------------------------------------------------
+epoch() { date -d "$1" +%s 2>/dev/null || echo 0; }
+
+{
+printf 'date\tpr\tjob_name\tplan\tlast_test\tgap_s\thas_124\tsignature\n'
+while IFS=$'\t' read -r rid created wf pr jid jname concl; do
+  log="$OUT/logs/$jid.txt"
+
+  # Anchor on the timestamp prefix: an unanchored "1..N" matches unrelated
+  # ranges elsewhere in the log.
+  plan=$(grep -a -m1 -E '^[0-9T:.Z-]+ 1\.\.[0-9]+' "$log" 2>/dev/null \
+         | cut -c30- | grep -oE '^1\.\.[0-9]+')
+  last_line=$(grep -a -E '^[0-9T:.Z-]+ (ok|not ok) [0-9]+ ' "$log" 2>/dev/null | tail -1)
+  last_test=$(printf '%s' "$last_line" | cut -c30- | grep -oE '^(ok|not ok) [0-9]+' | grep -oE '[0-9]+$')
+
+  # Gap between the last line of real output and the timeout error. Tens of
+  # minutes means something hung; seconds means the suite simply ran out of
+  # the 30-minute budget. Empty when the job did not time out.
+  gap=""
+  err_ts=$(grep -a -m1 'has timed out after' "$log" 2>/dev/null | cut -c1-28)
+  if [ -n "$err_ts" ]; then
+    prev_ts=$(grep -a -B 1 'has timed out after' "$log" 2>/dev/null | head -1 | cut -c1-28)
+    gap=$(( $(epoch "$err_ts") - $(epoch "$prev_ts") ))
+  fi
+
+  # A timeout(1) expiry often explains both a failed test and a hang in the
+  # same job, so surface it even when a louder symptom is present.
+  has_124=no
+  grep -a -qE 'status ?:? 124|exit code 124' "$log" 2>/dev/null && has_124=YES
+
+  sig=$(grep -a -m1 -E '^[0-9T:.Z-]+ not ok [0-9]+ ' "$log" 2>/dev/null | cut -c30-110)
+  [ -z "$sig" ] && sig=$(grep -a -m1 '##\[error\]' "$log" 2>/dev/null | cut -c30-110)
+
+  printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "${created%T*}" "$pr" "$jname" "${plan:--}" "${last_test:--}" "${gap:--}" "$has_124" "${sig:--}"
+done < "$OUT/jobs.raw"
+} > "$OUT/jobs.tsv"
+
+printf 'wrote %s\n' "$OUT/jobs.tsv" >&2


### PR DESCRIPTION
I haven't verified everything in the skill, but it can already generate
some helpful reports, so I think we can merge as is.

We can use this to "Generate a report on what's been flakey recently"
