### PR TITLE
chore: build and dev build improvements

### DIFF
--- a/pkgs/flox-activations/default.nix
+++ b/pkgs/flox-activations/default.nix
@@ -13,7 +13,7 @@
   stdenv,
 }:
 let
-  FLOX_VERSION = lib.fileContents ./../../VERSION;
+  FLOX_VERSION = lib.fileContents "${flox-src}/VERSION";
   # crane (<https://crane.dev/>) library for building rust packages
   craneLib = (inputs.crane.mkLib pkgsFor).overrideToolchain rust-toolchain.toolchain;
   envs = {
@@ -30,7 +30,7 @@ in
 craneLib.buildPackage (
   {
     pname = "flox-activations";
-    version = lib.fileContents ./../../VERSION;
+    version = lib.fileContents "${flox-src}/VERSION";
     src = flox-src;
 
     # Note about incremental compilation:

--- a/pkgs/flox-cli/default.nix
+++ b/pkgs/flox-cli/default.nix
@@ -20,7 +20,7 @@
   stdenv,
 }:
 let
-  FLOX_VERSION = lib.fileContents ./../../VERSION;
+  FLOX_VERSION = lib.fileContents "${flox-src}/VERSION";
 
   # crane (<https://crane.dev/>) library for building rust packages
   craneLib = (inputs.crane.mkLib pkgsFor).overrideToolchain rust-toolchain.toolchain;

--- a/pkgs/flox-src/default.nix
+++ b/pkgs/flox-src/default.nix
@@ -1,25 +1,27 @@
-{ }:
+# The repository, narrowed to what the Rust builds read: the cargo
+# workspace, plus the VERSION file they compile in.
+#
+# An allowlist rather than a denylist, which had to be extended by hand
+# every time the repository grew a directory, and invalidated every build
+# until someone did.
+#
+# The other packages here build from their own subdirectory and stay out,
+# so an edit to one of them does not rebuild the rest.
+{ lib }:
 let
   root = ./../..;
-  # Top-level entries that are not inputs to any flox-src consumer (the
-  # Rust crate builds under cli/). Keeping them out means commits that
-  # only touch them do not invalidate CLI builds or their caches.
-  exclude = [
-    "flake.nix"
-    "flake.lock"
-    "pkgs"
-    "shells"
-    "target"
-    "modules"
+
+  members = (builtins.fromTOML (builtins.readFile "${toString root}/Cargo.toml")).workspace.members;
+
+  # What cargo reads before it reaches a crate; the crates are `members`.
+  workspaceFiles = [
+    ".cargo"
+    "Cargo.toml"
+    "Cargo.lock"
+    "VERSION"
   ];
-  # The filter receives paths as strings, so the exclusions must be
-  # compared as strings anchored at the source root; comparing against
-  # path values (or paths resolved relative to this file's directory)
-  # never matches.
-  excludePaths = map (f: "${toString root}/${f}") exclude;
 in
-builtins.path {
-  name = "flox-src";
-  path = root;
-  filter = path: type: !builtins.elem path excludePaths;
+lib.fileset.toSource {
+  inherit root;
+  fileset = lib.fileset.unions (map (p: root + "/${p}") (workspaceFiles ++ members));
 }

--- a/pkgs/nef-lock-catalog/default.nix
+++ b/pkgs/nef-lock-catalog/default.nix
@@ -12,7 +12,7 @@
   stdenv,
 }:
 let
-  FLOX_VERSION = lib.fileContents ./../../VERSION;
+  FLOX_VERSION = lib.fileContents "${flox-src}/VERSION";
   # crane (<https://crane.dev/>) library for building rust packages
   craneLib = (inputs.crane.mkLib pkgsFor).overrideToolchain rust-toolchain.toolchain;
   envs = {
@@ -32,7 +32,7 @@ in
 craneLib.buildPackage (
   {
     pname = "nef-lock-catalog";
-    version = lib.fileContents ./../../VERSION;
+    version = lib.fileContents "${flox-src}/VERSION";
     src = flox-src;
 
     # Note about incremental compilation:

--- a/pkgs/rust-external-deps/default.nix
+++ b/pkgs/rust-external-deps/default.nix
@@ -34,7 +34,7 @@ let
       # even though the dependencies of the flox-cli haven't changed.
       version = "unversioned";
 
-      src = craneLib.cleanCargoSource (craneLib.path flox-src);
+      src = craneLib.cleanCargoSource flox-src;
 
       # runtime dependencies of the dependent crates
       buildInputs = [

--- a/pkgs/rust-internal-deps/default.nix
+++ b/pkgs/rust-internal-deps/default.nix
@@ -22,7 +22,7 @@
   stdenv,
 }:
 let
-  FLOX_VERSION = lib.fileContents ./../../VERSION;
+  FLOX_VERSION = lib.fileContents "${flox-src}/VERSION";
 
   # crane (<https://crane.dev/>) library for building rust packages
   craneLib = (inputs.crane.mkLib pkgsFor).overrideToolchain rust-toolchain.toolchain;


### PR DESCRIPTION
- **build(nix): pick the flox-src contents with an allowlist**
  A denylist of top-level entries has to be extended every time the
  repository grows a directory, and until someone remembers, the new
  content invalidates every Rust build and the cache entries behind it.
  Invert it. The tree is now the cargo workspace files plus the workspace
  members read out of `Cargo.toml`, which is all any consumer of
  `flox-src` -- rust-external-deps, rust-internal-deps, flox-cli,
  flox-activations, nef-lock-catalog -- builds from.
  
  `.github`, `docs`, `test_data`, `modules` and the agent instruction
  files are excluded without being named, and so is `cli/tests`: the bats
  suites reach flox-cli-tests as `./../../cli/tests` from the flake
  source, never through `flox-src`, so editing a bats file no longer
  rebuilds the CLI.
  
  Verified on aarch64-linux: packages.flox-cli, packages.flox-activations
  and packages.nef-lock-catalog all build from the narrowed tree, and its
  store path stops changing when `cli/tests`, `.github/workflows`,
  `flake.nix` or `AGENTS.md` are edited.
  
  CLI-216

  
  Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
  