### PR TITLE
fix(tests): don't let wait_for_activations lose its own diagnostics

### DIFF
--- a/cli/tests/test_support.bash
+++ b/cli/tests/test_support.bash
@@ -314,14 +314,20 @@ wait_for_activations() {
 
       echo "Activation state dir: $activation_state_dir" >&3
 
-      echo "state.json"
-      cat "${activation_state_dir}"/state.json >&3
+      # Cleanup finishing between the check above and here means the wait was
+      # only just too short, which is worth knowing before reading any further.
+      if [ ! -d "$activation_state_dir" ]; then
+        echo "(cleaned up while this output was being collected)" >&3
+      fi
+
+      echo "state.json:" >&3
+      cat "${activation_state_dir}"/state.json >&3 2>&3 || true
 
       echo "Executive logs:" >&3
-      cat "${project_dir}"/.flox/log/executive.* >&3
+      cat "${project_dir}"/.flox/log/executive.* >&3 2>&3 || true
 
       echo "Bats processes:" >&3
-      pstree -ws "$BATS_RUN_TMPDIR" >&3
+      pstree -ws "$BATS_RUN_TMPDIR" >&3 2>&3 || true
 
       return 1
     fi


### PR DESCRIPTION
When the wait expires, the diagnostics it prints are the only record of
what leaked, and in the runs where it fired they were unreadable.

`state.json` was labelled on stdout and dumped on FD 3, so in the log
the contents arrived with no heading. It was also frequently empty
without explanation: cleanup had landed between the check and the dump,
which is worth saying out loud, since it means the wait was only just
too short rather than that anything leaked.

Worse, a missing `state.json` or executive log aborted `teardown` on the
spot, taking with it the `pstree` that names the processes still
holding the activation open — the one line that says what happened.
Tolerate both and always get to the end.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
