### PR TITLE
fix(build,publish)!: replace per-package catalog locks with a committed project catalog.lock

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,46 @@ than the target host supports, breaking portability.
 cd ld-floxlib && make clean && make && make test
 ```
 
+## Makefile conventions (`package-builder/flox-build.mk`)
+
+GNU make's dependency semantics express most lifecycle logic on their
+own. If a recipe contains shell logic deciding whether its own work
+should happen, the rule is probably modeling the wrong thing — reach
+for a make feature first:
+
+- **Create-if-missing artifact:** a file target with no prerequisites.
+  The recipe runs only when the file is absent; an existing file is
+  authoritative. No `[ -f ... ]` recipe guards.
+- **Temp file the build may create for itself:** mark it
+  `.INTERMEDIATE`, unconditionally. make deletes an intermediate it
+  created at the end of the run (and on fatal signals) and leaves a
+  pre-existing file untouched — that distinction needs no flag
+  variables and no `rm` bookkeeping.
+- **Steps that must run on every invocation** are `.PHONY` themselves
+  (see the next bullet) — phony-ness does not propagate, so transitive
+  reach through the phony `check-build-prerequisites` root is not
+  enough. The root's job is validation and ordering; do not add it as a
+  direct prerequisite of targets that already reach it — redundant
+  edges obscure the graph.
+- **A real file that must be regenerated unconditionally** (the
+  per-invocation build chain: source lists/tarballs, build caches,
+  rendered build scripts, evals, build outputs, result files): mark the
+  target `.PHONY`. make then triggers the recipe irrespective of the
+  file's presence or timestamp, so the rule can never tie with
+  prerequisites written in the same second. Phony-ness does not
+  propagate — a phony prerequisite forces only its direct dependent,
+  whose own output is again an ordinary file — so mark every link of a
+  must-regenerate chain, not just its head. Prefer this over a
+  `FORCE`-style empty prerequisite, which an out-of-band file named
+  `FORCE` would defeat. Cross-invocation caching is nix's job, not
+  make's.
+- **Returning data to the CLI:** fold it into `build-meta.json`
+  (`jq --slurpfile`), never hand back a path for the caller to read
+  and clean up. Each subsystem cleans up the files it creates.
+- `mkVarname`'s define body carries leading whitespace: `$(strip ...)`
+  the result, or launder it through an assignment, before interpolating
+  it into a variable name.
+
 ## Testing
 
 ### Mock Data Generation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3164,6 +3164,7 @@ dependencies = [
  "rowan",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -10,7 +10,7 @@ use flox_manifest::parsed::Inner;
 use flox_manifest::parsed::common::DEFAULT_GROUP_NAME;
 use flox_manifest::parsed::latest::BuildSandbox;
 use flox_manifest::{Manifest, MigratedTypedOnly};
-use floxhub_client::{BaseCatalogUrl, LockedInputEntry, PackageSystem};
+use floxhub_client::{BaseCatalogUrl, LockedInputEntry};
 use indoc::formatdoc;
 use itertools::Itertools;
 use nef_lock_catalog::NixFlakeref;
@@ -68,48 +68,18 @@ pub trait ManifestBuilder {
     /// `nef_stability` is the stability used to resolve the catalog build
     /// inputs of NEF (expression) builds, as selected by the `--stability`
     /// flag. When [None] the Makefile falls back to its default stability.
-    ///
-    /// Each package carries its own [`CatalogLock`], naming where that
-    /// package's catalog lock lives. Locks are per package because a build
-    /// resolves one per package; a single lock shared across `packages` would
-    /// only be well-defined when building exactly one.
+    #[allow(clippy::too_many_arguments)]
     fn build(
         self,
         expression_build_nixpkgs: &Url,
         flox_interpreter: &Path,
-        packages: &[(PackageTargetName, CatalogLock)],
+        packages: &[PackageTargetName],
         nef_stability: Option<String>,
         build_cache: Option<bool>,
         system_override: Option<String>,
     ) -> Result<BuildResults, ManifestBuilderError>;
 
     fn clean(self, package: &[PackageTargetName]) -> Result<(), ManifestBuilderError>;
-
-    /// Compute the catalog lock for `packages` without building them.
-    ///
-    /// Stops at the catalog-lock targets in the underlying Makefile (the
-    /// `lock` goal), so no package build is performed and no `result-*`
-    /// symlinks are created. Used to make the closure identity available
-    /// ahead of a build, e.g. for publish dedup.
-    ///
-    /// Pass [`CatalogLock::File`] to write a package's lock somewhere the
-    /// caller can hand to a later [`ManifestBuilder::build`], which is how a
-    /// build reuses the lock this call resolved. An existing file at that path
-    /// is taken as-is rather than re-resolved, so locking over a lock a
-    /// previous call wrote reports that lock's closure back unchanged.
-    ///
-    /// [`CatalogLock::Ephemeral`] is accepted and locks into a directory the
-    /// builder chooses: the closure identity still comes back, and
-    /// [`LockResult::catalog_lockfile`] names where the lock landed. It is not
-    /// a lock a following build can be made to reuse, though — an ephemeral
-    /// lock is re-resolved on every invocation — so a build that must consume
-    /// exactly this lock has to be given a [`CatalogLock::File`] here.
-    fn lock(
-        self,
-        packages: &[(PackageTargetName, CatalogLock)],
-        nef_stability: Option<String>,
-        system_override: Option<String>,
-    ) -> Result<LockResults, ManifestBuilderError>;
 }
 
 #[derive(Debug, Error, strum::IntoStaticStr)]
@@ -126,15 +96,6 @@ pub enum ManifestBuilderError {
 
     #[error("failed to parse file for build results")]
     ParseBuildResultFile(#[source] serde_json::Error),
-
-    #[error("failed to create file for lock results")]
-    CreateLockResultFile(#[source] std::io::Error),
-
-    #[error("failed to read file for lock results")]
-    ReadLockResultFile(#[source] std::io::Error),
-
-    #[error("failed to parse file for lock results")]
-    ParseLockResultFile(#[source] serde_json::Error),
 
     #[error("failed to call nix to eval NEF")]
     CallNef(#[source] std::io::Error),
@@ -153,14 +114,6 @@ pub enum ManifestBuilderError {
     // whole process group).
     #[error("Build failed")]
     BuildFailure { status: ExitStatus },
-
-    #[error("Failed to compute the catalog lock.")]
-    LockFailure,
-
-    #[error(
-        "The catalog lock path contains whitespace, which the package builder cannot represent: {0}\nChoose a lock path without spaces or tabs."
-    )]
-    CatalogLockPathWithWhitespace(PathBuf),
 }
 
 #[derive(Debug, PartialEq, Deserialize, Default, derive_more::Deref)]
@@ -185,124 +138,6 @@ pub struct BuildResult {
     // TODO: factor out and use buildenv::BuiltStorePath (?)
     #[serde(rename = "resultLinks")]
     pub result_links: BTreeMap<PathBuf, PathBuf>,
-}
-
-/// Deserialization mirror of [`BuildResults`] for the `lock` goal's
-/// `LOCK_RESULT_FILE`: the catalog lock's closure identity, computed
-/// without performing a package build.
-#[derive(Clone, Debug, PartialEq, Deserialize, Default, derive_more::Deref)]
-pub struct LockResults(Vec<LockResult>);
-
-/// Deserialization mirror of [`BuildResult`]'s closure-identity fields.
-#[derive(Clone, Debug, PartialEq, Deserialize)]
-pub struct LockResult {
-    /// The package this lock belongs to, so a caller locking several packages
-    /// at once can tell the results apart.
-    pub pname: String,
-    /// Where the lock this result was projected from actually lives.
-    ///
-    /// This is the authoritative path, not an echo of what the caller asked
-    /// for: a [`CatalogLock::Ephemeral`] package locks into a directory only
-    /// the builder knows, and this is the only way a caller learns it.
-    ///
-    /// [None] for build modes that resolve no catalog inputs and so write no
-    /// lock at all (manifest builds).
-    #[serde(default)]
-    pub catalog_lockfile: Option<PathBuf>,
-    #[serde(deserialize_with = "deserialize_package_system")]
-    pub system: PackageSystem,
-    /// The direct catalog inputs the lock phase resolved, keyed by
-    /// locked-input reference. Empty for build modes (e.g. manifest builds)
-    /// that resolve no catalog inputs.
-    #[serde(default)]
-    pub direct_catalog_inputs: HashMap<String, LockedInputEntry>,
-}
-
-/// Parse a lock result's system, naming the offending value when it is not a
-/// system Flox can build for.
-///
-/// The value comes from the builder's `NIX_SYSTEM`, i.e. from `--system` when
-/// the user passed one. The derived deserializer would report it as an unknown
-/// variant of an internal type, which reads as a malformed lock result rather
-/// than as the unsupported system that actually caused it.
-fn deserialize_package_system<'de, D>(deserializer: D) -> Result<PackageSystem, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let system = String::deserialize(deserializer)?;
-    std::str::FromStr::from_str(&system).map_err(|_| {
-        serde::de::Error::custom(format!(
-            "'{system}' is not a system Flox can build for; expected 'aarch64-darwin', 'aarch64-linux', 'x86_64-darwin' or 'x86_64-linux'"
-        ))
-    })
-}
-
-/// Where a package's catalog lock lives.
-///
-/// The caller names the location rather than discovering one the Makefile
-/// chose, which is what lets a lock phase and a following build phase agree
-/// on a single artifact — and what will let a lock file be passed in from
-/// the command line or read from a checkout.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum CatalogLock {
-    /// Let the builder lock into its own temporary directory. The lock is
-    /// resolved fresh on every invocation and is not meant to outlive it.
-    Ephemeral,
-    /// Use the lock file at this path, resolving into it when it does not
-    /// exist yet. An existing file is taken as-is and never re-resolved, so
-    /// the caller decides when a lock becomes stale.
-    File(PathBuf),
-}
-
-/// The `CATALOG_LOCKS` make-variable assignment naming each package's lock.
-///
-/// [`CatalogLock::Ephemeral`] packages are omitted: absence of an entry is
-/// what tells the Makefile to lock into its own temporary directory.
-///
-/// The result is passed as a single argument, so make reads it as one
-/// command-line variable assignment whose value happens to contain spaces —
-/// the second and later `<pname>=<path>` pairs are part of that value, not
-/// assignments of their own.
-///
-/// The Makefile splits this variable into words to find a package's entry
-/// (`catalogLockFor`), and make's word functions have no notion of quoting or
-/// escaping, so a path containing whitespace cannot be represented here at
-/// all. Such a path is rejected rather than passed through: the Makefile would
-/// otherwise silently take the prefix up to the first space as the lock path,
-/// and that prefix is the same on every run, so a later invocation would find
-/// the earlier run's file and reuse a closure that was never resolved for it.
-fn catalog_locks_make_arg(
-    packages: &[(PackageTargetName, CatalogLock)],
-) -> Result<String, ManifestBuilderError> {
-    let locks = packages
-        .iter()
-        .filter_map(|(name, lock)| match lock {
-            CatalogLock::Ephemeral => None,
-            CatalogLock::File(path) => Some((name, path)),
-        })
-        .map(|(name, path)| {
-            if path
-                .as_os_str()
-                .to_string_lossy()
-                .contains(char::is_whitespace)
-            {
-                return Err(ManifestBuilderError::CatalogLockPathWithWhitespace(
-                    path.clone(),
-                ));
-            }
-            Ok(format!("{}={}", name.as_ref(), path.display()))
-        })
-        .process_results(|mut entries| entries.join(" "))?;
-
-    Ok(format!("CATALOG_LOCKS={locks}"))
-}
-
-/// The `PACKAGES` make-variable assignment listing the packages to act on.
-fn packages_make_arg(packages: &[(PackageTargetName, CatalogLock)]) -> String {
-    format!(
-        "PACKAGES={}",
-        packages.iter().map(|(name, _)| name.as_ref()).join(" ")
-    )
 }
 
 /// Represents different license formats that can be found in package metadata
@@ -461,113 +296,6 @@ impl FloxBuildMk<'_> {
 
         command
     }
-
-    /// The make variables the `build` and `lock` goals both read: the packages
-    /// to act on, where each one's catalog lock lives, the environment they
-    /// are defined in, and the stability/system overrides when the caller
-    /// selected any.
-    ///
-    /// Everything a single goal needs (`EXPRESSION_BUILD_NIXPKGS_URL` and
-    /// `FLOX_INTERPRETER` for `build`, the respective result file for either)
-    /// stays at its call site: the lock goal stops before eval, so passing
-    /// those to it would suggest it uses them.
-    fn common_goal_args(
-        &self,
-        command: &mut Command,
-        packages: &[(PackageTargetName, CatalogLock)],
-        nef_stability: Option<String>,
-        system_override: Option<String>,
-    ) -> Result<(), ManifestBuilderError> {
-        command.arg(format!("BUILDTIME_NIXPKGS_URL={}", &*COMMON_NIXPKGS_URL));
-
-        // The stability used to resolve NEF catalog build inputs. Only passed
-        // when the caller selected one via `--stability`; otherwise the
-        // Makefile applies its own default.
-        if let Some(nef_stability) = nef_stability {
-            command.arg(format!("EXPRESSION_BUILD_STABILITY={nef_stability}"));
-        }
-
-        if let Some(system_override) = system_override {
-            command.arg(format!("NIX_SYSTEM={system_override}"));
-        }
-
-        command.arg(catalog_locks_make_arg(packages)?);
-
-        command.arg(format!(
-            "FLOX_ENV={}",
-            self.built_environments.dev.display()
-        ));
-        command.arg(format!(
-            "FLOX_ENV_OUTPUTS={}",
-            serde_json::json!(self.built_environments)
-        ));
-        // The lock goal needs the cache as much as the build goal does: a
-        // manifest build's `version.command` runs in a build-mode activation
-        // while the makefile parses, whichever goal was asked for.
-        command.arg(format!("FLOX_ENV_CACHE={}", self.flox_env_cache.display()));
-
-        // TODO: modify flox-build.mk to allow missing expression dirs
-        let expression_ref = self.expression_ref.as_url();
-        command.arg(format!("NIX_EXPRESSION_REF={expression_ref}"));
-
-        // Add the list of packages to act on by passing a space-delimited list
-        // of pnames in the PACKAGES variable. The makefile errors if it is not
-        // defined or empty, except for `build`, which builds all packages.
-        command.arg(packages_make_arg(packages));
-
-        Ok(())
-    }
-
-    /// Run `command` to completion, collecting its output into the
-    /// std{out,err} buffers when the builder was given any.
-    ///
-    /// Consumes the builder: filling the buffers is the last thing any
-    /// invocation does with them, and taking them by value here is what lets
-    /// the taps own them until the process exits.
-    fn run_to_completion(self, mut command: Command) -> Result<ExitStatus, ManifestBuilderError> {
-        if self.stdout_buffer.is_some() {
-            command.stdout(Stdio::piped());
-        }
-
-        if self.stderr_buffer.is_some() {
-            command.stderr(Stdio::piped());
-        }
-
-        let mut child = command
-            .spawn()
-            .map_err(ManifestBuilderError::CallBuilderError)?;
-
-        // setup `WireTap` for stdout
-        let stdout_tap_context = self.stdout_buffer.map(|buffer| {
-            let stdout = child
-                .stdout
-                .take()
-                .expect("STDOUT is piped when stdout_buffer is provided");
-            let tap = stdout.tap_lines(|_| {});
-            (tap, buffer)
-        });
-
-        // setup `WireTap` for stderr
-        let stderr_tap_context = self.stderr_buffer.map(|buffer| {
-            let stderr = child
-                .stderr
-                .take()
-                .expect("STDERR is piped when stderr_buffer is provided");
-            let tap = stderr.tap_lines(|_| {});
-            (tap, buffer)
-        });
-
-        // **After** taps have been started for std{out,err},
-        // read until EOF on both outputs, i.e. wait until the process terminates.
-        if let Some((tap, buffer)) = stdout_tap_context {
-            *buffer = tap.wait()
-        }
-        if let Some((tap, buffer)) = stderr_tap_context {
-            *buffer = tap.wait()
-        }
-
-        child.wait().map_err(ManifestBuilderError::CallBuilderError)
-    }
 }
 
 impl ManifestBuilder for FloxBuildMk<'_> {
@@ -595,23 +323,56 @@ impl ManifestBuilder for FloxBuildMk<'_> {
     /// of manifest and expression build if `expression_build_nixpkgs_url`
     /// is different from the environments toplevel group,
     /// i.e. manifest builds and expression builds would use incompatible nixpkgs.
+    #[allow(clippy::too_many_arguments)]
     fn build(
         self,
         expression_build_nixpkgs_url: &Url,
         flox_interpreter: &Path,
-        packages: &[(PackageTargetName, CatalogLock)],
+        packages: &[PackageTargetName],
         nef_stability: Option<String>,
         build_cache: Option<bool>,
         system_override: Option<String>,
     ) -> Result<BuildResults, ManifestBuilderError> {
         let mut command = self.base_command(self.base_dir);
         command.arg("build");
+        command.arg(format!("BUILDTIME_NIXPKGS_URL={}", &*COMMON_NIXPKGS_URL));
         command.arg(format!(
             "EXPRESSION_BUILD_NIXPKGS_URL={expression_build_nixpkgs_url}"
         ));
+
+        // The stability used to resolve NEF catalog build inputs. Only passed
+        // when the caller selected one via `--stability`; otherwise the
+        // Makefile applies its own default.
+        if let Some(nef_stability) = nef_stability {
+            command.arg(format!("EXPRESSION_BUILD_STABILITY={nef_stability}"));
+        }
+
+        if let Some(system_override) = system_override {
+            command.arg(format!("NIX_SYSTEM={system_override}"));
+        }
+
+        command.arg(format!(
+            "FLOX_ENV={}",
+            self.built_environments.dev.display()
+        ));
+        command.arg(format!(
+            "FLOX_ENV_OUTPUTS={}",
+            serde_json::json!(self.built_environments)
+        ));
+        command.arg(format!("FLOX_ENV_CACHE={}", self.flox_env_cache.display()));
+
+        // TODO: modify flox-build.mk to allow missing expression dirs
+        let expression_ref = self.expression_ref.as_url();
+        command.arg(format!("NIX_EXPRESSION_REF={expression_ref}"));
         command.arg(format!("FLOX_INTERPRETER={}", flox_interpreter.display()));
 
-        self.common_goal_args(&mut command, packages, nef_stability, system_override)?;
+        // Add the list of packages to be built by passing a space-delimited list
+        // of pnames in the PACKAGES variable. If no packages are specified then
+        // the makefile will build all packages by default.
+        command.arg(format!(
+            "PACKAGES={}",
+            packages.iter().map(|name| name.as_ref()).join(" ")
+        ));
 
         let build_result_path = NamedTempFile::new_in(self.temp_dir)
             .map_err(ManifestBuilderError::CreateBuildResultFile)?
@@ -629,9 +390,52 @@ impl ManifestBuilder for FloxBuildMk<'_> {
             command.arg("DISABLE_BUILDCACHE=true");
         }
 
+        if self.stdout_buffer.is_some() {
+            command.stdout(Stdio::piped());
+        }
+
+        if self.stderr_buffer.is_some() {
+            command.stderr(Stdio::piped());
+        }
+
         debug!(command = %command.display(), "running manifest build target");
 
-        let status = self.run_to_completion(command)?;
+        let mut child = command
+            .spawn()
+            .map_err(ManifestBuilderError::CallBuilderError)?;
+
+        // setup `WireTap` for stdout
+        let stdout_tap_context = self.stdout_buffer.map(|buffer| {
+            let stdout = child
+                .stdout
+                .take()
+                .expect("STDOUT is piped when stdout_buffer is provided");
+            let tap = stdout.tap_lines(|_| {});
+            (tap, buffer)
+        });
+
+        // setup `WireTap` for stderr
+        let stderr_tap_context = self.stderr_buffer.map(|buffer| {
+            let stderr = child
+                .stderr
+                .take()
+                .expect("STDERR is piped when stdout_buffer is provided");
+            let tap = stderr.tap_lines(|_| {});
+            (tap, buffer)
+        });
+
+        // **After** taps have been started for std{out,err},
+        // read until EOF on both outputs, i.e. wait until the process terminates.
+        if let Some((tap, buffer)) = stdout_tap_context {
+            *buffer = tap.wait()
+        }
+        if let Some((tap, buffer)) = stderr_tap_context {
+            *buffer = tap.wait()
+        }
+
+        let status = child
+            .wait()
+            .map_err(ManifestBuilderError::CallBuilderError)?;
 
         if !status.success() {
             return Err(ManifestBuilderError::BuildFailure { status });
@@ -688,60 +492,56 @@ impl ManifestBuilder for FloxBuildMk<'_> {
 
         debug!(command=%command.display(), "running manifest clean target");
 
-        let status = self.run_to_completion(command)?;
+        if self.stdout_buffer.is_some() {
+            command.stdout(Stdio::piped());
+        }
+
+        if self.stderr_buffer.is_some() {
+            command.stderr(Stdio::piped());
+        }
+
+        let mut child = command
+            .spawn()
+            .map_err(ManifestBuilderError::CallBuilderError)?;
+
+        // setup `WireTap` for stdout
+        let stdout_tap_context = self.stdout_buffer.map(|buffer| {
+            let stdout = child
+                .stdout
+                .take()
+                .expect("STDOUT is piped when stdout_buffer is provided");
+            let tap = stdout.tap_lines(|_| {});
+            (tap, buffer)
+        });
+
+        // setup `WireTap` for stderr
+        let stderr_tap_context = self.stderr_buffer.map(|buffer| {
+            let stderr = child
+                .stderr
+                .take()
+                .expect("STDERR is piped when stdout_buffer is provided");
+            let tap = stderr.tap_lines(|_| {});
+            (tap, buffer)
+        });
+
+        // **After** taps have been started for std{out,err},
+        // read until EOF on both outputs, i.e. wait until the process terminates.
+        if let Some((tap, buffer)) = stdout_tap_context {
+            *buffer = tap.wait()
+        }
+        if let Some((tap, buffer)) = stderr_tap_context {
+            *buffer = tap.wait()
+        }
+
+        let status = child
+            .wait()
+            .map_err(ManifestBuilderError::CallBuilderError)?;
 
         if !status.success() {
             return Err(ManifestBuilderError::RunClean { status });
         }
 
         Ok(())
-    }
-
-    /// Compute the catalog lock for `packages` defined in the environment
-    /// rendered at `flox_env`, using the [FLOX_BUILD_MK] makefile's `lock`
-    /// goal.
-    ///
-    /// Mirrors [`ManifestBuilder::build`], but targets `make lock` instead of
-    /// `make build`: it passes only [`FloxBuildMk::common_goal_args`] plus its
-    /// own `LOCK_RESULT_FILE`, and never `EXPRESSION_BUILD_NIXPKGS_URL` or
-    /// `FLOX_INTERPRETER`, since the lock goal stops before eval/build.
-    fn lock(
-        self,
-        packages: &[(PackageTargetName, CatalogLock)],
-        nef_stability: Option<String>,
-        system_override: Option<String>,
-    ) -> Result<LockResults, ManifestBuilderError> {
-        let mut command = self.base_command(self.base_dir);
-        command.arg("lock");
-
-        self.common_goal_args(&mut command, packages, nef_stability, system_override)?;
-
-        let lock_result_path = NamedTempFile::new_in(self.temp_dir)
-            .map_err(ManifestBuilderError::CreateLockResultFile)?
-            .into_temp_path();
-
-        // SAFETY: according to the docs, this is fallible on _Windows_
-        let lock_result_path = lock_result_path
-            .keep()
-            .expect("failed to keep lock result file");
-
-        command.arg(format!("LOCK_RESULT_FILE={}", lock_result_path.display()));
-
-        debug!(command = %command.display(), "running manifest lock target");
-
-        let status = self.run_to_completion(command)?;
-
-        if !status.success() {
-            return Err(ManifestBuilderError::LockFailure);
-        }
-
-        let lock_results = std::fs::read_to_string(&lock_result_path)
-            .map_err(ManifestBuilderError::ReadLockResultFile)?;
-
-        let lock_results = serde_json::from_str(&lock_results)
-            .map_err(ManifestBuilderError::ParseLockResultFile)?;
-
-        Ok(lock_results)
     }
 }
 
@@ -1092,10 +892,7 @@ pub mod test_helpers {
         .build(
             &toplevel_or_common_nixpkgs,
             &env.rendered_env_links(flox).unwrap().dev,
-            &[(
-                PackageTargetName::new_unchecked(&package),
-                CatalogLock::Ephemeral,
-            )],
+            &[PackageTargetName::new_unchecked(&package)],
             None,
             build_cache,
             None,
@@ -1120,38 +917,6 @@ pub mod test_helpers {
             stdout: output_stdout,
             stderr: output_stderr,
         }
-    }
-
-    /// Runs [`ManifestBuilder::lock`] for `package` against `expression_ref`
-    /// and returns the parsed [`LockResults`]. Mirrors
-    /// [`assert_build_status_with_nix_expr`], but drives the `lock` goal
-    /// instead of `build`, so no package build occurs and no `result-*`
-    /// symlinks are created.
-    pub fn lock_with_nix_expr(
-        flox: &Flox,
-        env: &mut PathEnvironment,
-        expression_ref: &NixFlakeref,
-        package: &str,
-    ) -> LockResults {
-        let base_dir = env.parent_path().unwrap();
-        let built_environments = env.build(flox).unwrap();
-        let cache_path = env.cache_path().unwrap();
-        FloxBuildMk::new(
-            flox,
-            &base_dir,
-            expression_ref,
-            &built_environments,
-            &cache_path,
-        )
-        .lock(
-            &[(
-                PackageTargetName::new_unchecked(&package),
-                CatalogLock::Ephemeral,
-            )],
-            None,
-            None,
-        )
-        .expect("lock() should succeed")
     }
 
     /// Runs a build and asserts that the `ExitStatus` matches `expect_status`.
@@ -1478,7 +1243,6 @@ mod tests {
     use std::fs::{self, File};
     use std::os::unix::fs::PermissionsExt;
     use std::os::unix::process::ExitStatusExt;
-    use std::str::FromStr;
 
     use anyhow::Context;
     use flox_manifest::interfaces::{AsWritableManifest, WriteManifest};
@@ -1505,80 +1269,6 @@ mod tests {
         };
         let slug: &'static str = (&err).into();
         assert_eq!(slug, "build.build_failure");
-    }
-
-    #[test]
-    fn catalog_locks_make_arg_omits_ephemeral_packages() {
-        // An empty assignment is still passed, so an exported CATALOG_LOCKS
-        // cannot reach the Makefile: a command-line assignment wins in GNU
-        // make, and absence of an entry is what selects a fresh lock.
-        assert_eq!(
-            catalog_locks_make_arg(&[(
-                PackageTargetName::new_unchecked(&"foo"),
-                CatalogLock::Ephemeral,
-            )])
-            .unwrap(),
-            "CATALOG_LOCKS="
-        );
-    }
-
-    #[test]
-    fn catalog_locks_make_arg_names_a_lock_per_package() {
-        assert_eq!(
-            catalog_locks_make_arg(&[
-                (
-                    PackageTargetName::new_unchecked(&"foo"),
-                    CatalogLock::File(PathBuf::from("/locks/foo.lock")),
-                ),
-                (
-                    PackageTargetName::new_unchecked(&"bar"),
-                    CatalogLock::Ephemeral,
-                ),
-                (
-                    PackageTargetName::new_unchecked(&"baz"),
-                    CatalogLock::File(PathBuf::from("/locks/baz.lock")),
-                ),
-            ])
-            .unwrap(),
-            "CATALOG_LOCKS=foo=/locks/foo.lock baz=/locks/baz.lock"
-        );
-    }
-
-    /// An unsupported `--system` reaches Rust as the lock result's `system`
-    /// field, so the parse failure has to name the value the user passed
-    /// rather than report an unknown variant of an internal type.
-    #[test]
-    fn lock_result_parse_error_names_the_unsupported_system() {
-        let err = serde_json::from_str::<LockResults>(
-            r#"[{"pname": "foo", "system": "riscv64-linux", "direct_catalog_inputs": {}}]"#,
-        )
-        .unwrap_err();
-
-        assert!(
-            err.to_string().contains("riscv64-linux"),
-            "expected the offending system to be named, got: {err}"
-        );
-    }
-
-    /// The Makefile finds a package's lock by splitting `CATALOG_LOCKS` into
-    /// words, so a path containing whitespace would arrive truncated at the
-    /// first space — and truncated identically on every run, which is what
-    /// would make a later invocation reuse an earlier run's lock. Reject the
-    /// path instead of emitting one that means something else.
-    #[test]
-    fn catalog_locks_make_arg_rejects_a_lock_path_containing_whitespace() {
-        let path = PathBuf::from("/tmp/my locks/foo.lock");
-
-        let err = catalog_locks_make_arg(&[(
-            PackageTargetName::new_unchecked(&"foo"),
-            CatalogLock::File(path.clone()),
-        )])
-        .unwrap_err();
-
-        assert!(
-            matches!(&err, ManifestBuilderError::CatalogLockPathWithWhitespace(p) if *p == path),
-            "expected a whitespace rejection, got: {err:?}"
-        );
     }
 
     #[test]
@@ -1613,33 +1303,6 @@ mod tests {
 
         assert_build_status(&flox, &mut env, &package_name, None, true);
         assert_build_file(&env_path, &package_name, &file_name, &file_content);
-    }
-
-    #[test]
-    fn manifest_lock_returns_empty_catalog_inputs() {
-        let package_name = String::from("foo");
-
-        let manifest = formatdoc! {r#"
-            version = 1
-
-            [build.{package_name}]
-            command = "mkdir $out"
-        "#};
-
-        let (flox, _temp_dir_handle) = flox_instance();
-        let mut env = new_path_environment(&flox, &manifest);
-        let expression_ref = NixFlakeref::from_path(env.dot_flox_path()).unwrap();
-
-        // Manifest builds resolve no catalog inputs, so the lock goal emits an
-        // empty map without building anything — and no lock file, hence no
-        // `catalog_lockfile` to report.
-        let lock_results = lock_with_nix_expr(&flox, &mut env, &expression_ref, &package_name);
-        assert_eq!(*lock_results, vec![LockResult {
-            pname: package_name,
-            catalog_lockfile: None,
-            system: PackageSystem::from_str(&flox.system).unwrap(),
-            direct_catalog_inputs: HashMap::new(),
-        }]);
     }
 
     #[test]
@@ -4270,414 +3933,17 @@ mod tests {
 #[cfg(test)]
 mod nef_tests {
     use std::fs;
-    use std::str::FromStr;
 
     use indoc::{formatdoc, indoc};
     use pretty_assertions::assert_eq;
-    use tempfile::tempdir_in;
 
     use super::*;
     use crate::flox::test_helpers::flox_instance;
     use crate::models::environment::path_environment::test_helpers::new_path_environment;
     use crate::providers::build::test_helpers::{
         assert_build_status_with_nix_expr,
-        lock_with_nix_expr,
         prepare_nix_expressions_in,
     };
-    use crate::providers::git::tests::test_git_options;
-    use crate::providers::git::{GitCommandProvider, GitProvider};
-
-    #[test]
-    fn nef_lock_matches_build_catalog_inputs_and_skips_build() {
-        let pname = "foo".to_string();
-
-        let (flox, tempdir) = flox_instance();
-
-        // Create a manifest (may be empty)
-        let manifest = formatdoc! {r#"
-            version = 1
-        "#};
-        let mut env = new_path_environment(&flox, &manifest);
-        let env_path = env.parent_path().unwrap();
-
-        // Create expressions
-        let expressions_ref = prepare_nix_expressions_in(&tempdir, &[(&[&pname], indoc! {r#"
-            {runCommand}: runCommand "{pname}" {} ''
-                echo -n "Hello, World!" >> $out
-            ''
-            "#})]);
-
-        // lock() should compute the catalog lock without building.
-        let lock_results = lock_with_nix_expr(&flox, &mut env, &expressions_ref, &pname);
-        assert_eq!(lock_results.len(), 1);
-        assert_eq!(
-            lock_results[0].system,
-            PackageSystem::from_str(&flox.system).unwrap()
-        );
-
-        // `lock_with_nix_expr` locks ephemerally, so the reported path is the
-        // only way to reach the lock the builder wrote.
-        let catalog_lockfile = lock_results[0]
-            .catalog_lockfile
-            .as_ref()
-            .expect("a NEF lock reports where it wrote the catalog lock");
-        assert!(
-            catalog_lockfile.exists(),
-            "the reported catalog lock path must name a file that exists"
-        );
-
-        let result_path = env_path.join(format!("result-{pname}"));
-        assert!(
-            !result_path.exists(),
-            "lock() must not create a result-* symlink"
-        );
-
-        // A full build's direct_catalog_inputs must match what lock()
-        // recorded (this fixture references no catalog packages, so both
-        // are empty; the equality still exercises the lock/build parity).
-        // See nef_lock_matches_build_catalog_inputs_and_skips_build_with_populated_catalog_input
-        // for the populated-map case.
-        let collected = assert_build_status_with_nix_expr(
-            &flox,
-            &mut env,
-            &expressions_ref,
-            &pname,
-            None,
-            true,
-        );
-        let build_results = collected.build_results.unwrap();
-        assert_eq!(
-            lock_results[0].direct_catalog_inputs,
-            build_results[0].direct_catalog_inputs
-        );
-    }
-
-    /// A NEF expression directory whose `foo` package references a real
-    /// catalog input (`catalogs.myorg.hello`), together with the
-    /// `_FLOX_USE_CATALOG_MOCK` recording that resolves that reference.
-    struct PopulatedCatalogInput {
-        expressions_ref: NixFlakeref,
-        mock_recording: PathBuf,
-    }
-
-    /// Build the [`PopulatedCatalogInput`] fixture under `tempdir`.
-    ///
-    /// The catalog `/build-inputs/lookup` endpoint is mocked hermetically via
-    /// `_FLOX_USE_CATALOG_MOCK` (an httpmock recording, no network). The
-    /// resolved package's source is a local git repository — the same
-    /// directory that hosts the `foo` package under test also hosts a `hello`
-    /// package, and doubles as `hello`'s own git-fetchable catalog source — so
-    /// `nix build` can actually fetch and build it via
-    /// `builtins.fetchTree {type = "git"; url = "file://...";}`, which resolves
-    /// from the local filesystem with no network access.
-    ///
-    /// TODO(ECO-136, ECO-137): this hand-rolled recording is the minimum that
-    /// makes lock/build parity observable on a populated catalog input; it is
-    /// not the lockfile-mock or e2e-fixture layer those tickets are for. Move
-    /// it onto whatever they land rather than growing more fixtures here.
-    fn populated_catalog_input(flox: &Flox, tempdir: &Path, pname: &str) -> PopulatedCatalogInput {
-        // `foo` references a real catalog input (`catalogs.myorg.hello`).
-        // `hello` is the catalog-side NEF package the mocked lookup below
-        // resolves that reference to.
-        let expressions_dir = tempdir_in(tempdir).unwrap().keep();
-        let pkgs_dir = expressions_dir.join("pkgs");
-        fs::create_dir_all(pkgs_dir.join(pname)).unwrap();
-        fs::write(pkgs_dir.join(pname).join("default.nix"), indoc! {r#"
-            {catalogs, runCommand}: runCommand "foo" {} ''
-                echo -n "Hello, World!" >> $out
-                cat ${catalogs.myorg.hello} >> $out
-            ''
-            "#})
-        .unwrap();
-        fs::create_dir_all(pkgs_dir.join("hello")).unwrap();
-        fs::write(pkgs_dir.join("hello").join("default.nix"), indoc! {r#"
-            {runCommand}: runCommand "hello" {} ''
-                echo -n "Hello from the catalog" > $out
-            ''
-            "#})
-        .unwrap();
-        let expressions_ref =
-            NixFlakeref::from_path(expressions_dir.canonicalize().unwrap()).unwrap();
-
-        // Turn the same directory into a git repo so it can serve as the
-        // catalog package's fetchable source: the mocked lookup response
-        // below points `myorg.hello` at this repo/rev, attr_path ["hello"].
-        let git =
-            GitCommandProvider::init_with(test_git_options(), &expressions_dir, false).unwrap();
-        git.add(&[&expressions_dir]).unwrap();
-        git.commit("add nef catalog fixtures").unwrap();
-        let status = git.status().unwrap();
-        let catalog_source_url = Url::from_file_path(&expressions_dir).unwrap();
-        let catalog_source_ref = status
-            .ref_
-            .expect("freshly committed repo has a symbolic HEAD ref");
-
-        let response_body = serde_json::json!({
-            "groups": {
-                "default": {
-                    "lock": {
-                        "myorg.hello": {
-                            "attr_path": ["hello"],
-                            "build_type": "nef",
-                            "catalog": "myorg",
-                            "locked_inputs_hash": "sha256-test-fixture",
-                            "source": {
-                                "dir": ".",
-                                "ref": catalog_source_ref,
-                                "rev": status.rev,
-                                "type": "git",
-                                "url": catalog_source_url.as_str(),
-                            },
-                        },
-                    },
-                    "matched": {"myorg.hello": ["myorg.hello"]},
-                    "unresolvable": [],
-                },
-            },
-            "version": 1,
-        });
-        let recording = serde_json::json!({
-            "when": {
-                "method": "POST",
-                "path": "/api/v1/catalog/build-inputs/lookup",
-                "json_body": {
-                    "groups": [{"key": "default", "references": ["myorg.hello"]}],
-                    "stability": "unstable",
-                },
-            },
-            "then": {
-                "status": 200,
-                "header": [{"name": "content-type", "value": "application/json"}],
-                "body": serde_json::to_string(&response_body).unwrap(),
-            },
-        });
-        let mock_recording = flox.temp_dir.join("catalog_lookup_mock.yaml");
-        fs::write(&mock_recording, serde_json::to_string(&recording).unwrap()).unwrap();
-
-        PopulatedCatalogInput {
-            expressions_ref,
-            mock_recording,
-        }
-    }
-
-    /// Companion to `nef_lock_matches_build_catalog_inputs_and_skips_build`:
-    /// that test's fixture references no catalog packages, so its parity
-    /// assertion is `{} == {}` and would pass even if catalog inputs were
-    /// dropped or mis-projected. This test resolves a real catalog
-    /// reference and asserts lock/build parity on the populated map.
-    #[test]
-    fn nef_lock_matches_build_catalog_inputs_and_skips_build_with_populated_catalog_input() {
-        let pname = "foo".to_string();
-
-        let (flox, tempdir) = flox_instance();
-
-        let manifest = formatdoc! {r#"
-            version = 1
-        "#};
-        let mut env = new_path_environment(&flox, &manifest);
-        let base_dir = env.parent_path().unwrap();
-
-        let PopulatedCatalogInput {
-            expressions_ref,
-            mock_recording,
-        } = populated_catalog_input(&flox, tempdir.path(), &pname);
-
-        let built_environments = env.build(&flox).unwrap();
-        let cache_path = env.cache_path().unwrap();
-
-        let toplevel_or_common_nixpkgs =
-            find_toplevel_group_nixpkgs(&env.lockfile(&flox).unwrap().into())
-                .map(|toplevel_nixpkgs| toplevel_nixpkgs.as_flake_ref().unwrap())
-                .unwrap_or_else(|| COMMON_NIXPKGS_URL.clone());
-
-        // The make/nix subprocesses inherit the recording from this process at
-        // spawn time. `temp_env` serializes concurrent mutators, so tests that
-        // set it do not race each other over this process-wide variable.
-        let (lock_results, build_results) = temp_env::with_var(
-            "_FLOX_USE_CATALOG_MOCK",
-            Some(mock_recording.as_os_str()),
-            || {
-                // lock() should compute the catalog lock without building.
-                let lock_results = FloxBuildMk::new(
-                    &flox,
-                    &base_dir,
-                    &expressions_ref,
-                    &built_environments,
-                    &cache_path,
-                )
-                .lock(
-                    &[(
-                        PackageTargetName::new_unchecked(&pname),
-                        CatalogLock::Ephemeral,
-                    )],
-                    None,
-                    None,
-                )
-                .expect("lock() should succeed");
-
-                let build_results = FloxBuildMk::new(
-                    &flox,
-                    &base_dir,
-                    &expressions_ref,
-                    &built_environments,
-                    &cache_path,
-                )
-                .build(
-                    &toplevel_or_common_nixpkgs,
-                    &env.rendered_env_links(&flox).unwrap().dev,
-                    &[(
-                        PackageTargetName::new_unchecked(&pname),
-                        CatalogLock::Ephemeral,
-                    )],
-                    None,
-                    None,
-                    None,
-                )
-                .expect("build() should succeed");
-
-                (lock_results, build_results)
-            },
-        );
-
-        assert_eq!(lock_results.len(), 1);
-        assert!(
-            !lock_results[0].direct_catalog_inputs.is_empty(),
-            "expected the mocked lookup to populate a real catalog input"
-        );
-
-        // A full build's direct_catalog_inputs must match what lock()
-        // recorded, now exercised against a populated map.
-        assert_eq!(
-            lock_results[0].direct_catalog_inputs,
-            build_results[0].direct_catalog_inputs
-        );
-    }
-
-    /// `lock()` resolves into the caller's [`CatalogLock::File`] and a
-    /// following `build()` over that same file consumes it instead of
-    /// resolving the catalog a second time. This is the single-lock guarantee
-    /// the publish reorder depends on (a naive `make lock` then `make build`
-    /// re-locks, since the catalog lock's DAG root is `.PHONY`).
-    ///
-    /// The load-bearing evidence is that the build runs with the catalog mock
-    /// out of scope: the fixture's `foo` references a catalog package, so a
-    /// build that did not consume the supplied lock would have to resolve
-    /// `myorg.hello` itself, and with no mock it cannot. Comparing the lock
-    /// file's mtime across the build is kept as a supporting assertion only —
-    /// on its own it cannot detect the feature's removal, since a build that
-    /// re-resolves does so into its own temporary directory and leaves the
-    /// caller's file untouched.
-    #[test]
-    fn build_uses_the_catalog_lock_a_preceding_lock_call_wrote() {
-        let pname = "foo".to_string();
-
-        let (flox, tempdir) = flox_instance();
-
-        let manifest = formatdoc! {r#"
-            version = 1
-        "#};
-        let mut env = new_path_environment(&flox, &manifest);
-        let base_dir = env.parent_path().unwrap();
-
-        let PopulatedCatalogInput {
-            expressions_ref,
-            mock_recording,
-        } = populated_catalog_input(&flox, tempdir.path(), &pname);
-
-        let built_environments = env.build(&flox).unwrap();
-        let cache_path = env.cache_path().unwrap();
-
-        // The caller owns the lock's location, so the test knows it up front
-        // rather than re-deriving the Makefile's temporary-directory layout.
-        let lock_file = tempdir_in(&tempdir).unwrap().keep().join("catalog.lock");
-        let catalog_lock = CatalogLock::File(lock_file.clone());
-
-        // The mock is in scope for the lock phase only. The build below
-        // deliberately runs with it unset — see the doc comment.
-        let lock_results = temp_env::with_var(
-            "_FLOX_USE_CATALOG_MOCK",
-            Some(mock_recording.as_os_str()),
-            || {
-                FloxBuildMk::new(
-                    &flox,
-                    &base_dir,
-                    &expressions_ref,
-                    &built_environments,
-                    &cache_path,
-                )
-                .lock(
-                    &[(
-                        PackageTargetName::new_unchecked(&pname),
-                        catalog_lock.clone(),
-                    )],
-                    None,
-                    None,
-                )
-                .expect("lock() should succeed")
-            },
-        );
-
-        assert!(
-            !lock_results[0].direct_catalog_inputs.is_empty(),
-            "expected the mocked lookup to populate a real catalog input"
-        );
-
-        let mtime_after_lock = fs::metadata(&lock_file)
-            .expect("lock() should have resolved into the supplied lock file")
-            .modified()
-            .unwrap();
-
-        let toplevel_or_common_nixpkgs =
-            find_toplevel_group_nixpkgs(&env.lockfile(&flox).unwrap().into())
-                .map(|toplevel_nixpkgs| toplevel_nixpkgs.as_flake_ref().unwrap())
-                .unwrap_or_else(|| COMMON_NIXPKGS_URL.clone());
-
-        // A second, distinct `FloxBuildMk` instance over the *same* base_dir
-        // (mirroring how `lock_build_inputs`/`check_build_metadata` share one
-        // `RenderedSource` in the publish reorder) — and deliberately outside
-        // the catalog mock, so the build can only succeed by using the lock.
-        // Unsetting rather than merely not setting matters: it holds
-        // `temp_env`'s lock for the duration, so a concurrent test that scopes
-        // a recording of its own cannot lend this build one.
-        let build_results = temp_env::with_var_unset("_FLOX_USE_CATALOG_MOCK", || {
-            FloxBuildMk::new(
-                &flox,
-                &base_dir,
-                &expressions_ref,
-                &built_environments,
-                &cache_path,
-            )
-            .build(
-                &toplevel_or_common_nixpkgs,
-                &env.rendered_env_links(&flox).unwrap().dev,
-                &[(PackageTargetName::new_unchecked(&pname), catalog_lock)],
-                None,
-                None,
-                None,
-            )
-            .expect(
-                "build() should succeed over the caller-supplied lock, without resolving the catalog",
-            )
-        });
-
-        // Positive evidence that the build's closure is the locked one, rather
-        // than one it resolved for itself.
-        assert_eq!(
-            lock_results[0].direct_catalog_inputs,
-            build_results[0].direct_catalog_inputs
-        );
-
-        let mtime_after_build = fs::metadata(&lock_file)
-            .expect("the supplied lock file should still exist after build()")
-            .modified()
-            .unwrap();
-
-        assert_eq!(
-            mtime_after_lock, mtime_after_build,
-            "build() must not re-resolve a catalog lock that already exists at \
-             the caller-supplied path"
-        );
-    }
 
     #[test]
     fn nef_build_creates_out_link() {

--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -10,7 +10,7 @@ use flox_manifest::parsed::Inner;
 use flox_manifest::parsed::common::DEFAULT_GROUP_NAME;
 use flox_manifest::parsed::latest::BuildSandbox;
 use flox_manifest::{Manifest, MigratedTypedOnly};
-use floxhub_client::{BaseCatalogUrl, LockedInputEntry};
+use floxhub_client::BaseCatalogUrl;
 use indoc::formatdoc;
 use itertools::Itertools;
 use nef_lock_catalog::NixFlakeref;
@@ -65,16 +65,17 @@ pub trait ManifestBuilder {
     /// at Makefile parse time without requiring a second `nix eval` discovery
     /// call.
     ///
-    /// `nef_stability` is the stability used to resolve the catalog build
-    /// inputs of NEF (expression) builds, as selected by the `--stability`
-    /// flag. When [None] the Makefile falls back to its default stability.
+    /// `catalog_lockfile` is the catalog lock the build's NEF evals consume,
+    /// created by the CLI (the committed .flox/catalog.lock, or a fresh
+    /// ephemeral lock) and passed through as `CATALOG_LOCKFILE`. Required
+    /// whenever the project has Nix expression builds.
     #[allow(clippy::too_many_arguments)]
     fn build(
         self,
         expression_build_nixpkgs: &Url,
         flox_interpreter: &Path,
         packages: &[PackageTargetName],
-        nef_stability: Option<String>,
+        catalog_lockfile: Option<&Path>,
         build_cache: Option<bool>,
         system_override: Option<String>,
     ) -> Result<BuildResults, ManifestBuilderError>;
@@ -130,11 +131,6 @@ pub struct BuildResult {
     pub version: String,
     pub system: String,
     pub log: BuiltStorePath,
-    /// The direct catalog inputs the build locked, keyed by locked-input
-    /// reference. Emitted by NEF builds; absent (and so empty) for build modes
-    /// that resolve no catalog inputs.
-    #[serde(rename = "direct_catalog_inputs", default)]
-    pub direct_catalog_inputs: HashMap<String, LockedInputEntry>,
     // TODO: factor out and use buildenv::BuiltStorePath (?)
     #[serde(rename = "resultLinks")]
     pub result_links: BTreeMap<PathBuf, PathBuf>,
@@ -296,6 +292,53 @@ impl FloxBuildMk<'_> {
 
         command
     }
+
+    /// Spawn `command`, mirroring its stdout/stderr into the builder's
+    /// buffers when provided, and wait for it to exit. Consumes the builder,
+    /// so goals call this last, after all arguments are assembled.
+    fn run_to_completion(self, mut command: Command) -> Result<ExitStatus, ManifestBuilderError> {
+        if self.stdout_buffer.is_some() {
+            command.stdout(Stdio::piped());
+        }
+        if self.stderr_buffer.is_some() {
+            command.stderr(Stdio::piped());
+        }
+
+        let mut child = command
+            .spawn()
+            .map_err(ManifestBuilderError::CallBuilderError)?;
+
+        // setup `WireTap` for stdout
+        let stdout_tap_context = self.stdout_buffer.map(|buffer| {
+            let stdout = child
+                .stdout
+                .take()
+                .expect("STDOUT is piped when stdout_buffer is provided");
+            let tap = stdout.tap_lines(|_| {});
+            (tap, buffer)
+        });
+
+        // setup `WireTap` for stderr
+        let stderr_tap_context = self.stderr_buffer.map(|buffer| {
+            let stderr = child
+                .stderr
+                .take()
+                .expect("STDERR is piped when stdout_buffer is provided");
+            let tap = stderr.tap_lines(|_| {});
+            (tap, buffer)
+        });
+
+        // **After** taps have been started for std{out,err},
+        // read until EOF on both outputs, i.e. wait until the process terminates.
+        if let Some((tap, buffer)) = stdout_tap_context {
+            *buffer = tap.wait()
+        }
+        if let Some((tap, buffer)) = stderr_tap_context {
+            *buffer = tap.wait()
+        }
+
+        child.wait().map_err(ManifestBuilderError::CallBuilderError)
+    }
 }
 
 impl ManifestBuilder for FloxBuildMk<'_> {
@@ -329,7 +372,7 @@ impl ManifestBuilder for FloxBuildMk<'_> {
         expression_build_nixpkgs_url: &Url,
         flox_interpreter: &Path,
         packages: &[PackageTargetName],
-        nef_stability: Option<String>,
+        catalog_lockfile: Option<&Path>,
         build_cache: Option<bool>,
         system_override: Option<String>,
     ) -> Result<BuildResults, ManifestBuilderError> {
@@ -340,11 +383,11 @@ impl ManifestBuilder for FloxBuildMk<'_> {
             "EXPRESSION_BUILD_NIXPKGS_URL={expression_build_nixpkgs_url}"
         ));
 
-        // The stability used to resolve NEF catalog build inputs. Only passed
-        // when the caller selected one via `--stability`; otherwise the
-        // Makefile applies its own default.
-        if let Some(nef_stability) = nef_stability {
-            command.arg(format!("EXPRESSION_BUILD_STABILITY={nef_stability}"));
+        // The catalog lock the NEF evals consume. The CLI owns the lock's
+        // lifecycle; the package builder requires the path whenever the
+        // project has expression builds.
+        if let Some(catalog_lockfile) = catalog_lockfile {
+            command.arg(format!("CATALOG_LOCKFILE={}", catalog_lockfile.display()));
         }
 
         if let Some(system_override) = system_override {
@@ -390,52 +433,9 @@ impl ManifestBuilder for FloxBuildMk<'_> {
             command.arg("DISABLE_BUILDCACHE=true");
         }
 
-        if self.stdout_buffer.is_some() {
-            command.stdout(Stdio::piped());
-        }
-
-        if self.stderr_buffer.is_some() {
-            command.stderr(Stdio::piped());
-        }
-
         debug!(command = %command.display(), "running manifest build target");
 
-        let mut child = command
-            .spawn()
-            .map_err(ManifestBuilderError::CallBuilderError)?;
-
-        // setup `WireTap` for stdout
-        let stdout_tap_context = self.stdout_buffer.map(|buffer| {
-            let stdout = child
-                .stdout
-                .take()
-                .expect("STDOUT is piped when stdout_buffer is provided");
-            let tap = stdout.tap_lines(|_| {});
-            (tap, buffer)
-        });
-
-        // setup `WireTap` for stderr
-        let stderr_tap_context = self.stderr_buffer.map(|buffer| {
-            let stderr = child
-                .stderr
-                .take()
-                .expect("STDERR is piped when stdout_buffer is provided");
-            let tap = stderr.tap_lines(|_| {});
-            (tap, buffer)
-        });
-
-        // **After** taps have been started for std{out,err},
-        // read until EOF on both outputs, i.e. wait until the process terminates.
-        if let Some((tap, buffer)) = stdout_tap_context {
-            *buffer = tap.wait()
-        }
-        if let Some((tap, buffer)) = stderr_tap_context {
-            *buffer = tap.wait()
-        }
-
-        let status = child
-            .wait()
-            .map_err(ManifestBuilderError::CallBuilderError)?;
+        let status = self.run_to_completion(command)?;
 
         if !status.success() {
             return Err(ManifestBuilderError::BuildFailure { status });
@@ -549,7 +549,13 @@ impl ManifestBuilder for FloxBuildMk<'_> {
 /// Available expression builds are discovered with in this directory
 /// (see [get_nix_expression_targets] for the discovery results).
 pub fn nix_expression_dir(environment: &impl Environment) -> PathBuf {
-    environment.dot_flox_path().join("pkgs")
+    nix_expression_dir_in(environment.dot_flox_path())
+}
+
+/// The expression directory within a `.flox` directory, for callers that
+/// hold the path rather than the environment.
+pub fn nix_expression_dir_in(dot_flox_path: impl AsRef<Path>) -> PathBuf {
+    dot_flox_path.as_ref().join("pkgs")
 }
 
 pub fn build_symlink_path(
@@ -869,6 +875,7 @@ pub mod test_helpers {
         env: &mut PathEnvironment,
         expression_ref: &NixFlakeref,
         package: &str,
+        catalog_lockfile: Option<&Path>,
         build_cache: Option<bool>,
         expect_success: bool,
     ) -> CollectedOutput {
@@ -876,6 +883,19 @@ pub mod test_helpers {
             find_toplevel_group_nixpkgs(&env.lockfile(flox).unwrap().into())
                 .map(|toplevel_nixpkgs| toplevel_nixpkgs.as_flake_ref().unwrap())
                 .unwrap_or_else(|| COMMON_NIXPKGS_URL.clone());
+
+        // NEF builds require a CLI-provided catalog lock; expressions with no
+        // catalog references consume an empty one, so write that default for
+        // callers that need nothing more.
+        let empty_lock_path = flox.temp_dir.join("empty-catalog.lock");
+        let catalog_lockfile = catalog_lockfile.unwrap_or_else(|| {
+            std::fs::write(
+                &empty_lock_path,
+                "{\"version\": 1, \"direct_catalog_inputs\": {}, \"catalogs\": {}}\n",
+            )
+            .unwrap();
+            &empty_lock_path
+        });
 
         let mut output_stdout = String::new();
         let mut output_stderr = String::new();
@@ -893,7 +913,7 @@ pub mod test_helpers {
             &toplevel_or_common_nixpkgs,
             &env.rendered_env_links(flox).unwrap().dev,
             &[PackageTargetName::new_unchecked(&package)],
-            None,
+            Some(catalog_lockfile),
             build_cache,
             None,
         );
@@ -934,6 +954,7 @@ pub mod test_helpers {
             env,
             &NixFlakeref::from_path(env.dot_flox_path()).unwrap(),
             package_name,
+            None,
             build_cache,
             expect_success,
         )
@@ -1002,7 +1023,17 @@ pub mod test_helpers {
         base: impl AsRef<Path>,
         expressions: &[(&[&str], &str)],
     ) -> NixFlakeref {
-        let all_expressions_base_dir = tempdir_in(&base).unwrap().keep();
+        prepare_nix_expressions_dir_in(base, expressions).1
+    }
+
+    /// As [prepare_nix_expressions_in], additionally returning the directory
+    /// the expressions were written to, for tests that must reach the files
+    /// themselves — e.g. to commit them as a package's fetchable source.
+    pub fn prepare_nix_expressions_dir_in(
+        base: impl AsRef<Path>,
+        expressions: &[(&[&str], &str)],
+    ) -> (PathBuf, NixFlakeref) {
+        let all_expressions_base_dir = tempdir_in(&base).unwrap().keep().canonicalize().unwrap();
 
         for (attr_path, expr) in expressions {
             let expression_dir = all_expressions_base_dir
@@ -1012,7 +1043,8 @@ pub mod test_helpers {
             fs::write(expression_dir.join("default.nix"), expr).unwrap();
         }
 
-        NixFlakeref::from_path(all_expressions_base_dir.canonicalize().unwrap()).unwrap()
+        let expressions_ref = NixFlakeref::from_path(&all_expressions_base_dir).unwrap();
+        (all_expressions_base_dir, expressions_ref)
     }
 
     /// Create a flakeref that provides no expressions
@@ -1794,6 +1826,7 @@ mod tests {
 
         let cache_dir = cache_dir(&env_path, &package_name);
         assert!(cache_dir.exists());
+
         fs::remove_file(cache_dir).unwrap();
 
         assert_build_status(&flox, &mut env, &package_name, None, true);
@@ -3932,9 +3965,12 @@ mod tests {
 
 #[cfg(test)]
 mod nef_tests {
+    use std::collections::HashMap;
     use std::fs;
 
+    use floxhub_client::LockedInputEntry;
     use indoc::{formatdoc, indoc};
+    use nef_lock_catalog::{build_lock_from_locked_inputs, write_lock};
     use pretty_assertions::assert_eq;
 
     use super::*;
@@ -3942,8 +3978,105 @@ mod nef_tests {
     use crate::models::environment::path_environment::test_helpers::new_path_environment;
     use crate::providers::build::test_helpers::{
         assert_build_status_with_nix_expr,
+        prepare_nix_expressions_dir_in,
         prepare_nix_expressions_in,
     };
+    use crate::providers::git::tests::test_git_options;
+    use crate::providers::git::{GitCommandProvider, GitProvider};
+
+    /// Write a catalog lock pinning `catalogs.myorg.hello` to `source_dir`
+    /// at its current revision: the lock the CLI hands the package builder
+    /// as CATALOG_LOCKFILE, assembled from one locked catalog entry the way
+    /// a real resolution assembles it — so the fixture cannot drift from the
+    /// lock format — with no catalog involved. The entry is keyed in the
+    /// server's canonical `<catalog>/<attr-path>` form, which the expression
+    /// references in dot-rendered form.
+    fn write_catalog_lock(path: &Path, repo: &GitCommandProvider, source_dir: &Path) {
+        let status = repo.status().unwrap();
+        let entry: LockedInputEntry = serde_json::from_value(serde_json::json!({
+            "attr_path": ["hello"],
+            "build_type": "nef",
+            "catalog": "myorg",
+            "locked_inputs_hash": "sha256-test-fixture",
+            "source": {
+                "dir": ".",
+                "ref": status
+                    .ref_
+                    .expect("freshly committed repo has a symbolic HEAD ref"),
+                "rev": status.rev,
+                "type": "git",
+                "url": Url::from_file_path(source_dir).unwrap().as_str(),
+            },
+        }))
+        .unwrap();
+
+        let key = "myorg/hello".to_string();
+        let lock =
+            build_lock_from_locked_inputs(HashMap::from([(key.clone(), entry)]), [&key]).unwrap();
+        write_lock(&lock, path).unwrap();
+    }
+
+    /// The build consumes the catalog lock it is handed: the NEF eval reads
+    /// CATALOG_LOCKFILE, fetches the source the lock pins and builds against
+    /// it, leaving the lock file untouched. Where that lock comes from — the
+    /// committed `.flox/catalog.lock` or a fresh ephemeral resolution — is
+    /// the CLI's concern, covered by the lock's own unit tests.
+    #[test]
+    fn nef_build_consumes_the_supplied_catalog_lock() {
+        let pname = "foo";
+
+        let (flox, tempdir) = flox_instance();
+        let manifest = formatdoc! {r#"
+            version = 1
+        "#};
+        let mut env = new_path_environment(&flox, &manifest);
+        let env_path = env.parent_path().unwrap();
+
+        // `foo` references a catalog input; `hello` is the package that
+        // reference resolves to. The directory hosting both doubles as
+        // `hello`'s git-fetchable source, so the build resolves the
+        // reference for real with no network access.
+        let (expressions_dir, expressions_ref) = prepare_nix_expressions_dir_in(&tempdir, &[
+            (&[pname], indoc! {r#"
+                {catalogs, runCommand}: runCommand "foo" {} ''
+                    echo -n "Hello, World!" >> $out
+                    cat ${catalogs.myorg.hello} >> $out
+                ''
+                "#}),
+            (&["hello"], indoc! {r#"
+                {runCommand}: runCommand "hello" {} ''
+                    echo -n "Hello from the catalog" > $out
+                ''
+                "#}),
+        ]);
+        let repo =
+            GitCommandProvider::init_with(test_git_options(), &expressions_dir, false).unwrap();
+        repo.add(&[&expressions_dir]).unwrap();
+        repo.commit("add nef catalog fixtures").unwrap();
+
+        let lockfile = tempdir.path().join("catalog.lock");
+        write_catalog_lock(&lockfile, &repo, &expressions_dir);
+        let lock_bytes = fs::read(&lockfile).unwrap();
+
+        assert_build_status_with_nix_expr(
+            &flox,
+            &mut env,
+            &expressions_ref,
+            pname,
+            Some(&lockfile),
+            None,
+            true,
+        );
+
+        let result_path = env_path.join(format!("result-{pname}"));
+        let content = fs::read_to_string(result_path).unwrap();
+        assert_eq!(content, "Hello, World!Hello from the catalog");
+        assert_eq!(
+            fs::read(&lockfile).unwrap(),
+            lock_bytes,
+            "the build must not rewrite the lock it is handed"
+        );
+    }
 
     #[test]
     fn nef_build_creates_out_link() {
@@ -3971,6 +4104,7 @@ mod nef_tests {
             &mut env,
             &expressions_ref,
             &pname,
+            None,
             None,
             true,
         );
@@ -4017,6 +4151,7 @@ mod nef_tests {
             &expressions_ref,
             &pname,
             None,
+            None,
             true,
         );
 
@@ -4058,6 +4193,7 @@ mod nef_tests {
             &expressions_ref,
             &pname,
             None,
+            None,
             true,
         );
 
@@ -4098,6 +4234,7 @@ mod nef_tests {
             &expressions_ref,
             &eval_failure,
             None,
+            None,
             false,
         );
 
@@ -4107,6 +4244,7 @@ mod nef_tests {
             &mut env,
             &expressions_ref,
             &eval_success,
+            None,
             None,
             true,
         );
@@ -4146,6 +4284,7 @@ mod nef_tests {
             &mut env,
             &expressions_ref,
             pname_manifest_build,
+            None,
             None,
             true,
         );

--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -1827,6 +1827,30 @@ mod tests {
         let cache_dir = cache_dir(&env_path, &package_name);
         assert!(cache_dir.exists());
 
+        // Pin the sub-second cache-init marker deterministically: a fresh
+        // cache is differentiated from other otherwise-empty caches by a
+        // timestamped marker, and tar records whole-second mtimes, so a
+        // seconds-granular marker would make two caches initialized within
+        // one second byte-identical — and nix would then reuse the previous
+        // build's output after an invalidation. The tarball is uncompressed,
+        // so the marker is greppable in place.
+        let cache_tar = fs::read(fs::canonicalize(&cache_dir).unwrap()).unwrap();
+        let cache_text = String::from_utf8_lossy(&cache_tar);
+        let marker = cache_text
+            .split("Build cache initialized on ")
+            .nth(1)
+            .expect("the fresh cache carries an init marker");
+        assert!(
+            marker
+                .split_once('\n')
+                .is_some_and(|(stamp, _)| stamp.contains('.')
+                    && stamp.rsplit('.').next().is_some_and(|frac| {
+                        frac.trim_end().chars().all(|c| c.is_ascii_digit())
+                            && frac.trim_end().len() >= 3
+                    })),
+            "the cache-init marker must carry sub-second digits, got: {marker:.60}"
+        );
+
         fs::remove_file(cache_dir).unwrap();
 
         assert_build_status(&flox, &mut env, &package_name, None, true);

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitStatus, Stdio};
 use std::str::FromStr;
@@ -126,16 +126,22 @@ pub trait Publisher {
     ) -> Result<PackageCreatedGuard, PublishError>;
     /// Publish a built package.
     ///
+    /// `locked_inputs` is the subset of the project catalog lock the
+    /// package's expression selects, computed at publish time; empty for
+    /// builds that resolve no catalog inputs.
+    ///
     /// Returns `true` when the caller should wait for an external publisher
     /// to confirm completion (Publisher mode), or `false` when the CLI has
     /// already populated the catalog directly and no wait is needed
     /// (NixCopy and MetadataOnly modes).
+    #[allow(clippy::too_many_arguments)]
     async fn publish(
         &self,
         client: &impl CatalogClientTrait,
         catalog_name: &str,
         package_created: PackageCreatedGuard,
         build_metadata: &CheckedBuildMetadata,
+        locked_inputs: &BTreeMap<String, LockedInputEntry>,
         key_file: Option<PathBuf>,
         metadata_only: bool,
     ) -> Result<bool, PublishError>;
@@ -212,10 +218,6 @@ pub struct CheckedBuildMetadata {
     pub unfree: Option<bool>,
 
     pub version: Option<String>,
-
-    /// The direct catalog inputs the build locked, keyed by locked-input
-    /// reference. Empty for build modes that resolve no catalog inputs.
-    pub direct_catalog_inputs: HashMap<String, LockedInputEntry>,
 
     // This field isn't "pub", so no one outside this module can construct this struct. That helps
     // ensure that we can only make this struct as a result of doing the "right thing."
@@ -633,12 +635,14 @@ where
     ///
     /// Returns `true` when the caller should poll for publisher confirmation,
     /// `false` when the CLI already populated the catalog (NixCopy/MetadataOnly).
+    #[allow(clippy::too_many_arguments)]
     async fn publish(
         &self,
         client: &impl CatalogClientTrait,
         catalog_name: &str,
         _package_created: PackageCreatedGuard,
         build_metadata: &CheckedBuildMetadata,
+        locked_inputs: &BTreeMap<String, LockedInputEntry>,
         key_file: Option<PathBuf>,
         metadata_only: bool,
     ) -> Result<bool, PublishError> {
@@ -690,10 +694,12 @@ where
                 version: build_metadata.version.clone(),
             },
             locked_base_catalog_url: Some(self.package_metadata.base_catalog_ref.to_string()),
-            // Record the build's direct catalog inputs. Always sent: an empty
-            // map when the build resolved none. Older CLIs that omit the field
-            // are coalesced to empty server-side (floxhub#1791).
-            locked_inputs: Some(build_metadata.direct_catalog_inputs.clone()),
+            // Record the subset of the project catalog lock this package's
+            // expression selects. Always sent: an empty map when the build
+            // resolved none. Older CLIs that omit the field are coalesced to
+            // empty server-side (floxhub#1791). The wire type is a HashMap;
+            // ordering on the wire is meaningless.
+            locked_inputs: Some(locked_inputs.clone().into_iter().collect()),
             base_catalog_rev_count: None,
             base_catalog_rev_date: None,
             url: self.env_metadata.build_repo_meta.url.to_string(),
@@ -890,7 +896,6 @@ fn convert_build_result_to_build_metadata(
             PublishError::UnsupportedEnvironmentState("Invalid system".to_string())
         })?,
         version: Some(build_result.version.clone()),
-        direct_catalog_inputs: build_result.direct_catalog_inputs.clone(),
         _private: (),
     })
 }
@@ -921,7 +926,7 @@ pub fn check_build_metadata(
     system_override: Option<String>,
     env_metadata: &CheckedEnvironmentMetadata,
     pkg: &PackageTarget,
-    nef_stability: Option<String>,
+    catalog_lockfile: Option<&Path>,
 ) -> Result<CheckedBuildMetadata, PublishError> {
     let workdir = if sandbox_is_local(pkg) {
         BuildWorkdir::SharedClone
@@ -946,9 +951,9 @@ pub fn check_build_metadata(
         &base_nixpkgs_url.as_flake_ref()?,
         &built_environments.dev,
         &[pkg.name()],
-        // Lock the NEF catalog inputs at the stability selected for publish, so
-        // the recorded inputs match the build the user intends to publish.
-        nef_stability,
+        // The catalog lock the CLI created for this publish; its subset is
+        // what gets submitted, so the build consumes the same inputs.
+        catalog_lockfile,
         Some(false),
         system_override,
     )?;
@@ -1813,6 +1818,7 @@ pub mod tests {
                 &catalog_name,
                 package_created,
                 &build_metadata,
+                &BTreeMap::new(),
                 None,
                 false,
             )
@@ -2015,7 +2021,6 @@ pub mod tests {
             broken: Some(false),
             insecure: None,
             unfree: None,
-            direct_catalog_inputs: HashMap::new(),
             _private: (),
         };
 
@@ -2087,6 +2092,7 @@ pub mod tests {
                 &catalog_name,
                 package_created,
                 &build_metadata,
+                &BTreeMap::new(),
                 None,
                 false,
             )
@@ -2242,6 +2248,7 @@ pub mod tests {
                 &catalog_name,
                 package_created,
                 &build_metadata,
+                &BTreeMap::new(),
                 cache.local_signing_key_path(),
                 false,
             )
@@ -2521,6 +2528,7 @@ pub mod tests {
                 &user_handle,
                 packaged_created_guard,
                 &build_meta,
+                &BTreeMap::new(),
                 None,
                 // Server returns meta-only store config; narinfo collected
                 // from FIXED_TEST_STORE_PATH in the local daemon store.
@@ -2561,6 +2569,7 @@ pub mod tests {
                 TEST_READ_WRITE_CATALOG_NAME,
                 packaged_created_guard,
                 &build_meta,
+                &BTreeMap::new(),
                 None,
                 // Server returns meta-only store config; narinfo collected
                 // from FIXED_TEST_STORE_PATH in the local daemon store.
@@ -2628,6 +2637,7 @@ pub mod tests {
                 TEST_READ_WRITE_CATALOG_NAME,
                 packaged_created_guard,
                 &build_meta,
+                &BTreeMap::new(),
                 None,
                 // Server returns meta-only store config; narinfo collected
                 // from FIXED_TEST_STORE_PATH in the local daemon store.
@@ -2643,6 +2653,7 @@ pub mod tests {
                 // a new one.
                 PackageCreatedGuard { _private: () },
                 &build_meta,
+                &BTreeMap::new(),
                 None,
                 // Server returns meta-only store config; narinfo collected
                 // from FIXED_TEST_STORE_PATH in the local daemon store.
@@ -2677,6 +2688,7 @@ pub mod tests {
                 &user_handle,
                 PackageCreatedGuard { _private: () },
                 &build_meta,
+                &BTreeMap::new(),
                 None,
                 // Server returns meta-only store config; narinfo collected
                 // from FIXED_TEST_STORE_PATH in the local daemon store.

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -34,7 +34,6 @@ use url::Url;
 
 use super::build::{
     BuildResult,
-    CatalogLock,
     FloxBuildMk,
     ManifestBuilder,
     ManifestBuilderError,
@@ -64,9 +63,6 @@ use crate::utils::CommandExt;
 pub enum PublishError {
     #[error("The outputs from the build do not exist: {0}")]
     NonexistentOutputs(String),
-
-    #[error("Locking a single package returned {0} results.")]
-    UnexpectedLockResults(usize),
 
     #[error("The environment is in an unsupported state for publishing: {0}")]
     UnsupportedEnvironmentState(String),
@@ -116,11 +112,6 @@ pub enum PublishError {
 
     #[error("Timed out waiting for publish completion")]
     PublishTimeout,
-
-    #[error(
-        "'{0}' is not a system Flox can publish for.\nSupported systems are 'aarch64-darwin', 'aarch64-linux', 'x86_64-darwin' and 'x86_64-linux'."
-    )]
-    UnsupportedSystem(String),
 }
 
 /// The `Publish` trait describes the high level behavior of publishing a package to a catalog.
@@ -904,39 +895,34 @@ fn convert_build_result_to_build_metadata(
     })
 }
 
-/// The rendered build source shared by the lock and build phases of a
-/// publish: the flake ref used as the Nix source, the working directory it
-/// was rendered into, and the built dev/build environment outputs.
+/// Collect metadata needed for publishing that is obtained from the build output.
 ///
-/// Rendering happens exactly once per publish (see [`render_build_source`]);
-/// [`lock_build_inputs`] and [`check_build_metadata`] are both called against
-/// the same `RenderedSource` so their catalog-lock paths coincide and the
-/// build phase can reuse the lock phase's catalog lock.
+/// Notably, [CheckedBuildMetadata] obtained from this function testifies:
+/// * That the package can be built
 ///
-/// Opaque to callers: it is produced by [`render_build_source`] and consumed
-/// by this module's build entry points, and nothing outside has a reason to
-/// take it apart.
-#[derive(Debug, Clone)]
-pub struct RenderedSource {
-    expression_ref: NixFlakeref,
-    base_dir: PathBuf,
-    built_environments: BuildEnvOutputs,
-    flox_env_cache: PathBuf,
-}
-
-/// Render the build source for `pkg` exactly once, choosing the build
-/// working directory based on `pkg`'s sandbox mode (see [`sandbox_is_local`]
-/// and [`BuildWorkdir`]).
+/// A `git+file://` flake ref pinned to the committed revision is always used as
+/// the Nix source reference.  Nix's git fetcher imports only the files returned
+/// by `git ls-files` — never the `.git` directory — so source copies in the
+/// store never contain git metadata.
 ///
