### PR TITLE
feat(config): match auto_activate_environments keys as glob patterns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1661,6 +1661,7 @@ dependencies = [
  "anyhow",
  "config",
  "flox-core",
+ "glob",
  "indoc",
  "itertools 0.14.0",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ flox-manifest = { path = "cli/flox-manifest" }
 fslock = "0.2.1"
 fs_extra = "1.3.0"
 futures = "0.3"
+glob = "0.3.3"
 git-url-parse = "0.6.0"
 http = "1.4.0"
 # git pending:

--- a/cli/flox-activations/Cargo.toml
+++ b/cli/flox-activations/Cargo.toml
@@ -19,7 +19,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "ansi"]
 tracing-appender = "0.2"
 flox-core.workspace = true
 fslock.workspace = true
-glob = "0.3.3"
+glob.workspace = true
 nix.workspace = true
 sentry.workspace = true
 serde.workspace = true

--- a/cli/flox-config/Cargo.toml
+++ b/cli/flox-config/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 anyhow.workspace = true
 config.workspace = true
 flox-core.workspace = true
+glob.workspace = true
 itertools.workspace = true
 serde.workspace = true
 thiserror.workspace = true

--- a/cli/flox-config/src/config.rs
+++ b/cli/flox-config/src/config.rs
@@ -7,8 +7,10 @@ use anyhow::Result;
 use flox_core::activate::context::AutoActivateFishMode;
 use flox_core::data::environment_ref::RemoteEnvironmentRef;
 use flox_core::features::Features;
+use glob::{MatchOptions, Pattern};
 use serde::{Deserialize, Serialize};
 use toml_edit::Key;
+use tracing::debug;
 use url::Url;
 use xdg::BaseDirectories;
 
