### PR TITLE
fix(nixos): make services.flox.enable the switch for everything materialized

### DIFF
--- a/modules/README.md
+++ b/modules/README.md
@@ -28,7 +28,7 @@ at `/etc/nixos/configuration.nix`) enable Flox by adding the following line:
 {...}: {
 
   imports = [
-    /etc/nixos/flox/modules/nixos.nix
+    /etc/nixos/flox/modules/nixos
   ]
 
   # The rest of your NixOS configuration

--- a/modules/nixos/README.md
+++ b/modules/nixos/README.md
@@ -42,6 +42,7 @@ from the activated Flox environment.
 
 Example:
 ```nix
+  services.flox.enable = true;
   systemd.services.echoip.flox = {
     environment = "flox/echoip";
     trustEnvironment = true;
@@ -49,6 +50,10 @@ Example:
     execStart = "echoip -l 127.0.0.1:8080 -H X-Real-IP";
   };
 ```
+
+`services.flox.enable` switches on the units and state directory that both
+methods share, so it is required for this method as well.
+Without it nothing is added to the system and the override is not applied.
 
 While the Services method presents the easiest/most intuitive interface
 from a Flox perspective, the overrides approach makes it possible to leverage the

--- a/modules/nixos/check.nix
+++ b/modules/nixos/check.nix
@@ -66,12 +66,39 @@ let
   serviceOptionDocs = descriptionsOf sys.options.services.flox;
   overridesOptionDocs = descriptionsOf (sys.options.systemd.services.type.getSubOptions [ ]).flox;
 
+  # With the services subsystem disabled nothing is added to the system:
+  # the `programs.flox` half only installs the CLI and sets substituters.
+  disabledSys = lib.nixosSystem {
+    system = "x86_64-linux";
+    modules = [
+      module
+      {
+        system.stateVersion = "25.05";
+        systemd.services.sample-override.flox = {
+          environment = "flox/sample";
+          execStart = "sample --flag";
+        };
+      }
+    ];
+  };
+  disabledUnits = lib.filter (lib.hasPrefix "flox-") (lib.attrNames disabledSys.config.systemd.units);
+  disabledTmpfiles = lib.filter (lib.hasInfix "flox") disabledSys.config.systemd.tmpfiles.rules;
+
+  # An override configured without `services.flox.enable` is reported
+  # rather than left to fail at runtime on a missing flox-pull@ unit.
+  disabledAssertions = lib.filter (
+    assertion: !assertion.assertion && lib.hasInfix "services.flox.enable" assertion.message
+  ) disabledSys.config.assertions;
+
   moduleAssertions = lib.filter (
     assertion: !assertion.assertion && lib.hasInfix "flox" assertion.message
   ) sys.config.assertions;
 
 in
 assert moduleAssertions == [ ];
+assert disabledUnits == [ ];
+assert disabledTmpfiles == [ ];
+assert lib.length disabledAssertions == 1;
 builtins.deepSeq (unitTexts ++ serviceOptionDocs ++ overridesOptionDocs) (
   pkgs.writeText "flox-nixos-module-check" "ok"
 )

--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -40,6 +40,7 @@ in
          environment.
 
          Enabled with:
+           services.flox.enable = true;
            systemd.services.echoip.flox = {
              environment = "flox/echoip";
              trustEnvironment = true;

--- a/modules/nixos/overrides.nix
+++ b/modules/nixos/overrides.nix
@@ -8,7 +8,7 @@
 
 let
   inherit (config.programs.flox) package;
-  inherit (config.services.flox) stateDir;
+  inherit (config.services.flox) enable stateDir;
   inherit (utils.systemdUtils.lib) makeJobScript;
   inherit (lib)
     escapeShellArgs
@@ -118,7 +118,7 @@ let
         };
       };
 
