### PR TITLE
feat(telemetry): report CLI credential type

### DIFF
--- a/cli/flox-events/src/client.rs
+++ b/cli/flox-events/src/client.rs
@@ -30,9 +30,9 @@ pub const BATCH_SIZE: usize = 100;
 /// (e.g. `github|3670948`). It is never the user's email, handle, or
 /// display name.
 /// Setting this is the caller's responsibility. In practice we use the
-/// OIDC `sub` field. Invocations using PAT machine tokens or kerberos,
-/// or that aren't logged in yet, pass `None`, causing every emitted
-/// [`Event`] to omit the field.
+/// OIDC `sub` field directly for JWTs and the accounts `/me` identity for
+/// PATs and SATs. Kerberos and logged-out invocations pass `None`, causing
+/// every emitted [`Event`] to omit the field.
 ///
 /// Like `device_id` and `invocation_id`, the value is a per-process
 /// snapshot: a token change mid-invocation does not re-stamp events.

--- a/cli/flox-events/src/lib.rs
+++ b/cli/flox-events/src/lib.rs
@@ -199,6 +199,25 @@ pub enum EventKind {
     CliUpdatePrompted {},
 }
 
+/// Authentication material available to the CLI for this invocation.
+///
+/// This reports the local credential kind only. It never resolves token
+/// identity or includes credential contents.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CredentialType {
+    /// OAuth access token issued by a supported OIDC provider.
+    #[serde(rename = "oauth_access_token")]
+    OAuthAccessToken,
+    /// FloxHub personal access token.
+    Pat,
+    /// FloxHub service account token.
+    ServiceToken,
+    /// No supported token authentication. This includes Kerberos mode.
+    #[default]
+    None,
+}
+
 /// Shared metadata fields stamped onto every `cli.*` command event payload.
 ///
 /// These fields drive existing `cli.telemetry` reporting downstream, so the