@@ -170,7 +172,12 @@ pub struct FloxConfig {
     pub auto_activate_fish_mode: Option<AutoActivateFishMode>,
 
     /// Per-directory auto-activation preferences.
-    /// Maps absolute paths to explicit allow/deny decisions.
+    ///
+    /// Keys are absolute project directories (the parent of `.flox`) or
+    /// shell-style glob patterns over such directories (`*` matches one path
+    /// component, `**` any depth), each mapping to an explicit allow/deny
+    /// decision. See [`resolve_auto_activation_preference`] for how a
+    /// directory is matched against the entries.
     #[serde(default)]
     pub auto_activate_environments: HashMap<PathBuf, AutoActivationPreference>,
 
@@ -242,6 +249,60 @@ pub enum AutoActivationPreference {
     Deny,
 }
 
+/// Resolve the auto-activation preference for `path` (a canonical project
+/// directory) from the `auto_activate_environments` config.
+///
+/// An exact key always wins. Otherwise every key is tried as a shell-style
+/// glob against `path`: `*` matches exactly one path component and `**`
+/// matches any depth, so `/home/me/work/*` covers the repositories directly
+/// under `work` but not `work` itself or anything nested deeper. When several
+/// patterns match and disagree, the result is `Deny`: auto-activation runs
+/// hooks, so an ambiguous configuration must not activate. Exact keys (as
+/// written by `flox activate allow`/`deny` and the consent prompt) remain the
+/// way to carve out a single directory from a pattern.
+///
+/// Keys that aren't valid UTF-8 or don't compile as a pattern are skipped so
+/// that one bad hand-edited entry can't fail every shell prompt.
+pub fn resolve_auto_activation_preference(
+    preferences: &HashMap<PathBuf, AutoActivationPreference>,
+    path: &Path,
+) -> Option<AutoActivationPreference> {
+    if let Some(preference) = preferences.get(path) {
+        return Some(preference.clone());
+    }
+
+    // A literal directory name containing a glob metacharacter is still
+    // served by the exact lookup above; it may additionally match siblings
+    // as a pattern, which is accepted rather than escaping keys on write.
+    let options = MatchOptions {
+        case_sensitive: true,
+        require_literal_separator: true,
+        require_literal_leading_dot: false,
+    };
+    let matching = preferences.iter().filter(|(key, _)| {
+        let Some(key) = key.to_str() else {
+            debug!(?key, "skipping non-UTF-8 auto_activate_environments key");
+            return false;
+        };
+        match Pattern::new(key) {
+            Ok(pattern) => pattern.matches_path_with(path, options),
+            Err(err) => {
+                debug!(key, %err, "skipping invalid auto_activate_environments pattern");
+                false
+            },
+        }
+    });
+
+    matching.fold(None, |resolved, (_, preference)| {
+        match (resolved, preference) {
+            (_, AutoActivationPreference::Deny) | (Some(AutoActivationPreference::Deny), _) => {
+                Some(AutoActivationPreference::Deny)
+            },
+            (_, AutoActivationPreference::Allow) => Some(AutoActivationPreference::Allow),
+        }
+    })
+}
+
 impl Display for InstallerChannel {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -310,5 +371,123 @@ mod tests {
             let serialized = serde_json::to_string(&channel).unwrap();
             prop_assert_eq!(display_quoted, serialized);
         }
+    }
+
+    fn preferences(
+        entries: &[(&str, AutoActivationPreference)],
+    ) -> HashMap<PathBuf, AutoActivationPreference> {
+        entries
+            .iter()
+            .map(|(key, preference)| (PathBuf::from(key), preference.clone()))
+            .collect()
+    }
+
+    fn resolve(
+        entries: &[(&str, AutoActivationPreference)],
+        path: &str,
+    ) -> Option<AutoActivationPreference> {
+        resolve_auto_activation_preference(&preferences(entries), Path::new(path))
+    }
+
+    #[test]
+    fn exact_key_matches() {
+        let entries = [("/w/a", AutoActivationPreference::Allow)];
+        assert_eq!(
+            resolve(&entries, "/w/a"),
+            Some(AutoActivationPreference::Allow)
+        );
+    }
+
+    #[test]
+    fn no_match_is_unregistered() {
+        let entries = [
+            ("/w/a", AutoActivationPreference::Allow),
+            ("/w/b/*", AutoActivationPreference::Deny),
+        ];
+        assert_eq!(resolve(&entries, "/w/c"), None);
+    }
+
+    #[test]
+    fn star_matches_single_component_only() {
+        let entries = [("/w/*", AutoActivationPreference::Allow)];
+        assert_eq!(
+            resolve(&entries, "/w/a"),
+            Some(AutoActivationPreference::Allow)
+        );
+        assert_eq!(resolve(&entries, "/w/a/b"), None);
+        assert_eq!(resolve(&entries, "/w"), None);
+    }
+
+    #[test]
+    fn double_star_matches_any_depth() {
+        let entries = [("/w/**", AutoActivationPreference::Allow)];
+        assert_eq!(
+            resolve(&entries, "/w/a"),
+            Some(AutoActivationPreference::Allow)
+        );
+        assert_eq!(
+            resolve(&entries, "/w/a/b/c"),
+            Some(AutoActivationPreference::Allow)
+        );
+    }
+
+    #[test]
+    fn exact_allow_beats_pattern_deny() {
+        let entries = [
+            ("/w/*", AutoActivationPreference::Deny),
+            ("/w/a", AutoActivationPreference::Allow),
+        ];
+        assert_eq!(
+            resolve(&entries, "/w/a"),
+            Some(AutoActivationPreference::Allow)
+        );
+        assert_eq!(
+            resolve(&entries, "/w/b"),
+            Some(AutoActivationPreference::Deny)
+        );
+    }
+
+    #[test]
+    fn exact_deny_beats_pattern_allow() {
+        let entries = [
+            ("/w/*", AutoActivationPreference::Allow),
+            ("/w/a", AutoActivationPreference::Deny),
+        ];
+        assert_eq!(
+            resolve(&entries, "/w/a"),
+            Some(AutoActivationPreference::Deny)
+        );
+        assert_eq!(
+            resolve(&entries, "/w/b"),
+            Some(AutoActivationPreference::Allow)
+        );
+    }
+
+    #[test]
+    fn conflicting_patterns_deny() {
+        let entries = [
+            ("/w/**", AutoActivationPreference::Allow),
+            ("/w/vendor/*", AutoActivationPreference::Deny),
+        ];
+        assert_eq!(
+            resolve(&entries, "/w/vendor/x"),
+            Some(AutoActivationPreference::Deny)
+        );
+        assert_eq!(
+            resolve(&entries, "/w/app"),
+            Some(AutoActivationPreference::Allow)
+        );
+    }
+
+    #[test]
+    fn invalid_pattern_is_skipped() {
+        let entries = [
+            ("/w/[", AutoActivationPreference::Deny),
+            ("/w/*", AutoActivationPreference::Allow),
+        ];
+        assert_eq!(
+            resolve(&entries, "/w/a"),
+            Some(AutoActivationPreference::Allow)
+        );
     }
 }

