### PR TITLE
fix: better FD 3 handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1624,6 +1624,7 @@ dependencies = [
  "anyhow",
  "base64",
  "clap",
+ "close_fds",
  "dirs",
  "expect-test",
  "flate2",

--- a/cli/flox-activations/Cargo.toml
+++ b/cli/flox-activations/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 [dependencies]
 anyhow.workspace = true
 base64.workspace = true
+close_fds.workspace = true
 flate2.workspace = true
 clap = { version = "4.5.56", default-features = false, features = [
     "std",

--- a/cli/flox-activations/src/start.rs
+++ b/cli/flox-activations/src/start.rs
@@ -224,6 +224,30 @@ fn spawn_executive(
         .stdout(Stdio::null())
         .stderr(Stdio::null());
 
+    // The executive outlives the shell that started it, so it must not keep
+    // the descriptors that shell happened to have open. Anything it holds
+    // stays open for whoever is on the other end: under bats that is FD 3,
+    // which the runner waits on before it finishes, so one executive
+    // outliving its test turns a failed test into a run that hangs until CI
+    // kills it. It also inherits the activation state lock, which it has no
+    // use for and re-acquires for itself when it needs one.
+    //
+    // ## SAFETY:
+    //
+    // [pre_exec](std::os::unix::process::CommandExt::pre_exec) is unsafe
+    // because it runs in the forked child, in an environment where many of
+    // the guarantees provided by the Rust ownership model do not hold. The
+    // closure is limited to marking inherited descriptors close-on-exec,
+    // which is safer than closing them after exec, where the process may
+    // already have opened descriptors of its own.
+    unsafe {
+        use std::os::unix::process::CommandExt as _;
+        executive.pre_exec(|| {
+            close_fds::CloseFdsBuilder::new().cloexecfrom(3);
+            Ok(())
+        });
+    }
+
     debug!(
         "Spawning executive process to start activation: {:?}",
         executive

--- a/cli/tests/activate.bats
+++ b/cli/tests/activate.bats
@@ -3099,7 +3099,7 @@ attach_runs_hooks_once() {
   TEARDOWN_FIFO="$PROJECT_DIR/teardown_activate"
   mkfifo "$TEARDOWN_FIFO"
 
-  FLOX_SHELL=bash "$FLOX_BIN" activate -c "echo > activate_started_fifo && echo > \"$TEARDOWN_FIFO\"" 2> output &
+  FLOX_SHELL=bash "$FLOX_BIN" activate -c "echo > activate_started_fifo && echo > \"$TEARDOWN_FIFO\"" 2> output 3>&- &
 
   cat activate_started_fifo
   run cat output
@@ -3160,7 +3160,7 @@ attach_runs_profile_twice() {
   mkfifo "$TEARDOWN_FIFO"
 
   # Our tcsh quoting appears to be broken so don't quote $TEARDOWN_FIFO
-  FLOX_SHELL="$shell" "$FLOX_BIN" activate -c "bash -c \"echo > activate_started_fifo && echo > $TEARDOWN_FIFO\"" >> output 2>&1 &
+  FLOX_SHELL="$shell" "$FLOX_BIN" activate -c "bash -c \"echo > activate_started_fifo && echo > $TEARDOWN_FIFO\"" >> output 2>&1 3>&- &
 
   cat activate_started_fifo
   run cat output
@@ -3288,7 +3288,7 @@ EOF
   mkfifo "$TEARDOWN_FIFO"
 
   # Our tcsh quoting appears to be broken so don't quote $TEARDOWN_FIFO
-  FLOX_SHELL="$shell" "$FLOX_BIN" activate -c "bash -c \"echo > activate_started_fifo && echo > $TEARDOWN_FIFO\"" >> output 2>&1 &
+  FLOX_SHELL="$shell" "$FLOX_BIN" activate -c "bash -c \"echo > activate_started_fifo && echo > $TEARDOWN_FIFO\"" >> output 2>&1 3>&- &
 
   cat activate_started_fifo
 
@@ -3404,7 +3404,7 @@ attach_sets_profile_vars() {
   mkfifo "$TEARDOWN_FIFO"
 
   # Our tcsh quoting appears to be broken so don't quote $TEARDOWN_FIFO
-  FLOX_SHELL="$shell" "$FLOX_BIN" activate -c "bash -c \"echo > activate_started_fifo && echo > $TEARDOWN_FIFO\"" &
+  FLOX_SHELL="$shell" "$FLOX_BIN" activate -c "bash -c \"echo > activate_started_fifo && echo > $TEARDOWN_FIFO\"" 3>&- &
 
   cat activate_started_fifo
 
@@ -3591,10 +3591,10 @@ EOF
   # Start a first_activation which sets FOO=first_activation
   case "$mode" in
     command)
-      FLOX_SHELL=bash injected="first_activation" "$FLOX_BIN" activate -c "echo \$FOO > output && echo > activate_started_fifo && echo > $TEARDOWN_FIFO" &
+      FLOX_SHELL=bash injected="first_activation" "$FLOX_BIN" activate -c "echo \$FOO > output && echo > activate_started_fifo && echo > $TEARDOWN_FIFO" 3>&- &
       ;;
     in-place)
-      TEARDOWN_FIFO="$TEARDOWN_FIFO" injected="first_activation" bash -c 'eval "$("$FLOX_BIN" activate)" && echo $FOO > output && echo > activate_started_fifo && echo > "$TEARDOWN_FIFO"' &
+      TEARDOWN_FIFO="$TEARDOWN_FIFO" injected="first_activation" bash -c 'eval "$("$FLOX_BIN" activate)" && echo $FOO > output && echo > activate_started_fifo && echo > "$TEARDOWN_FIFO"' 3>&- &
       ;;
   esac
 
@@ -3839,7 +3839,7 @@ PIDs of the running activations: ${ACTIVATION_PID}"
       refute_output --regexp ".*$PROJECT_DIR/emacs/.flox/run/$NIX_SYSTEM.emacs-dev/share/man.*"
 
       # vim gets added to MANPATH
-      _man=$_man FLOX_SHELL=bash "$FLOX_BIN" activate -d vim -c "$_man --path vim > output; echo > activate_started_fifo && echo > \"$TEARDOWN_FIFO\"" &
+      _man=$_man FLOX_SHELL=bash "$FLOX_BIN" activate -d vim -c "$_man --path vim > output; echo > activate_started_fifo && echo > \"$TEARDOWN_FIFO\"" 3>&- &
       cat activate_started_fifo
       run cat output
       assert_success
@@ -3864,7 +3864,7 @@ PIDs of the running activations: ${ACTIVATION_PID}"
       refute_output --regexp ".*$PROJECT_DIR/emacs/.flox/run/$NIX_SYSTEM.emacs-dev/share/man.*"
 
       # vim gets added to MANPATH
-      FLOX_SHELL=bash "$FLOX_BIN" activate -d vim -c "/usr/bin/manpath > output && echo > activate_started_fifo && echo > \"$TEARDOWN_FIFO\"" &
+      FLOX_SHELL=bash "$FLOX_BIN" activate -d vim -c "/usr/bin/manpath > output && echo > activate_started_fifo && echo > \"$TEARDOWN_FIFO\"" 3>&- &
       cat activate_started_fifo
       run cat output
       assert_success
@@ -3912,7 +3912,7 @@ PIDs of the running activations: ${ACTIVATION_PID}"
   run command -v emacs
   refute_output "$(realpath "$PROJECT_DIR")/emacs/.flox/run/$NIX_SYSTEM.emacs-dev/bin/emacs"
 
-  FLOX_SHELL=bash "$FLOX_BIN" activate -d vim -c "command -v vim > output; echo > activate_started_fifo && echo > \"$TEARDOWN_FIFO\"" &
+  FLOX_SHELL=bash "$FLOX_BIN" activate -d vim -c "command -v vim > output; echo > activate_started_fifo && echo > \"$TEARDOWN_FIFO\"" 3>&- &
   cat activate_started_fifo
 
   run cat output
@@ -3975,7 +3975,7 @@ EOF
   # Start `shared` inside an activation of `first` and hold it open so a
   # later activation of `shared` attaches to this start.
   FLOX_SHELL=bash "$FLOX_BIN" activate -d first -c \
-    "\"$FLOX_BIN\" activate -d shared -c 'echo > activate_started_fifo && echo > \"$TEARDOWN_FIFO\"'" &
+    "\"$FLOX_BIN\" activate -d shared -c 'echo > activate_started_fifo && echo > \"$TEARDOWN_FIFO\"'" 3>&- &
   cat activate_started_fifo
 
   # Attach `shared` inside an activation of `second`, probing the attach in
@@ -4050,7 +4050,7 @@ EOF
   # start open so shell #2 attaches to it.
   export FOO=defined
   FLOX_SHELL=bash "$FLOX_BIN" activate -d proj -c \
-    "echo > activate_started_fifo && echo > \"$TEARDOWN_FIFO\"" &
+    "echo > activate_started_fifo && echo > \"$TEARDOWN_FIFO\"" 3>&- &
   unset FOO
   cat activate_started_fifo
 
@@ -4109,7 +4109,7 @@ EOF
   # intent. Hold the start open so later activations attach to it.
   export HOOKVAR=hookval
   FLOX_SHELL=bash "$FLOX_BIN" activate -d proj -c \
-    "echo > activate_started_fifo && echo > \"$TEARDOWN_FIFO\"" &
+    "echo > activate_started_fifo && echo > \"$TEARDOWN_FIFO\"" 3>&- &
   unset HOOKVAR
   cat activate_started_fifo
 
@@ -4173,7 +4173,7 @@ EOF
 
   # Shell #1 starts the activation and holds it open.
   FLOX_SHELL=bash "$FLOX_BIN" activate -d proj -c \
-    "echo > activate_started_fifo && echo > \"$TEARDOWN_FIFO\"" &
+    "echo > activate_started_fifo && echo > \"$TEARDOWN_FIFO\"" 3>&- &
   cat activate_started_fifo
 
   # Shell #2 attaches; the start-count guard proves it attached rather
@@ -4685,8 +4685,8 @@ Setting PATH from ${rc_file}"
   #       instead of JSON mock files.
   env -u _FLOX_USE_CATALOG_MOCK -u FLOX_INTERPRETER -u FLOX_ACTIVATIONS_BIN \
     setsid ./result/bin/flox activate -c \
-    "echo > activate_started_fifo && echo > $TEARDOWN_FIFO" > output 2>&1 &
-  timeout 15s tail -f output &
+    "echo > activate_started_fifo && echo > $TEARDOWN_FIFO" > output 2>&1 3>&- &
+  timeout 15s tail -f output 3>&- &
 
   # Longer timeout to allow for `nix run` locking.
   background_pid="$!"

--- a/cli/tests/environment-managed.bats
+++ b/cli/tests/environment-managed.bats
@@ -556,7 +556,7 @@ EOF
   TEARDOWN_FIFO="$PROJECT_DIR/finished"
   mkfifo "$TEARDOWN_FIFO"
 
-  "$FLOX_BIN" activate -- bash -c "echo > started && echo > \"$TEARDOWN_FIFO\"" >> output 2>&1 &
+  "$FLOX_BIN" activate -- bash -c "echo > started && echo > \"$TEARDOWN_FIFO\"" >> output 2>&1 3>&- &
   timeout 2 cat started
   run cat output
   assert_success

--- a/cli/tests/environment-remote.bats
+++ b/cli/tests/environment-remote.bats
@@ -461,7 +461,7 @@ EOF
   mkfifo "$TEARDOWN_FIFO"
 
   ensure_remote_environment_built "$OWNER/test"
-  _FLOX_TESTING_NO_BUILD=true "$FLOX_BIN" activate --trust -r "$OWNER/test" -- bash -c "echo > started && echo > \"$TEARDOWN_FIFO\"" >> output 2>&1 &
+  _FLOX_TESTING_NO_BUILD=true "$FLOX_BIN" activate --trust -r "$OWNER/test" -- bash -c "echo > started && echo > \"$TEARDOWN_FIFO\"" >> output 2>&1 3>&- &
   timeout 8 cat started
   run cat output
   assert_success

--- a/cli/tests/on_deactivate.bats
+++ b/cli/tests/on_deactivate.bats
@@ -157,13 +157,13 @@ EOF
 
   # The timeout self-heals a failed test; on success `echo > hold1` below
   # releases it immediately.
-  FLOX_SHELL=bash "$FLOX_BIN" activate -c "echo > started1 && timeout 30 cat hold1" > output1 2>&1 &
+  FLOX_SHELL=bash "$FLOX_BIN" activate -c "echo > started1 && timeout 30 cat hold1" > output1 2>&1 3>&- &
   cat started1
 
   # Editing the manifest gives the next activation a new store path, so it
   # starts a second start instead of attaching to the first.
   _write_on_deactivate_manifest_with_foo "second-start"
-  FLOX_SHELL=bash "$FLOX_BIN" activate -c "echo > started2 && echo > \"$TEARDOWN_FIFO\"" > output2 2>&1 &
+  FLOX_SHELL=bash "$FLOX_BIN" activate -c "echo > started2 && echo > \"$TEARDOWN_FIFO\"" > output2 2>&1 3>&- &
   cat started2
 
   # Release the first activation: its start is emptied while the second

--- a/cli/tests/services.bats
+++ b/cli/tests/services.bats
@@ -812,7 +812,7 @@ EOF
     read < ./resume-one.pipe
     read < ./resume-mostly-deterministic.pipe
 
-    "$FLOX_BIN" services logs --follow > logs &
+    "$FLOX_BIN" services logs --follow > logs 3>&- &
     logs_pid="$!"
 
     timeout 5s bash -c '
@@ -851,7 +851,7 @@ EOF
     read < ./resume-one.pipe
     read < ./resume-mostly-deterministic.pipe
 
-    "$FLOX_BIN" services logs --follow > logs &
+    "$FLOX_BIN" services logs --follow > logs 3>&- &
     logs_pid="$!"
 
     timeout 5s bash -c '
@@ -920,7 +920,7 @@ EOF
   mkfifo activate_started_fifo
   TEARDOWN_FIFO="$PROJECT_DIR/finished"
   mkfifo "$TEARDOWN_FIFO"
-  "$FLOX_BIN" activate -s -- bash -c "echo > activate_started_fifo && echo > $TEARDOWN_FIFO" &
+  "$FLOX_BIN" activate -s -- bash -c "echo > activate_started_fifo && echo > $TEARDOWN_FIFO" 3>&- &
 
   # Make sure the first `process-compose` gets up and running
   cat activate_started_fifo
@@ -1098,7 +1098,7 @@ EOF
     echo > started
     echo > finished
 EOF
-  ) &
+  ) 3>&- &
   timeout 8 cat started
 
   run "$FLOX_BIN" activate --start-services -r "${OWNER}/${PROJECT_NAME}" -- true
@@ -1118,7 +1118,7 @@ EOF
     echo > started
     timeout 8 cat finished
 EOF
-  ) &
+  ) 3>&- &
   timeout 8 cat started
 
   run "$FLOX_BIN" services status -r "${OWNER}/${PROJECT_NAME}"
@@ -1475,7 +1475,7 @@ EOF
   # Start a background activation with an initial value of FOO.
   TEARDOWN_FIFO="$PROJECT_DIR/finished"
   mkfifo "$TEARDOWN_FIFO"
-  "$FLOX_BIN" activate -s -c "echo > \"$TEARDOWN_FIFO\"" &
+  "$FLOX_BIN" activate -s -c "echo > \"$TEARDOWN_FIFO\"" 3>&- &
 
   # The initial value of FOO should be written.
   wait_for_file_content out foo_one
@@ -1699,7 +1699,7 @@ EOF
   # Will get cat'ed in teardown
   TEARDOWN_FIFO="$PROJECT_DIR/finished_1"
   mkfifo "$TEARDOWN_FIFO"
-  "$FLOX_BIN" activate --start-services -- bash -c "echo > started_1 && echo > $TEARDOWN_FIFO" &
+  "$FLOX_BIN" activate --start-services -- bash -c "echo > started_1 && echo > $TEARDOWN_FIFO" 3>&- &
   timeout 10 cat started_1
 
   # Check that services and executive are both running
@@ -1725,7 +1725,7 @@ EOF
   mkfifo started_2
   mkfifo finished_2
 
-  "$FLOX_BIN" activate --start-services -- bash -c "echo > started_2 && echo > finished_2" 2>output &
+  "$FLOX_BIN" activate --start-services -- bash -c "echo > started_2 && echo > finished_2" 2>output 3>&- &
 
   timeout 10 cat started_2
   # Swap out teardown fifo and immediately teardown first activation
@@ -1888,7 +1888,7 @@ EOF
     echo > started
     echo > "$TEARDOWN_FIFO"
 EOF
-  ) &
+  ) 3>&- &
   timeout 10 cat started
 
   "${TESTS_DIR}"/services/wait_for_service_status.sh initial:Completed