-      config = mkIf (fCfg.environment != null) {
+      config = mkIf (enable && fCfg.environment != null) {
         # The pull unit provisions the environment on first start and
         # refreshes it thereafter (see pullAtServiceStart). A failed
         # refresh of an existing environment exits successfully, so this
@@ -158,7 +158,11 @@ in
 
   config = {
     assertions =
-      mapAttrsToList (name: svc: {
+      mapAttrsToList (name: _: {
+        assertion = enable;
+        message = "systemd.services.${name}.flox.environment is set but services.flox.enable is false. Set services.flox.enable = true to run units from Flox environments.";
+      }) floxManagedServices
+      ++ mapAttrsToList (name: svc: {
         assertion = svc.flox.execStart != "" || svc.flox.script != "" || svc.script != "";
         message = "systemd.services.${name}.flox.environment is set but there is no command to run. Set systemd.services.${name}.flox.execStart or systemd.services.${name}.flox.script.";
       }) floxManagedServices
@@ -169,21 +173,23 @@ in
 
     # Provisioning, scheduled pulls and restart-on-change are handled by
     # the flox-pull@/flox-autopull@ template units; see pull.nix.
-    services.flox.pull.configs = mapAttrs (name: svc: {
-      unit = "${name}.service";
-      user = toString (svc.serviceConfig.User or "root");
-      group = toString (svc.serviceConfig.Group or "");
-      environment = svc.flox.environment;
-      workingDirectory = workingDirectory name;
-      inherit (svc.flox)
-        extraFloxArgs
-        extraFloxPullArgs
-        pullAtServiceStart
-        floxHubTokenFile
-        ;
-      autoPull = svc.flox.autoPull.enable;
-      autoPullDates = svc.flox.autoPull.dates;
-      autoRestart = svc.flox.autoRestart.enable;
-    }) floxManagedServices;
+    services.flox.pull.configs = mkIf enable (
+      mapAttrs (name: svc: {
+        unit = "${name}.service";
+        user = toString (svc.serviceConfig.User or "root");
+        group = toString (svc.serviceConfig.Group or "");
+        environment = svc.flox.environment;
+        workingDirectory = workingDirectory name;
+        inherit (svc.flox)
+          extraFloxArgs
+          extraFloxPullArgs
+          pullAtServiceStart
+          floxHubTokenFile
+          ;
+        autoPull = svc.flox.autoPull.enable;
+        autoPullDates = svc.flox.autoPull.dates;
+        autoRestart = svc.flox.autoRestart.enable;
+      }) floxManagedServices
+    );
   };
 }

--- a/modules/nixos/pull.nix
+++ b/modules/nixos/pull.nix
@@ -7,13 +7,14 @@
 
 let
   inherit (config.programs.flox) package;
-  inherit (config.services.flox) stateDir workingDirectoryMode;
+  inherit (config.services.flox) enable stateDir workingDirectoryMode;
   inherit (lib)
     escapeShellArg
     escapeShellArgs
     filterAttrs
     mapAttrs'
     mapAttrsToList
+    mkIf
     mkOption
     nameValuePair
     optionalString
@@ -202,10 +203,11 @@ in
     };
   };
 
-  config = {
-    # The templates are inert without instances, so they are declared
-    # unconditionally. Gating them on `pullConfigs != { }` would make the
-    # merge of `systemd.services` depend on its own values and diverge.
+  config = mkIf enable {
+    # The templates are inert without instances, so instances are not part
+    # of the condition here. It must stay a plain user-set flag: gating on
+    # `pullConfigs != { }` would make the merge of `systemd.services`
+    # depend on its own values and diverge.
     systemd.services."flox-pull@" = templateUnit "start";
     systemd.services."flox-autopull@" = templateUnit "timer";
 


### PR DESCRIPTION
Stacked on #2873, targeting that branch rather than `main`.

## Proposed Changes

The module being replaced (`modules/nixos.nix`) contributed exactly two things: the Flox CLI in `environment.systemPackages` when `programs.flox.enable` is set, and the cache substituters. The new module keeps that interface intact — same option names, same defaults, same output, verified by diffing an evaluated NixOS system against both — but `pull.nix` also declared the `flox-pull@` and `flox-autopull@` template units and a `d /var/lib/flox` tmpfiles rule unconditionally.

That means importing `nixosModules.flox` purely to install the CLI creates `/var/lib/flox` and places two unit files on the system, even with `programs.flox.enable = false`. It is not maskable in any reasonable way: `disabledModules` on `pull.nix` orphans the `services.flox.pull.configs` declaration, `mkForce` on `systemd.tmpfiles.rules` discards every other module's rules, and all rules share one generated `00-nixos.conf` so file-level masking takes everything with it.

This gates both on `services.flox.enable`, so `programs.flox` installs the CLI and sets substituters and nothing else.

The recursion constraint noted in `pull.nix` still holds and the comment is kept — gating on `pullConfigs != { }` would make the merge of `systemd.services` depend on its own values. `services.flox.enable` is a plain user-set flag, so it does not have that problem.

### Interface change

The Overrides method previously worked without `services.flox.enable`, so the flag really meant "the activations method is on" rather than "the Flox services subsystem is on". With the shared template units gated, an override configured without the flag would emit a unit with `Requires=flox-pull@<name>.service` and no template to satisfy it — a runtime unit-not-found with nothing caught at evaluation.

So the flag now gates both methods, with an assertion when an override is configured without it:

```
systemd.services.echoip.flox.environment is set but services.flox.enable is false.
Set services.flox.enable = true to run units from Flox environments.
```

The README example and the `default.nix` doc comment gain the required line. Since #2873 has not merged, nothing outside this branch depends on the old behavior.

## Testing

`checks.<system>.nixos-module` gains a second evaluated system asserting that with the subsystem disabled no `flox-` units and no flox tmpfiles rules are produced, and that a bare override is reported. Confirmed the guard fails when the `pull.nix` gating is reverted.

Verified by evaluating a NixOS system across five configurations:

| config | flox in PATH | substituters | flox units | `/var/lib/flox` | users |
|---|---|---|---|---|---|
| nothing set | yes | yes | none | none | none |
| `programs.flox.enable = false` | no | yes | none | none | none |
| `services.flox.enable` + activation | yes | yes | 3 | yes | `flox-echoip` |
| override, flag unset | yes | yes | none (assertion) | none | none |
| override + flag | yes | yes | 3 | yes | — |

The first two rows match the module being replaced exactly.

Also fixes `modules/README.md`, which still pointed the non-flake import at the deleted `modules/nixos.nix`.