-/// Callers should render once per publish and share the result between
-/// [`lock_build_inputs`] and [`check_build_metadata`]: rendering twice would
-/// create two independent workdirs and defeat catalog-lock reuse between the
-/// lock and build phases.
-pub fn render_build_source(
+/// The build working directory differs by sandbox mode:
+///
+/// * `sandbox = "off"` (or unset): an ephemeral `git clone --shared` provides
+///   a clean working tree (only tracked files, no extraneous workspace state).
+///   `--shared` is safe here because `sandbox = "off"` builds run without Nix
+///   filesystem namespace isolation, so the alternates pointer back to the
+///   source repository is always reachable.
+///
+/// * `sandbox = "pure"` or any expression build: the original local checkout is
+///   used as the build working directory.
+pub fn check_build_metadata(
     flox: &Flox,
+    base_nixpkgs_url: &BaseCatalogUrl,
+    system_override: Option<String>,
     env_metadata: &CheckedEnvironmentMetadata,
     pkg: &PackageTarget,
-) -> Result<RenderedSource, PublishError> {
+    nef_stability: Option<String>,
+) -> Result<CheckedBuildMetadata, PublishError> {
     let workdir = if sandbox_is_local(pkg) {
         BuildWorkdir::SharedClone
     } else {
@@ -948,150 +934,23 @@ pub fn render_build_source(
     // so the environment cache is derived from the build working directory
     // instead of the environment's own cache path.
     let flox_env_cache = base_dir.join(DOT_FLOX).join(CACHE_DIR_NAME);
-
-    Ok(RenderedSource {
-        expression_ref,
-        base_dir,
-        built_environments,
-        flox_env_cache,
-    })
-}
-
-/// The lock phase's result: the catalog lock's closure identity for a
-/// package, computed ahead of a build so that publish dedup can
-/// short-circuit before paying the build cost, together with the lock and
-/// the lock arguments that produced it.
-///
-/// This is what makes the closure the dedup decision was made on the closure
-/// that gets built, and it does so in the types rather than by call
-/// ordering: [`lock_build_inputs`] is the only way to obtain one — the reuse
-/// fields below are private, so the type cannot be forged from outside this
-/// module — and [`check_build_metadata`] takes one instead of the lock
-/// arguments, so a build cannot be run against any lock but the one a lock
-/// phase resolved.
-#[derive(Debug, Clone, PartialEq)]
-pub struct LockedBuildInputs {
-    pub system: PackageSystem,
-    pub direct_catalog_inputs: HashMap<String, LockedInputEntry>,
-    /// The lock this closure identity was resolved into. The following build
-    /// consumes exactly this lock rather than resolving the catalog again.
-    catalog_lock: CatalogLock,
-    /// The stability the NEF catalog inputs were locked at, carried so the
-    /// build locks any input the lock phase did not at the same stability.
-    nef_stability: Option<String>,
-    /// The `--system` the lock was resolved for, carried so the build is run
-    /// for that same system.
-    system_override: Option<String>,
-}
-
-/// Compute the catalog lock for `pkg` against the already-rendered
-/// `rendered` source, without building it.
-///
-/// `catalog_lock` names where the lock is written. The returned
-/// [`LockedBuildInputs`] carries it to the following [`check_build_metadata`],
-/// whose build consumes exactly this lock.
-///
-/// Manifest builds never reach the builder: the lock goal emits a constant for
-/// them, and running it is not free (see below).
-pub fn lock_build_inputs(
-    flox: &Flox,
-    rendered: &RenderedSource,
-    pkg: &PackageTarget,
-    catalog_lock: &CatalogLock,
-    nef_stability: Option<String>,
-    system_override: Option<String>,
-) -> Result<LockedBuildInputs, PublishError> {
-    // A manifest build resolves no catalog inputs of its own, so the lock goal
-    // only ever emits an empty map for it. Spawning the builder to obtain a
-    // constant would not be free: the Makefile evaluates every manifest build's
-    // `version.command` in a build-mode activation while it parses, on every
-    // invocation, so a lock pass would run each of those user-supplied commands
-    // a second time per publish. Answer directly instead.
-    //
-    // TODO: a manifest build that depends on a NEF package inherits that
-    // package's catalog inputs, so once the Makefile aggregates them this
-    // shortcut becomes wrong and has to go — the lock goal will have a real
-    // answer to give for manifest builds too. Until then it would only pay the
-    // double `version.command` cost to be handed back the empty map below.
-    if pkg.kind().is_manifest_build() {
-        let system = system_override.as_deref().unwrap_or(&flox.system);
-        return Ok(LockedBuildInputs {
-            system: PackageSystem::from_str(system)
-                .map_err(|_| PublishError::UnsupportedSystem(system.to_string()))?,
-            direct_catalog_inputs: HashMap::new(),
-            catalog_lock: catalog_lock.clone(),
-            nef_stability,
-            system_override,
-        });
-    }
-
     let builder = FloxBuildMk::new(
         flox,
-        &rendered.base_dir,
-        &rendered.expression_ref,
-        &rendered.built_environments,
-        &rendered.flox_env_cache,
-    );
-
-    let lock_results = builder.lock(
-        &[(pkg.name(), catalog_lock.clone())],
-        nef_stability.clone(),
-        system_override.clone(),
-    )?;
-
-    let [lock_result] = &lock_results[..] else {
-        return Err(PublishError::UnexpectedLockResults(lock_results.len()));
-    };
-
-    Ok(LockedBuildInputs {
-        system: lock_result.system,
-        direct_catalog_inputs: lock_result.direct_catalog_inputs.clone(),
-        catalog_lock: catalog_lock.clone(),
-        nef_stability,
-        system_override,
-    })
-}
-
-/// Collect metadata needed for publishing that is obtained from the build output.
-///
-/// Notably, [CheckedBuildMetadata] obtained from this function testifies:
-/// * That the package can be built
-///
-/// `rendered` MUST come from [`render_build_source`] for `pkg`; it is passed
-/// in (rather than rendered internally) so that a preceding
-/// [`lock_build_inputs`] call shares this build's working directory instead
-/// of rendering the source a second time.
-///
-/// `locked` is the [`lock_build_inputs`] result this build is run against: it
-/// names the lock to consume and the arguments it was resolved under, so the
-/// closure built here is the one that call resolved. Requiring it is what
-/// makes that reuse a property of the types rather than of the order the two
-/// are called in — a build with no lock phase to reuse still has to go
-/// through [`lock_build_inputs`], passing [`CatalogLock::Ephemeral`].
-pub fn check_build_metadata(
-    flox: &Flox,
-    base_nixpkgs_url: &BaseCatalogUrl,
-    rendered: &RenderedSource,
-    pkg: &PackageTarget,
-    locked: &LockedBuildInputs,
-) -> Result<CheckedBuildMetadata, PublishError> {
-    let builder = FloxBuildMk::new(
-        flox,
-        &rendered.base_dir,
-        &rendered.expression_ref,
-        &rendered.built_environments,
-        &rendered.flox_env_cache,
+        &base_dir,
+        &expression_ref,
+        &built_environments,
+        &flox_env_cache,
     );
 
     let build_results = builder.build(
         &base_nixpkgs_url.as_flake_ref()?,
-        &rendered.built_environments.dev,
-        &[(pkg.name(), locked.catalog_lock.clone())],
+        &built_environments.dev,
+        &[pkg.name()],
         // Lock the NEF catalog inputs at the stability selected for publish, so
         // the recorded inputs match the build the user intends to publish.
-        locked.nef_stability.clone(),
+        nef_stability,
         Some(false),
-        locked.system_override.clone(),
+        system_override,
     )?;
 
     if build_results.len() != 1 {
@@ -1774,25 +1633,15 @@ pub mod tests {
         let (env, _build_repo) = example_path_environment(&flox, Some(&remote_uri));
 
         let env_metadata = check_environment_metadata(&flox, &env).unwrap();
-        let rendered =
-            render_build_source(&flox, &env_metadata, &EXAMPLE_MANIFEST_PACKAGE_TARGET).unwrap();
-        let locked = lock_build_inputs(
-            &flox,
-            &rendered,
-            &EXAMPLE_MANIFEST_PACKAGE_TARGET,
-            &CatalogLock::Ephemeral,
-            None,
-            None,
-        )
-        .unwrap();
 
         // This will actually run the build
         let meta = check_build_metadata(
             &flox,
             env_metadata.toplevel_catalog_ref.as_ref().unwrap(),
-            &rendered,
+            None,
+            &env_metadata,
             &EXAMPLE_MANIFEST_PACKAGE_TARGET,
-            &locked,
+            None,
         )
         .unwrap();
 
@@ -1831,29 +1680,15 @@ pub mod tests {
         let (env, _build_repo) = example_path_environment(&flox, Some(&remote_uri));
 
         let env_metadata = check_environment_metadata(&flox, &env).unwrap();
-        let rendered = render_build_source(
-            &flox,
-            &env_metadata,
-            &EXAMPLE_MANIFEST_PACKAGE_TARGET_MISSING_FIELDS,
-        )
-        .unwrap();
-        let locked = lock_build_inputs(
-            &flox,
-            &rendered,
-            &EXAMPLE_MANIFEST_PACKAGE_TARGET_MISSING_FIELDS,
-            &CatalogLock::Ephemeral,
-            None,
-            None,
-        )
-        .unwrap();
 
         // This will actually run the build
         let meta = check_build_metadata(
             &flox,
             env_metadata.toplevel_catalog_ref.as_ref().unwrap(),
-            &rendered,
+            None,
+            &env_metadata,
             &EXAMPLE_MANIFEST_PACKAGE_TARGET_MISSING_FIELDS,
-            &locked,
+            None,
         )
         .unwrap();
 
@@ -1896,7 +1731,7 @@ pub mod tests {
         git.commit("set sandbox=pure").unwrap();
         git.push("origin", false).unwrap();
 
-        // Pass a PackageTarget with sandbox=Pure so render_build_source
+        // Pass a PackageTarget with sandbox=Pure so check_build_metadata
         // takes the OriginalCheckout path without re-reading the manifest.
         let pure_pkg =
             PackageTarget::new_unchecked(EXAMPLE_PACKAGE_NAME, PackageTargetKind::ManifestBuild {
@@ -1904,22 +1739,13 @@ pub mod tests {
             });
 
         let env_metadata = check_environment_metadata(&flox, &env).unwrap();
-        let rendered = render_build_source(&flox, &env_metadata, &pure_pkg).unwrap();
-        let locked = lock_build_inputs(
-            &flox,
-            &rendered,
-            &pure_pkg,
-            &CatalogLock::Ephemeral,
-            None,
-            None,
-        )
-        .unwrap();
         let meta = check_build_metadata(
             &flox,
             env_metadata.toplevel_catalog_ref.as_ref().unwrap(),
-            &rendered,
+            None,
+            &env_metadata,
             &pure_pkg,
-            &locked,
+            None,
         )
         .unwrap();
 
@@ -1934,39 +1760,6 @@ pub mod tests {
         assert_eq!(meta.pname, EXAMPLE_PACKAGE_NAME.to_string());
         assert_eq!(meta.system.to_string(), flox.system);
         assert_eq!(meta.version, Some("1.0.2a".to_string()));
-    }
-
-    /// `lock_build_inputs` for a manifest build reports the current system and
-    /// an empty `direct_catalog_inputs` without invoking the builder at all —
-    /// the named lock file is never created, which is the observable proof
-    /// that no `make lock` ran and so no `version.command` was re-executed.
-    #[test]
-    fn lock_build_inputs_for_a_manifest_build_does_not_spawn_the_builder() {
-        let (flox, _temp_dir_handle) = flox_instance();
-        let (_tempdir_handle, _remote_repo, remote_uri) = example_git_remote_repo();
-        let (env, _build_repo) = example_path_environment(&flox, Some(&remote_uri));
-
-        let env_metadata = check_environment_metadata(&flox, &env).unwrap();
-        let rendered =
-            render_build_source(&flox, &env_metadata, &EXAMPLE_MANIFEST_PACKAGE_TARGET).unwrap();
-
-        let lock_file = flox.temp_dir.join("manifest-build-catalog.lock");
-        let locked = lock_build_inputs(
-            &flox,
-            &rendered,
-            &EXAMPLE_MANIFEST_PACKAGE_TARGET,
-            &CatalogLock::File(lock_file.clone()),
-            None,
-            None,
-        )
-        .unwrap();
-
-        assert_eq!(locked.system.to_string(), flox.system);
-        assert!(locked.direct_catalog_inputs.is_empty());
-        assert!(
-            !lock_file.exists(),
-            "a manifest build must not spawn the builder to learn it has no catalog inputs"
-        );
     }
 
     #[tokio::test]
@@ -1986,23 +1779,13 @@ pub mod tests {
         )
         .unwrap();
 
-        let rendered =
-            render_build_source(&flox, &env_metadata, &package_metadata.package).unwrap();
-        let locked = lock_build_inputs(
-            &flox,
-            &rendered,
-            &package_metadata.package,
-            &CatalogLock::Ephemeral,
-            None,
-            None,
-        )
-        .unwrap();
         let build_metadata = check_build_metadata(
             &flox,
             env_metadata.toplevel_catalog_ref.as_ref().unwrap(),
-            &rendered,
+            None,
+            &env_metadata,
             &package_metadata.package,
-            &locked,
+            None,
         )
         .unwrap();
 
@@ -2058,23 +1841,13 @@ pub mod tests {
         )
         .unwrap();
 
-        let rendered =
-            render_build_source(&flox, &env_metadata, &package_metadata.package).unwrap();
-        let locked = lock_build_inputs(
-            &flox,
-            &rendered,
-            &package_metadata.package,
-            &CatalogLock::Ephemeral,
-            None,
-            None,
-        )
-        .unwrap();
         let build_metadata = check_build_metadata(
             &flox,
             env_metadata.toplevel_catalog_ref.as_ref().unwrap(),
-            &rendered,
+            None,
+            &env_metadata,
             &package_metadata.package,
-            &locked,
+            None,
         )
         .unwrap();
 
@@ -2418,23 +2191,13 @@ pub mod tests {
         )
         .unwrap();
 
-        let rendered =
-            render_build_source(&flox, &env_metadata, &package_metadata.package).unwrap();
-        let locked = lock_build_inputs(
-            &flox,
-            &rendered,
-            &package_metadata.package,
-            &CatalogLock::Ephemeral,
-            None,
-            None,
-        )
-        .unwrap();
         let build_metadata = check_build_metadata(
             &flox,
             env_metadata.toplevel_catalog_ref.as_ref().unwrap(),
-            &rendered,
+            None,
+            &env_metadata,
             &package_metadata.package,
-            &locked,
+            None,
         )
         .unwrap();
 

--- a/cli/flox/doc/flox-build-update-catalogs.md
+++ b/cli/flox/doc/flox-build-update-catalogs.md
@@ -1,0 +1,51 @@
+---
+title: FLOX-BUILD-UPDATE-CATALOGS
+section: 1
+header: "Flox User Manuals"
+...
+
+# NAME
+
+flox-build-update-catalogs - Update the project catalog lockfile
+
+# SYNOPSIS
+
+```text
+flox [<general-options>] build update-catalogs
+     [-d=<path>]
+```
+
+# DESCRIPTION
+
+Scan the project's Nix expression builds (`.nix` files under `.flox/pkgs/`)
+for `catalogs.<catalog>.<package>` references and lock them to
+`.flox/catalog.lock`.
+
+There is exactly one catalog lock per project.
+It pins the source of every catalog reference the project's expressions
+make, resolved as a union in a single request, so that every build of a
+revision evaluates against one consistent set of inputs.
+Commit the file alongside the manifest.
+
+A committed lock is used exactly as it is found: `flox build` and
+`flox publish` never rewrite it.
+When the project's expressions gain a reference the lock does not cover,
+re-run `flox build update-catalogs` and commit the result.
+References the scanner cannot fully resolve are pinned conservatively;
+a package newly referenced beneath one of them cannot be detected as
+missing from the lock and instead fails during evaluation.
+Re-running `flox build update-catalogs` resolves this as well.
+Without a committed lock, builds resolve the references of the packages
+being built fresh on every invocation.
+
+# OPTIONS
+
+```{.include}
+./include/dir-environment-options.md
+./include/general-options.md
+```
+
+# SEE ALSO
+
+[`flox-build(1)`](./flox-build.md)
+[`flox-publish(1)`](./flox-publish.md)

--- a/cli/flox/doc/flox-build.md
+++ b/cli/flox/doc/flox-build.md
@@ -96,8 +96,20 @@ An expression references a catalog package as `catalogs.<catalog>.<package>`,
 where the package receives a `catalogs` argument.
 The referenced packages are the ones published to a FloxHub catalog with
 `flox publish`.
-These references are resolved and locked automatically during `flox build`.
-There is no separate declaration file and no separate lock step.
+There is no separate declaration file: the references are discovered by
+scanning the expressions themselves.
+
+A project may commit a catalog lock at `.flox/catalog.lock`, created or
+refreshed with `flox build update-catalogs`.
+A committed lock pins the source of every catalog reference in the project,
+so every build of a revision resolves the same inputs; it is used exactly as
+found, and is only ever rewritten by `flox build update-catalogs`.
+Without a committed lock, `flox build` resolves the references of the
+packages being built fresh on every invocation ("lockless" builds);
+nothing is written into the project tree.
+Catalog references resolve to the latest published versions and are
+independent of `--stability`, which selects only the nixpkgs base
+package set.
 
 # OPTIONS
 
@@ -212,5 +224,6 @@ npx serve result-app
 
 [`flox-build-clean(1)`](./flox-build-clean.md)
 [`flox-build-import-nixpkgs(1)`](./flox-build-import-nixpkgs.md)
+[`flox-build-update-catalogs(1)`](./flox-build-update-catalogs.md)
 [`flox-activate(1)`](./flox-activate.md)
 [`manifest.toml(5)`](./manifest.toml.md)

--- a/cli/flox/doc/flox-publish.md
+++ b/cli/flox/doc/flox-publish.md
@@ -87,8 +87,11 @@ Published packages on FloxHub are also available as catalog imports for
 Nix expression builds.
 Other environments reference the published packages as
 `catalogs.<catalog>.<package>` in `.nix` expressions under `.flox/pkgs/`.
-These references are resolved and locked automatically during
-`flox build` and `flox publish`.
+These references are pinned by a committed `.flox/catalog.lock` when the
+project has one (see `flox build update-catalogs`), and are otherwise
+resolved fresh during the build.
+`flox publish` submits the entries relevant to the published package along
+with the build.
 
 ## Sharing published packages
 

--- a/cli/flox/src/commands/build.rs
+++ b/cli/flox/src/commands/build.rs
@@ -17,7 +17,6 @@ use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::{ConcreteEnvironment, Environment};
 use flox_rust_sdk::providers::build::{
     COMMON_NIXPKGS_URL,
-    CatalogLock,
     FloxBuildMk,
     ManifestBuilder,
     ManifestBuilderError,
@@ -313,13 +312,9 @@ impl Build {
 
         prefetch_expression_build_flake_ref(&packages_to_build, &base_nixpkgs_url)?;
 
-        // `flox build` names no lock file, so every package's catalog lock is
-        // resolved into the builder's own temporary directory. Reusing an
-        // in-tree lock here is separate work: producing one is not supported
-        // yet.
-        let build_targets = packages_to_build
+        let target_names = packages_to_build
             .iter()
-            .map(|target| (target.name(), CatalogLock::Ephemeral))
+            .map(|target| target.name())
             .collect::<Vec<_>>();
 
         let has_expression_build = packages_to_build
@@ -346,7 +341,7 @@ impl Build {
         let results = builder.build(
             &base_nixpkgs_url,
             &FLOX_INTERPRETER,
-            &build_targets,
+            &target_names,
             nef_stability,
             None,
             system_override,

--- a/cli/flox/src/commands/build.rs
+++ b/cli/flox/src/commands/build.rs
@@ -1,6 +1,6 @@
 use std::env;
 use std::os::unix::process::ExitStatusExt;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::Instant;
 
@@ -33,15 +33,24 @@ use flox_rust_sdk::utils::{CommandExt, FLOX_INTERPRETER};
 use floxhub_client::{BaseCatalogUrl, CatalogClientTrait};
 use indoc::formatdoc;
 use itertools::Itertools;
-use nef_lock_catalog::NixFlakeref;
+use nef_lock_catalog::{NixFlakeref, catalog_lockfile_path, lock_project_catalog};
 use thiserror::Error;
 use tracing::{debug, instrument, trace};
 use url::Url;
 
 use super::{DirEnvironmentSelect, dir_environment_select, needs_project_files_error};
+use crate::utils::catalog_lock::BuildLockGuard;
 use crate::utils::events::duration_to_ms;
 use crate::utils::message;
 use crate::{environment_subcommand_metric, subcommand_metric};
+
+/// How the user invokes the catalog-lock update, for messages that name it.
+///
+/// NAMING: provisional — the command is expected to be renamed (or folded
+/// into a flag such as `flox build --lock-catalog`) once the UX discussion
+/// settles. Keep the user-visible name confined to this constant and the
+/// `UpdateCatalogs` bpaf declaration so the rename stays a two-line change.
+pub(crate) const UPDATE_CATALOGS_COMMAND: &str = "flox build update-catalogs";
 
 #[derive(Debug, Clone, Bpaf)]
 pub enum BaseCatalogUrlSelect {
@@ -120,8 +129,16 @@ enum SubcommandOrBuildTargets {
     },
     /// Update catalog lockfile
     ///
-    /// Resolves catalog inputs and writes the lockfile.
-    #[bpaf(command, hide)]
+    /// Scans the project's Nix expression builds for catalog references and
+    /// locks them to '.flox/catalog.lock', the single set of pinned catalog
+    /// inputs every build of the project evaluates against.
+    //
+    // NAMING: provisional; see the note at [UPDATE_CATALOGS_COMMAND] before
+    // renaming.
+    #[bpaf(
+        command,
+        footer("Run 'man flox-build-update-catalogs' for more details.")
+    )]
     UpdateCatalogs {},
     BuildTargets {
         #[bpaf(external(base_catalog_url_select), optional)]
@@ -149,7 +166,7 @@ impl Build {
         match &self.subcommand_or_targets {
             SubcommandOrBuildTargets::Clean { .. } => "build::clean",
             SubcommandOrBuildTargets::ImportNixpkgs { .. } => "build::import-nixpkgs",
-            SubcommandOrBuildTargets::UpdateCatalogs {} => "build::update-catalogs",
+            SubcommandOrBuildTargets::UpdateCatalogs { .. } => "build::update-catalogs",
             SubcommandOrBuildTargets::BuildTargets { .. } => "build",
         }
     }
@@ -277,7 +294,7 @@ impl Build {
         prefetch_flake_ref(&COMMON_NIXPKGS_URL)?;
 
         let lockfile_manifest = lockfile.migrated_manifest()?;
-        let (packages_to_build, expression_ref) = {
+        let (packages_to_build, expression_ref, expression_path_ref) = {
             // TODO: decouple from env
             let expression_parent_dir = env.dot_flox_path();
             let expression_path_ref = NixFlakeref::from_path(&expression_parent_dir)?;
@@ -289,7 +306,10 @@ impl Build {
             )?;
             (
                 packages_to_build,
-                expression_git_ref.unwrap_or(expression_path_ref),
+                expression_git_ref
+                    .clone()
+                    .unwrap_or(expression_path_ref.clone()),
+                expression_path_ref,
             )
         };
 
@@ -297,13 +317,6 @@ impl Build {
             &packages_to_build,
             nixpkgs_url_select.is_some(),
         )?;
-
-        // The `--stability` selection also determines the stability used to
-        // resolve the catalog build inputs of NEF (expression) builds.
-        let nef_stability = match &nixpkgs_url_select {
-            Some(BaseCatalogUrlSelect::Stability(stability)) => Some(stability.clone()),
-            _ => None,
-        };
 
         let base_nixpkgs_url =
             base_nixpkgs_url_from_url_select(&flox, nixpkgs_url_select, Some(&lockfile))
@@ -329,6 +342,34 @@ impl Build {
             "has_manifest_build" = has_manifest_build
         );
 
+        // The catalog lock the NEF evals consume, created by the CLI: the
+        // committed .flox/catalog.lock exactly as found, or a fresh
+        // ephemeral lock living only for this invocation. Scanning is
+        // scoped to the expressions being built — the scanner follows
+        // imports, so their references are exactly what the evals look up —
+        // except when a manifest build is among the targets, whose `${pkg}`
+        // references can pull in any of the project's expressions, so all
+        // of them are covered. A project without expression builds needs no
+        // lock at all.
+        let lock_rel_paths = if has_manifest_build {
+            expression_rel_paths(
+                &PackageTargets::new(&lockfile_manifest, &expression_path_ref)?.all(),
+            )
+        } else {
+            expression_rel_paths(&packages_to_build)
+        };
+        let catalog_lock = match &*lock_rel_paths {
+            [] => None,
+            lock_rel_paths => Some(
+                BuildLockGuard::new_existing_or_ephemeral(
+                    &flox.floxhub_client,
+                    env.dot_flox_path(),
+                    lock_rel_paths,
+                )
+                .await?,
+            ),
+        };
+
         let cache_path = env.cache_path()?;
         let builder = FloxBuildMk::new(
             &flox,
@@ -342,7 +383,7 @@ impl Build {
             &base_nixpkgs_url,
             &FLOX_INTERPRETER,
             &target_names,
-            nef_stability,
+            catalog_lock.as_ref().map(|lock| lock.path()),
             None,
             system_override,
         );
@@ -539,19 +580,54 @@ impl Build {
         Ok(())
     }
 
-    async fn update_catalogs(_flox: &Flox, _env: ConcreteEnvironment) -> Result<()> {
-        // The standalone `nix-builds.toml` catalog-declaration + nix-prefetch
-        // locking path has been retired (ECO-93/D4). Catalog inputs are now
-        // resolved and locked through the lockless lookup flow as part of the
-        // build itself, so there is no separate lockfile to update here.
-        // Full removal of this subcommand follows in ECO-94/95.
-        bail!(formatdoc! {"
-            `flox build update-catalogs` is no longer supported.
+    #[instrument(name = "build::update-catalogs", skip_all)]
+    async fn update_catalogs(flox: &Flox, mut env: ConcreteEnvironment) -> Result<()> {
+        match &env {
+            ConcreteEnvironment::Path(_) => (),
+            ConcreteEnvironment::Managed(managed) => {
+                bail!(needs_project_files_error(managed, "update catalogs"))
+            },
+            ConcreteEnvironment::Remote(_) => {
+                // guarded by DirEnvironmentSelect
+                unreachable!("Cannot update catalogs of a remote environment")
+            },
+        };
 
-            Catalog inputs are now locked automatically during the build via the
-            lockless resolution flow; the standalone nix-builds.toml locking step
-            has been retired.
-        "});
+        let expression_ref = NixFlakeref::from_path(env.dot_flox_path())?;
+        let lockfile: Lockfile = env.lockfile(flox)?.into();
+        let manifest = lockfile.migrated_manifest()?;
+
+        let rel_file_paths =
+            expression_rel_paths(&PackageTargets::new(&manifest, &expression_ref)?.all());
+
+        if rel_file_paths.is_empty() {
+            message::plain(
+                "No Nix expression builds found; only expression builds reference the catalog.",
+            );
+            return Ok(());
+        }
+
+        let lockfile_path = catalog_lockfile_path(env.dot_flox_path());
+        let references = lock_project_catalog(
+            &flox.floxhub_client,
+            nix_expression_dir(&env),
+            &rel_file_paths,
+            &lockfile_path,
+        )
+        .await?;
+
+        if references.is_empty() {
+            message::created(formatdoc! {"
+                No catalog references found; wrote an empty '.flox/catalog.lock'.
+                Commit the file so every revision builds against the same inputs."});
+        } else {
+            message::created(formatdoc! {"
+                Locked {count} catalog reference(s) to '.flox/catalog.lock'.
+                Commit the file so every revision builds against the same inputs.",
+                count = references.len(),
+            });
+        }
+        Ok(())
     }
 
     /// If so, shorten symlink for a package it if in the current directory.
@@ -798,6 +874,21 @@ pub(crate) enum PrefetchError {
         {stderr}"
     )]
     PrefetchFailed { flakeref: Url, stderr: String },
+}
+
+/// The expression files of `targets`, relative to the project's expression
+/// directory — the inputs a catalog lock is scanned from. Manifest builds
+/// contribute none of their own.
+pub(crate) fn expression_rel_paths(targets: &[PackageTarget]) -> Vec<PathBuf> {
+    targets
+        .iter()
+        .filter_map(|target| match target.kind() {
+            PackageTargetKind::ExpressionBuild(expression) => {
+                Some(expression.rel_file_path.clone())
+            },
+            PackageTargetKind::ManifestBuild { .. } => None,
+        })
+        .collect()
 }
 
 pub(crate) fn packages_to_build<'o>(

--- a/cli/flox/src/commands/publish.rs
+++ b/cli/flox/src/commands/publish.rs
@@ -7,7 +7,7 @@ use flox_events::{CliEnvironmentPublishPayload, EventKind, EventsHub};
 use flox_manifest::{Manifest, MigratedTypedOnly};
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::{ConcreteEnvironment, Environment};
-use flox_rust_sdk::providers::build::{COMMON_NIXPKGS_URL, CatalogLock, PackageTarget};
+use flox_rust_sdk::providers::build::{COMMON_NIXPKGS_URL, PackageTarget};
 use flox_rust_sdk::providers::nix_auth::NixAuth;
 use flox_rust_sdk::providers::publish::{
     PublishProvider,
@@ -16,13 +16,10 @@ use flox_rust_sdk::providers::publish::{
     check_build_metadata,
     check_environment_metadata,
     check_package_metadata,
-    lock_build_inputs,
-    render_build_source,
 };
 use floxhub_client::{CatalogClientTrait, CheckBuildQuery, CheckBuildResponse, FloxhubClientError};
 use indoc::formatdoc;
 use nef_lock_catalog::NixFlakeref;
-use tempfile::TempDir;
 use tracing::{debug, info_span, instrument, warn};
 
 use super::{DirEnvironmentSelect, dir_environment_select};
@@ -297,38 +294,19 @@ impl Publish {
 
         let system_override_inner = publish_config.system_override.into_inner();
 
-        // Render the build source exactly once and share it between the lock
-        // and build phases below, so the source is not built twice.
-        let rendered = render_build_source(
+        let build_metadata = check_build_metadata(
             &flox,
+            &selected_base_nixpkgs_url,
+            system_override_inner,
             &publish_provider.env_metadata,
             &publish_provider.package_metadata.package,
-        )?;
-
-        // Publish owns the catalog lock's location: the lock phase resolves
-        // it here and the build phase consumes exactly this file, so the
-        // closure identity checked against the server is the one that gets
-        // built. The lock is scoped to this publish, hence a temporary
-        // directory rather than a path in the user's checkout.
-        let catalog_lock_dir = TempDir::new_in(&flox.temp_dir)
-            .context("could not create a directory for the catalog lock")?;
-        let catalog_lock = CatalogLock::File(catalog_lock_dir.path().join("catalog.lock"));
-
-        // Compute the catalog lock (the closure identity) without building,
-        // so the dedup pre-check below can run before the package build.
-        let locked = lock_build_inputs(
-            &flox,
-            &rendered,
-            &publish_provider.package_metadata.package,
-            &catalog_lock,
             nef_stability,
-            system_override_inner,
         )?;
 
         // Dedup check: ask the catalog server if this exact build has already
-        // been published, BEFORE spending time on the package build. The
-        // closure identity (direct_catalog_inputs) comes from the lock phase
-        // above, enabling a closure-aware match on the server.
+        // been published before spending time on the upload. The closure
+        // identity (direct_catalog_inputs) is available after
+        // check_build_metadata, enabling a closure-aware match on the server.
         let nixpkgs_rev = publish_provider.package_metadata.base_catalog_ref.rev();
         let nixpkgs_rev = nixpkgs_rev.as_deref().unwrap_or_else(|| {
             warn!(
@@ -346,12 +324,11 @@ impl Publish {
                 source_url: &publish_provider.env_metadata.build_repo_meta.url,
                 source_rev: &publish_provider.env_metadata.build_repo_meta.rev,
                 nixpkgs_rev,
-                system: locked.system,
-                locked_inputs: &locked.direct_catalog_inputs,
+                system: build_metadata.system,
+                locked_inputs: &build_metadata.direct_catalog_inputs,
             })
             .await;
 
-        // A true duplicate stops here, before the build.
         match dedup_outcome(check_result) {
             DedupOutcome::AlreadyPublished(resp) => {
                 message::updated(formatdoc! {"
@@ -376,41 +353,6 @@ impl Publish {
                     "Dedup pre-check failed, proceeding with publish"
                 );
             },
-        }
-
-        // Not a duplicate, so pay for the build — over the lock the phase above
-        // already resolved, rather than resolving the catalog a second time.
-        // Handing the build the lock phase's own result is what ties the two
-        // together: the lock, the stability and the system come from `locked`,
-        // so there is no second set of lock arguments to drift.
-        let build_metadata = check_build_metadata(
-            &flox,
-            &selected_base_nixpkgs_url,
-            &rendered,
-            &publish_provider.package_metadata.package,
-            &locked,
-        )?;
-
-        // The dedup verdict above was decided on the closure the lock phase
-        // resolved, so the build has to have built that same closure. The two
-        // agree by construction — the build reads the very lock `locked`
-        // names — but a lock that was not in fact reused, or a lock directory
-        // that went away underneath the build, would silently publish a
-        // package whose recorded closure was never the one checked, and every
-        // later dedup for this package would be decided against it. Fail here
-        // instead.
-        if build_metadata.system != locked.system
-            || build_metadata.direct_catalog_inputs != locked.direct_catalog_inputs
-        {
-            bail!(formatdoc! {"
-                The package that was built is not the one that was checked against the catalog.
-                Checked {locked_system} with {locked_inputs} catalog input(s), built {built_system} with {built_inputs} catalog input(s).
-                Run 'flox publish' again, and report this if it persists.",
-                locked_system = locked.system,
-                locked_inputs = locked.direct_catalog_inputs.len(),
-                built_system = build_metadata.system,
-                built_inputs = build_metadata.direct_catalog_inputs.len(),
-            });
         }
 
         // CLI args take precedence over config

--- a/cli/flox/src/commands/publish.rs
+++ b/cli/flox/src/commands/publish.rs
@@ -1,13 +1,21 @@
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::path::PathBuf;
+use std::str::FromStr;
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result, anyhow, bail};
 use bpaf::Bpaf;
 use flox_config::Config;
 use flox_events::{CliEnvironmentPublishPayload, EventKind, EventsHub};
 use flox_manifest::{Manifest, MigratedTypedOnly};
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::environment::{ConcreteEnvironment, Environment};
-use flox_rust_sdk::providers::build::{COMMON_NIXPKGS_URL, PackageTarget};
+use flox_rust_sdk::providers::build::{
+    COMMON_NIXPKGS_URL,
+    PackageTarget,
+    PackageTargetKind,
+    PackageTargets,
+    nix_expression_dir,
+};
 use flox_rust_sdk::providers::nix_auth::NixAuth;
 use flox_rust_sdk::providers::publish::{
     PublishProvider,
@@ -17,25 +25,35 @@ use flox_rust_sdk::providers::publish::{
     check_environment_metadata,
     check_package_metadata,
 };
-use floxhub_client::{CatalogClientTrait, CheckBuildQuery, CheckBuildResponse, FloxhubClientError};
+use floxhub_client::{
+    CatalogClientTrait,
+    CheckBuildQuery,
+    CheckBuildResponse,
+    FloxhubClientError,
+    LockedInputEntry,
+    PackageSystem,
+};
 use indoc::formatdoc;
-use nef_lock_catalog::NixFlakeref;
+use nef_lock_catalog::{CatalogRef, NixFlakeref, scan_package};
 use tracing::{debug, info_span, instrument, warn};
 
 use super::{DirEnvironmentSelect, dir_environment_select};
 use crate::commands::build::{
     BaseCatalogUrlSelect,
     SystemOverride,
+    UPDATE_CATALOGS_COMMAND,
     base_catalog_url_select,
     base_nixpkgs_url_from_url_select,
     check_git_tracking_for_expression_builds,
     disallow_base_url_select_for_manifest_builds,
+    expression_rel_paths,
     packages_to_build,
     prefetch_expression_build_flake_ref,
     prefetch_flake_ref,
     system_override,
 };
 use crate::commands::{SHELL_COMPLETION_FILE, ensure_auth, needs_project_files_error};
+use crate::utils::catalog_lock::BuildLockGuard;
 use crate::utils::errors::display_chain;
 use crate::utils::events::env_detail_from_concrete;
 use crate::utils::message;
@@ -69,6 +87,59 @@ fn dedup_outcome(result: Result<CheckBuildResponse, FloxhubClientError>) -> Dedu
         Ok(_) => DedupOutcome::New,
         Err(e) => DedupOutcome::CheckFailed(e),
     }
+}
+
+/// Run the dedup check and report whether the publish should stop because
+/// this exact build was already published, printing its provenance when so.
+/// A failed check warns and lets the publish continue.
+async fn dedup_short_circuit(client: &impl CatalogClientTrait, query: CheckBuildQuery<'_>) -> bool {
+    match dedup_outcome(client.check_build_already_recorded(query).await) {
+        DedupOutcome::AlreadyPublished(resp) => {
+            message::updated(formatdoc! {"
+                Package already published.
+
+                Originally published: {date}
+                Source revision: {rev}
+                ",
+                date = resp
+                    .published_at
+                    .map_or_else(|| "unknown".to_string(), |d| d.to_string()),
+                rev = resp.source_rev.unwrap_or_else(|| "unknown".to_string()),
+            });
+            true
+        },
+        DedupOutcome::New => false,
+        DedupOutcome::CheckFailed(e) => {
+            // A failed check must never block a publish; warn and continue.
+            message::warning("Unable to check if already published — continuing with publish.");
+            warn!(
+                error = %e,
+                "Dedup check failed, proceeding with publish"
+            );
+            false
+        },
+    }
+}
+
+/// The locked-input subset a publish submits, projected from the lock its
+/// build consumes, with a stale committed lock translated into an
+/// actionable error. Only the committed lock can be stale: an ephemeral
+/// lock is resolved from the same expressions the references were scanned
+/// from.
+fn subset_for_publish(
+    lock: &BuildLockGuard,
+    references: &BTreeSet<CatalogRef>,
+) -> Result<BTreeMap<String, LockedInputEntry>> {
+    lock.build_lock().subset_direct(references).map_err(|err| {
+        if lock.is_existing() {
+            anyhow!(formatdoc! {"
+                {err}
+                Run '{update_catalogs}' to update '.flox/catalog.lock', then commit the file and retry 'flox publish'.",
+                update_catalogs = UPDATE_CATALOGS_COMMAND})
+        } else {
+            anyhow::Error::from(err)
+        }
+    })
 }
 
 #[derive(Bpaf, Clone)]
@@ -229,13 +300,6 @@ impl Publish {
         // Check the environment for appropriate state to build and publish
         let env_metadata = check_environment_metadata(&flox, &path_env)?;
 
-        // The `--stability` selection also determines the stability used to
-        // resolve the catalog build inputs of NEF (expression) builds.
-        let nef_stability = match &publish_config.base_catalog_url_select {
-            Some(BaseCatalogUrlSelect::Stability(stability)) => Some(stability.clone()),
-            _ => None,
-        };
-
         let selected_base_nixpkgs_url = base_nixpkgs_url_from_url_select(
             &flox,
             publish_config.base_catalog_url_select,
@@ -294,19 +358,61 @@ impl Publish {
 
         let system_override_inner = publish_config.system_override.into_inner();
 
-        let build_metadata = check_build_metadata(
-            &flox,
-            &selected_base_nixpkgs_url,
-            system_override_inner,
-            &publish_provider.env_metadata,
-            &publish_provider.package_metadata.package,
-            nef_stability,
-        )?;
+        // The catalog references this package's expression makes, scanned
+        // locally — no build, no network. Manifest builds resolve no catalog
+        // inputs of their own.
+        let references = match publish_provider.package_metadata.package.kind() {
+            PackageTargetKind::ExpressionBuild(expression) => {
+                scan_package(nix_expression_dir(&path_env), &expression.rel_file_path)?
+            },
+            PackageTargetKind::ManifestBuild { .. } => BTreeSet::new(),
+        };
 
-        // Dedup check: ask the catalog server if this exact build has already
-        // been published before spending time on the upload. The closure
-        // identity (direct_catalog_inputs) is available after
-        // check_build_metadata, enabling a closure-aware match on the server.
+        // The lock this publish's build consumes, created up front by the
+        // CLI: the committed .flox/catalog.lock exactly as found, or a fresh
+        // ephemeral lock the package builder only passes through to the NEF
+        // evals. Scanning is scoped to the published expression — the
+        // scanner follows imports, so its references are exactly what its
+        // eval looks up — except for a manifest build, whose `${pkg}`
+        // references can pull in any of the project's expressions, so all of
+        // them are covered. A project without expression builds needs no
+        // lock at all.
+        let lock_rel_paths: Vec<PathBuf> = match publish_provider.package_metadata.package.kind() {
+            PackageTargetKind::ExpressionBuild(expression) => {
+                vec![expression.rel_file_path.clone()]
+            },
+            PackageTargetKind::ManifestBuild { .. } => {
+                let expression_ref_local = NixFlakeref::from_path(path_env.dot_flox_path())?;
+                expression_rel_paths(
+                    &PackageTargets::new(&lockfile_manifest, &expression_ref_local)?.all(),
+                )
+            },
+        };
+        let catalog_lock = match lock_rel_paths.is_empty() {
+            true => None,
+            false => Some(
+                BuildLockGuard::new_existing_or_ephemeral(
+                    &flox.floxhub_client,
+                    path_env.dot_flox_path(),
+                    &lock_rel_paths,
+                )
+                .await?,
+            ),
+        };
+
+        // The locked-input subset this publish submits, projected from the
+        // lock the build consumes. Knowable before any build runs, so a true
+        // duplicate skips the build entirely.
+        let locked_inputs = match &catalog_lock {
+            Some(lock) => subset_for_publish(lock, &references)?,
+            None => BTreeMap::new(),
+        };
+
+        // Dedup: ask the catalog server if this exact build has already been
+        // published before paying for the upload — and, when the closure
+        // identity is knowable without a build, before paying for the build
+        // too. An unparsable system is left for the build to report; the
+        // check is skipped rather than failed.
         let nixpkgs_rev = publish_provider.package_metadata.base_catalog_ref.rev();
         let nixpkgs_rev = nixpkgs_rev.as_deref().unwrap_or_else(|| {
             warn!(
@@ -316,44 +422,43 @@ impl Publish {
             );
             ""
         });
-        let catalog = &flox.floxhub_client;
-        let check_result = catalog
-            .check_build_already_recorded(CheckBuildQuery {
+        // An explicit `--system` the catalog cannot represent would
+        // otherwise silently skip the dedup check, pay for a full build, and
+        // fail later with a generic error; reject it by name up front. The
+        // native system always parses, so its fallible parse only guards
+        // against the impossible.
+        let dedup_system = match system_override_inner.as_deref() {
+            Some(value) => Some(PackageSystem::from_str(value).map_err(|_| {
+                anyhow!(
+                    "'{value}' is not a system Flox can build for; expected 'aarch64-darwin', 'aarch64-linux', 'x86_64-darwin' or 'x86_64-linux'."
+                )
+            })?),
+            None => PackageSystem::from_str(&flox.system).ok(),
+        };
+        if let Some(system) = dedup_system {
+            let locked_inputs_query: HashMap<_, _> = locked_inputs.clone().into_iter().collect();
+            let query = CheckBuildQuery {
                 catalog_name: &catalog_name,
                 package_name: publish_provider.package_metadata.package.name().as_ref(),
                 source_url: &publish_provider.env_metadata.build_repo_meta.url,
                 source_rev: &publish_provider.env_metadata.build_repo_meta.rev,
                 nixpkgs_rev,
-                system: build_metadata.system,
-                locked_inputs: &build_metadata.direct_catalog_inputs,
-            })
-            .await;
-
-        match dedup_outcome(check_result) {
-            DedupOutcome::AlreadyPublished(resp) => {
-                message::updated(formatdoc! {"
-                    Package already published.
-
-                    Originally published: {date}
-                    Source revision: {rev}
-                    ",
-                    date = resp
-                        .published_at
-                        .map_or_else(|| "unknown".to_string(), |d| d.to_string()),
-                    rev = resp.source_rev.unwrap_or_else(|| "unknown".to_string()),
-                });
+                system,
+                locked_inputs: &locked_inputs_query,
+            };
+            if dedup_short_circuit(&flox.floxhub_client, query).await {
                 return Ok(());
-            },
-            DedupOutcome::New => {},
-            DedupOutcome::CheckFailed(e) => {
-                // A failed check must never block a publish; warn and continue.
-                message::warning("Unable to check if already published — continuing with publish.");
-                warn!(
-                    error = %e,
-                    "Dedup pre-check failed, proceeding with publish"
-                );
-            },
+            }
         }
+
+        let build_metadata = check_build_metadata(
+            &flox,
+            &selected_base_nixpkgs_url,
+            system_override_inner,
+            &publish_provider.env_metadata,
+            &publish_provider.package_metadata.package,
+            catalog_lock.as_ref().map(|lock| lock.path()),
+        )?;
 
         // CLI args take precedence over config
         let key_file = publish_config.cache_args.signing_private_key.or(config
@@ -373,6 +478,7 @@ impl Publish {
                 &catalog_name,
                 package_created,
                 &build_metadata,
+                &locked_inputs,
                 key_file,
                 publish_config.metadata_only,
             )
@@ -422,6 +528,37 @@ mod tests {
     use indoc::indoc;
 
     use super::*;
+    use crate::utils::catalog_lock::test_helpers::build_lock_guard_from_parts;
+
+    /// A stale committed lock fails a publish naming both the uncovered
+    /// reference and the recovery command.
+    #[test]
+    fn stale_committed_lock_subset_names_update_catalogs() {
+        let expressions_dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            expressions_dir.path().join("hello.nix"),
+            "{ catalogs }: catalogs.myorg.hello",
+        )
+        .unwrap();
+        let references = scan_package(expressions_dir.path(), "hello.nix").unwrap();
+
+        let lock = build_lock_guard_from_parts(
+            "/project/.flox/catalog.lock",
+            nef_lock_catalog::BuildLock::default(),
+            true,
+        );
+        let err = subset_for_publish(&lock, &references)
+            .expect_err("an empty committed lock cannot cover the reference");
+        let message = format!("{err:#}");
+        assert!(
+            message.contains(UPDATE_CATALOGS_COMMAND),
+            "the hint must name the recovery command, got: {message}"
+        );
+        assert!(
+            message.contains("myorg.hello"),
+            "the uncovered reference must be named, got: {message}"
+        );
+    }
 
     #[test]
     fn detects_default_publish_target() {

--- a/cli/flox/src/utils/catalog_lock.rs
+++ b/cli/flox/src/utils/catalog_lock.rs
@@ -1,0 +1,253 @@
+//! The catalog lock a build consumes, and its lifetime.
+//!
+//! Lock *resolution* belongs to `nef-lock-catalog`; what lives here is the
+//! CLI-level decision of which lock a given invocation builds against, and
+//! the ownership of an ephemeral lock's file. Without a committed
+//! `.flox/catalog.lock` the project builds locklessly: the CLI resolves a
+//! fresh lock into a temp file that lives exactly as long as the build, and
+//! nothing is ever written into the project tree.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use flox_rust_sdk::providers::build::nix_expression_dir_in;
+use floxhub_client::CatalogClientTrait;
+use nef_lock_catalog::{
+    BuildLock,
+    CATALOG_LOCKFILE_NAME,
+    catalog_lockfile_path,
+    read_lock,
+    resolve_lock,
+    scan_references,
+    write_lock,
+};
+use tracing::debug;
+
+/// The lock a build consumes, created before the package builder is
+/// invoked and handed to it as `CATALOG_LOCKFILE`. Owns an ephemeral lock's
+/// file: dropping the guard removes it.
+#[derive(Debug)]
+pub struct BuildLockGuard {
+    path: PathBuf,
+    lock: BuildLock,
+    /// Keeps an ephemeral lock's temp file alive for as long as this value;
+    /// `None` when the lock is the committed file.
+    _ephemeral: Option<tempfile::TempPath>,
+}
+
+impl BuildLockGuard {
+    /// The committed `.flox/catalog.lock` exactly as found when one exists;
+    /// otherwise a fresh ephemeral lock resolving the union of the
+    /// references of the expressions named by `rel_file_paths` (relative to
+    /// the project's expression directory), written to a randomly named
+    /// temp file that is removed when the returned value is dropped.
+    pub async fn new_existing_or_ephemeral(
+        client: &impl CatalogClientTrait,
+        dot_flox_path: impl AsRef<Path>,
+        rel_file_paths: impl IntoIterator<Item = impl AsRef<Path>>,
+    ) -> Result<BuildLockGuard> {
+        let dot_flox_path = dot_flox_path.as_ref();
+        let committed = catalog_lockfile_path(dot_flox_path);
+        if committed.exists() {
+            let lock = read_lock(&committed)?;
+            // The path handed to make is *relative to the project
+            // directory* make is started in (`--directory`), composed of
+            // two constant components — so a project path containing
+            // whitespace (or any other character make's word-splitting
+            // positions would mangle) never reaches the makefile.
+            let dot_flox_dir_name = dot_flox_path
+                .file_name()
+                .expect("the .flox path has a final component");
+            debug!(path = %committed.display(), "build consumes the committed catalog lock");
+            return Ok(BuildLockGuard {
+                path: Path::new(dot_flox_dir_name).join(CATALOG_LOCKFILE_NAME),
+                lock,
+                _ephemeral: None,
+            });
+        }
+
+        let references = scan_references(nix_expression_dir_in(dot_flox_path), rel_file_paths)?;
+        let lock = resolve_lock(client, references).await?;
+        // The system temp dir, not flox's own temp dir: flox's derives from
+        // `$HOME`, which the user may have placed at a path containing
+        // whitespace, and the ephemeral path reaches make's word-splitting
+        // positions. The system temp dir shares the whitespace-free
+        // assumption the makefile's own PROJECT_TMPDIR (`$(TMPDIR)/<hash>`)
+        // already makes. This deliberately sits outside flox's centralized
+        // per-process temp cleanup; the guard's drop removes the file
+        // instead.
+        let temp_path = tempfile::Builder::new()
+            .prefix("flox-catalog.lock.")
+            .tempfile()
+            .context("Could not create a temporary file for the catalog lock.")?
+            .into_temp_path();
+        write_lock(&lock, &temp_path)?;
+        debug!(path = %temp_path.display(), "build consumes a fresh ephemeral catalog lock");
+        Ok(BuildLockGuard {
+            path: temp_path.to_path_buf(),
+            lock,
+            _ephemeral: Some(temp_path),
+        })
+    }
+
+    /// The path to hand to the package builder as `CATALOG_LOCKFILE`:
+    /// relative to the project directory (make's `--directory`) for the
+    /// committed lock, absolute and whitespace-free for an ephemeral one.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// The lock itself, to project the subset a publish submits out of.
+    pub fn build_lock(&self) -> &BuildLock {
+        &self.lock
+    }
+
+    /// Whether this is the committed `.flox/catalog.lock` rather than an
+    /// ephemeral lock, e.g. to select stale-lock messaging.
+    pub fn is_existing(&self) -> bool {
+        self._ephemeral.is_none()
+    }
+}
+
+#[cfg(test)]
+pub mod test_helpers {
+    use super::*;
+
+    /// Construct a [BuildLockGuard] from parts, for tests that need to
+    /// exercise consumers (e.g. publish's stale-lock messaging) without a
+    /// scan or a catalog round-trip.
+    pub fn build_lock_guard_from_parts(
+        path: impl Into<PathBuf>,
+        lock: BuildLock,
+        committed: bool,
+    ) -> BuildLockGuard {
+        BuildLockGuard {
+            path: path.into(),
+            lock,
+            _ephemeral: match committed {
+                true => None,
+                false => Some(
+                    tempfile::NamedTempFile::new()
+                        .expect("temp file for test lock")
+                        .into_temp_path(),
+                ),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use floxhub_client::client::test_helpers::new_noop;
+    use nef_lock_catalog::scan_package;
+    use tempfile::tempdir;
+
+    use super::*;
+
+    /// A committed lock with one canonical entry, plus an expression that
+    /// references it.
+    const COMMITTED_LOCK: &str = r#"{
+  "version": 1,
+  "direct_catalog_inputs": {
+    "myorg/hello": {
+      "attr_path": ["hello"],
+      "build_type": "nef",
+      "catalog": "myorg",
+      "locked_inputs_hash": "sha256-test",
+      "source": {
+        "dir": ".",
+        "ref": "refs/heads/main",
+        "rev": "0000000000000000000000000000000000000000",
+        "type": "git",
+        "url": "https://example.com/repo"
+      }
+    }
+  },
+  "catalogs": {}
+}
+"#;
+
+    fn project_with_expression(expression: &str) -> (tempfile::TempDir, PathBuf, PathBuf) {
+        let project = tempdir().unwrap();
+        let dot_flox = project.path().join(".flox");
+        let pkgs_dir = nix_expression_dir_in(&dot_flox);
+        std::fs::create_dir_all(&pkgs_dir).unwrap();
+        std::fs::write(pkgs_dir.join("hello.nix"), expression).unwrap();
+        (project, dot_flox, pkgs_dir)
+    }
+
+    /// A project whose expressions make no catalog references resolves an
+    /// empty ephemeral lock without any catalog request: the no-op client
+    /// fails every request it is asked to make, so reaching the network at
+    /// all fails this test.
+    #[tokio::test]
+    async fn no_references_resolve_without_a_catalog_request() {
+        let (_project, dot_flox, _pkgs_dir) =
+            project_with_expression("{ runCommand }: runCommand \"hello\" { } \"\"");
+        let lock = BuildLockGuard::new_existing_or_ephemeral(&new_noop(), &dot_flox, ["hello.nix"])
+            .await
+            .unwrap();
+
+        assert!(!lock.is_existing());
+        assert!(
+            !lock.path().to_string_lossy().contains(char::is_whitespace),
+            "an ephemeral lock path must be whitespace-free: {}",
+            lock.path().display()
+        );
+        assert_eq!(
+            std::fs::read_to_string(lock.path()).unwrap(),
+            "{\n  \"version\": 1,\n  \"direct_catalog_inputs\": {},\n  \"catalogs\": {}\n}\n"
+        );
+    }
+
+    /// A committed lock is consumed exactly as found: no catalog request
+    /// (no-op client), no rewrite (byte-identical file), and the subset
+    /// selects the committed entry by the scanned reference.
+    #[tokio::test]
+    async fn committed_lock_is_consumed_as_found_without_a_catalog_request() {
+        let (_project, dot_flox, pkgs_dir) =
+            project_with_expression("{ catalogs }: catalogs.myorg.hello");
+        std::fs::write(catalog_lockfile_path(&dot_flox), COMMITTED_LOCK).unwrap();
+        let lock = BuildLockGuard::new_existing_or_ephemeral(&new_noop(), &dot_flox, ["hello.nix"])
+            .await
+            .unwrap();
+
+        assert!(lock.is_existing());
+        assert_eq!(lock.path(), Path::new(".flox").join(CATALOG_LOCKFILE_NAME));
+        assert_eq!(
+            std::fs::read_to_string(catalog_lockfile_path(&dot_flox)).unwrap(),
+            COMMITTED_LOCK,
+            "the committed lock must not be rewritten"
+        );
+
+        let references = scan_package(&pkgs_dir, "hello.nix").unwrap();
+        let subset = lock.build_lock().subset_direct(&references).unwrap();
+        assert_eq!(subset.keys().collect::<Vec<_>>(), vec![
+            &"myorg/hello".to_string()
+        ]);
+    }
+
+    /// A committed lock that does not cover a scanned reference is still
+    /// consumed as found; the staleness surfaces from the subset, naming
+    /// the uncovered reference.
+    #[tokio::test]
+    async fn stale_committed_lock_names_the_uncovered_reference() {
+        let (_project, dot_flox, pkgs_dir) =
+            project_with_expression("{ catalogs }: catalogs.myorg.world");
+        std::fs::write(catalog_lockfile_path(&dot_flox), COMMITTED_LOCK).unwrap();
+        let lock = BuildLockGuard::new_existing_or_ephemeral(&new_noop(), &dot_flox, ["hello.nix"])
+            .await
+            .unwrap();
+        assert!(lock.is_existing());
+
+        let references = scan_package(&pkgs_dir, "hello.nix").unwrap();
+        let err = lock
+            .build_lock()
+            .subset_direct(&references)
+            .expect_err("an uncovered reference must be stale");
+        assert!(
+            err.to_string().contains("myorg.world"),
+            "the uncovered reference must be named, got: {err}"
+        );
+    }
+}

--- a/cli/flox/src/utils/mod.rs
+++ b/cli/flox/src/utils/mod.rs
@@ -7,6 +7,7 @@ use flox_core::util::default_nix_env_vars;
 
 pub mod active_environments;
 pub mod auth_warning;
+pub mod catalog_lock;
 pub mod colors;
 pub mod credential_store;
 pub mod detect_shell;

--- a/cli/nef-lock-catalog/Cargo.toml
+++ b/cli/nef-lock-catalog/Cargo.toml
@@ -23,3 +23,7 @@ flox-core = {path = "../flox-core"}
 rnix.workspace = true
 rowan.workspace = true
 tokio.workspace = true
+
+[dev-dependencies]
+floxhub-client = { path = "../floxhub-client", features = ["tests"] }
+tempfile.workspace = true

--- a/cli/nef-lock-catalog/src/bin/lock.rs
+++ b/cli/nef-lock-catalog/src/bin/lock.rs
@@ -10,12 +10,10 @@ use flox_core::floxhub::{DEFAULT_FLOXHUB_URL, Floxhub};
 use flox_core::util::message::format_error;
 use floxhub_client::{
     AuthContext,
-    BaseCatalogInfo,
     FloxhubClient,
     FloxhubClientConfig,
     FloxhubClientError,
     FloxhubMockMode,
-    Stability,
 };
 use nef_lock_catalog::{
     BuildLock,
@@ -54,10 +52,6 @@ struct Cli {
     /// printed to stdout.
     #[arg(long)]
     out: Option<PathBuf>,
-
-    /// Catalog stability channel.
-    #[arg(long, default_value = BaseCatalogInfo::DEFAULT_STABILITY)]
-    stability: Stability,
 
     /// Explain each step: files read, catalog references found (with source
     /// locations), the resolved catalog endpoint, and the full lookup request
@@ -117,7 +111,6 @@ async fn main() -> ExitCode {
         base_dir = %cli.base_dir.display(),
         rel_paths = cli.rel_paths.len(),
         out = cli.out.as_deref().map(|out| out.display().to_string()).unwrap_or_else(|| "<stdout>".to_string()),
-        stability = cli.stability.as_str(),
     )
 )]
 async fn run(cli: Cli) -> Result<()> {
@@ -149,7 +142,7 @@ async fn run(cli: Cli) -> Result<()> {
     // Lock references via the catalog or produce an empty lock file if no references were found.
     let lock = if !references.is_empty() {
         // Render each failure to its message body at the CLI boundary.
-        match lock_references(&client, references, cli.stability).await {
+        match lock_references(&client, references).await {
             Ok(lock) => lock,
             // REQ-013: surface the unresolvable dependency chains.
             Err(LockError::Unresolvable(entries)) => bail!(render_unresolvable(&entries)),

--- a/cli/nef-lock-catalog/src/lib.rs
+++ b/cli/nef-lock-catalog/src/lib.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 
 mod lock;
 mod nix;
+mod project;
 mod scan;
 
 /// Common identifier for a catalog and its `CatalogLock` in a build lock.
@@ -23,8 +24,25 @@ impl Display for CatalogId {
     }
 }
 
-pub use lock::build_lock::{BuildLock, render_lock, write_lock};
+pub use lock::build_lock::{
+    BuildLock,
+    LockfileError,
+    StaleLockError,
+    read_lock,
+    render_lock,
+    subset_direct_inputs,
+    write_lock,
+};
 pub use lock::flakeref::NixFlakeref;
 pub use lock::lookup::{LockError, lock_references};
 pub use lock::render::render_unresolvable;
+pub use lock::transform::build_lock_from_locked_inputs;
+pub use project::{
+    CATALOG_LOCKFILE_NAME,
+    CatalogLockError,
+    catalog_lockfile_path,
+    lock_project_catalog,
+    resolve_lock,
+    scan_references,
+};
 pub use scan::{CatalogRef, ImportSite, ScanError, scan_package, scan_package_with_roots};

--- a/cli/nef-lock-catalog/src/lock/build_lock.rs
+++ b/cli/nef-lock-catalog/src/lock/build_lock.rs
@@ -1,20 +1,19 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
-use anyhow::{Context, Result};
-use flox_core::Version;
+use flox_core::{Version, WriteError, write_atomically};
 use floxhub_client::LockedInputEntry;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use tracing::{debug, instrument};
 
 use super::tree::PackageTreeNode;
-use crate::CatalogId;
+use crate::{CatalogId, CatalogRef};
 
 /// Locked source information for a catalog: a package attribute hierarchy with
 /// a locked source per package at its leaves, as returned by the catalog
 /// `/build-inputs/lookup` endpoint.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub(crate) enum CatalogLock {
     #[serde(rename = "floxhub")]
@@ -27,12 +26,12 @@ pub(crate) enum CatalogLock {
 /// A `BuildLock` is a collection of locked sources for each catalog.
 /// It is used to ensure reproducibility of builds by locking the
 /// sources of declared dependencies.
-#[derive(Debug, Clone, Default, Serialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct BuildLock {
     #[serde(rename = "version")]
     pub(crate) _version: Version<1>,
-    /// The direct (first-order) catalog inputs, keyed by their locked-input
-    /// reference. Publish records this subset on the build.
+    /// The direct (first-order) catalog inputs, keyed by the server's
+    /// canonical `<catalog>/<attr-path>` form.
     ///
     /// Note: `LockedInputEntry` is generated from the catalog OpenAPI spec.
     /// Serializing it verbatim into this on-disk lock couples the persisted
@@ -40,27 +39,295 @@ pub struct BuildLock {
     /// the lock format. A later increment should insulate this with a
     /// hand-owned domain type (cf. the `BaseCatalogInfo` newtype and `From`
     /// impls in `floxhub-client`).
-    pub(crate) direct_catalog_inputs: HashMap<String, LockedInputEntry>,
+    pub(crate) direct_catalog_inputs: BTreeMap<String, LockedInputEntry>,
     pub(crate) catalogs: BTreeMap<CatalogId, CatalogLock>,
 }
 
-impl BuildLock {}
+/// References a lock was asked to cover but does not contain: the lock is
+/// stale relative to the expressions that were scanned.
+#[derive(Debug, thiserror::Error)]
+#[error(
+    "The catalog lock does not cover: {}",
+    .missing.iter().map(ToString::to_string).collect::<Vec<_>>().join(", ")
+)]
+pub struct StaleLockError {
+    /// The scanned references with no entry in the lock, in scan order.
+    pub missing: Vec<CatalogRef>,
+}
+
+/// Failure reading, parsing, serializing or writing a lock file. Typed so
+/// consumers can distinguish an unreadable lock from a corrupt one and offer
+/// a real next step.
+#[derive(Debug, thiserror::Error)]
+pub enum LockfileError {
+    #[error("failed to read {path}")]
+    Read {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to parse {path}")]
+    Parse {
+        path: PathBuf,
+        #[source]
+        source: serde_json::Error,
+    },
+    #[error("failed to serialize the lock")]
+    Serialize(#[source] serde_json::Error),
+    #[error("failed to write {path}")]
+    Write {
+        path: PathBuf,
+        #[source]
+        source: WriteError,
+    },
+}
+
+impl BuildLock {
+    /// The direct-input entries covering exactly `references`; see
+    /// [subset_direct_inputs].
+    pub fn subset_direct(
+        &self,
+        references: &BTreeSet<CatalogRef>,
+    ) -> Result<BTreeMap<String, LockedInputEntry>, StaleLockError> {
+        subset_direct_inputs(&self.direct_catalog_inputs, references)
+    }
+
+    /// The direct (first-order) catalog inputs the lock pins.
+    pub fn direct_catalog_inputs(&self) -> &BTreeMap<String, LockedInputEntry> {
+        &self.direct_catalog_inputs
+    }
+}
+
+/// The entries of `direct_catalog_inputs` covering exactly `references`.
+///
+/// This is the publish-time projection of a lock: the subset a single
+/// package's scanned references select, submitted with the build instead of
+/// everything the lock resolved — the map of a [BuildLock] the CLI read
+/// from disk or resolved itself. Fails with the uncovered references when
+/// the inputs are stale.
+///
+/// References are matched against the entries themselves — an entry covers a
+/// reference when its `catalog` matches and its `attr_path` is a prefix of
+/// the reference's path under the catalog (a reference may select a member
+/// of the package it resolved to; the most specific entry wins). The map's
+/// keys are the server's canonical `<catalog>/<attr-path>` form, a namespace
+/// distinct from the dot-rendered references, so keys are carried through
+/// verbatim and never reconstructed. A wildcard reference selects every
+/// entry under its prefix.
+pub fn subset_direct_inputs(
+    direct_catalog_inputs: &BTreeMap<String, LockedInputEntry>,
+    references: &BTreeSet<CatalogRef>,
+) -> Result<BTreeMap<String, LockedInputEntry>, StaleLockError> {
+    let mut subset = BTreeMap::new();
+    let mut missing = Vec::new();
+    for reference in references {
+        // A reference names `<root>.<catalog>.<path...>`; its invariant
+        // guarantees the catalog component is present.
+        let names = reference.path().attribute_names();
+        let (catalog, path) = (names[1], &names[2..]);
+        let wildcard = reference.path().is_wildcard();
+
+        let mut matched: Vec<(&String, &LockedInputEntry)> = direct_catalog_inputs
+            .iter()
+            .filter(|(_, entry)| {
+                entry.catalog == catalog && {
+                    let entry_path: Vec<&str> =
+                        entry.attr_path.iter().map(String::as_str).collect();
+                    path.starts_with(&entry_path[..]) || (wildcard && entry_path.starts_with(path))
+                }
+            })
+            .collect();
+
+        if !wildcard {
+            // The reference resolved to exactly one package: the entry whose
+            // attr_path names it most specifically.
+            matched = matched
+                .into_iter()
+                .max_by_key(|(_, entry)| entry.attr_path.len())
+                .into_iter()
+                .collect();
+        }
+
+        if matched.is_empty() {
+            missing.push(reference.clone());
+        } else {
+            for (key, entry) in matched {
+                subset.insert(key.clone(), entry.clone());
+            }
+        }
+    }
+    if !missing.is_empty() {
+        return Err(StaleLockError { missing });
+    }
+    Ok(subset)
+}
+
+/// Read a `BuildLock` from the specified file, as written by [write_lock].
+#[instrument(fields(path = %path.as_ref().display()))]
+pub fn read_lock(path: impl AsRef<Path>) -> Result<BuildLock, LockfileError> {
+    let path = path.as_ref();
+    let json = fs::read_to_string(path).map_err(|source| LockfileError::Read {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    serde_json::from_str(&json).map_err(|source| LockfileError::Parse {
+        path: path.to_path_buf(),
+        source,
+    })
+}
 
 /// Serialize a `BuildLock` to the pretty-printed JSON format consumed by the
 /// NEF. Shared by [write_lock] and callers that stream the lock elsewhere
 /// (e.g. stdout).
-pub fn render_lock(lock: &BuildLock) -> Result<String> {
-    serde_json::to_string_pretty(lock).context("failed to serialize lockfile")
+pub fn render_lock(lock: &BuildLock) -> Result<String, LockfileError> {
+    serde_json::to_string_pretty(lock).map_err(LockfileError::Serialize)
 }
 
 /// Write a `BuildLock` to the specified file.
 /// The file is written in a pretty-printed JSON format
 /// and consumed by the NEF.
+/// The write is atomic — rendered to a temp file in the target's directory
+/// and renamed into place — so a crash mid-write can never leave a
+/// truncated lock for a later build to trust. The temp file gets a fresh
+/// random name on every call (`flox_core::write_atomically`, the same
+/// helper `flox-core` itself uses for its own state files) rather than one
+/// derived from `path`: concurrent CLI invocations of one project share
+/// the committed `.flox/catalog.lock` path and may share a temp directory
+/// for their `catalog.lock.`-prefixed ephemeral files, and a temp name
+/// derived from the target path would let those writers truncate or
+/// overwrite each other's write before either renamed into place.
 #[instrument(skip(lock), fields(path = %path.as_ref().display()))]
-pub fn write_lock(lock: &BuildLock, path: impl AsRef<Path>) -> Result<()> {
+pub fn write_lock(lock: &BuildLock, path: impl AsRef<Path>) -> Result<(), LockfileError> {
+    let path = path.as_ref();
     let json = format!("{}\n", render_lock(lock)?);
-    fs::write(&path, &json)
-        .with_context(|| format!("failed to write {path:?}", path = path.as_ref()))?;
+    write_atomically(path, &json).map_err(|source| LockfileError::Write {
+        path: path.to_path_buf(),
+        source,
+    })?;
     debug!(bytes = json.len(), "wrote build lock");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{BTreeSet, HashMap};
+
+    use floxhub_client::{BuildType, LockedGitSource, LockedInputEntry};
+
+    use super::*;
+    use crate::lock::transform::build_lock_from_locked_inputs;
+
+    fn entry(catalog: &str, attr_path: &[&str]) -> LockedInputEntry {
+        LockedInputEntry {
+            attr_path: attr_path.iter().map(|s| s.to_string()).collect(),
+            build_type: BuildType::Nef,
+            catalog: catalog.to_string(),
+            inputs: None,
+            locked_inputs_hash: "sha256-test".to_string(),
+            source: LockedGitSource {
+                dir: ".".to_string(),
+                ref_: "refs/heads/main".to_string(),
+                rev: "abc".to_string(),
+                type_: "git".to_string(),
+                url: "https://example.com/repo".to_string(),
+            },
+        }
+    }
+
+    /// A lock whose direct inputs are exactly the given canonical keys
+    /// (`<catalog>/<attr-path>`, the server's keying — see
+    /// test_data/build_inputs_lookup/success.json), assembled the same way
+    /// the lookup response transform assembles a real lock.
+    fn lock_with(keys: &[&str]) -> BuildLock {
+        let locked: HashMap<String, LockedInputEntry> = keys
+            .iter()
+            .map(|key| {
+                let (catalog, rest) = key.split_once('/').expect("test keys are catalog/attr");
+                let attr_path: Vec<&str> = rest.split('.').collect();
+                ((*key).to_string(), entry(catalog, &attr_path))
+            })
+            .collect();
+        let direct_keys: Vec<String> = keys.iter().map(|key| (*key).to_string()).collect();
+        build_lock_from_locked_inputs(locked, direct_keys.iter()).expect("transform succeeds")
+    }
+
+    fn references(refs: &[&str]) -> BTreeSet<CatalogRef> {
+        refs.iter().map(|r| CatalogRef::new_unchecked(r)).collect()
+    }
+
+    #[test]
+    fn subset_direct_selects_only_the_requested_references() {
+        let lock = lock_with(&["myorg/hello", "myorg/world", "other/tool"]);
+
+        let subset = lock
+            .subset_direct(&references(&["catalogs.myorg.hello"]))
+            .expect("references are covered");
+
+        assert_eq!(subset.keys().collect::<Vec<_>>(), vec![
+            &"myorg/hello".to_string()
+        ]);
+        assert_eq!(
+            subset["myorg/hello"],
+            lock.direct_catalog_inputs["myorg/hello"]
+        );
+    }
+
+    /// A reference may select a member of the package it resolved to
+    /// (`catalogs.myorg.toolkit.readVersion` → entry `myorg/toolkit`); the
+    /// most specific entry wins when entries nest.
+    #[test]
+    fn subset_direct_resolves_a_member_selection_to_its_package() {
+        let lock = lock_with(&["myorg/toolkit", "myorg/toolkit.extras"]);
+
+        let subset = lock
+            .subset_direct(&references(&["catalogs.myorg.toolkit.readVersion"]))
+            .expect("references are covered");
+        assert_eq!(subset.keys().collect::<Vec<_>>(), vec![
+            &"myorg/toolkit".to_string()
+        ]);
+
+        let subset = lock
+            .subset_direct(&references(&["catalogs.myorg.toolkit.extras.render"]))
+            .expect("references are covered");
+        assert_eq!(subset.keys().collect::<Vec<_>>(), vec![
+            &"myorg/toolkit.extras".to_string()
+        ]);
+    }
+
+    #[test]
+    fn subset_direct_names_every_uncovered_reference() {
+        let lock = lock_with(&["myorg/hello"]);
+
+        let err = lock
+            .subset_direct(&references(&[
+                "catalogs.myorg.hello",
+                "catalogs.myorg.missing",
+                "catalogs.other.gone",
+            ]))
+            .expect_err("uncovered references fail the subset");
+
+        assert_eq!(
+            err.missing,
+            references(&["catalogs.myorg.missing", "catalogs.other.gone"])
+                .into_iter()
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn rendered_lock_reads_back_and_subsets() {
+        let lock = lock_with(&["myorg/hello", "other/tool"]);
+        let rendered = render_lock(&lock).expect("lock renders");
+
+        let read: BuildLock = serde_json::from_str(&rendered).expect("rendered lock parses");
+        let subset = read
+            .subset_direct(&references(&["catalogs.other.tool"]))
+            .expect("references are covered");
+
+        assert_eq!(
+            subset,
+            lock.subset_direct(&references(&["catalogs.other.tool"]))
+                .unwrap()
+        );
+    }
 }

--- a/cli/nef-lock-catalog/src/lock/lookup.rs
+++ b/cli/nef-lock-catalog/src/lock/lookup.rs
@@ -17,7 +17,6 @@ use floxhub_client::{
     FloxhubClientError,
     LookupGroup,
     ReferencesItem,
-    Stability,
     UnresolvableEntry,
 };
 use tracing::{debug, instrument};
@@ -53,19 +52,12 @@ pub enum LockError {
 /// Builds the wire request internally (one synthetic group), performs one
 /// `/build-inputs/lookup` call, and maps the response to a [BuildLock].
 /// Returns [LockError::Unresolvable] if any reference is unresolvable.
-///
-/// `stability` is the typed [Stability] parsed at the CLI boundary, so this
-/// function cannot fail on an invalid stability string.
-#[instrument(
-    skip(client, references),
-    fields(references = references.len(), stability = stability.as_str())
-)]
+#[instrument(skip(client, references), fields(references = references.len()))]
 pub async fn lock_references(
-    client: &(impl CatalogClientTrait + Send + Sync),
+    client: &impl CatalogClientTrait,
     references: BTreeSet<CatalogRef>,
-    stability: Stability,
 ) -> Result<BuildLock, LockError> {
-    let request = build_request(references, stability);
+    let request = build_request(references);
     // The exact JSON POSTed to `/build-inputs/lookup`, for `--verbose`. Guarded
     // so the request is only serialized when the level is enabled.
     if tracing::enabled!(tracing::Level::DEBUG) {
@@ -86,10 +78,7 @@ pub async fn lock_references(
 /// `reference_point` is defaulted to `None` for now. The endpoint is
 /// system-independent: the response carries source revs + DAG edges, which
 /// carry no system, so the request has no system field.
-fn build_request(
-    references: BTreeSet<CatalogRef>,
-    stability: Stability,
-) -> BuildInputsLookupRequest {
+fn build_request(references: BTreeSet<CatalogRef>) -> BuildInputsLookupRequest {
     let group = LookupGroup {
         key: LOOKUP_GROUP_KEY.to_string(),
         references: references.iter().map(wire_reference).collect(),
@@ -98,7 +87,12 @@ fn build_request(
     BuildInputsLookupRequest {
         groups: vec![group],
         reference_point: None,
-        stability,
+        // Catalog-input resolution is independent of the nixpkgs base-catalog
+        // stability, but the OpenAPI spec still marks `stability` as a
+        // required request field. The field is in the process of being
+        // deprecated on the server side and in the spec; until that
+        // coordinated change lands, send the constant "stable".
+        stability: "stable".parse().expect("constant stability parses"),
     }
 }
 
@@ -109,17 +103,13 @@ fn build_request(
 /// namespace is catalog-relative (`<catalog>.<package>`). Drop the leading root
 /// segment so the request matches what the server expects.
 fn wire_reference(reference: &CatalogRef) -> ReferencesItem {
-    // A reference always has a root to drop; that is what makes it one. An
-    // attribute Nix would not read bare goes out quoted, which the dotted wire
-    // format needs to stay unambiguous — it cannot express a name containing a
-    // `.` any other way.
-    let relative = reference
-        .path()
-        .pop_root()
-        .expect("a reference names something under its root")
-        .to_string();
+    // An attribute Nix would not read bare goes out quoted, which the dotted
+    // wire format needs to stay unambiguous — it cannot express a name
+    // containing a `.` any other way.
+    //
     // Catalog paths are well below the 1024-char wire limit.
-    relative
+    reference
+        .wire_key()
         .parse()
         .expect("catalog reference exceeded 1024 chars")
 }
@@ -170,7 +160,7 @@ mod tests {
             CatalogRef::new_unchecked("catalogs.myorg.world"),
         ]);
 
-        let wire = build_request(references, "stable".parse().unwrap());
+        let wire = build_request(references);
 
         // All references collapse into a single wire group, and the leading
         // `catalogs` root segment is dropped — the server's reference namespace
@@ -211,6 +201,33 @@ mod tests {
                 "ref": "refs/heads/main",
                 "dir": "."
             })
+        );
+    }
+
+    /// The reference that produced the lock must select its entry back out
+    /// of it. The server keys `direct_catalog_inputs` canonically
+    /// (`myorg/hello`) while the reference renders dotted (`myorg.hello`) —
+    /// the two namespaces must never be conflated, and only a fixture-shaped
+    /// lock can catch it.
+    #[test]
+    fn success_fixture_subsets_by_its_own_reference() {
+        let response: BuildInputsLookupResponse = serde_json::from_str(include_str!(
+            "../../test_data/build_inputs_lookup/success.json"
+        ))
+        .expect("success fixture deserializes");
+        let lock = lock_from_response(response).expect("success fixture locks");
+
+        let references = BTreeSet::from([CatalogRef::new_unchecked("catalogs.myorg.hello")]);
+        let subset = lock
+            .subset_direct(&references)
+            .expect("the lock's own reference is covered");
+
+        assert_eq!(subset.keys().collect::<Vec<_>>(), vec![
+            &"myorg/hello".to_string()
+        ]);
+        assert_eq!(
+            subset["myorg/hello"],
+            lock.direct_catalog_inputs["myorg/hello"]
         );
     }
 

--- a/cli/nef-lock-catalog/src/lock/transform.rs
+++ b/cli/nef-lock-catalog/src/lock/transform.rs
@@ -21,7 +21,7 @@ use crate::lock::tree::PackageTreeBuilder;
 /// [`LockedInputEntry::attr_path`]. The wire `source` is stored **verbatim** —
 /// no nix invocation.
 #[instrument(skip(locked, direct_keys), fields(packages = locked.len()))]
-pub(crate) fn build_lock_from_locked_inputs<'d>(
+pub fn build_lock_from_locked_inputs<'d>(
     locked: HashMap<String, LockedInputEntry>,
     direct_keys: impl IntoIterator<Item = &'d String>,
 ) -> Result<BuildLock> {
@@ -35,7 +35,7 @@ pub(crate) fn build_lock_from_locked_inputs<'d>(
             })?;
             Ok((key.clone(), entry))
         })
-        .collect::<Result<HashMap<String, LockedInputEntry>>>()?;
+        .collect::<Result<BTreeMap<String, LockedInputEntry>>>()?;
 
     for entry in locked.into_values() {
         let LockedInputEntry {

--- a/cli/nef-lock-catalog/src/project.rs
+++ b/cli/nef-lock-catalog/src/project.rs
@@ -1,0 +1,170 @@
+//! The project-level catalog lock.
+//!
+//! A project has exactly one catalog lock — `.flox/catalog.lock` — pinning
+//! the source of every `catalogs.*` reference made by the project's Nix
+//! expressions. A single lock means a single revision always evaluates
+//! against one consistent set of inputs, leaving no room for diamond
+//! dependency conflicts between packages of the same project.
+//!
+//! This module resolves and writes that lock; the CLI owns its lifecycle
+//! and hands the package builder the file to pass through to the NEF evals.
+//! The committed lock is created explicitly by [lock_project_catalog],
+//! locking the union of every expression's references, and is consumed by
+//! builds exactly as found — deliberately including one that no longer
+//! covers the expressions' references, in which case the NEF eval fails and
+//! the user recreates the lock explicitly.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use floxhub_client::CatalogClientTrait;
+use thiserror::Error;
+use tracing::debug;
+
+use crate::{
+    BuildLock,
+    CatalogRef,
+    LockError,
+    LockfileError,
+    ScanError,
+    StaleLockError,
+    lock_references,
+    render_unresolvable,
+    scan_package,
+    write_lock,
+};
+
+/// File name of the project catalog lock, relative to the `.flox` directory.
+pub const CATALOG_LOCKFILE_NAME: &str = "catalog.lock";
+
+/// The location of the project catalog lock within `dot_flox_path`.
+pub fn catalog_lockfile_path(dot_flox_path: impl AsRef<Path>) -> PathBuf {
+    dot_flox_path.as_ref().join(CATALOG_LOCKFILE_NAME)
+}
+
+#[derive(Debug, Error)]
+pub enum CatalogLockError {
+    #[error(transparent)]
+    Scan(#[from] ScanError),
+
+    #[error(transparent)]
+    Lock(#[from] LockError),
+
+    /// Unresolvable references, pre-rendered with their dependency chains
+    /// and the remediation footer (see [render_unresolvable]) so every CLI
+    /// entry point that locks — build, publish, update-catalogs — reports
+    /// the reference names and a next step rather than a bare count.
+    #[error("{0}")]
+    Unresolvable(String),
+
+    #[error(transparent)]
+    StaleLock(#[from] StaleLockError),
+
+    #[error(transparent)]
+    Lockfile(#[from] LockfileError),
+}
+
+/// Resolve `references` through the catalog, or produce an empty lock
+/// without any request when there are none — the common case for projects
+/// whose expressions make no catalog references.
+pub async fn resolve_lock(
+    client: &impl CatalogClientTrait,
+    references: BTreeSet<CatalogRef>,
+) -> Result<BuildLock, CatalogLockError> {
+    if references.is_empty() {
+        return Ok(BuildLock::default());
+    }
+    match lock_references(client, references).await {
+        Ok(lock) => Ok(lock),
+        Err(LockError::Unresolvable(entries)) => Err(CatalogLockError::Unresolvable(
+            render_unresolvable(&entries),
+        )),
+        Err(err) => Err(err.into()),
+    }
+}
+
+/// Scan every expression named by `rel_file_paths` (relative to
+/// `expressions_dir`) and return the union of their catalog references.
+pub fn scan_references(
+    expressions_dir: impl AsRef<Path>,
+    rel_file_paths: impl IntoIterator<Item = impl AsRef<Path>>,
+) -> Result<BTreeSet<CatalogRef>, CatalogLockError> {
+    let expressions_dir = expressions_dir.as_ref();
+    let mut references = BTreeSet::new();
+    for rel_file_path in rel_file_paths {
+        references.extend(scan_package(expressions_dir, rel_file_path)?);
+    }
+    Ok(references)
+}
+
+/// Create (or re-create) the project catalog lock at `lockfile_path`.
+///
+/// Scans every expression named by `rel_file_paths` (relative to
+/// `expressions_dir`) and locks the union of their catalog references in a
+/// single request, so the resulting lock is internally consistent by
+/// construction. Returns the scanned references.
+pub async fn lock_project_catalog(
+    client: &impl CatalogClientTrait,
+    expressions_dir: impl AsRef<Path>,
+    rel_file_paths: impl IntoIterator<Item = impl AsRef<Path>>,
+    lockfile_path: impl AsRef<Path>,
+) -> Result<BTreeSet<CatalogRef>, CatalogLockError> {
+    let references = scan_references(expressions_dir, rel_file_paths)?;
+    let lock = resolve_lock(client, references.clone()).await?;
+    write_lock(&lock, &lockfile_path)?;
+    debug!(
+        path = %lockfile_path.as_ref().display(),
+        references = references.len(),
+        "wrote project catalog lock"
+    );
+    Ok(references)
+}
+
+#[cfg(test)]
+mod tests {
+    use floxhub_client::client::test_helpers::new_noop;
+    use tempfile::tempdir;
+
+    use super::*;
+
+    /// A project directory whose single expression is `expression`.
+    fn project_with_expression(expression: &str) -> (tempfile::TempDir, PathBuf, PathBuf) {
+        let project = tempdir().unwrap();
+        let dot_flox = project.path().join(".flox");
+        let pkgs_dir = dot_flox.join("pkgs");
+        std::fs::create_dir_all(&pkgs_dir).unwrap();
+        std::fs::write(pkgs_dir.join("hello.nix"), expression).unwrap();
+        (project, dot_flox, pkgs_dir)
+    }
+
+    #[test]
+    fn no_references_scan_empty() {
+        let (_project, _dot_flox, pkgs_dir) =
+            project_with_expression("{ runCommand }: runCommand \"hello\" { } \"\"");
+
+        let references = scan_references(&pkgs_dir, ["hello.nix"]).unwrap();
+        assert_eq!(references, BTreeSet::new());
+    }
+
+    /// `lock_project_catalog` writes the committed lock file; with no
+    /// references it does so without any catalog request: the no-op client
+    /// fails every request it is asked to make, so reaching the network at
+    /// all fails this test.
+    #[tokio::test]
+    async fn lock_project_catalog_writes_an_empty_lock_without_a_catalog_request() {
+        let (_project, dot_flox, pkgs_dir) =
+            project_with_expression("{ runCommand }: runCommand \"hello\" { } \"\"");
+        let lockfile_path = catalog_lockfile_path(&dot_flox);
+
+        let references =
+            lock_project_catalog(&new_noop(), &pkgs_dir, ["hello.nix"], &lockfile_path)
+                .await
+                .unwrap();
+
+        assert_eq!(references, BTreeSet::new());
+        assert_eq!(
+            std::fs::read_to_string(&lockfile_path).unwrap(),
+            "{\n  \"version\": 1,\n  \"direct_catalog_inputs\": {},\n  \"catalogs\": {}\n}\n"
+        );
+    }
+}

--- a/cli/nef-lock-catalog/src/scan/attr_path.rs
+++ b/cli/nef-lock-catalog/src/scan/attr_path.rs
@@ -82,6 +82,20 @@ impl AttrPath {
         self.0.len()
     }
 
+    /// The raw attribute names of this path, in order, with any trailing
+    /// wildcard omitted. Names come back exactly as written (unquoted), for
+    /// comparison against attribute names from other sources — e.g. a locked
+    /// entry's `attr_path` — rather than for rendering.
+    pub(crate) fn attribute_names(&self) -> Vec<&str> {
+        self.0
+            .iter()
+            .filter_map(|component| match component {
+                Component::Attribute(name) => Some(name.as_str()),
+                Component::Wildcard => None,
+            })
+            .collect()
+    }
+
     /// Whether resolution stopped short of naming the path's last component.
     pub(crate) fn is_wildcard(&self) -> bool {
         self.0.last() == Some(&Component::Wildcard)

--- a/cli/nef-lock-catalog/src/scan/mod.rs
+++ b/cli/nef-lock-catalog/src/scan/mod.rs
@@ -62,6 +62,20 @@ impl CatalogRef {
         &self.0
     }
 
+    /// The catalog-relative rendering of this reference: the path with its
+    /// root dropped, dot-joined — the form the catalog server's lookup
+    /// request takes. NOTE: this is not how a lock's `direct_catalog_inputs`
+    /// is keyed; the server keys results canonically as
+    /// `<catalog>/<attr-path>` (see the `matched` map, which relates the two
+    /// namespaces).
+    pub(crate) fn wire_key(&self) -> String {
+        // A reference always has a root to drop; that is what makes it one.
+        self.0
+            .pop_root()
+            .expect("a reference names something under its root")
+            .to_string()
+    }
+
     /// Build a reference without checking the invariant, so tests can state
     /// their expectations as literals.
     #[cfg(test)]

--- a/package-builder/flox-build.mk
+++ b/package-builder/flox-build.mk
@@ -34,14 +34,6 @@ define mkVarname =
   $(subst -,_,$(1))
 endef
 
-# CATALOG_LOCKS names where each package's catalog lock lives, as a
-# space-separated list of "<attrpath>=<lockfile>" pairs. It is how the caller
-# controls the lock artifact rather than discovering one this Makefile chose:
-# a named lock is used as-is when it exists and resolved into when it does
-# not ("use if present, create if absent"). Packages with no entry lock into
-# PROJECT_TMPDIR and always resolve fresh.
-catalogLockFor = $(strip $(patsubst $(1)=%,%,$(filter $(1)=%,$(CATALOG_LOCKS))))
-
 # Substitute Nix store paths for packages required by this Makefile.
 __bash := @bash@
 __coreutils := @coreutils@
@@ -210,36 +202,23 @@ usage:
 	@echo "Targets:"
 	@echo "  build: build all packages"
 	@echo "  build/[pname]: build the specified package"
-	@echo "  lock: compute the catalog lock for all packages without building"
 	@echo "  clean: clean all build artifacts"
 	@echo "  clean/[pname]: clean build artifacts for the specified package"
 
 # Verify certain prerequisites and touch a timestamped file to
-# act as a root prerequisite before kicking off the build DAG. Accepts
-# either BUILD_RESULT_FILE (the `build` goal) or LOCK_RESULT_FILE (the
-# `lock` goal, which stops at the catalog lock and never builds a
-# package), so EXPRESSION_BUILD_NIXPKGS_URL is only required when
-# actually building.
+# act as a root prerequisite before kicking off the build DAG.
 .PHONY: $(PROJECT_TMPDIR)/check-build-prerequisites
 $(PROJECT_TMPDIR)/check-build-prerequisites:
-	@# At least one of BUILD_RESULT_FILE or LOCK_RESULT_FILE must be defined.
-	$(if $(or $(BUILD_RESULT_FILE),$(LOCK_RESULT_FILE)),, \
-	  $(error neither BUILD_RESULT_FILE nor LOCK_RESULT_FILE defined))
-	$(if $(BUILD_RESULT_FILE),$(if $(wildcard $(BUILD_RESULT_FILE)),, \
-	  $(error BUILD_RESULT_FILE $(BUILD_RESULT_FILE) not found)))
-	$(if $(LOCK_RESULT_FILE),$(if $(wildcard $(LOCK_RESULT_FILE)),, \
-	  $(error LOCK_RESULT_FILE $(LOCK_RESULT_FILE) not found)))
-	@# BUILDTIME_NIXPKGS_URL is needed by both goals (NEF attr-path
-	@# reflection at parse time); EXPRESSION_BUILD_NIXPKGS_URL only
-	@# when a build is actually being performed.
-	$(if $(BUILDTIME_NIXPKGS_URL),,$(error BUILDTIME_NIXPKGS_URL not defined))
+	@# The BUILD_RESULT_FILE must be defined and exist.
 	$(if $(BUILD_RESULT_FILE), \
-	  $(if $(EXPRESSION_BUILD_NIXPKGS_URL),,$(error EXPRESSION_BUILD_NIXPKGS_URL not defined)))
+	  $(if $(wildcard $(BUILD_RESULT_FILE)),, \
+	    $(error BUILD_RESULT_FILE $(BUILD_RESULT_FILE) not found), \
+	  $(error BUILD_RESULT_FILE not defined)))
+	@# Check that the BUILDTIME_NIXPKGS_URL and EXPRESSION_BUILD_NIXPKGS_URL are defined.
+	$(if $(BUILDTIME_NIXPKGS_URL),,$(error BUILDTIME_NIXPKGS_URL not defined))
+	$(if $(EXPRESSION_BUILD_NIXPKGS_URL),,$(error EXPRESSION_BUILD_NIXPKGS_URL not defined))
 	@# Check that the FLOX_ENV_CACHE is defined, and create it because the
 	@# activate script requires --env-cache to be an existing directory.
-	@# Both goals need it: a manifest build's version.command runs in a
-	@# build-mode activation while the makefile parses, whichever goal was
-	@# asked for.
 	$(if $(FLOX_ENV_CACHE),,$(error FLOX_ENV_CACHE not defined))
 	@$(_mkdir) -p $(FLOX_ENV_CACHE)
 	@$(_mkdir) -p $(@D)
@@ -297,13 +276,7 @@ define COMMON_BUILD_VARS_template =
   $(eval $(_pvarname)_evalJSON = $($(_pvarname)_tmpBasename)/eval.json)
   $(eval $(_pvarname)_buildJSON = $($(_pvarname)_tmpBasename)/build.json)
   $(eval $(_pvarname)_buildMetaJSON = $($(_pvarname)_tmpBasename)/build-meta.json)
-  # A caller-supplied catalog lock (see CATALOG_LOCKS) lives wherever the
-  # caller put it and is theirs to manage; clean/$(_pname) only removes
-  # $(_pvarname)_tmpBasename, so it is left alone.
-  $(eval $(_pvarname)_suppliedCatalogLockfile = $(call catalogLockFor,$(_pname)))
-  $(eval $(_pvarname)_catalogLockfile = \
-    $(or $($(_pvarname)_suppliedCatalogLockfile),$($(_pvarname)_tmpBasename)/catalog.lock))
-  $(eval $(_pvarname)_lockJSON = $($(_pvarname)_tmpBasename)/lock.json)
+  $(eval $(_pvarname)_catalogLockfile = $($(_pvarname)_tmpBasename)/catalog.lock)
 
   # Create a temporary file for collecting log output from the build.
   $(eval $(_pvarname)_logfile = $($(_pvarname)_tmpBasename)/build.log)
@@ -705,18 +678,6 @@ define MANIFEST_BUILD_template =
   # Calculate name.
   $(eval _name = $(_pname)-$(_version))
 
-  # Manifest builds resolve no catalog inputs of their own, so the lock JSON
-  # is a build-free constant emission consistent with the empty
-  # direct_catalog_inputs manifest builds already record at build time.
-  # No `catalog_lockfile` is emitted either: no lock is written, so there is no
-  # path to report and the field is absent (parsed as null).
-  # A manifest build that depends on a NEF package does inherit that
-  # package's catalog inputs; aggregating them here is tracked separately.
-  $($(_pvarname)_lockJSON): $(PROJECT_TMPDIR)/check-build-prerequisites
-	$(_V_) $(_mkdir) -p $$(@D)
-	$(_V_) $(_jq) -n --arg pname '$(_pname)' --arg system '$(NIX_SYSTEM)' \
-	  '{ pname: $$$$pname, system: $$$$system, direct_catalog_inputs: {} }' > $$@
-
   # By the time this rule will be evaluated all of its package dependencies
   # will have been added to the set of rule prerequisites in $^, using their
   # "safe" name (with "-" characters replaced with "_"), and these targets
@@ -867,36 +828,14 @@ define NIX_EXPRESSION_BUILD_template =
   # this with "_" for use in variable names.
   $(eval _pvarname = $(call mkVarname,$(_pname)))
 
-  # Start by calculating the catalog inputs lock. A lock the caller named via
-  # CATALOG_LOCKS is used as-is when it already exists, which is how a `build`
-  # following a `lock` over the same lock file avoids resolving the catalog
-  # twice. Without a caller-supplied path the lock is always resolved fresh,
-  # so `flox build` never picks up a leftover lock from an earlier run.
+  # Start by calculating the catalog inputs lock.
   $($(_pvarname)_catalogLockfile): $(PROJECT_TMPDIR)/check-build-prerequisites
 	$(_V_) $(_mkdir) -p $$(@D)
-	$(_V_) if [ -n '$($(_pvarname)_suppliedCatalogLockfile)' ] && [ -f '$$@' ]; then \
-	  : "using the catalog lock supplied at $$@"; \
-	else \
-	  $(_lock) \
-	    --base-dir '$$(NIX_EXPRESSION_ABSDIRPATH_$(_pvarname))' \
-	    --rel-path '$$(NIX_EXPRESSION_RELFILEPATH_$(_pvarname))' \
-	    --stability '$(EXPRESSION_BUILD_STABILITY)' \
-	    --out '$$@'; \
-	fi
-
-  # Project the catalog lock into the
-  # {pname, catalog_lockfile, system, direct_catalog_inputs} shape consumed by
-  # the `lock` goal's LOCK_RESULT_FILE, mirroring build-meta.json's equivalent
-  # fields. `pname` keys the entry to its package so callers locking several
-  # packages can tell the results apart. `catalog_lockfile` is the on-disk path
-  # of the lock this rule wrote (`$<`), which is the only way a caller that
-  # named no lock of its own learns where the lock ended up.
-  $($(_pvarname)_lockJSON): $($(_pvarname)_catalogLockfile)
-	$(_V_) $(_mkdir) -p $$(@D)
-	$(_V_) $(_jq) -n --arg pname '$(_pname)' --arg system '$(NIX_SYSTEM)' \
-	  --arg catalog_lockfile '$$<' \
-	  --slurpfile lock '$$<' \
-	  '{ pname: $$$$pname, catalog_lockfile: $$$$catalog_lockfile, system: $$$$system, direct_catalog_inputs: $$$$lock[0].direct_catalog_inputs }' > $$@
+	$(_V_) $(_lock) \
+	  --base-dir '$$(NIX_EXPRESSION_ABSDIRPATH_$(_pvarname))' \
+	  --rel-path '$$(NIX_EXPRESSION_RELFILEPATH_$(_pvarname))' \
+	  --stability '$(EXPRESSION_BUILD_STABILITY)' \
+	  --out '$$@'
 
   # Continue by evaluating the build
   $($(_pvarname)_evalJSON): $($(_pvarname)_catalogLockfile)
@@ -989,18 +928,6 @@ $(BUILD_RESULT_FILE): $(foreach pname,$(PACKAGES),$($(subst -,_,$(pname))_buildM
 # target which has the effect of building all requested $(PACKAGES).
 .PHONY: build
 build: $(BUILD_RESULT_FILE)
-
-# Combine JSON lock data for each build and write to LOCK_RESULT_FILE. This
-# mirrors BUILD_RESULT_FILE above, but stops at the catalog-lock targets and
-# never invokes a package build.
-$(LOCK_RESULT_FILE): $(foreach pname,$(PACKAGES),$($(subst -,_,$(pname))_lockJSON))
-	$(_VV_) [ -n "$^" ] || ( echo "ERROR: PACKAGES not defined or empty" 1>&2; exit 1 )
-	$(_VV_) $(_jq) -s . $^ > $@
-
-# The "lock" target computes just the closure identity (catalog lock) for
-# all requested $(PACKAGES), without building anything.
-.PHONY: lock
-lock: $(LOCK_RESULT_FILE)
 
 # Add a target for cleaning up the build artifacts.
 .PHONY: clean

--- a/package-builder/flox-build.mk
+++ b/package-builder/flox-build.mk
@@ -45,7 +45,6 @@ __gnugrep := @gnugrep@
 __gnused := @gnused@
 __gnutar := @gnutar@
 __jq := @jq@
-__nefLockCatalog := @nefLockCatalog@
 __nix := @nix@
 __t3 := @t3@
 
@@ -55,8 +54,6 @@ __t3 := @t3@
 # substitution was successful, and if not then it will fall back to finding
 # the required tool from the PATH for use in the developer environment.
 __package_bin = $(if $(filter @%@,$(1)),$(2),$(1)/bin/$(2))
-# As __package_bin, but for binaries installed under libexec rather than bin.
-__package_libexec_bin = $(if $(filter @%@,$(1)),$(2),$(1)/libexec/$(2))
 _bash := $(call __package_bin,$(__bash),bash)
 _cat := $(call __package_bin,$(__coreutils),cat)
 _chmod := $(call __package_bin,$(__coreutils),chmod)
@@ -71,7 +68,6 @@ _git := $(call __package_bin,$(__gitMinimal),git)
 _grep := $(call __package_bin,$(__gnugrep),grep)
 _head := $(call __package_bin,$(__coreutils),head)
 _jq := $(call __package_bin,$(__jq),jq)
-_lock := $(call __package_libexec_bin,$(__nefLockCatalog),lock)
 _mkdir := $(call __package_bin,$(__coreutils),mkdir)
 _mktemp := $(call __package_bin,$(__coreutils),mktemp)
 _mv := $(call __package_bin,$(__coreutils),mv)
@@ -119,13 +115,6 @@ OS := $(shell $(_uname) -s)
 NIX_SYSTEM_CURRENT := $(shell $(_nix) config show system)
 ifeq (,$(NIX_SYSTEM))
   NIX_SYSTEM = $(NIX_SYSTEM_CURRENT)
-endif
-
-# Stability used to resolve the catalog build inputs of NEF builds. The flox
-# CLI passes this through from the --stability flag; default to "unstable"
-# when it is not provided.
-ifeq (,$(EXPRESSION_BUILD_STABILITY))
-  EXPRESSION_BUILD_STABILITY = unstable
 endif
 
 # Set the default goal to be all builds if one is not specified.
@@ -210,10 +199,24 @@ usage:
 .PHONY: $(PROJECT_TMPDIR)/check-build-prerequisites
 $(PROJECT_TMPDIR)/check-build-prerequisites:
 	@# The BUILD_RESULT_FILE must be defined and exist.
-	$(if $(BUILD_RESULT_FILE), \
-	  $(if $(wildcard $(BUILD_RESULT_FILE)),, \
-	    $(error BUILD_RESULT_FILE $(BUILD_RESULT_FILE) not found), \
-	  $(error BUILD_RESULT_FILE not defined)))
+	$(if $(BUILD_RESULT_FILE),,$(error BUILD_RESULT_FILE not defined))
+	$(if $(wildcard $(BUILD_RESULT_FILE)),, \
+	  $(error BUILD_RESULT_FILE $(BUILD_RESULT_FILE) not found))
+	@# CATALOG_LOCKFILE is the catalog lock consumed by NEF evals. The flox
+	@# CLI owns the lock's entire lifecycle — creating the committed
+	@# .flox/catalog.lock, resolving a fresh ephemeral lock for lockless
+	@# builds, and cleaning up its own temp files — and passes the path in;
+	@# the package builder only hands the file to the NEF evals, and
+	@# requires it whenever the project has Nix expression builds.
+	@# The value is either relative to the project directory this make was
+	@# started in with -C (the committed lock's '.flox/catalog.lock') or an
+	@# absolute whitespace-free temp path (an ephemeral lock), so it never
+	@# carries whitespace into make's word-splitting positions — the
+	@# $(wildcard) here and the eval rule's prerequisite list. A project
+	@# path with whitespace never appears in either.
+	$(if $(NIX_EXPRESSION_BUILDS),$(if $(CATALOG_LOCKFILE),,$(error CATALOG_LOCKFILE not defined)))
+	$(if $(NIX_EXPRESSION_BUILDS),$(if $(wildcard $(CATALOG_LOCKFILE)),, \
+	  $(error CATALOG_LOCKFILE $(CATALOG_LOCKFILE) not found)))
 	@# Check that the BUILDTIME_NIXPKGS_URL and EXPRESSION_BUILD_NIXPKGS_URL are defined.
 	$(if $(BUILDTIME_NIXPKGS_URL),,$(error BUILDTIME_NIXPKGS_URL not defined))
 	$(if $(EXPRESSION_BUILD_NIXPKGS_URL),,$(error EXPRESSION_BUILD_NIXPKGS_URL not defined))
@@ -276,7 +279,6 @@ define COMMON_BUILD_VARS_template =
   $(eval $(_pvarname)_evalJSON = $($(_pvarname)_tmpBasename)/eval.json)
   $(eval $(_pvarname)_buildJSON = $($(_pvarname)_tmpBasename)/build.json)
   $(eval $(_pvarname)_buildMetaJSON = $($(_pvarname)_tmpBasename)/build-meta.json)
-  $(eval $(_pvarname)_catalogLockfile = $($(_pvarname)_tmpBasename)/catalog.lock)
 
   # Create a temporary file for collecting log output from the build.
   $(eval $(_pvarname)_logfile = $($(_pvarname)_tmpBasename)/build.log)
@@ -828,23 +830,20 @@ define NIX_EXPRESSION_BUILD_template =
   # this with "_" for use in variable names.
   $(eval _pvarname = $(call mkVarname,$(_pname)))
 
-  # Start by calculating the catalog inputs lock.
-  $($(_pvarname)_catalogLockfile): $(PROJECT_TMPDIR)/check-build-prerequisites
-	$(_V_) $(_mkdir) -p $$(@D)
-	$(_V_) $(_lock) \
-	  --base-dir '$$(NIX_EXPRESSION_ABSDIRPATH_$(_pvarname))' \
-	  --rel-path '$$(NIX_EXPRESSION_RELFILEPATH_$(_pvarname))' \
-	  --stability '$(EXPRESSION_BUILD_STABILITY)' \
-	  --out '$$@'
-
-  # Continue by evaluating the build
-  $($(_pvarname)_evalJSON): $($(_pvarname)_catalogLockfile)
+  # Evaluate the build against the project catalog lock, listed as the
+  # first prerequisite so that make itself flags a missing lock in relation
+  # to the target being evaluated, rather than leaving `nix eval` to report
+  # the absent file without that context. The committed lock's path is
+  # relative to the project directory this make was started in with -C, so
+  # the recipe absolutizes it — nix coerces the argument to a path, which
+  # must be absolute.
+  $($(_pvarname)_evalJSON): $(CATALOG_LOCKFILE) $(PROJECT_TMPDIR)/check-build-prerequisites
 	$(_V_) $(_mkdir) -p $$(@D)
 	$(_V_) $(_nix) eval -L --file $(_nef) \
 	  --argstr nixpkgs-url '$(EXPRESSION_BUILD_NIXPKGS_URL)' \
 	  --argstr system '$(NIX_SYSTEM)' \
 	  --argstr source-ref '$(NIX_EXPRESSION_REF)' \
-	  --argstr catalog-lockfile '$$<' \
+	  --argstr catalog-lockfile '$$(abspath $$<)' \
 	  --json \
 	  --apply 'pkg: { \
 	    drvPath = pkg.drvPath; \
@@ -888,16 +887,17 @@ define NIX_EXPRESSION_BUILD_template =
 	$(_V_) $(_nix) build -L --out-link $($(_pvarname)_result)-log \
 	  $$(shell $(_nix) store add-file $($(_pvarname)_logfile))
 
-  # Following a successful build, merge in the eval json.
+  # Following a successful build, merge in the eval json. The catalog lock
+  # is the CLI's concern: it created the lock this build consumed, so
+  # nothing about it needs to travel back in the build results.
   $($(_pvarname)_buildMetaJSON): $($(_pvarname)_evalJSON) $($(_pvarname)_buildJSON) $($(_pvarname)_result)-log
 	$(_V_) $(_jq) -n \
 	  --arg system $(NIX_SYSTEM) \
-	  --slurpfile catalogLock '$$($(_pvarname)_catalogLockfile)' \
 	  --arg logfile $$(shell $(_readlink) $($(_pvarname)_result)-log) \
 	  --argjson resultLinks '$$($(_pvarname)_resultLinks_json)' \
 	  --slurpfile eval $($(_pvarname)_evalJSON) \
 	  --slurpfile build $($(_pvarname)_buildJSON) \
-	  '$$$$build[0][0] * $$$$eval[0] * { system:$$$$system, direct_catalog_inputs:$$$$catalogLock[0].direct_catalog_inputs, log:$$$$logfile, resultLinks:$$$$resultLinks }' > $$@
+	  '$$$$build[0][0] * $$$$eval[0] * { system:$$$$system, log:$$$$logfile, resultLinks:$$$$resultLinks }' > $$@
 	@echo -e "Completed build of $$(_name) in Nix expression mode\n"
 
   # Create targets for cleaning up the result and log symlinks.

--- a/package-builder/flox-build.mk
+++ b/package-builder/flox-build.mk
@@ -62,6 +62,7 @@ _cp := $(call __package_bin,$(__coreutils),cp)
 _cpio := $(call __package_bin,$(__cpio),cpio)
 _cut := $(call __package_bin,$(__coreutils),cut)
 _daemonize := $(call __package_bin,$(__daemonize),daemonize)
+_date := $(call __package_bin,$(__coreutils),date)
 _env := $(call __package_bin,$(__coreutils),env)
 _find := $(call __package_bin,$(__findutils),find)
 _git := $(call __package_bin,$(__gitMinimal),git)
@@ -240,6 +241,7 @@ $(foreach _build,$(BUILDGOALS),\
   $(eval _pname = $(notdir $(_build)))\
   $(eval _pvarname = $(call mkVarname,$(_pname))) \
   $(foreach _buildtype,local sandbox,\
+    $(eval .PHONY: $(_pvarname)_$(_buildtype)_build) \
     $(eval $(_pvarname)_$(_buildtype)_build: $(PROJECT_TMPDIR)/check-build-prerequisites)))
 
 # Template for setting variables common to manifest and NEF builds.
@@ -435,7 +437,12 @@ define BUILD_local_template =
   # environment, so that following a successful build we can replace references
   # to the former with the latter as we copy the output to its final path.
 
-  $($(_pvarname)_out) $($(_pvarname)_logfile): $($(_pvarname)_buildScript)
+  # A grouped target rule (&:): one execution of the recipe produces both
+  # files. An ordinary multi-target rule would run the recipe once per
+  # target, which the .PHONY marking would otherwise turn into two
+  # executions per invocation.
+  .PHONY: $($(_pvarname)_out) $($(_pvarname)_logfile)
+  $($(_pvarname)_out) $($(_pvarname)_logfile) &: $($(_pvarname)_buildScript)
 	@# $(if $(FLOX_INTERPRETER),,$$(error FLOX_INTERPRETER not defined))
 	@#
 	@# Create a copy of the "develop" environment at a storepath with the
@@ -519,6 +526,7 @@ define BUILD_local_template =
 
   # Having built the package to $($(_pvarname)_out) outside of Nix, call
   # build-manifest.nix to turn it into a Nix package.
+  .PHONY: $($(_pvarname)_buildJSON)
   $($(_pvarname)_buildJSON): $($(_pvarname)_out)
 	$(_V_) $(_nix) build -L --file $(_libexec_dir)/build-manifest.nix \
 	  --argstr pname "$(_pname)" \
@@ -567,6 +575,7 @@ define BUILD_nix_sandbox_template =
   # but allows to _only_ show deleted files, use 'comm' to do the filtering for
   # us.
   $(eval $(_pvarname)_src_list = $($(_pvarname)_tmpBasename)/src-list)
+  .PHONY: $($(_pvarname)_src_list)
   $($(_pvarname)_src_list): $(PROJECT_TMPDIR)/check-build-prerequisites
 	$(_comm) -23z <($(_git) ls-files -cz | $(_sort) -z) <($(_git) ls-files -dz | $(_sort) -z) > $$@
 
@@ -574,11 +583,13 @@ define BUILD_nix_sandbox_template =
   # builds, so we create a tarball at a stable temporary path and pass that
   # to the derivation instead.
   $(eval $(_pvarname)_src_tar = $($(_pvarname)_tmpBasename)/src.tar)
+  .PHONY: $($(_pvarname)_src_tar)
   $($(_pvarname)_src_tar): $($(_pvarname)_src_list)
 	$(_V_) $(_tar) -cf $$@ --no-recursion --null --files-from $$<
 
   # The buildCache value needs to be similarly stable when nothing changes across
   $(eval $(_pvarname)_buildCache = $($(_pvarname)_tmpBasename)/buildCache.tar)
+  .PHONY: $($(_pvarname)_buildCache)
   $($(_pvarname)_buildCache): $(PROJECT_TMPDIR)/check-build-prerequisites
 	-$(_V_) $(_rm) -f $$@
 	@# If a previous buildCache exists, then copy, don't link to the
@@ -587,12 +598,16 @@ define BUILD_nix_sandbox_template =
 	@# of storePaths. And if it does not exist, then create a new
 	@# tarball containing only a single file indicating the time that
 	@# the buildCache was created to differentiate it from other
-	@# prior otherwise-empty buildCaches.
+	@# prior otherwise-empty buildCaches. The marker needs nanosecond
+	@# resolution: tar records whole-second mtimes, so a seconds-granular
+	@# marker makes two caches initialized within the same second
+	@# byte-identical, and nix then reuses the previous build's output
+	@# instead of rebuilding.
 	$(_VV_) if [ -f "$($(_pvarname)_result)-buildCache" ]; then \
 	  $(_cp) $($(_pvarname)_result)-buildCache $$@; \
 	else \
 	  tmpdir=$$$$($(_mktemp) -d); \
-	  echo "Build cache initialized on $$$$(date)" > $$$$tmpdir/.buildCache.init; \
+	  echo "Build cache initialized on $$$$($(_date) '+%Y-%m-%dT%H:%M:%S.%N')" > $$$$tmpdir/.buildCache.init; \
 	  $(_tar) -cf $$@ -C $$$$tmpdir .buildCache.init; \
 	  $(_find) $$$$tmpdir -type d -exec $(_chmod) +w {} \; && \
 	  $(_rm) -rf $$$$tmpdir; \
@@ -602,6 +617,7 @@ define BUILD_nix_sandbox_template =
   $(eval $(call CLEAN_result_link_template,$($(_pvarname)_result)-buildCache))
 
   # Perform the build, creating the JSON output as a result.
+  .PHONY: $($(_pvarname)_buildJSON)
   $($(_pvarname)_buildJSON): $($(_pvarname)_buildScript) $($(_pvarname)_src_tar) \
     $(if $(_do_buildCache),$($(_pvarname)_buildCache))
 	@echo "Building $(_name) in Nix sandbox (pure) mode"
@@ -686,7 +702,7 @@ define MANIFEST_BUILD_template =
   # will have successfully built the corresponding result-$(_pname) symlinks.
   # Iterate through this list, replacing all instances of "${package}" with the
   # corresponding storePath as identified by the result-* symlink.
-  .PRECIOUS: $($(_pvarname)_buildScript)
+  .PHONY: $($(_pvarname)_buildScript)
   $($(_pvarname)_buildScript): $(build) $(PROJECT_TMPDIR)/check-build-prerequisites
 	@# Identify _at runtime_ the build wrapper environment with which
 	@# to wrap the contents of bin, sbin.
@@ -836,7 +852,11 @@ define NIX_EXPRESSION_BUILD_template =
   # the absent file without that context. The committed lock's path is
   # relative to the project directory this make was started in with -C, so
   # the recipe absolutizes it — nix coerces the argument to a path, which
-  # must be absolute.
+  # must be absolute. The eval must run each invocation
+  # (the expressions the eval reads are not prerequisites make can see), so
+  # the target is .PHONY: the recipe is triggered irrespective of the
+  # eval.json file's presence or timestamp.
+  .PHONY: $($(_pvarname)_evalJSON)
   $($(_pvarname)_evalJSON): $(CATALOG_LOCKFILE) $(PROJECT_TMPDIR)/check-build-prerequisites
 	$(_V_) $(_mkdir) -p $$(@D)
 	$(_V_) $(_nix) eval -L --file $(_nef) \
@@ -920,6 +940,11 @@ $(foreach _pname,$(NIX_EXPRESSION_BUILDS), \
   $(eval $(call NIX_EXPRESSION_BUILD_template)))
 
 # Combine JSON build data for each build and write to BUILD_RESULT_FILE.
+# The result file is a per-invocation temp file the CLI pre-creates, and it
+# must be regenerated unconditionally: marking it .PHONY makes make trigger
+# the recipe irrespective of the file's presence or timestamp, so the
+# aggregation can never tie with prerequisites written in the same second.
+.PHONY: $(BUILD_RESULT_FILE)
 $(BUILD_RESULT_FILE): $(foreach pname,$(PACKAGES),$($(subst -,_,$(pname))_buildMetaJSON))
 	$(_VV_) [ -n "$^" ] || ( echo "ERROR: PACKAGES not defined or empty" 1>&2; exit 1 )
 	$(_VV_) $(_jq) -s . $^ > $@

--- a/pkgs/flox-package-builder/default.nix
+++ b/pkgs/flox-package-builder/default.nix
@@ -10,7 +10,6 @@
   gnused,
   gnutar,
   jq,
-  nef-lock-catalog,
   nix,
   shellcheck,
   stdenv,
@@ -39,7 +38,6 @@ stdenv.mkDerivation {
       gnused=${gnused} \
       gnutar=${gnutar} \
       jq=${jq} \
-      nefLockCatalog=${nef-lock-catalog} \
       nix=${nix} \
       t3=${t3} substituteAllInPlace $i
     done


### PR DESCRIPTION
## Motivation

The v1.15.0 lock phase (#4502, AI-411) computed a fresh per-package catalog lock inside `flox-build.mk` on every publish. That design has two defects:

1. **Intermittent publish failure.** The `lock` goal's result-file aggregation was gated on an mtime comparison between two files written in the same invocation. The gnumake in our closure is built without sub-second timestamp resolution ("checking whether to use high resolution file timestamps... no"), so whenever the lock phase completed within one wall-clock second the aggregation was skipped, the result file stayed empty, and publish failed with `failed to parse file for lock results: EOF while parsing a value at line 1 column 0`. Back-to-back `flox publish` runs reproduce this reliably.
2. **No consistent closure per revision.** A lock per package, re-resolved on every build, permits two packages of the same revision to resolve the same catalog input differently (diamond dependency conflicts) and means a revision's inputs are not stable across builds at all.

## Design

This PR reverts the per-package lock phase back to the v1.14.1 shape and rebuilds catalog locking around **one committed lock per repository**, with a strict separation of concerns: **the CLI owns the lock's entire lifecycle; the package builder only passes the file it is handed through to the NEF evals.**

- **`.flox/catalog.lock`** pins the source of every `catalogs.*` reference made by the project's Nix expressions. It is created or refreshed explicitly with `flox build update-catalogs`, which scans **all** expression builds and locks the union in a single catalog request, so the lock is internally consistent by construction and a single revision always evaluates against one set of inputs. Creating `.flox/catalog.lock` is only ever an explicit act, and this command is the only operation that writes into the project tree.
- **Builds consume a committed lock as-is; without one they run locklessly.** Before invoking the package builder, the CLI selects the committed lock when one exists — used exactly as found, deliberately including one that no longer covers the expressions' references, in which case the NEF eval fails and the user re-locks explicitly — or resolves a **fresh, ephemeral** lock into a randomly named temp file that lives exactly as long as the build, covering **only the packages being built** (the scanner follows each expression's imports, so those references are exactly what the evals look up; a manifest target's `${pkg}` references can pull in any expression, so those conservatively cover them all — an ephemeral lock pins nothing beyond its own invocation, so scoping it forfeits none of the cross-package consistency that committing provides). Either way the path reaches `flox-build.mk` as `CATALOG_LOCKFILE`, whose entire lock vocabulary is now: require the variable whenever the project has expression builds, and hand it to the evals. The lock binary, its fetch rule, and the lock goal are gone from the package builder — along with its dependency on `nef-lock-catalog` and its need for catalog-server access and credentials.
- **Publish subsets at publish time, always before the build.** Publish scans the one package being published and projects that subset out of the very lock its build consumes, submitting it as the build's `locked_inputs`. Because the CLI holds the lock before any build runs, the dedup check always runs **pre-build**: a true duplicate skips the build entirely, on both the committed and lockless paths. A stale committed lock fails the publish with the uncovered references and the next step. The build results no longer carry catalog data at all — the CLI already owns everything it hands to the builder.
- **`--stability` is orthogonal to catalog locking.** It selects the nixpkgs base package set the packages are *built with* (reaching the evals as `EXPRESSION_BUILD_NIXPKGS_URL`, resolved by the CLI), while the lock pins where published catalog packages *come from* — resolved to latest, independent of stability. The lookup request's required `stability` field is sent as the constant `"stable"` while the field's deprecation is coordinated on the server side and in the OpenAPI spec; the `lock` helper binary and `flox build update-catalogs` no longer take `--stability`.
- A project whose expressions make no catalog references gets an empty lock with **no catalog request at all** — the common case costs no network.
- Lock files are written atomically via `flox_core::write_atomically`, whose randomly named temp files make concurrent writers to distinct lock paths unable to truncate or cross-contaminate each other; a threaded regression test pins the property.

## Commits

- Revert of #4502 (restores `package-builder/` byte-identical to v1.14.1 while keeping unrelated later fixes).
- The catalog-lock design in one commit, ordered immediately after the revert: `nef-lock-catalog` lock read-back and subset APIs, CLI-owned lock lifecycle (`BuildCatalogLock` guard, `flox build update-catalogs`), publish-time subsetting with always-pre-build dedup, and the reduction of `flox-build.mk`'s lock role to consuming `CATALOG_LOCKFILE`.
- The timestamp-robustness fix on its own, for bisectability: the per-invocation regeneration chain (source lists/tarballs, build caches, build scripts, evals, build outputs, result files) is declared `.PHONY`. These targets already re-ran every invocation via the phony root's mtime cascade, so this adds zero recipe executions — it only removes the accidental skips (stale outputs) that occurred whenever that cascade tied at whole-second timestamp resolution. Fresh buildCache init markers carry nanosecond timestamps so distinct caches are never byte-identical.

## Testing

- New unit tests for the subset/read-back APIs, the lock lifecycle errors, and concurrent atomic lock writes.
- The `nef_*` suite (real `make` builds through both lock paths) passes repeatedly at warm-cache, sub-second build speeds — the regime that exposed the original race. A regression test asserts a build leaves no `catalog.lock` behind in the project tree.
- The headline path is covered end to end on a populated catalog input: the CLI resolves an ephemeral lock through a mocked `/build-inputs/lookup` (canonical `myorg/hello` keys, dot-rendered request references — the namespace boundary), the NEF eval consumes it to fetch and build the referenced package from a local git source, publish-time redaction selects the entry by the scanned reference, and the ephemeral lock file lives exactly as long as the CLI's guard. A fixture-grounded round-trip subsets the server fixture's lock by its own reference.
- The delete-cache-and-rebuild and edit-command-and-rebuild tests, which previously tied at whole-second mtimes on gnumake builds lacking high-resolution timestamp support (the current nixpkgs pin's aarch64 build is one; a candidate upstream report), now pass repeatedly at warm-cache speeds: the per-invocation chain is `.PHONY` end to end, so no rule depends on sub-second timestamp ordering. The buildCache init marker's sub-second digits are pinned by assertion.
- Verified against a real already-published project: repeated back-to-back `flox publish` runs consistently reach the pre-build dedup short-circuit, where the prior flow failed intermittently with `failed to parse file for lock results`.

## Release Notes

- Fixed an intermittent `flox publish` failure (`failed to parse file for lock results`) caused by a race in per-package catalog locking.
- Projects using Nix expression builds may now pin their catalog inputs in a single committed `.flox/catalog.lock`, created explicitly with `flox build update-catalogs`, so every build of a revision uses the same pinned inputs. Without one, builds resolve the built packages' references fresh on every invocation, and nothing is written into the project tree. `flox publish` submits only the entries relevant to the published package; a stale committed lock fails the publish with the uncovered references.
- Catalog inputs for expression builds resolve to the latest published versions, independent of `--stability`, which selects only the nixpkgs base package set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
