### PR TITLE
fix(auth): honor auth_notifications for the catalog resolve warning

### DIFF
--- a/cli/flox-config/src/config.rs
+++ b/cli/flox-config/src/config.rs
@@ -141,9 +141,11 @@ pub struct FloxConfig {
     /// (default: true)
     pub upgrade_notifications: Option<bool>,
 
-    /// Print the advisory FloxHub login reminder when not logged in
-    /// ("You are not logged in to FloxHub. Run 'flox auth login' to
-    /// log in."). Authentication *errors* — from commands such as
+    /// Print the advisory FloxHub authentication messages: the login
+    /// reminder shown when not logged in ("You are not logged in to
+    /// FloxHub. Run 'flox auth login' to log in.") and the warning
+    /// shown when packages are resolved against the catalog without
+    /// authentication. Authentication *errors* — from commands such as
     /// 'flox push' that genuinely require a login — are unaffected.
     ///
     /// (default: true)

--- a/cli/flox/doc/flox-auth.md
+++ b/cli/flox/doc/flox-auth.md
@@ -23,8 +23,9 @@ Authenticate with FloxHub so that you can push and pull environments.
 ## Quieting login reminders
 
 Flox reminds you to log in when you run a command without a FloxHub
-account.
-To turn this reminder off:
+account, and warns when it resolves packages against the catalog
+without a login.
+To turn these messages off:
 
 ```bash
 flox config --set auth_notifications false

--- a/cli/flox/doc/flox-config.md
+++ b/cli/flox/doc/flox-config.md
@@ -71,13 +71,9 @@ flox config --set 'trusted_environments."owner/name"' trust
 # SUPPORTED CONFIGURATION OPTIONS
 
 `auth_notifications`
-:   Print the advisory reminder shown after a command when you are not
-    logged in to FloxHub:
-    ```console
-    You are not logged in to FloxHub. Run 'flox auth login' to log in.
-    ```
-
-    Set to `false` to quiet it.
+:   Print the advisory FloxHub authentication messages.
+    Set to `false` to quiet both the reminder to log in and the warnings
+    that resolution will soon require authentication.
     Authentication *errors* are unaffected: commands that require a
     login, such as `flox push`, still fail with an explanation.
 

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -429,18 +429,21 @@ impl FloxArgs {
         // Warn when the catalog is actually contacted for resolution while
         // unauthenticated (see `FloxhubClient::resolve`). Rate limiting lives
         // in `warn_unauthenticated_resolve`. The hook is not installed for
-        // the prompt-hook flow (like other advisory messages) or under `-q`:
-        // installing-but-silencing would still write the 8-hour stamp and
-        // mute the next interactive warning the user never saw.
+        // the prompt-hook flow (like other advisory messages), under `-q`, or
+        // when `auth_notifications` is `false`: installing-but-silencing would
+        // still write the 8-hour stamp and mute the next interactive warning
+        // the user never saw.
         //
         // This deliberately coexists with the once-per-shell-session
         // logged-out reminder from `resolve_auth_context`: the reminder
         // reports current status on every command, while this warning fires
         // only on the resolve that will start failing once catalog auth
         // gating is enforced — at which point it becomes an error (or an
-        // interactive login prompt) and the overlap gets revisited.
-        let install_resolve_warning =
-            !self.is_prompt_hook_flow() && !matches!(self.verbosity, Verbosity::Quiet);
+        // interactive login prompt) and the overlap gets revisited. Both are
+        // advisory, so both answer to `auth_notifications`.
+        let install_resolve_warning = !self.is_prompt_hook_flow()
+            && !matches!(self.verbosity, Verbosity::Quiet)
+            && config.flox.auth_notifications.unwrap_or(true);
         let on_unauthenticated_resolve = install_resolve_warning.then(|| {
             let cache_dir = config.flox.cache_dir.clone();
             UnauthenticatedResolveHook::new(move || {

--- a/cli/flox/src/utils/auth_warning.rs
+++ b/cli/flox/src/utils/auth_warning.rs
@@ -41,9 +41,9 @@ struct LastResolveAuthWarning {
 ///
 /// Emitted via [`message::warning`], landing on stderr like every other
 /// advisory message. The stamp is only written when the warning is actually
-/// emitted: invocations that suppress it (`-q`, the prompt-hook flow) never
-/// install the hook that calls this (see `FloxArgs::handle`), so they cannot
-/// consume the 8-hour window.
+/// emitted: invocations that suppress it (`-q`, `auth_notifications = false`,
+/// the prompt-hook flow) never install the hook that calls this (see
+/// `FloxArgs::handle`), so they cannot consume the 8-hour window.
 pub(crate) fn warn_unauthenticated_resolve(cache_dir: impl AsRef<Path>) {
     let stamp_file = cache_dir.as_ref().join(RESOLVE_AUTH_WARNING_FILE_NAME);
     let now = OffsetDateTime::now_utc();

--- a/cli/tests/catalog-auth-warnings.bats
+++ b/cli/tests/catalog-auth-warnings.bats
@@ -104,6 +104,34 @@ teardown() {
   assert_output --partial "$RESOLVE_AUTH_WARNING"
 }
 
+@test "'auth_notifications = false' suppresses the auth warning" {
+  skip_x86_64_darwin_replay
+  unset FLOX_FLOXHUB_TOKEN
+  mkdir -p "$FLOX_CONFIG_DIR"
+  echo 'auth_notifications = false' >> "$FLOX_CONFIG_DIR/flox.toml"
+  "$FLOX_BIN" init
+  run "$FLOX_BIN" install hello
+  assert_success
+  refute_output --partial "$RESOLVE_AUTH_WARNING"
+}
+
+@test "'auth_notifications = false' does not consume the rate-limit window" {
+  skip_x86_64_darwin_replay
+  unset FLOX_FLOXHUB_TOKEN
+  mkdir -p "$FLOX_CONFIG_DIR"
+  echo 'auth_notifications = false' >> "$FLOX_CONFIG_DIR/flox.toml"
+  "$FLOX_BIN" init
+  run "$FLOX_BIN" install hello
+  refute_output --partial "$RESOLVE_AUTH_WARNING"
+  # Quieting must not have written the stamp: a user who turns the key back
+  # on still gets the next warning rather than an already-consumed window.
+  rm .flox/env/manifest.lock
+  rm "$FLOX_CONFIG_DIR/flox.toml"
+  run "$FLOX_BIN" list
+  assert_success
+  assert_output --partial "$RESOLVE_AUTH_WARNING"
+}
+
 @test "resolving with an expired token prints the auth warning" {
   skip_x86_64_darwin_replay
   # Same shape as the suite token but with exp in the past (2001-09-09).


### PR DESCRIPTION
The unauthenticated-resolve warning (DEV-199) was gated only on the
prompt-hook flow and `-q`, so `auth_notifications = false` (DEV-268)
silenced the logged-out reminder but left this warning firing once
every 8 hours. Both messages are advisory FloxHub auth notices, and
`flox-auth(1)` already promised the key "suppresses advisory messages
only", so the split was not something a user could predict.

Gate the hook installation rather than the message, matching the
existing `-q` handling: silencing at emission time would still write
the 8-hour stamp and swallow the next warning the user would have
seen after turning the key back on.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