--- a/cli/flox-config/src/lib.rs
+++ b/cli/flox-config/src/lib.rs
@@ -22,5 +22,6 @@ pub use config::{
     PublishConfig,
     SearchLimit,
     TokenStorageMode,
+    resolve_auto_activation_preference,
 };
 pub use write::ReadWriteError;

--- a/cli/flox/doc/flox-activate-allow.md
+++ b/cli/flox/doc/flox-activate-allow.md
@@ -28,6 +28,9 @@ The preference is stored in the user config file under
 `auto_activate_environments`,
 keyed by the absolute path of the directory that contains the `.flox`
 directory.
+To cover many directories with one entry,
+set a glob pattern with `flox config --set` instead
+(see `auto_activate_environments` in [`flox-config(1)`](./flox-config.md)).
 
 By default `flox activate allow` targets the environment in the current
 directory.

--- a/cli/flox/doc/flox-activate-deny.md
+++ b/cli/flox/doc/flox-activate-deny.md
@@ -27,6 +27,9 @@ The preference is stored in the user config file under
 `auto_activate_environments`,
 keyed by the absolute path of the directory that contains the `.flox`
 directory.
+To cover many directories with one entry,
+set a glob pattern with `flox config --set` instead
+(see `auto_activate_environments` in [`flox-config(1)`](./flox-config.md)).
 
 Denying an environment does not deactivate it if it is already active;
 it only prevents future auto-activation.

--- a/cli/flox/doc/flox-activate.md
+++ b/cli/flox/doc/flox-activate.md
@@ -146,6 +146,17 @@ Manage these decisions ahead of time with the
 [`flox-activate-deny(1)`](./flox-activate-deny.md) subcommands.
 Decisions are stored in the user config file under `auto_activate_environments`.
 
+To allow or deny many directories at once,
+add a glob pattern to `auto_activate_environments` with `flox config --set`
+(`*` matches one directory name, `**` any depth):
+
+```bash
+flox config --set 'auto_activate_environments."/home/me/work/*"' allow
+```
+
+An exact path always wins over patterns;
+if matching patterns disagree, the directory is denied.
+
 See [`flox-config(1)`](./flox-config.md) for the `auto_activate`,
 `auto_activate_environments`, `auto_activate_fish_mode`, and `disable_hook`
 options.

--- a/cli/flox/doc/flox-config.md
+++ b/cli/flox/doc/flox-config.md
@@ -101,6 +101,21 @@ flox config --set 'trusted_environments."owner/name"' trust
     These are normally written for you by `flox activate allow` and
     `flox activate deny` rather than edited by hand.
 
+    A key may also be a glob pattern, so that one entry covers many
+    directories:
+    `*` matches a single directory name and `**` matches any depth.
+    An exact path always wins over patterns.
+    If several patterns match a directory and disagree, the directory is
+    denied.
+    Patterns are matched against the canonical (symlink-resolved) directory
+    path.
+    Set patterns with `flox config --set`, quoting the key:
+
+    ```bash
+    flox config --set 'auto_activate_environments."/home/me/work/*"' allow
+    flox config --set 'auto_activate_environments."/home/me/work/vendor/**"' deny
+    ```
+
 `auto_activate_fish_mode`
 :   Controls how the `fish` shell hook responds to directory changes during
     auto-activation, mirroring direnv's `direnv_fish_mode`.

--- a/cli/flox/src/commands/hook_env.rs
+++ b/cli/flox/src/commands/hook_env.rs
@@ -6,7 +6,12 @@ use anyhow::{Context, Result, bail};
 use bpaf::Bpaf;
 use flox_activations::attach_diff::diff_serializer::FLOX_HOOK_DIFF_VAR;
 use flox_activations::deactivate::embedded_hook_diff;