### PR DESCRIPTION
- **fix(activate): stop the executive inheriting the caller's descriptors**
  The executive is spawned to outlive the shell that started it, and it
  keeps every file descriptor that shell had open. stdio is already
  redirected to /dev/null; everything from FD 3 up is not.
  
  Under bats that is the descriptor the runner reads until every process
  holding it has gone, so an executive that outlives its test stops being
  one failed test and becomes a run that produces no further output until
  CI kills it at the 30 minute mark. Verified on the merge queue's own
  layout: before this change the executive's FD 3 is the suite's pipe and
  FD 4 is the test's output file; after it, neither appears.
  
  It also inherits the activation state lock, which it has no use for —
  `flox-activations start` releases that lock immediately afterwards, and
  the executive acquires its own when it needs one.
  
  Mark inherited descriptors close-on-exec in `pre_exec`, the same way
  `spawn_detached_check_for_upgrades_process` already does for the
  background upgrade check.
  
  Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
  

- **test: close FD 3 on every process a test backgrounds**
  BATS reads FD 3 until every process holding it is gone, so a process
  that outlives its test can leave the run with nothing left to print and
  no way to finish. In a file that serializes itself with
  `BATS_NO_PARALLELIZE_WITHIN_FILE` — hook.bats and containerize.bats —
  that descriptor is not a per-test file but a pipe reaching all the way
  out to whoever is reading the suite, which in CI is the job.
  
  `teardown`'s `wait_for_activations` is meant to catch leaks like this,
  but it only covers activations, only in the suites that call it, and it
  cannot help at all in the window before it runs. Closing FD 3 at the
  point of backgrounding costs nothing and keeps a leak to the one test
  that caused it.
  
  The change is mechanical: every one of the 28 edited lines, across five
  suites, is the line it replaces with ` 3>&-` inserted before the `&`.
  Nothing else is touched.
  
  Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
  