### PR TITLE
docs: fix command syntax in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTORS.csv
+++ b/.github/CONTRIBUTORS.csv
@@ -30,3 +30,4 @@ yes,noor-latif,Noor Latif,<noor@latif.se>
 yes,martijnarts,Martijn Arts,<martijn@martijnarts.com>
 yes,electricalen,David Sawyer,<electricalen@gmail.com>
 yes,jsoref,Josh Soref,<jsoref@gmail.com>
+yes,esteve,Esteve Fernández,<github@nara.ac>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,16 +2,16 @@
 
 ## Quick Start
 ```console
-$ cd git clone git@github.com/flox/flox.git;
-$ cd flox;
+$ git clone https://github.com/flox/flox.git
+$ cd flox
 # Enter Dev Shell
-$ nix develop;
+$ nix develop
 # Build `flox' and its subsystems
-$ just build;
+$ just build
 # Run the build
-$ ./target/debug/flox --help;
+$ ./target/debug/flox --help
 # Run the test suite
-$ just test-all;
+$ just test-all
 ```
 
 ## PR Guidelines


### PR DESCRIPTION
This fixes the clone command and removes the trailing `;` for readability

<!-- The PR title becomes the merge commit message, so it must follow the conventional commits format (e.g. "feat(parser): add ability to parse arrays"). See CONTRIBUTING.md. -->

## Proposed Changes

<!-- Describe the changes proposed in this pull request. -->
<!-- Please provide links to any issue(s) which are expected to be resolved. -->

The clone command was incorrect, I removed the incorrect `cd` and fixed the URL for cloning the repo.

## Release Notes

<!-- Describe any user facing changes. Use "N/A" if not applicable. -->
N/A

<!-- Many thanks! -->