-use flox_config::{AutoActivate, AutoActivationPreference, Config};
+use flox_config::{
+    AutoActivate,
+    AutoActivationPreference,
+    Config,
+    resolve_auto_activation_preference,
+};
 use flox_core::activate::context::{InvocationKind, InvocationTypes};
 use flox_core::activate::vars::{
     FLOX_AUTO_ACTIVATED_ENVIRONMENTS_VAR,
@@ -466,12 +471,11 @@ struct AutoActivateContext {
     auto_activated: Vec<PathBuf>,
     /// Project directories suppressed from auto-activation in this shell.
     suppressed: Vec<PathBuf>,
-    /// Project directories the user has allowed auto-activation for via the
-    /// consent prompt or `flox activate allow` (config
-    /// `auto_activate_environments`).
+    /// Discovered project directories whose resolved preference (config
+    /// `auto_activate_environments`, exact key or pattern) is allow.
     allowed: Vec<PathBuf>,
-    /// Project directories the user has denied auto-activation for via
-    /// `flox activate deny` (config `auto_activate_environments`).
+    /// Discovered project directories whose resolved preference (config
+    /// `auto_activate_environments`, exact key or pattern) is deny.
     denied: Vec<PathBuf>,
     /// The user's `auto_activate` config value. Drives whether the planner
     /// activates allowed environments and whether it prompts for
@@ -835,7 +839,7 @@ fn gather_auto_activate_context(
     pending_deactivations: bool,
 ) -> Result<AutoActivateContext> {
     let cwd = std::env::current_dir().context("failed to read current directory")?;
-    let discovered = find_all_dot_flox(&cwd)
+    let discovered: Vec<PathBuf> = find_all_dot_flox(&cwd)
         .context("failed to discover environments for auto-activation")?
         .into_iter()
         .filter_map(|dot_flox| dot_flox.path.parent().map(Path::to_path_buf))
@@ -855,20 +859,19 @@ fn gather_auto_activate_context(
         .map(|env| env.path().and_then(Path::parent).map(Path::to_path_buf))
         .collect();
     // `flox activate allow`/`deny` key the config by the environment's parent
-    // path, which they derive by popping `.flox` off a `CanonicalPath`. Those
+    // path, which they derive by popping `.flox` off a `CanonicalPath`. Exact
     // keys are therefore already canonical and comparable to `discovered`
-    // without re-canonicalizing here.
-    let preference = |want: AutoActivationPreference| {
-        config
-            .flox
-            .auto_activate_environments
-            .iter()
-            .filter(move |(_, pref)| **pref == want)
-            .map(|(path, _)| path.clone())
-            .collect::<Vec<_>>()
-    };
-    let allowed = preference(AutoActivationPreference::Allow);
-    let denied = preference(AutoActivationPreference::Deny);
+    // without re-canonicalizing here; pattern keys are matched against the
+    // same canonical directories.
+    let mut allowed = Vec::new();
+    let mut denied = Vec::new();
+    for path in &discovered {
+        match resolve_auto_activation_preference(&config.flox.auto_activate_environments, path) {
+            Some(AutoActivationPreference::Allow) => allowed.push(path.clone()),
+            Some(AutoActivationPreference::Deny) => denied.push(path.clone()),
+            None => {},
+        }
+    }
     let auto_activate = config.flox.auto_activate.clone().unwrap_or_default();
     Ok(AutoActivateContext {
         cwd,

--- a/cli/tests/hook.bats
+++ b/cli/tests/hook.bats
@@ -636,6 +636,77 @@ EXPIRED_FLOXHUB_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3gu
 }
 
 # ---------------------------------------------------------------------------- #
+# Config: glob patterns in `auto_activate_environments` cover many directories
+# ---------------------------------------------------------------------------- #
+
+# Write a pattern entry for the directory containing the per-test projects.
+# The key is double-quoted so a `.` in the tmpdir path is not split into
+# nested tables, and `realpath` matches the canonical directories the hook
+# discovers (macOS tmpdirs live under a `/var` -> `/private/var` symlink).
+set_auto_activate_pattern() {
+  local parent
+  parent="$(dirname "$(realpath "${PROJECT2_DIR?}")")"
+  "$FLOX_BIN" config --set "auto_activate_environments.\"$parent/*\"" "$1"
+}
+
+# bats test_tags=hook:pattern:bash
+@test "bash: hook auto-activates an environment allowed by a pattern" {
+  project_setup
+  project2_setup
+  set_auto_activate_pattern allow
+
+  run --separate-stderr bash -c "
+    export FLOX_SHELL=\$(which bash)
+    eval \"\$($FLOX_BIN activate -d $PROJECT_DIR)\"
+    cd $PROJECT2_DIR
+    _flox_hook
+    echo \"var2:\${TEST_VAR2:-unset}\"
+    echo \"tracked:\${_FLOX_AUTO_ACTIVATED_ENVIRONMENTS:-unset}\"
+  "
+  assert_success
+  # Activated without a consent prompt, and tracked as an auto-activation.
+  assert_output --partial "var2:auto2"
+  assert_output --partial "$(realpath "$PROJECT2_DIR")"
+}
+
+# bats test_tags=hook:pattern:bash
+@test "bash: hook skips an environment denied by a pattern" {
+  project_setup
+  project2_setup
+  set_auto_activate_pattern deny
+
+  run --separate-stderr bash -c "
+    export FLOX_SHELL=\$(which bash)
+    eval \"\$($FLOX_BIN activate -d $PROJECT_DIR)\"
+    cd $PROJECT2_DIR
+    _flox_hook
+    echo \"var2:\${TEST_VAR2:-unset}\"
+    echo \"tracked:\${_FLOX_AUTO_ACTIVATED_ENVIRONMENTS:-unset}\"
+  "
+  assert_success
+  assert_output --partial "var2:unset"
+  assert_output --partial "tracked:unset"
+}
+
+# bats test_tags=hook:pattern:bash
+@test "bash: exact 'flox activate allow' overrides a deny pattern" {
+  project_setup
+  project2_setup
+  set_auto_activate_pattern deny
+  "$FLOX_BIN" activate allow -d "$PROJECT2_DIR"
+
+  run --separate-stderr bash -c "
+    export FLOX_SHELL=\$(which bash)
+    eval \"\$($FLOX_BIN activate -d $PROJECT_DIR)\"
+    cd $PROJECT2_DIR
+    _flox_hook
+    echo \"var2:\${TEST_VAR2:-unset}\"
+  "
+  assert_success
+  assert_output --partial "var2:auto2"
+}
+
+# ---------------------------------------------------------------------------- #
 # Config: 'prompt' mode (the default) asks for consent before auto-activating
 # ---------------------------------------------------------------------------- #
 


### PR DESCRIPTION
Resolves DEV-280.

## Summary

`auto_activate_environments` keys can now be shell-style glob patterns, so one entry can allow or deny auto-activation for many project directories — the path analogue of the `owner/*` wildcard that `trusted_environments` already supports.

```bash
flox config --set 'auto_activate_environments."/home/me/work/*"' allow
flox config --set 'auto_activate_environments."/home/me/work/vendor/**"' deny
```

### Semantics

- `*` matches exactly one path component, `**` any depth (`glob::Pattern` with `require_literal_separator`). `/home/me/work/*` matches `/home/me/work/repo` but not `/home/me/work` itself or `/home/me/work/a/b`.
- An exact key always wins over patterns.
- If several patterns match a directory and disagree, the directory is **denied**: auto-activation runs hooks, so an ambiguous configuration must not activate. Exact keys (written by `flox activate allow -d` and the consent prompt) remain the way to carve out a single directory.
- Keys that don't compile as a pattern (or aren't UTF-8) are skipped with a debug log so one bad hand-edited entry can't fail every shell prompt.

### Implementation

- `resolve_auto_activation_preference` in `flox-config` next to `AutoActivationPreference`, mirroring `resolve_trust`.
- `gather_auto_activate_context` resolves each discovered directory up front; `plan_auto_activation` and its tests are untouched.
- Config format is unchanged (`HashMap<PathBuf, AutoActivationPreference>`): a pattern is just a key. No migration. `flox activate allow`/`deny` and the consent prompt keep writing exact canonical paths.
- `glob` promoted to a workspace dependency (was pinned directly in `flox-activations`).
- Docs updated in `flox-config.md`, `flox-activate.md`, `flox-activate-allow.md`, `flox-activate-deny.md`.

A `--pattern` flag for `flox activate allow`/`deny` is deliberately out of scope; it will be tracked as a follow-up.

## Testing

- Unit tests for the resolver in `flox-config` (exact, `*` vs `**`, exact-beats-pattern both ways, conflicting patterns deny, invalid pattern skipped).
- Three new `hook.bats` tests (tag `hook:pattern:bash`): allowed by pattern, denied by pattern, exact `flox activate allow` overriding a deny pattern.
- Full `hook.bats` (48/48) and `hook_env` planner unit tests pass unchanged.

## Release Notes

`auto_activate_environments` keys may now be glob patterns (`*` matches one directory name, `**` any depth), so a single entry can allow or deny auto-activation for many repositories. An exact path always wins; if matching patterns disagree, the directory is denied. Example: `flox config --set 'auto_activate_environments."/home/me/work/*"' allow`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
