### PR TITLE
fix(nixos): dispatch the autoRestart with --no-block

### DIFF
--- a/modules/nixos/pull.nix
+++ b/modules/nixos/pull.nix
@@ -124,7 +124,12 @@ let
       ${optionalString cfg.autoRestart ''
         if [ "$mode" = "timer" ] && [ "$before" != "$after" ]; then
           echo "Flox environment ${cfg.environment} changed; restarting ${cfg.unit}" >&2
-          systemctl try-restart ${escapeShellArg cfg.unit}
+          # --no-block is required, not an optimization. The unit being
+          # restarted requires flox-pull@<name>.service, which blocks on the
+          # lock this script is still holding. Waiting for the restart to
+          # finish would deadlock: the restart cannot proceed until the lock
+          # is released, and the lock is not released until this script exits.
+          systemctl --no-block try-restart ${escapeShellArg cfg.unit}
         fi
       ''}
     '';


### PR DESCRIPTION
## Proposed Changes

`services.flox.*.autoRestart` deadlocks the `flox-autopull@` unit the first time a scheduled pull fetches a new generation.

The pull script holds a `flock` on the service's working directory for its whole run, and called a blocking `systemctl try-restart`. The unit being restarted has `requires = [ "flox-pull@<name>.service" ]`, and that unit blocks on the same lock. So the restart cannot proceed until the lock is released, and the lock is not released until the restart returns.

Dispatching with `--no-block` lets the script exit and release the lock, after which the queued restart proceeds.

The failure only appears when `autoRestart.enable = true` **and** a scheduled pull actually brings in a new generation, so it survives a smoke test and then hangs the first time an environment is updated in production. The `flox-autopull@` unit sits running indefinitely, holding the lock, and every subsequent pull queues behind it.

### How this was found

Reproduced against an equivalent set of units while porting this module to non-NixOS systemd distributions. `systemctl list-jobs` showed the cycle directly:

```
JOB UNIT                              TYPE  STATE
662 floxtest@epsilon.service          start waiting
667 floxtest-pull@epsilon.service     start running   <- blocked on the flock
643 floxtest-autopull@epsilon.service start running   <- holds the flock, blocked in try-restart
```

There, a bats test covers it: reverting `--no-block` makes the test hang, restoring it passes.

### Verification here

- `nix build .#checks.<system>.nixos-module` passes.
- `--no-block` reaches the generated script, confirmed with `nix derivation show` on `flox-pull-sample.drv`:
  ```
  systemctl --no-block try-restart sample.service
  ```

Realising the script itself requires building the `flox` package, so this change is verified by evaluation rather than by running it on NixOS. The behavioural proof is in the port, against the same unit structure. A NixOS VM test would close that gap; there is no runtime coverage for this module today.

## Release Notes

Fixed a hang in the NixOS module's `autoRestart` option. Previously, when a scheduled pull fetched a new generation of an environment, the unit responsible for restarting the service would deadlock against itself and remain running indefinitely, blocking all later pulls for that service.