@@ -212,6 +231,9 @@ pub struct CommandPayload {
     /// `activate`, or nested `services::start` using the `parent::child`
     /// join encoding).
     subcommand: String,
+    /// Authentication material available when the invocation started.
+    #[serde(default)]
+    credential_type: CredentialType,
     /// Flox CLI version string.
     flox_version: String,
     /// Coarse operating system family (e.g. `Mac OS`, `Linux`).
@@ -262,6 +284,7 @@ pub struct CommandPayload {
 /// [`SharedMetadataTemplate::into_payload`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SharedMetadataTemplate {
+    pub credential_type: CredentialType,
     pub flox_version: String,
     pub os_family: Option<String>,
     pub os_family_release: Option<String>,
@@ -280,6 +303,7 @@ impl SharedMetadataTemplate {
     pub fn into_payload(&self, subcommand: String) -> CommandPayload {
         CommandPayload {
             subcommand,
+            credential_type: self.credential_type,
             flox_version: self.flox_version.clone(),
             os_family: self.os_family.clone(),
             os_family_release: self.os_family_release.clone(),
@@ -892,6 +916,7 @@ mod tests {
     fn command_payload(subcommand: &str) -> CommandPayload {
         CommandPayload {
             subcommand: subcommand.to_string(),
+            credential_type: CredentialType::OAuthAccessToken,
             flox_version: "0.0.0-test".to_string(),
             os_family: Some("Linux".to_string()),
             os_family_release: Some("6.10.0".to_string()),
@@ -908,6 +933,7 @@ mod tests {
     fn expected_payload_json(subcommand: &str) -> serde_json::Value {
         json!({
             "subcommand": subcommand,
+            "credential_type": "oauth_access_token",
             "flox_version": "0.0.0-test",
             "os_family": "Linux",
             "os_family_release": "6.10.0",
@@ -942,6 +968,21 @@ mod tests {
     }
 
     #[test]
+    fn credential_type_serializes_to_contract_values() {
+        let value = serde_json::to_value([
+            CredentialType::OAuthAccessToken,
+            CredentialType::Pat,
+            CredentialType::ServiceToken,
+            CredentialType::None,
+        ])
+        .expect("credential types serialize");
+        assert_eq!(
+            value,
+            json!(["oauth_access_token", "pat", "service_token", "none"])
+        );
+    }
+
+    #[test]
     fn command_run_machine_context_envelope_golden() {
         // macOS-shaped run row: product version distinct from the kernel
         // release in `os_family_release`.
@@ -959,6 +1000,7 @@ mod tests {
         .expect("event serializes");
         let expected = command_run_envelope_json(json!({
             "subcommand": "install",
+            "credential_type": "oauth_access_token",
             "flox_version": "0.0.0-test",
             "os_family": "Mac OS",
             "os_family_release": "24.5.0",
@@ -980,6 +1022,20 @@ mod tests {
         let payload: CommandPayload = serde_json::from_value(expected_payload_json("install"))
             .expect("payload without machine-context keys deserializes");
         assert_eq!(payload, command_payload("install"));
+    }
+
+    #[test]
+    fn command_payload_without_credential_type_defaults_to_none() {
+        let mut json = expected_payload_json("install");
+        json.as_object_mut()
+            .expect("payload object")
+            .remove("credential_type");
+
+        let payload: CommandPayload =
+            serde_json::from_value(json).expect("payload without credential_type deserializes");
+        let mut expected = command_payload("install");
+        expected.credential_type = CredentialType::None;
+        assert_eq!(payload, expected);
     }
 
     #[test]
@@ -1163,6 +1219,7 @@ mod tests {
     /// Template fixture matching [`command_payload`].
     fn shared_metadata_for_payload_tests() -> SharedMetadataTemplate {
         SharedMetadataTemplate {
+            credential_type: CredentialType::OAuthAccessToken,
             flox_version: "0.0.0-test".to_string(),
             os_family: Some("Linux".to_string()),
             os_family_release: Some("6.10.0".to_string()),
@@ -1832,6 +1889,7 @@ mod pipeline_tests {
 
     fn shared_metadata() -> SharedMetadataTemplate {
         SharedMetadataTemplate {
+            credential_type: CredentialType::OAuthAccessToken,
             flox_version: "0.0.0-test".to_string(),
             os_family: Some("Linux".to_string()),
             os_family_release: Some("6.10.0".to_string()),

--- a/cli/flox-events/src/lib.rs
+++ b/cli/flox-events/src/lib.rs
@@ -55,10 +55,10 @@ pub struct Event {
     pub invocation_id: Uuid,
     /// Stable per-installation id.
     pub device_id: Uuid,
-    /// Pseudonymous authenticated-subject identifier — the OIDC/JWT
-    /// `sub` claim (sourced from the auth token) when known. Must not
-    /// contain email addresses, raw user handles, or token bytes — those
-    /// are PII and a different category from this field's pseudonymous-
+    /// Pseudonymous authenticated-subject identifier — the OIDC/JWT `sub`
+    /// claim or the equivalent accounts `/me.user_id` for an opaque token.
+    /// Must not contain email addresses, raw user handles, or token bytes —
+    /// those are PII and a different category from this field's pseudonymous-
     /// identifier contract.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub auth_subject: Option<String>,

--- a/cli/flox-events/src/lib.rs
+++ b/cli/flox-events/src/lib.rs
@@ -206,13 +206,12 @@ pub enum EventKind {
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum CredentialType {
-    /// OAuth access token issued by a supported OIDC provider.
-    #[serde(rename = "oauth_access_token")]
-    OAuthAccessToken,
+    /// JSON Web Token issued by a supported OIDC provider.
+    Jwt,
     /// FloxHub personal access token.
     Pat,
     /// FloxHub service account token.
-    ServiceToken,
+    Sat,
     /// No supported token authentication. This includes Kerberos mode.
     #[default]
     None,
@@ -916,7 +915,7 @@ mod tests {
     fn command_payload(subcommand: &str) -> CommandPayload {
         CommandPayload {
             subcommand: subcommand.to_string(),
-            credential_type: CredentialType::OAuthAccessToken,
+            credential_type: CredentialType::Jwt,
             flox_version: "0.0.0-test".to_string(),
             os_family: Some("Linux".to_string()),
             os_family_release: Some("6.10.0".to_string()),
@@ -933,7 +932,7 @@ mod tests {
     fn expected_payload_json(subcommand: &str) -> serde_json::Value {
         json!({
             "subcommand": subcommand,
-            "credential_type": "oauth_access_token",
+            "credential_type": "jwt",
             "flox_version": "0.0.0-test",
             "os_family": "Linux",
             "os_family_release": "6.10.0",
@@ -970,16 +969,13 @@ mod tests {
     #[test]
     fn credential_type_serializes_to_contract_values() {
         let value = serde_json::to_value([
-            CredentialType::OAuthAccessToken,
+            CredentialType::Jwt,
             CredentialType::Pat,
-            CredentialType::ServiceToken,
+            CredentialType::Sat,
             CredentialType::None,
         ])
         .expect("credential types serialize");
-        assert_eq!(
-            value,
-            json!(["oauth_access_token", "pat", "service_token", "none"])
-        );
+        assert_eq!(value, json!(["jwt", "pat", "sat", "none"]));
     }
 
     #[test]
@@ -1000,7 +996,7 @@ mod tests {
         .expect("event serializes");
         let expected = command_run_envelope_json(json!({
             "subcommand": "install",
-            "credential_type": "oauth_access_token",
+            "credential_type": "jwt",
             "flox_version": "0.0.0-test",
             "os_family": "Mac OS",
             "os_family_release": "24.5.0",
@@ -1219,7 +1215,7 @@ mod tests {
     /// Template fixture matching [`command_payload`].
     fn shared_metadata_for_payload_tests() -> SharedMetadataTemplate {
         SharedMetadataTemplate {
-            credential_type: CredentialType::OAuthAccessToken,
+            credential_type: CredentialType::Jwt,
             flox_version: "0.0.0-test".to_string(),
             os_family: Some("Linux".to_string()),
             os_family_release: Some("6.10.0".to_string()),
@@ -1889,7 +1885,7 @@ mod pipeline_tests {
 
     fn shared_metadata() -> SharedMetadataTemplate {
         SharedMetadataTemplate {
-            credential_type: CredentialType::OAuthAccessToken,
+            credential_type: CredentialType::Jwt,
             flox_version: "0.0.0-test".to_string(),
             os_family: Some("Linux".to_string()),
             os_family_release: Some("6.10.0".to_string()),

--- a/cli/flox-events/src/lib.rs
+++ b/cli/flox-events/src/lib.rs
@@ -212,6 +212,8 @@ pub enum CredentialType {
     Pat,
     /// FloxHub service account token.
     Sat,
+    /// A token is present, but its credential type is not recognized.
+    Unknown,
     /// No supported token authentication. This includes Kerberos mode.
     #[default]
     None,
@@ -972,10 +974,11 @@ mod tests {
             CredentialType::Jwt,
             CredentialType::Pat,
             CredentialType::Sat,
+            CredentialType::Unknown,
             CredentialType::None,
         ])
         .expect("credential types serialize");
-        assert_eq!(value, json!(["jwt", "pat", "sat", "none"]));
+        assert_eq!(value, json!(["jwt", "pat", "sat", "unknown", "none"]));
     }
 
     #[test]

--- a/cli/flox-rust-sdk/src/flox.rs
+++ b/cli/flox-rust-sdk/src/flox.rs
@@ -90,10 +90,11 @@ impl Flox {
 
     /// The identity behind the current credential — the one uniform way to
     /// answer "who is authenticated": JWT claims for an Auth0-shaped token,
-    /// `GET /api/v1/accounts/me` for any credential that doesn't identify
-    /// its owner — a bare JWT or an opaque access token (a successful
-    /// resolution is cached for the process) — and the principal for
-    /// Kerberos.
+    /// the accounts service's `GET /api/v1/accounts/me` for any credential
+    /// that doesn't identify its owner — a bare JWT or an opaque access token
+    /// (a successful resolution is cached for the process) — and the principal
+    /// for Kerberos. The public gateway exposes that endpoint at
+    /// `/accounts/api/v1/accounts/me`.
     ///
     /// - `Ok(Some(identity))` — authenticated. Expiry is reported *in* the
     ///   identity ([`UserIdentity::is_expired`]), not as a failure — what
@@ -111,6 +112,7 @@ impl Flox {
         match &self.auth_context {
             AuthContext::Auth0(Some(token)) => Ok(Some(UserIdentity {
                 handle: token.handle().to_string(),
+                sub: token.sub().map(str::to_owned),
                 expires_at: Some(token.expires_at()),
             })),
             AuthContext::Auth0(None) => Err(AuthFailure::NotLoggedIn),
@@ -137,6 +139,7 @@ impl Flox {
             },
             AuthContext::Kerberos(Some(material)) => Ok(Some(UserIdentity {
                 handle: material.principal.clone(),
+                sub: None,
                 expires_at: None,
             })),
             AuthContext::Kerberos(None) => Err(AuthFailure::NoKerberosTicket),
@@ -363,6 +366,7 @@ pub mod tests {
             flox.get_identity().await.unwrap(),
             Some(UserIdentity {
                 handle: "test".to_string(),
+                sub: None,
                 expires_at: Some(expires_at),
             })
         );
@@ -414,6 +418,7 @@ pub mod tests {
             flox.get_identity().await.unwrap(),
             Some(UserIdentity {
                 handle: "dexter".to_string(),
+                sub: Some("oidc|dexter".to_string()),
                 expires_at,
             })
         );

--- a/cli/flox-rust-sdk/src/utils/mod.rs
+++ b/cli/flox-rust-sdk/src/utils/mod.rs
@@ -18,6 +18,8 @@ pub use invocation_sources::INVOCATION_SOURCES;
 
 /// HTTP header name for the device UUID telemetry header.
 pub const HEADER_DEVICE_UUID: &str = "flox-device-uuid";
+/// HTTP header name for the CLI invocation UUID telemetry header.
+pub const HEADER_INVOCATION_ID: &str = "flox-invocation-id";
 /// HTTP header name for the invocation source telemetry header.
 pub const HEADER_INVOCATION_SOURCE: &str = "flox-invocation-source";
 

--- a/cli/flox/src/commands/auth.rs
+++ b/cli/flox/src/commands/auth.rs
@@ -728,7 +728,7 @@ mod tests {
     use std::fs;
 
     use flox_config::FLOX_CONFIG_FILE;
-    use flox_events::{EventsBuffer, EventsClient, SharedMetadataTemplate};
+    use flox_events::{CredentialType, EventsBuffer, EventsClient, SharedMetadataTemplate};
     use flox_rust_sdk::flox::FloxhubToken;
     use flox_rust_sdk::flox::test_helpers::{create_test_token, flox_instance};
     use floxhub_client::test_helpers::{FAKE_EXPIRED_TOKEN, FAKE_TOKEN_WITH_SUB};
@@ -774,6 +774,7 @@ mod tests {
             Uuid::new_v4(),
             Some("previous-subject".to_string()),
             SharedMetadataTemplate {
+                credential_type: CredentialType::None,
                 flox_version: "0.0.0-test".to_string(),
                 os_family: None,
                 os_family_release: None,

--- a/cli/flox/src/commands/auth.rs
+++ b/cli/flox/src/commands/auth.rs
@@ -622,10 +622,10 @@ fn complete_login(
         }
     }
 
-    if let Err(err) = EventsHub::global().record_event_with_auth_subject(
-        EventKind::CliAuthenticated {},
-        flox.auth_context.user_subject(),
-    ) {
+    let auth_subject = flox.auth_context.user_subject();
+    if let Err(err) = EventsHub::global()
+        .record_event_with_auth_subject(EventKind::CliAuthenticated {}, auth_subject.as_deref())
+    {
         debug!(error = %err, "Failed to record v2 cli.authenticated event");
     }
 

--- a/cli/flox/src/commands/init/mod.rs
+++ b/cli/flox/src/commands/init/mod.rs
@@ -740,7 +740,7 @@ mod tests {
 
     use flox_core::data::environment_ref::EnvironmentOwner;
     use flox_events::test_helpers::MockEventsConnection;
-    use flox_events::{EnvDetail, Event, EventsClient, SharedMetadataTemplate};
+    use flox_events::{CredentialType, EnvDetail, Event, EventsClient, SharedMetadataTemplate};
     use flox_rust_sdk::flox::test_helpers::{flox_instance, flox_instance_with_optional_floxhub};
     use flox_rust_sdk::models::environment::{DOT_FLOX, EnvJson, ManagedPointer};
     use flox_rust_sdk::utils::logging::test_helpers::test_subscriber_message_only;
@@ -1048,6 +1048,7 @@ mod tests {
                 Uuid::new_v4(),
                 None,
                 SharedMetadataTemplate {
+                    credential_type: CredentialType::None,
                     flox_version: "0.0.0-test".to_string(),
                     os_family: Some("Linux".to_string()),
                     os_family_release: None,

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -297,8 +297,11 @@ impl FloxArgs {
             )
             .await;
             if update_prompted
-                && let Some(events_client) =
-                    build_events_client(&config, resolve_invocation_id(), None)
+                && let Some(events_client) = build_events_client(
+                    &config,
+                    resolve_invocation_id(),
+                    &AuthContext::new_from_token(None),
+                )
                 && let Err(err) = events_client.record_event(EventKind::CliUpdatePrompted {})
             {
                 debug!(error = %err, "Failed to record v2 cli.update_prompted event");
@@ -368,9 +371,9 @@ impl FloxArgs {
         // `resolve_auth_context` is deliberately not behind this gate — it
         // still runs in the hook flow (returning the token, suppressing
         // messages) and gates on the auth mode alone. Consequently, hook-flow
-        // invocations by keyring-storage users emit with `auth_subject`
-        // absent — an accepted gap; a prompt hook must never trigger a
-        // keyring unlock.
+        // invocations by keyring-storage users emit with `auth_subject` absent
+        // and `credential_type` set to `none` — an accepted gap; a prompt hook
+        // must never trigger a keyring unlock.
         let stores = CredentialStores::new(floxhub.base_url(), &config.flox.config_dir);
         let is_auth0 = !matches!(
             config.flox.floxhub_authn_mode,
@@ -391,12 +394,9 @@ impl FloxArgs {
         }
 
         let credential = self.resolve_auth_context(&config);
+        let invocation_id = resolve_invocation_id();
 
-        if let Some(events_client) = build_events_client(
-            &config,
-            resolve_invocation_id(),
-            credential.user_subject().map(String::from),
-        ) {
+        if let Some(events_client) = build_events_client(&config, invocation_id, &credential) {
             EventsHub::global().set_client(events_client);
         }
 
@@ -405,8 +405,8 @@ impl FloxArgs {
         // `activate` before it replaces the process); the hub deduplicates.
         //
         // "Dispatch start" sits after credential resolution so the event
-        // carries `auth_subject` (see the block above). The cost: an
-        // invocation that dies upstream — on the fallible FloxHub-URL
+        // carries `auth_subject` and `credential_type` (see the block above). The
+        // cost: an invocation that dies upstream — on the fallible FloxHub-URL
         // construction, killed while `resolve_into` waits on an OS keyring
         // unlock, or killed during credential resolution (e.g. kerberos
         // ticket I/O) — records neither `cli.command_run` nor the matching
@@ -455,6 +455,7 @@ impl FloxArgs {
             floxhub.api_url_str(),
             credential.clone(),
             metrics_device_uuid,
+            invocation_id,
             on_unauthenticated_resolve,
         )?;
 

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -301,7 +301,9 @@ impl FloxArgs {
                     &config,
                     resolve_invocation_id(),
                     &AuthContext::new_from_token(None),
+                    None,
                 )
+                .await
                 && let Err(err) = events_client.record_event(EventKind::CliUpdatePrompted {})
             {
                 debug!(error = %err, "Failed to record v2 cli.update_prompted event");
@@ -396,32 +398,6 @@ impl FloxArgs {
         let credential = self.resolve_auth_context(&config);
         let invocation_id = resolve_invocation_id();
 
-        if let Some(events_client) = build_events_client(&config, invocation_id, &credential) {
-            EventsHub::global().set_client(events_client);
-        }
-
-        // Emit the v2 `cli.command_run` once at dispatch start. The matching
-        // `cli.command_completed` is emitted when the dispatch finishes (or by
-        // `activate` before it replaces the process); the hub deduplicates.
-        //
-        // "Dispatch start" sits after credential resolution so the event
-        // carries `auth_subject` and `credential_type` (see the block above). The
-        // cost: an invocation that dies upstream — on the fallible FloxHub-URL
-        // construction, killed while `resolve_into` waits on an OS keyring
-        // unlock, or killed during credential resolution (e.g. kerberos
-        // ticket I/O) — records neither `cli.command_run` nor the matching
-        // `cli.command_completed` (no client installs, so the invocation is
-        // invisible to v2 telemetry). Accepted: such an invocation errors
-        // out or is aborted before doing any work.
-        let v2_subcommand: &'static str = self
-            .command
-            .as_ref()
-            .map(Commands::subcommand_name)
-            .unwrap_or("help");
-        if let Err(err) = EventsHub::global().record_command_run(v2_subcommand.to_string()) {
-            debug!(error = %err, "Failed to record v2 cli.command_run event");
-        }
-
         let metrics_device_uuid = (!config.flox.disable_metrics)
             .then(|| read_metrics_uuid(&config).ok())
             .flatten();
@@ -458,6 +434,38 @@ impl FloxArgs {
             invocation_id,
             on_unauthenticated_resolve,
         )?;
+
+        // Prompt hooks must not gain a telemetry-only network dependency.
+        // Their credential type still reflects an explicitly configured
+        // token, but opaque-token subjects remain absent in this flow.
+        let events_floxhub_client = (!self.is_prompt_hook_flow()).then_some(&floxhub_client);
+        if let Some(events_client) =
+            build_events_client(&config, invocation_id, &credential, events_floxhub_client).await
+        {
+            EventsHub::global().set_client(events_client);
+        }
+
+        // Emit the v2 `cli.command_run` once at dispatch start. The matching
+        // `cli.command_completed` is emitted when the dispatch finishes (or by
+        // `activate` before it replaces the process); the hub deduplicates.
+        //
+        // "Dispatch start" sits after credential resolution and best-effort
+        // PAT/SAT subject resolution so the event carries `auth_subject` and
+        // `credential_type`. The cost: an invocation that dies upstream — on
+        // fallible FloxHub setup, killed while `resolve_into` waits on an OS
+        // keyring unlock, or killed during credential resolution (e.g.
+        // kerberos ticket I/O) — records neither `cli.command_run` nor the
+        // matching `cli.command_completed` (no client installs, so the
+        // invocation is invisible to v2 telemetry). Accepted: such an
+        // invocation errors out or is aborted before doing any work.
+        let v2_subcommand: &'static str = self
+            .command
+            .as_ref()
+            .map(Commands::subcommand_name)
+            .unwrap_or("help");
+        if let Err(err) = EventsHub::global().record_command_run(v2_subcommand.to_string()) {
+            debug!(error = %err, "Failed to record v2 cli.command_run event");
+        }
 
         // we already make sure $USER corresponds to **euid** earlier on in the process.
         let system_user_name =

--- a/cli/flox/src/commands/upgrade.rs
+++ b/cli/flox/src/commands/upgrade.rs
@@ -265,7 +265,7 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     use flox_events::test_helpers::MockEventsConnection;
-    use flox_events::{Event, EventsClient, SharedMetadataTemplate};
+    use flox_events::{CredentialType, Event, EventsClient, SharedMetadataTemplate};
     use flox_manifest::lockfile::test_helpers::fake_catalog_package_lock;
     use flox_manifest::parsed::latest::PackageDescriptorCatalog;
     use flox_manifest::raw::PackageToInstall;
@@ -306,6 +306,7 @@ mod tests {
                 Uuid::new_v4(),
                 None,
                 SharedMetadataTemplate {
+                    credential_type: CredentialType::None,
                     flox_version: "0.0.0-test".to_string(),
                     os_family: Some("Linux".to_string()),
                     os_family_release: None,

--- a/cli/flox/src/utils/events.rs
+++ b/cli/flox/src/utils/events.rs
@@ -7,17 +7,17 @@
 //! `config.flox.disable_metrics` silences both.
 //!
 //! Authenticated invocations additionally carry a pseudonymous subject
-//! identifier as `auth_subject`, resolved by the caller from the auth
-//! context (`AuthContext::user_subject`) — see
-//! [`flox_events::EventsClient`] for the field's semantics.
+//! identifier as `auth_subject`. This wrapper derives it and `credential_type`
+//! from the invocation's `AuthContext`; the events client retains only those
+//! sanitized values.
 
 use std::env;
 use std::str::FromStr;
 use std::sync::{LazyLock, OnceLock};
 
 use flox_config::Config;
-use flox_events::{EnvDetail, EventsClient, EventsHub, SharedMetadataTemplate};
-use flox_rust_sdk::flox::{FLOX_VERSION, Flox};
+use flox_events::{CredentialType, EnvDetail, EventsClient, EventsHub, SharedMetadataTemplate};
+use flox_rust_sdk::flox::{AuthContext, FLOX_VERSION, Flox};
 use flox_rust_sdk::models::environment::generations::GenerationsExt;
 use flox_rust_sdk::models::environment::{ConcreteEnvironment, Environment};
 use flox_rust_sdk::utils::INVOCATION_SOURCES;
@@ -86,13 +86,28 @@ pub(crate) fn duration_to_ms(elapsed: std::time::Duration) -> u64 {
     u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX)
 }
 
+fn credential_type_from_context(auth_context: &AuthContext) -> CredentialType {
+    match auth_context {
+        AuthContext::Auth0(Some(_)) | AuthContext::Bare(_) => CredentialType::OAuthAccessToken,
+        AuthContext::AccessToken(token) if token.secret().starts_with("flox_pat_") => {
+            CredentialType::Pat
+        },
+        AuthContext::AccessToken(token) if token.secret().starts_with("flox_sat_") => {
+            CredentialType::ServiceToken
+        },
+        AuthContext::AccessToken(_) => CredentialType::OAuthAccessToken,
+        AuthContext::Auth0(None) | AuthContext::Kerberos(_) => CredentialType::None,
+    }
+}
+
 /// Build the [`SharedMetadataTemplate`] stamped onto every v2 event emitted
 /// by this process. The fields mirror the legacy
 /// [`crate::utils::metrics::MetricEntry`] so downstream consumers can
 /// reconstruct the existing columns.
-fn shared_metadata_template() -> SharedMetadataTemplate {
+fn shared_metadata_template(credential_type: CredentialType) -> SharedMetadataTemplate {
     let linux_release = sys_info::linux_os_release().ok();
     SharedMetadataTemplate {
+        credential_type,
         flox_version: FLOX_VERSION.to_string(),
         os_family: sys_info::os_type()
             .ok()
@@ -145,10 +160,10 @@ fn architecture_from_system(system: &str) -> Option<String> {
 /// a) metrics are disabled by config, or
 /// b) reading the metrics uuid fails.
 ///
-/// `auth_subject` is the caller-resolved pseudonymous subject identifier
-/// (`AuthContext::user_subject`) — the returned client snapshots it at
-/// construction (see [`flox_events::EventsClient`] for the snapshot
-/// semantics).
+/// `auth_context` is the credential selected for the invocation. The
+/// returned client snapshots its pseudonymous subject and local credential
+/// kind at construction (see [`flox_events::EventsClient`] for the snapshot
+/// semantics); credential material is never retained by the events client.
 ///
 /// Ordering invariant: [`shared_metadata_template`] performs machine-context
 /// detection, so it must stay behind the `disable_metrics` early return —
@@ -156,7 +171,7 @@ fn architecture_from_system(system: &str) -> Option<String> {
 pub fn build_events_client(
     config: &Config,
     invocation_id: Uuid,
-    auth_subject: Option<String>,
+    auth_context: &AuthContext,
 ) -> Option<EventsClient> {
     if config.flox.disable_metrics {
         debug!("v2 events: disable_metrics is true; not installing client");
@@ -171,6 +186,8 @@ pub fn build_events_client(
         },
     };
 
+    let auth_subject = auth_context.user_subject().map(String::from);
+    let credential_type = credential_type_from_context(auth_context);
     Some(EventsClient::new(
         device_id,
         &config.flox.data_dir,
@@ -178,7 +195,7 @@ pub fn build_events_client(
         METRICS_EVENTS_API_KEY_V2.clone(),
         invocation_id,
         auth_subject,
-        shared_metadata_template(),
+        shared_metadata_template(credential_type),
     ))
 }
 
@@ -294,6 +311,7 @@ mod tests {
     use flox_config::FloxConfig;
     use flox_events::test_helpers::MockEventsConnection;
     use flox_events::{EVENTS_BUFFER_FILE_NAME, EventsHub, LifecycleFields};
+    use floxhub_client::test_helpers::{FAKE_TOKEN, FAKE_TOKEN_NO_HANDLE, FAKE_TOKEN_WITH_SUB};
     use serial_test::serial;
     use temp_env::with_var;
     use tempfile::TempDir;
@@ -388,7 +406,7 @@ mod tests {
 
     #[test]
     fn shared_metadata_template_populates_machine_context() {
-        let template = shared_metadata_template();
+        let template = shared_metadata_template(CredentialType::OAuthAccessToken);
 
         // Whole-struct compare: machine-dependent fields are cloned from the
         // actual value, architecture is pinned from the compile-time target,
@@ -396,6 +414,7 @@ mod tests {
         // behavior is pinned in the detect_shell tests; the value-domain
         // assertion below guards the wire here.
         let expected = SharedMetadataTemplate {
+            credential_type: CredentialType::OAuthAccessToken,
             flox_version: FLOX_VERSION.to_string(),
             os_family: template.os_family.clone(),
             os_family_release: template.os_family_release.clone(),
@@ -445,6 +464,34 @@ mod tests {
     }
 
     #[test]
+    fn credential_type_reflects_local_auth_context() {
+        let contexts = [
+            AuthContext::new_from_token(Some(FAKE_TOKEN)),
+            AuthContext::new_from_token(Some(FAKE_TOKEN_NO_HANDLE)),
+            AuthContext::new_from_token(Some("flox_pat_test")),
+            AuthContext::new_from_token(Some("flox_sat_test")),
+            AuthContext::new_from_token(Some("opaque-access-token")),
+            AuthContext::new_from_token(Some("flox_unknown_test")),
+            AuthContext::new_from_token(None),
+            AuthContext::Kerberos(None),
+        ];
+
+        assert_eq!(
+            contexts.map(|context| credential_type_from_context(&context)),
+            [
+                CredentialType::OAuthAccessToken,
+                CredentialType::OAuthAccessToken,
+                CredentialType::Pat,
+                CredentialType::ServiceToken,
+                CredentialType::OAuthAccessToken,
+                CredentialType::OAuthAccessToken,
+                CredentialType::None,
+                CredentialType::None,
+            ]
+        );
+    }
+
+    #[test]
     #[serial(v2_events_wrapper_env)]
     fn build_events_client_returns_none_when_disable_metrics_is_true() {
         let tempdir = tempfile::tempdir().expect("tempdir");
@@ -454,7 +501,8 @@ mod tests {
             /* disable_metrics */ true,
         );
 
-        let client = build_events_client(&config, Uuid::new_v4(), None);
+        let auth_context = AuthContext::new_from_token(None);
+        let client = build_events_client(&config, Uuid::new_v4(), &auth_context);
         assert!(client.is_none(), "disable_metrics must take priority");
     }
 
@@ -467,7 +515,8 @@ mod tests {
         // No metrics-uuid file written: read_metrics_uuid errors.
         let config = test_config(&tempdir, data_dir, /* disable_metrics */ false);
 
-        let client = build_events_client(&config, Uuid::new_v4(), None);
+        let auth_context = AuthContext::new_from_token(None);
+        let client = build_events_client(&config, Uuid::new_v4(), &auth_context);
         assert!(client.is_none(), "missing uuid must short-circuit");
     }
 
@@ -478,26 +527,28 @@ mod tests {
         let uuid = Uuid::new_v4();
         let config = test_config_with_uuid(&tempdir, uuid);
 
-        let client = build_events_client(&config, Uuid::new_v4(), None);
+        let auth_context = AuthContext::new_from_token(None);
+        let client = build_events_client(&config, Uuid::new_v4(), &auth_context);
         assert!(client.is_some(), "v2 is enabled by default");
         assert_eq!(client.unwrap().device_id, uuid);
     }
 
-    /// The wrapper stamps whatever subject the caller resolved — which
-    /// subjects resolve for which auth states is pinned where that logic
-    /// lives (`AuthContext::user_subject` / `FloxhubToken::sub`).
+    /// The wrapper derives the subject from the same auth context used for
+    /// the credential type.
     #[test]
     #[serial(v2_events_wrapper_env)]
-    fn build_events_client_stamps_provided_auth_subject() {
+    fn build_events_client_derives_auth_subject_from_context() {
         let tempdir = tempfile::tempdir().expect("tempdir");
         let config = test_config_with_uuid(&tempdir, Uuid::new_v4());
 
+        let authenticated = AuthContext::new_from_token(Some(FAKE_TOKEN_WITH_SUB));
         let client =
-            build_events_client(&config, Uuid::new_v4(), Some("github|3670948".to_string()))
-                .expect("client installs");
-        assert_eq!(client.auth_subject.as_deref(), Some("github|3670948"));
+            build_events_client(&config, Uuid::new_v4(), &authenticated).expect("client installs");
+        assert_eq!(client.auth_subject.as_deref(), Some("github|424242"));
 
-        let client = build_events_client(&config, Uuid::new_v4(), None).expect("client installs");
+        let unauthenticated = AuthContext::new_from_token(None);
+        let client = build_events_client(&config, Uuid::new_v4(), &unauthenticated)
+            .expect("client installs");
         assert_eq!(client.auth_subject, None, "anonymous use stays anonymous");
     }
 
@@ -513,6 +564,7 @@ mod tests {
         let invocation_id = Uuid::new_v4();
 
         let template = SharedMetadataTemplate {
+            credential_type: CredentialType::None,
             flox_version: "0.0.0-test".to_string(),
             os_family: Some("Linux".to_string()),
             os_family_release: None,

--- a/cli/flox/src/utils/events.rs
+++ b/cli/flox/src/utils/events.rs
@@ -230,9 +230,7 @@ async fn auth_subject_from_context(
         debug!("v2 events: no FloxHub client available to resolve token subject");
         return None;
     };
-    let Some(secret) = auth_context.token_secret() else {
-        return None;
-    };
+    let secret = auth_context.token_secret()?;
 
     match tokio::time::timeout(
         AUTH_SUBJECT_RESOLUTION_TIMEOUT,
@@ -370,6 +368,7 @@ mod tests {
     use tempfile::TempDir;
 
     use super::*;
+    use crate::utils::init::init_floxhub_client;
 
     /// A `Config` value pointing at a fresh tempdir, with metrics enabled
     /// and a pre-written metrics uuid so the wrapper has everything it
@@ -577,7 +576,7 @@ mod tests {
         )
         .await;
         assert!(client.is_none(), "disable_metrics must take priority");
-        request.assert_hits(0);
+        request.assert_calls(0);
     }
 
     #[tokio::test]
@@ -612,7 +611,7 @@ mod tests {
         )
         .await;
         assert!(client.is_none(), "missing uuid must short-circuit");
-        request.assert_hits(0);
+        request.assert_calls(0);
     }
 
     #[tokio::test]
@@ -672,7 +671,7 @@ mod tests {
                 }));
             });
             let auth_context = AuthContext::new_from_token(Some(token));
-            let floxhub_client = crate::utils::init::floxhub_client::init_floxhub_client(
+            let floxhub_client = init_floxhub_client(
                 server.base_url(),
                 auth_context.clone(),
                 Some(Uuid::new_v4()),

--- a/cli/flox/src/utils/events.rs
+++ b/cli/flox/src/utils/events.rs
@@ -21,6 +21,7 @@ use flox_rust_sdk::flox::{AuthContext, FLOX_VERSION, Flox};
 use flox_rust_sdk::models::environment::generations::GenerationsExt;
 use flox_rust_sdk::models::environment::{ConcreteEnvironment, Environment};
 use flox_rust_sdk::utils::INVOCATION_SOURCES;
+use floxhub_client::FloxhubClient;
 use tracing::debug;
 use uuid::Uuid;
 
@@ -48,6 +49,10 @@ static METRICS_EVENTS_API_KEY_V2: LazyLock<String> = LazyLock::new(|| {
     std::env::var("_FLOX_METRICS_API_KEY_V2_OVERRIDE")
         .unwrap_or(env!("METRICS_EVENTS_API_KEY_V2").to_string())
 });
+
+/// Identity enrichment is useful telemetry, never a reason to delay a CLI
+/// command for the FloxHub client's full request timeout.
+const AUTH_SUBJECT_RESOLUTION_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
 
 /// Resolve the invocation id for the current process.
 ///
@@ -160,18 +165,21 @@ fn architecture_from_system(system: &str) -> Option<String> {
 /// a) metrics are disabled by config, or
 /// b) reading the metrics uuid fails.
 ///
-/// `auth_context` is the credential selected for the invocation. The
-/// returned client snapshots its pseudonymous subject and local credential
-/// kind at construction (see [`flox_events::EventsClient`] for the snapshot
+/// `auth_context` is the credential selected for the invocation. The returned
+/// client snapshots its pseudonymous subject and local credential kind at
+/// construction (see [`flox_events::EventsClient`] for the snapshot
 /// semantics); credential material is never retained by the events client.
+/// `floxhub_client` is optional for flows that never initialize the API client;
+/// it is used only to resolve the subject of opaque PAT/SAT credentials.
 ///
 /// Ordering invariant: [`shared_metadata_template`] performs machine-context
 /// detection, so it must stay behind the `disable_metrics` early return —
 /// opted-out runs do no metrics-only metadata work.
-pub fn build_events_client(
+pub async fn build_events_client(
     config: &Config,
     invocation_id: Uuid,
     auth_context: &AuthContext,
+    floxhub_client: Option<&FloxhubClient>,
 ) -> Option<EventsClient> {
     if config.flox.disable_metrics {
         debug!("v2 events: disable_metrics is true; not installing client");
@@ -186,8 +194,9 @@ pub fn build_events_client(
         },
     };
 
-    let auth_subject = auth_context.user_subject().map(String::from);
     let credential_type = credential_type_from_context(auth_context);
+    let auth_subject =
+        auth_subject_from_context(auth_context, credential_type, floxhub_client).await;
     Some(EventsClient::new(
         device_id,
         &config.flox.data_dir,
@@ -197,6 +206,50 @@ pub fn build_events_client(
         auth_subject,
         shared_metadata_template(credential_type),
     ))
+}
+
+/// Return the pseudonymous subject for telemetry without making identity
+/// resolution part of command success.
+///
+/// JWT subjects are read locally. PATs and SATs are opaque, so their subject
+/// comes from the accounts `/me` response. A failed lookup leaves the field
+/// absent and never fails the invocation.
+async fn auth_subject_from_context(
+    auth_context: &AuthContext,
+    credential_type: CredentialType,
+    floxhub_client: Option<&FloxhubClient>,
+) -> Option<String> {
+    if let Some(subject) = auth_context.user_subject() {
+        return Some(subject);
+    }
+    if !matches!(credential_type, CredentialType::Pat | CredentialType::Sat) {
+        return None;
+    }
+
+    let Some(floxhub_client) = floxhub_client else {
+        debug!("v2 events: no FloxHub client available to resolve token subject");
+        return None;
+    };
+    let Some(secret) = auth_context.token_secret() else {
+        return None;
+    };
+
+    match tokio::time::timeout(
+        AUTH_SUBJECT_RESOLUTION_TIMEOUT,
+        floxhub_client.resolve_identity(secret),
+    )
+    .await
+    {
+        Ok(Ok(identity)) => identity.sub,
+        Ok(Err(err)) => {
+            debug!(error = %err, "v2 events: could not resolve token subject");
+            None
+        },
+        Err(err) => {
+            debug!(error = %err, "v2 events: token subject resolution timed out");
+            None
+        },
+    }
 }
 
 /// Lineage fields for the environment the current invocation operates on.
@@ -491,65 +544,181 @@ mod tests {
         );
     }
 
-    #[test]
+    #[tokio::test(flavor = "multi_thread")]
     #[serial(v2_events_wrapper_env)]
-    fn build_events_client_returns_none_when_disable_metrics_is_true() {
+    async fn build_events_client_returns_none_when_disable_metrics_is_true() {
         let tempdir = tempfile::tempdir().expect("tempdir");
         let config = test_config(
             &tempdir,
             tempdir.path().join("data"),
             /* disable_metrics */ true,
         );
+        let server = httpmock::MockServer::start();
+        let request = server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path("/accounts/api/v1/accounts/me");
+            then.status(200).json_body(serde_json::json!({
+                "user_id": "auth0|123",
+                "handle": "testuser",
+                "expires_at": null,
+            }));
+        });
+        let floxhub_client = floxhub_client::FloxhubClient::new(
+            floxhub_client::client::test_helpers::client_config(&server.base_url()),
+        )
+        .expect("client initializes");
 
-        let auth_context = AuthContext::new_from_token(None);
-        let client = build_events_client(&config, Uuid::new_v4(), &auth_context);
+        let auth_context = AuthContext::new_from_token(Some("flox_pat_metrics-disabled"));
+        let client = build_events_client(
+            &config,
+            Uuid::new_v4(),
+            &auth_context,
+            Some(&floxhub_client),
+        )
+        .await;
         assert!(client.is_none(), "disable_metrics must take priority");
+        request.assert_hits(0);
     }
 
-    #[test]
+    #[tokio::test]
     #[serial(v2_events_wrapper_env)]
-    fn build_events_client_returns_none_when_uuid_unreadable() {
+    async fn build_events_client_returns_none_when_uuid_unreadable() {
         let tempdir = tempfile::tempdir().expect("tempdir");
         let data_dir = tempdir.path().join("data");
         std::fs::create_dir_all(&data_dir).expect("data dir");
         // No metrics-uuid file written: read_metrics_uuid errors.
         let config = test_config(&tempdir, data_dir, /* disable_metrics */ false);
+        let server = httpmock::MockServer::start();
+        let request = server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path("/accounts/api/v1/accounts/me");
+            then.status(200).json_body(serde_json::json!({
+                "user_id": "auth0|123",
+                "handle": "testuser",
+                "expires_at": null,
+            }));
+        });
+        let floxhub_client = floxhub_client::FloxhubClient::new(
+            floxhub_client::client::test_helpers::client_config(&server.base_url()),
+        )
+        .expect("client initializes");
 
-        let auth_context = AuthContext::new_from_token(None);
-        let client = build_events_client(&config, Uuid::new_v4(), &auth_context);
+        let auth_context = AuthContext::new_from_token(Some("flox_pat_uuid-unreadable"));
+        let client = build_events_client(
+            &config,
+            Uuid::new_v4(),
+            &auth_context,
+            Some(&floxhub_client),
+        )
+        .await;
         assert!(client.is_none(), "missing uuid must short-circuit");
+        request.assert_hits(0);
     }
 
-    #[test]
+    #[tokio::test]
     #[serial(v2_events_wrapper_env)]
-    fn build_events_client_returns_some_by_default() {
+    async fn build_events_client_returns_some_by_default() {
         let tempdir = tempfile::tempdir().expect("tempdir");
         let uuid = Uuid::new_v4();
         let config = test_config_with_uuid(&tempdir, uuid);
 
         let auth_context = AuthContext::new_from_token(None);
-        let client = build_events_client(&config, Uuid::new_v4(), &auth_context);
+        let client = build_events_client(&config, Uuid::new_v4(), &auth_context, None).await;
         assert!(client.is_some(), "v2 is enabled by default");
         assert_eq!(client.unwrap().device_id, uuid);
     }
 
     /// The wrapper derives the subject from the same auth context used for
     /// the credential type.
-    #[test]
+    #[tokio::test(flavor = "multi_thread")]
     #[serial(v2_events_wrapper_env)]
-    fn build_events_client_derives_auth_subject_from_context() {
+    async fn build_events_client_derives_auth_subject_from_context() {
         let tempdir = tempfile::tempdir().expect("tempdir");
         let config = test_config_with_uuid(&tempdir, Uuid::new_v4());
 
         let authenticated = AuthContext::new_from_token(Some(FAKE_TOKEN_WITH_SUB));
-        let client =
-            build_events_client(&config, Uuid::new_v4(), &authenticated).expect("client installs");
+        let client = build_events_client(&config, Uuid::new_v4(), &authenticated, None)
+            .await
+            .expect("client installs");
         assert_eq!(client.auth_subject.as_deref(), Some("github|424242"));
 
         let unauthenticated = AuthContext::new_from_token(None);
-        let client = build_events_client(&config, Uuid::new_v4(), &unauthenticated)
+        let client = build_events_client(&config, Uuid::new_v4(), &unauthenticated, None)
+            .await
             .expect("client installs");
         assert_eq!(client.auth_subject, None, "anonymous use stays anonymous");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[serial(v2_events_wrapper_env)]
+    async fn build_events_client_resolves_pat_and_sat_subjects_from_me() {
+        for (token, sub) in [
+            ("flox_pat_events-subject-test", "auth0|123"),
+            ("flox_sat_events-subject-test", "service|456"),
+        ] {
+            let tempdir = tempfile::tempdir().expect("tempdir");
+            let config = test_config_with_uuid(&tempdir, Uuid::new_v4());
+            let server = httpmock::MockServer::start();
+            let invocation_id = Uuid::new_v4();
+            let request = server.mock(|when, then| {
+                when.method(httpmock::Method::GET)
+                    .path("/accounts/api/v1/accounts/me")
+                    .header("authorization", format!("bearer {token}"))
+                    .header("flox-invocation-id", invocation_id.to_string());
+                then.status(200).json_body(serde_json::json!({
+                    "user_id": sub,
+                    "handle": "testuser",
+                    "expires_at": null,
+                }));
+            });
+            let auth_context = AuthContext::new_from_token(Some(token));
+            let floxhub_client = crate::utils::init::floxhub_client::init_floxhub_client(
+                server.base_url(),
+                auth_context.clone(),
+                Some(Uuid::new_v4()),
+                invocation_id,
+                None,
+            )
+            .expect("client initializes");
+
+            let client =
+                build_events_client(&config, invocation_id, &auth_context, Some(&floxhub_client))
+                    .await
+                    .expect("client installs");
+
+            request.assert();
+            assert_eq!(client.auth_subject.as_deref(), Some(sub));
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[serial(v2_events_wrapper_env)]
+    async fn build_events_client_omits_subject_when_me_rejects_token() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let config = test_config_with_uuid(&tempdir, Uuid::new_v4());
+        let server = httpmock::MockServer::start();
+        let request = server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path("/accounts/api/v1/accounts/me");
+            then.status(401);
+        });
+        let auth_context = AuthContext::new_from_token(Some("flox_pat_rejected-subject-test"));
+        let floxhub_client = floxhub_client::FloxhubClient::new(
+            floxhub_client::client::test_helpers::client_config(&server.base_url()),
+        )
+        .expect("client initializes");
+
+        let client = build_events_client(
+            &config,
+            Uuid::new_v4(),
+            &auth_context,
+            Some(&floxhub_client),
+        )
+        .await
+        .expect("identity enrichment must not block client installation");
+
+        request.assert();
+        assert_eq!(client.auth_subject, None);
     }
 
     /// End-to-end: install a hub-owned client backed by a

--- a/cli/flox/src/utils/events.rs
+++ b/cli/flox/src/utils/events.rs
@@ -88,14 +88,14 @@ pub(crate) fn duration_to_ms(elapsed: std::time::Duration) -> u64 {
 
 fn credential_type_from_context(auth_context: &AuthContext) -> CredentialType {
     match auth_context {
-        AuthContext::Auth0(Some(_)) | AuthContext::Bare(_) => CredentialType::OAuthAccessToken,
+        AuthContext::Auth0(Some(_)) | AuthContext::Bare(_) => CredentialType::Jwt,
         AuthContext::AccessToken(token) if token.secret().starts_with("flox_pat_") => {
             CredentialType::Pat
         },
         AuthContext::AccessToken(token) if token.secret().starts_with("flox_sat_") => {
-            CredentialType::ServiceToken
+            CredentialType::Sat
         },
-        AuthContext::AccessToken(_) => CredentialType::OAuthAccessToken,
+        AuthContext::AccessToken(_) => CredentialType::Jwt,
         AuthContext::Auth0(None) | AuthContext::Kerberos(_) => CredentialType::None,
     }
 }
@@ -406,7 +406,7 @@ mod tests {
 
     #[test]
     fn shared_metadata_template_populates_machine_context() {
-        let template = shared_metadata_template(CredentialType::OAuthAccessToken);
+        let template = shared_metadata_template(CredentialType::Jwt);
 
         // Whole-struct compare: machine-dependent fields are cloned from the
         // actual value, architecture is pinned from the compile-time target,
@@ -414,7 +414,7 @@ mod tests {
         // behavior is pinned in the detect_shell tests; the value-domain
         // assertion below guards the wire here.
         let expected = SharedMetadataTemplate {
-            credential_type: CredentialType::OAuthAccessToken,
+            credential_type: CredentialType::Jwt,
             flox_version: FLOX_VERSION.to_string(),
             os_family: template.os_family.clone(),
             os_family_release: template.os_family_release.clone(),
@@ -479,12 +479,12 @@ mod tests {
         assert_eq!(
             contexts.map(|context| credential_type_from_context(&context)),
             [
-                CredentialType::OAuthAccessToken,
-                CredentialType::OAuthAccessToken,
+                CredentialType::Jwt,
+                CredentialType::Jwt,
                 CredentialType::Pat,
-                CredentialType::ServiceToken,
-                CredentialType::OAuthAccessToken,
-                CredentialType::OAuthAccessToken,
+                CredentialType::Sat,
+                CredentialType::Jwt,
+                CredentialType::Jwt,
                 CredentialType::None,
                 CredentialType::None,
             ]

--- a/cli/flox/src/utils/events.rs
+++ b/cli/flox/src/utils/events.rs
@@ -100,7 +100,7 @@ fn credential_type_from_context(auth_context: &AuthContext) -> CredentialType {
         AuthContext::AccessToken(token) if token.secret().starts_with("flox_sat_") => {
             CredentialType::Sat
         },
-        AuthContext::AccessToken(_) => CredentialType::Jwt,
+        AuthContext::AccessToken(_) => CredentialType::Unknown,
         AuthContext::Auth0(None) | AuthContext::Kerberos(_) => CredentialType::None,
     }
 }
@@ -535,8 +535,8 @@ mod tests {
                 CredentialType::Jwt,
                 CredentialType::Pat,
                 CredentialType::Sat,
-                CredentialType::Jwt,
-                CredentialType::Jwt,
+                CredentialType::Unknown,
+                CredentialType::Unknown,
                 CredentialType::None,
                 CredentialType::None,
             ]

--- a/cli/flox/src/utils/init/floxhub_client.rs
+++ b/cli/flox/src/utils/init/floxhub_client.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use flox_rust_sdk::flox::FLOX_VERSION;
-use flox_rust_sdk::utils::{HEADER_DEVICE_UUID, INVOCATION_SOURCES};
+use flox_rust_sdk::utils::{HEADER_DEVICE_UUID, HEADER_INVOCATION_ID, INVOCATION_SOURCES};
 use floxhub_client::{
     AuthContext,
     FloxhubClient,
@@ -16,7 +16,8 @@ use uuid::Uuid;
 ///
 /// - Reads the catalog URL from config (defaults to the production catalog URL)
 /// - Configures mock replay mode if `_FLOX_USE_CATALOG_MOCK` is set
-/// - Includes device UUID and invocation-source headers when available
+/// - Includes device and invocation UUID headers when metrics are enabled
+/// - Includes invocation-source headers when available
 /// - Pins `resolve()` requests to a stability channel if
 ///   `_FLOX_RESOLVE_STABILITY` is set (test/regen-only, not user-facing)
 ///
@@ -27,15 +28,16 @@ pub fn init_floxhub_client(
     base_url: String,
     auth_context: AuthContext,
     metrics_device_uuid: Option<Uuid>,
+    invocation_id: Uuid,
     on_unauthenticated_resolve: Option<UnauthenticatedResolveHook>,
 ) -> Result<FloxhubClient, anyhow::Error> {
     let mut extra_headers = BTreeMap::new();
 
-    // Propagate the metrics UUID to catalog-server if metrics are enabled.
-    match metrics_device_uuid {
-        Some(uuid) => extra_headers.insert(HEADER_DEVICE_UUID.to_string(), uuid.to_string()),
-        None => Default::default(),
-    };
+    // Propagate the metrics and invocation UUIDs when metrics are enabled.
+    if let Some(uuid) = metrics_device_uuid {
+        extra_headers.insert(HEADER_DEVICE_UUID.to_string(), uuid.to_string());
+        extra_headers.insert(HEADER_INVOCATION_ID.to_string(), invocation_id.to_string());
+    }
     // Add invocation sources header if any sources are detected
     if !INVOCATION_SOURCES.is_empty() {
         let sources_str = INVOCATION_SOURCES.join(",");
@@ -56,4 +58,55 @@ pub fn init_floxhub_client(
 
     debug!("using catalog client with url: {}", client_config.base_url);
     Ok(FloxhubClient::new(client_config)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use floxhub_client::CatalogClientTrait;
+    use httpmock::MockServer;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn catalog_requests_include_the_cli_invocation_id() {
+        let invocation_id = Uuid::nil();
+        let server = MockServer::start_async().await;
+        let request = server.mock(|when, then| {
+            when.header("flox-invocation-id", invocation_id.to_string());
+            then.status(500);
+        });
+
+        let client = init_floxhub_client(
+            server.base_url(),
+            AuthContext::new_from_token(None),
+            Some(Uuid::new_v4()),
+            invocation_id,
+            None,
+        )
+        .expect("client initializes");
+        let _ = client.package_versions("hello").await;
+
+        request.assert();
+    }
+
+    #[tokio::test]
+    async fn catalog_requests_omit_the_cli_invocation_id_when_metrics_are_disabled() {
+        let server = MockServer::start_async().await;
+        let request = server.mock(|when, then| {
+            when.header_missing("flox-invocation-id");
+            then.status(500);
+        });
+
+        let client = init_floxhub_client(
+            server.base_url(),
+            AuthContext::new_from_token(None),
+            None,
+            Uuid::nil(),
+            None,
+        )
+        .expect("client initializes");
+        let _ = client.package_versions("hello").await;
+
+        request.assert();
+    }
 }

--- a/cli/floxhub-client/src/accounts.rs
+++ b/cli/floxhub-client/src/accounts.rs
@@ -8,9 +8,27 @@
 //! (the service emits a 3.0.2 schema for exactly this purpose) and replace
 //! the hand-written request, once the CLI grows beyond this one endpoint.
 
+use serde::Deserialize;
 use thiserror::Error;
 
 use crate::auth::UserIdentity;
+
+#[derive(Debug, Deserialize)]
+struct MeResponse {
+    user_id: String,
+    handle: String,
+    expires_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+impl From<MeResponse> for UserIdentity {
+    fn from(response: MeResponse) -> Self {
+        Self {
+            handle: response.handle,
+            sub: Some(response.user_id),
+            expires_at: response.expires_at,
+        }
+    }
+}
 
 #[derive(Debug, Error)]
 pub enum MeError {
@@ -61,7 +79,7 @@ impl AccountsApiClient {
             .send()
             .await?;
         match response.status() {
-            reqwest::StatusCode::OK => Ok(response.json().await?),
+            reqwest::StatusCode::OK => Ok(response.json::<MeResponse>().await?.into()),
             reqwest::StatusCode::UNAUTHORIZED => Err(MeError::Unauthorized),
             status => Err(MeError::UnexpectedStatus(status)),
         }
@@ -94,6 +112,7 @@ mod tests {
         mock.assert();
         assert_eq!(identity, UserIdentity {
             handle: "testuser".to_string(),
+            sub: Some("auth0|123".to_string()),
             expires_at: Some("2027-01-01T00:00:00Z".parse().unwrap()),
         });
     }

--- a/cli/floxhub-client/src/auth/auth_context.rs
+++ b/cli/floxhub-client/src/auth/auth_context.rs
@@ -100,23 +100,26 @@ impl AuthContext {
         }
     }
 
-    /// Return the pseudonymous subject identifier for telemetry
-    /// attribution, if one is available.
+    /// Return the pseudonymous subject identifier for telemetry attribution,
+    /// if one is available locally or in the process-wide identity cache.
     ///
     /// Auth0 tokens carry the OIDC `sub` claim ([`FloxhubToken::sub`]) —
     /// opaque and stable across the user's lifetime, so it remains valid
-    /// attribution even when the token has expired. Kerberos has no
-    /// pseudonymous equivalent today (the principal is directly
-    /// identifying), so kerberos-mode invocations return `None`.
+    /// attribution even when the token has expired. PATs and SATs read the
+    /// `/me.user_id` value after identity resolution has populated the cache.
+    /// Kerberos has no pseudonymous equivalent today (the principal is
+    /// directly identifying), so kerberos-mode invocations return `None`.
     ///
     /// [`FloxhubToken::sub`]: crate::auth::token::FloxhubToken::sub
-    pub fn user_subject(&self) -> Option<&str> {
+    pub fn user_subject(&self) -> Option<String> {
         match self {
-            AuthContext::Auth0(Some(token)) => token.sub(),
+            AuthContext::Auth0(Some(token)) => token.sub().map(str::to_owned),
             AuthContext::Auth0(None) => None,
-            AuthContext::Bare(token) => token.sub(),
-            // An opaque token carries no locally readable subject.
-            AuthContext::AccessToken(_) => None,
+            AuthContext::Bare(token) => token.sub().map(str::to_owned),
+            AuthContext::AccessToken(token) => {
+                crate::auth::identity::cached_identity(token.secret())
+                    .and_then(|identity| identity.sub)
+            },
             AuthContext::Kerberos(_) => None,
         }
     }
@@ -238,7 +241,7 @@ mod tests {
     fn user_subject_returns_sub_for_auth0_token() {
         let token = FloxhubToken::from_str(FAKE_TOKEN_WITH_SUB).expect("token parses");
         assert_eq!(
-            AuthContext::Auth0(Some(token)).user_subject(),
+            AuthContext::Auth0(Some(token)).user_subject().as_deref(),
             Some("github|424242")
         );
     }
@@ -250,7 +253,7 @@ mod tests {
         let token = FloxhubToken::from_str(FAKE_EXPIRED_TOKEN_WITH_SUB).expect("token parses");
         assert!(token.is_expired(), "test premise: token is expired");
         assert_eq!(
-            AuthContext::Auth0(Some(token)).user_subject(),
+            AuthContext::Auth0(Some(token)).user_subject().as_deref(),
             Some("github|424242")
         );
     }
@@ -296,6 +299,19 @@ mod tests {
     }
 
     #[test]
+    fn pat_subject_reads_the_cached_identity() {
+        let token = AccessToken::new("flox_pat_context-subject-test".to_string());
+        crate::auth::identity::cache_identity(token.secret(), &crate::auth::UserIdentity {
+            handle: "testuser".to_string(),
+            sub: Some("auth0|123".to_string()),
+            expires_at: None,
+        });
+        let auth = AuthContext::AccessToken(token);
+
+        assert_eq!(auth.user_subject().as_deref(), Some("auth0|123"));
+    }
+
+    #[test]
     fn pat_authorization_header_is_bearer_secret() {
         let auth = pat_unresolved();
         let url = Url::parse("https://api.flox.dev").unwrap();
@@ -320,8 +336,8 @@ mod tests {
 
     #[test]
     fn new_from_token_routes_flox_prefix_to_access_token() {
-        // Any flox_-prefixed token is an opaque access token: personal
-        // access tokens today, service account tokens to come.
+        // Any flox_-prefixed token is an opaque access token, including
+        // personal and service account tokens.
         for secret in ["flox_pat_abc123", "flox_sat_abc123"] {
             let auth = AuthContext::new_from_token(Some(secret));
             let AuthContext::AccessToken(token) = auth else {
@@ -373,7 +389,10 @@ mod tests {
         // comes from the /me-filled cache, like an opaque token's.
         let token = test_bare_token("context-bare-handle-test");
         let auth = AuthContext::Bare(token.clone());
-        assert_eq!(auth.user_subject(), Some("context-bare-handle-test"));
+        assert_eq!(
+            auth.user_subject().as_deref(),
+            Some("context-bare-handle-test")
+        );
         assert_eq!(auth.handle(), None);
 
         crate::auth::identity::cache_identity(token.secret(), &test_identity("dexter"));

--- a/cli/floxhub-client/src/auth/identity.rs
+++ b/cli/floxhub-client/src/auth/identity.rs
@@ -1,16 +1,16 @@
 //! The identity behind a FloxHub credential.
 //!
 //! [`UserIdentity`] cannot be derived locally from an opaque token; it is
-//! resolved through the FloxHub client (`GET /api/v1/accounts/me`) at the
-//! point of use and cached process-wide, keyed by token secret — a token's
-//! identity never changes. This module defines the data contract and the
-//! cache only — it carries no transport.
+//! resolved through the FloxHub client (the accounts service's
+//! `GET /api/v1/accounts/me`, exposed publicly at
+//! `/accounts/api/v1/accounts/me`) at the point of use and cached process-wide,
+//! keyed by token secret — a token's identity never changes. This module
+//! defines the data contract and the cache only — it carries no transport.
 
 use std::collections::HashMap;
 use std::sync::{LazyLock, Mutex};
 
 use chrono::{DateTime, Utc};
-use serde::Deserialize;
 use thiserror::Error;
 
 /// Placeholder handle shown when a credential could not be verified (e.g.
@@ -21,11 +21,14 @@ pub const UNKNOWN_HANDLE: &str = "UNKNOWN";
 /// The identity behind a credential.
 ///
 /// Uniform across credential kinds: derived from JWT claims for Auth0,
-/// resolved from `/me` for a personal access token, and from the principal
-/// for Kerberos.
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+/// resolved from `/me` for a personal or service account token, and from the
+/// principal for Kerberos.
+#[derive(Debug, Clone, PartialEq)]
 pub struct UserIdentity {
     pub handle: String,
+    /// Pseudonymous authenticated subject. For JWTs this is the `sub`
+    /// claim; for opaque credentials it is `/me.user_id`.
+    pub sub: Option<String>,
     /// Wall-clock expiry of the presenting credential;
     /// `None` when it never expires.
     pub expires_at: Option<DateTime<Utc>>,
@@ -86,6 +89,7 @@ pub mod test_helpers {
     pub fn test_identity(handle: &str) -> UserIdentity {
         UserIdentity {
             handle: handle.to_string(),
+            sub: None,
             expires_at: None,
         }
     }

--- a/cli/floxhub-client/src/auth/token/access_token.rs
+++ b/cli/floxhub-client/src/auth/token/access_token.rs
@@ -3,17 +3,19 @@
 use crate::auth::identity;
 
 /// Prefix identifying an opaque FloxHub access token. Individual kinds carry
-/// a longer prefix (`flox_pat_` personal access tokens, service account
-/// tokens to come), but the CLI treats them uniformly and never parses them.
+/// a longer prefix (`flox_pat_` personal access tokens and `flox_sat_` service
+/// account tokens), but authentication treats them uniformly and never parses
+/// them.
 pub(crate) const ACCESS_TOKEN_PREFIX: &str = "flox_";
 
-/// An opaque access token (`flox_…`) authenticating a caller with FloxHub —
-/// a `flox_pat_` personal access token today; service account tokens to
-/// come.
+/// An opaque access token (`flox_…`) authenticating a caller with FloxHub,
+/// including `flox_pat_` personal access tokens and `flox_sat_` service
+/// account tokens.
 ///
 /// The CLI cannot decode identity from an opaque token; it is resolved via
-/// `GET /api/v1/accounts/me` (`FloxhubClient::resolve_identity`) and cached
-/// process-wide, keyed by the secret. Until resolution succeeds,
+/// the accounts service's `GET /api/v1/accounts/me` (publicly
+/// `/accounts/api/v1/accounts/me`; `FloxhubClient::resolve_identity`) and
+/// cached process-wide, keyed by the secret. Until resolution succeeds,
 /// [`Self::handle`] returns `None` — the server's 401 is the authoritative
 /// backstop.
 #[derive(Clone)]


### PR DESCRIPTION
## Proposed Changes

- Add `credential_type` to `cli.command_run` events and derive it from `AuthContext` when the events client is created.
- Report `jwt`, `pat`, `sat`, or `none` without retaining credential material.
- Populate `auth_subject` for PAT and SAT invocations from accounts `/me.user_id`; omit it when the best-effort lookup fails.
- Send `flox-invocation-id` with metrics-enabled FloxHub requests, including the `/me` lookup, so service telemetry can join an exact CLI invocation.
- Update golden envelope/header coverage and identity-resolution tests.

Prompt-hook flows do not perform the telemetry-only `/me` lookup. Keyring-backed hook invocations continue to report `credential_type: none`; explicitly configured PAT/SAT hook invocations retain their credential type but omit `auth_subject`.

The `/me` enrichment is also skipped when metrics are disabled or the metrics device UUID is unavailable. The lookup is best effort and capped at two seconds so failures do not fail the command.

## Verification

- `cargo fmt --check`
- Whitespace validation
- Independent code review

Builds and tests were not run.

## Release Notes

N/A. This changes telemetry metadata only.

Closes ENT-269
