### PR TITLE
[EXPLORATION] add the session-wrap lifecycle hook

### DIFF
--- a/cli/flox-core/src/features.rs
+++ b/cli/flox-core/src/features.rs
@@ -6,4 +6,9 @@ pub struct Features {
     pub qa: bool,
     #[serde(default)]
     pub beta: bool,
+    /// Arms execution of `[plugin-hooks]` declarations (session-wrap and
+    /// friends). Deliberately separate from `beta`: enabling beta to try
+    /// subcommand extensions must not silently arm session handoff.
+    #[serde(default)]
+    pub plugin_hooks: bool,
 }

--- a/cli/flox-manifest/src/compose/mod.rs
+++ b/cli/flox-manifest/src/compose/mod.rs
@@ -81,6 +81,11 @@ impl_into_inner!(KeyPath, Vec<String>);
 #[non_exhaustive]
 pub enum Warning {
     Overriding(KeyPath),
+    /// An included manifest declared `[plugin-hooks]`, which is ignored:
+    /// hook participation is consent and must be authored in the top-level
+    /// manifest. The accompanying [`WarningWithContext`] names the include
+    /// whose declaration was ignored.
+    IgnoredPluginHooks(KeyPath),
 }
 
 /// A warning that occurred during the merge of two manifests,
@@ -143,6 +148,24 @@ impl CompositeManifest {
             .clone();
 
         let mut warnings = Vec::new();
+
+        // Hook participation is consent: only the composer's `[plugin-hooks]`
+        // section is effective. The pairwise merge below always keeps the
+        // higher-priority section, which drops include declarations without
+        // knowing whose they were — so name each ignored include here, where
+        // the manifest ids are in scope.
+        for (manifest_id, manifest) in &self.deps {
+            if manifest
+                .plugin_hooks
+                .as_ref()
+                .is_some_and(|hooks| !hooks.is_empty())
+            {
+                warnings.push(WarningWithContext {
+                    warning: Warning::IgnoredPluginHooks(KeyPath::from_iter(["plugin-hooks"])),
+                    higher_priority_name: manifest_id.clone(),
+                });
+            }
+        }
 
         for (manifest_id, manifest) in merges {
             debug!(name = manifest_id, "merging new manifest");
@@ -359,6 +382,7 @@ pub fn package_overrides_for_manifest_id(
                     None
                 }
             },
+            _ => None,
         })
         .collect::<Vec<_>>();
     // Make sure we emit the install IDs in a stable order
@@ -432,6 +456,77 @@ mod tests {
                 ..Default::default()
             })
         );
+    }
+
+    #[test]
+    fn include_declared_plugin_hooks_are_ignored_with_warning() {
+        use crate::parsed::latest::PluginHooks;
+
+        let composer = ManifestLatest {
+            plugin_hooks: Some(PluginHooks {
+                session_wrap: Some("composer-plugin".to_string()),
+            }),
+            ..Default::default()
+        };
+        let dep_with_hooks = ManifestLatest {
+            plugin_hooks: Some(PluginHooks {
+                session_wrap: Some("sneaky-plugin".to_string()),
+            }),
+            ..Default::default()
+        };
+        let dep_without_hooks = ManifestLatest::default();
+        let composite = CompositeManifest {
+            composer,
+            deps: vec![
+                ("dep1".to_string(), dep_with_hooks),
+                ("dep2".to_string(), dep_without_hooks),
+            ],
+        };
+
+        let (merged, warnings) = composite
+            .merge_all(ManifestMerger::Shallow(ShallowMerger))
+            .unwrap();
+
+        assert_eq!(
+            merged.plugin_hooks,
+            Some(PluginHooks {
+                session_wrap: Some("composer-plugin".to_string()),
+            }),
+            "only the composer's [plugin-hooks] should survive composition"
+        );
+        assert_eq!(warnings, vec![WarningWithContext {
+            warning: Warning::IgnoredPluginHooks(KeyPath::from_iter(["plugin-hooks"])),
+            higher_priority_name: "dep1".to_string(),
+        }]);
+    }
+
+    #[test]
+    fn composer_without_plugin_hooks_drops_include_declarations() {
+        use crate::parsed::latest::PluginHooks;
+
+        let dep_with_hooks = ManifestLatest {
+            plugin_hooks: Some(PluginHooks {
+                session_wrap: Some("sneaky-plugin".to_string()),
+            }),
+            ..Default::default()
+        };
+        let composite = CompositeManifest {
+            composer: ManifestLatest::default(),
+            deps: vec![("dep1".to_string(), dep_with_hooks)],
+        };
+
+        let (merged, warnings) = composite
+            .merge_all(ManifestMerger::Shallow(ShallowMerger))
+            .unwrap();
+
+        assert_eq!(
+            merged.plugin_hooks, None,
+            "an include must not smuggle hook declarations into the composed environment"
+        );
+        assert_eq!(warnings, vec![WarningWithContext {
+            warning: Warning::IgnoredPluginHooks(KeyPath::from_iter(["plugin-hooks"])),
+            higher_priority_name: "dep1".to_string(),
+        }]);
     }
 
     #[test]

--- a/cli/flox-manifest/src/compose/shallow.rs
+++ b/cli/flox-manifest/src/compose/shallow.rs
@@ -22,7 +22,7 @@ use crate::parsed::common::{
 };
 // merge_hook operates on the latest schema's Hook (which carries
 // `on-deactivate`), so composing environments preserves the field.
-use crate::parsed::latest::{Hook, Install, ManifestLatest, MinimumCliVersion};
+use crate::parsed::latest::{Hook, Install, ManifestLatest, MinimumCliVersion, PluginHooks};
 // merge_build operates on the latest schema's Build (which carries
 // `sandbox-allow`), so composing environments preserves the field.
 use crate::parsed::v1_13_0::{Build, Profile, ProfileDeactivate, Services};
@@ -300,6 +300,22 @@ impl ShallowMerger {
         Ok((Build(merged), warnings))
     }
 
+    /// Keeps only the higher-priority manifest's `[plugin-hooks]` section.
+    ///
+    /// Hook participation is consent and must be authored in the top-level
+    /// manifest, so declarations never flow through includes: because the
+    /// composer is the final (highest-priority) manifest in the fold, taking
+    /// the high-priority side at every step leaves exactly the composer's
+    /// section in the merged manifest. `merge_all` warns about each include
+    /// whose section is dropped, since only it knows the include names.
+    #[instrument(skip_all)]
+    fn merge_plugin_hooks(
+        _low_priority: Option<&PluginHooks>,
+        high_priority: Option<&PluginHooks>,
+    ) -> Result<(Option<PluginHooks>, Vec<Warning>), MergeError> {
+        Ok((high_priority.cloned(), vec![]))
+    }
+
     /// Merges plugin data whole-table per plugin name: the higher priority
     /// manifest's table for a given plugin wins outright rather than being
     /// merged key-by-key, since plugin data is opaque to Flox and partial
@@ -392,6 +408,12 @@ impl ManifestMergeTrait for ShallowMerger {
         let (plugins, plugins_warnings) =
             Self::merge_plugins(&low_priority.plugins, &high_priority.plugins)?;
 
+        trace!(section = "plugin-hooks", "merging manifest section");
+        let (plugin_hooks, plugin_hooks_warnings) = Self::merge_plugin_hooks(
+            low_priority.plugin_hooks.as_ref(),
+            high_priority.plugin_hooks.as_ref(),
+        )?;
+
         debug!("manifest pair merged successfully");
 
         let warnings = [
@@ -403,6 +425,7 @@ impl ManifestMergeTrait for ShallowMerger {
             build_warnings,
             containerize_warnings,
             plugins_warnings,
+            plugin_hooks_warnings,
         ]
         .into_iter()
         .flatten()
@@ -421,6 +444,7 @@ impl ManifestMergeTrait for ShallowMerger {
             containerize,
             include: Include::default(),
             plugins,
+            plugin_hooks,
         };
 
         Ok((merged_manifest, warnings))

--- a/cli/flox-manifest/src/interfaces/common_fields.rs
+++ b/cli/flox-manifest/src/interfaces/common_fields.rs
@@ -23,6 +23,7 @@ impl CommonFields for Parsed {
             Parsed::V1_13_0(m) => &m.services.service_map,
             Parsed::V1_14_0(m) => &m.services.service_map,
             Parsed::V1_15_0(m) => &m.services.service_map,
+            Parsed::V1_16_0(m) => &m.services.service_map,
         }
     }
 
@@ -35,6 +36,7 @@ impl CommonFields for Parsed {
             Parsed::V1_13_0(m) => &m.options,
             Parsed::V1_14_0(m) => &m.options,
             Parsed::V1_15_0(m) => &m.options,
+            Parsed::V1_16_0(m) => &m.options,
         }
     }
 
@@ -48,6 +50,7 @@ impl CommonFields for Parsed {
             Parsed::V1_13_0(m) => &mut m.options,
             Parsed::V1_14_0(m) => &mut m.options,
             Parsed::V1_15_0(m) => &mut m.options,
+            Parsed::V1_16_0(m) => &mut m.options,
         }
     }
 }

--- a/cli/flox-manifest/src/interfaces/inner_manifest.rs
+++ b/cli/flox-manifest/src/interfaces/inner_manifest.rs
@@ -7,6 +7,7 @@ use crate::parsed::v1_12_0::ManifestV1_12_0;
 use crate::parsed::v1_13_0::ManifestV1_13_0;
 use crate::parsed::v1_14_0::ManifestV1_14_0;
 use crate::parsed::v1_15_0::ManifestV1_15_0;
+use crate::parsed::v1_16_0::ManifestV1_16_0;
 use crate::{Manifest, Migrated, MigratedTypedOnly, Parsed, TypedOnly, Validated};
 
 /// A trait that allows you to generically extract a concrete inner manifest
@@ -70,6 +71,7 @@ impl InnerManifestMarker for ManifestV1_12_0 {}
 impl InnerManifestMarker for ManifestV1_13_0 {}
 impl InnerManifestMarker for ManifestV1_14_0 {}
 impl InnerManifestMarker for ManifestV1_15_0 {}
+impl InnerManifestMarker for ManifestV1_16_0 {}
 
 /// This trait is used to define which concrete manifest types can
 /// be extracted from `Manifest<State>` and in which `State`s.
@@ -204,6 +206,24 @@ impl GetInnerManifest<ManifestV1_15_0> for Manifest<Validated> {
     }
 }
 
+impl GetInnerManifest<ManifestV1_16_0> for Manifest<Validated> {
+    fn get_inner_manifest(&self) -> Option<&ManifestV1_16_0> {
+        if let Parsed::V1_16_0(ref manifest) = self.inner.parsed {
+            Some(manifest)
+        } else {
+            None
+        }
+    }
+
+    fn get_inner_manifest_mut(&mut self) -> Option<&mut ManifestV1_16_0> {
+        if let Parsed::V1_16_0(ref mut manifest) = self.inner.parsed {
+            Some(manifest)
+        } else {
+            None
+        }
+    }
+}
+
 impl GetInnerManifest<ManifestV1> for Manifest<TypedOnly> {
     fn get_inner_manifest(&self) -> Option<&ManifestV1> {
         if let Parsed::V1(ref manifest) = self.inner.parsed {
@@ -330,6 +350,24 @@ impl GetInnerManifest<ManifestV1_15_0> for Manifest<TypedOnly> {
     }
 }
 
+impl GetInnerManifest<ManifestV1_16_0> for Manifest<TypedOnly> {
+    fn get_inner_manifest(&self) -> Option<&ManifestV1_16_0> {
+        if let Parsed::V1_16_0(ref manifest) = self.inner.parsed {
+            Some(manifest)
+        } else {
+            None
+        }
+    }
+
+    fn get_inner_manifest_mut(&mut self) -> Option<&mut ManifestV1_16_0> {
+        if let Parsed::V1_16_0(ref mut manifest) = self.inner.parsed {
+            Some(manifest)
+        } else {
+            None
+        }
+    }
+}
+
 impl GetInnerManifest<ManifestV1> for Manifest<Migrated> {
     fn get_inner_manifest(&self) -> Option<&ManifestV1> {
         None
@@ -392,10 +430,20 @@ impl GetInnerManifest<ManifestV1_14_0> for Manifest<Migrated> {
 
 impl GetInnerManifest<ManifestV1_15_0> for Manifest<Migrated> {
     fn get_inner_manifest(&self) -> Option<&ManifestV1_15_0> {
-        Some(&self.inner.migrated_parsed)
+        None
     }
 
     fn get_inner_manifest_mut(&mut self) -> Option<&mut ManifestV1_15_0> {
+        None
+    }
+}
+
+impl GetInnerManifest<ManifestV1_16_0> for Manifest<Migrated> {
+    fn get_inner_manifest(&self) -> Option<&ManifestV1_16_0> {
+        Some(&self.inner.migrated_parsed)
+    }
+
+    fn get_inner_manifest_mut(&mut self) -> Option<&mut ManifestV1_16_0> {
         Some(&mut self.inner.migrated_parsed)
     }
 }
@@ -462,10 +510,20 @@ impl GetInnerManifest<ManifestV1_14_0> for Manifest<MigratedTypedOnly> {
 
 impl GetInnerManifest<ManifestV1_15_0> for Manifest<MigratedTypedOnly> {
     fn get_inner_manifest(&self) -> Option<&ManifestV1_15_0> {
-        Some(&self.inner.migrated_parsed)
+        None
     }
 
     fn get_inner_manifest_mut(&mut self) -> Option<&mut ManifestV1_15_0> {
+        None
+    }
+}
+
+impl GetInnerManifest<ManifestV1_16_0> for Manifest<MigratedTypedOnly> {
+    fn get_inner_manifest(&self) -> Option<&ManifestV1_16_0> {
+        Some(&self.inner.migrated_parsed)
+    }
+
+    fn get_inner_manifest_mut(&mut self) -> Option<&mut ManifestV1_16_0> {
         Some(&mut self.inner.migrated_parsed)
     }
 }

--- a/cli/flox-manifest/src/lib.rs
+++ b/cli/flox-manifest/src/lib.rs
@@ -48,6 +48,7 @@ use crate::parsed::v1_12_0::ManifestV1_12_0;
 use crate::parsed::v1_13_0::ManifestV1_13_0;
 use crate::parsed::v1_14_0::ManifestV1_14_0;
 use crate::parsed::v1_15_0::ManifestV1_15_0;
+use crate::parsed::v1_16_0::ManifestV1_16_0;
 use crate::raw::{
     SyncTypedToRaw,
     TomlEditError,
@@ -240,13 +241,14 @@ enum Parsed {
     V1_13_0(ManifestV1_13_0),
     V1_14_0(ManifestV1_14_0),
     V1_15_0(ManifestV1_15_0),
+    V1_16_0(ManifestV1_16_0),
 }
 
 impl Parsed {
     /// A helper function for creating a [`Parsed`] from whatever the latest
     /// manifest schema version happens to be.
     pub(crate) fn from_latest(manifest: ManifestLatest) -> Self {
-        Self::V1_15_0(manifest)
+        Self::V1_16_0(manifest)
     }
 
     /// Returns the known schema version of the contained manifest.
@@ -262,6 +264,7 @@ impl Parsed {
             Parsed::V1_13_0(_) => KnownSchemaVersion::V1_13_0,
             Parsed::V1_14_0(_) => KnownSchemaVersion::V1_14_0,
             Parsed::V1_15_0(_) => KnownSchemaVersion::V1_15_0,
+            Parsed::V1_16_0(_) => KnownSchemaVersion::V1_16_0,
         }
     }
 }
@@ -529,6 +532,11 @@ impl<S: ManifestState> Manifest<S> {
                     .map_err(ManifestError::Invalid)?;
                 Ok(Parsed::V1_15_0(manifest))
             },
+            KnownSchemaVersion::V1_16_0 => {
+                let manifest = toml_edit::de::from_document::<ManifestV1_16_0>(toml.clone())
+                    .map_err(ManifestError::Invalid)?;
+                Ok(Parsed::V1_16_0(manifest))
+            },
         }
     }
 }
@@ -634,6 +642,16 @@ impl<'de> Deserialize<'de> for Manifest<TypedOnly> {
                 Ok(Manifest {
                     inner: TypedOnly {
                         parsed: Parsed::V1_15_0(manifest),
+                    },
+                })
+            },
+            KnownSchemaVersion::V1_16_0 => {
+                let d = untyped.into_deserializer();
+                let manifest = ManifestV1_16_0::deserialize(d)
+                    .map_err(|err| serde::de::Error::custom(err.to_string()))?;
+                Ok(Manifest {
+                    inner: TypedOnly {
+                        parsed: Parsed::V1_16_0(manifest),
                     },
                 })
             },

--- a/cli/flox-manifest/src/lockfile/compose.rs
+++ b/cli/flox-manifest/src/lockfile/compose.rs
@@ -39,6 +39,7 @@ impl Compose {
                 crate::Parsed::V1_13_0(manifest) => manifest.resolve_install_id(package, version),
                 crate::Parsed::V1_14_0(manifest) => manifest.resolve_install_id(package, version),
                 crate::Parsed::V1_15_0(manifest) => manifest.resolve_install_id(package, version),
+                crate::Parsed::V1_16_0(manifest) => manifest.resolve_install_id(package, version),
             };
             match res {
                 Ok(_) => return Ok(Some(include.clone())),

--- a/cli/flox-manifest/src/migrate/mod.rs
+++ b/cli/flox-manifest/src/migrate/mod.rs
@@ -5,6 +5,7 @@ use crate::migrate::v1_11_0_to_v1_12_0::migrate_manifest_v1_11_0_to_v1_12_0;
 use crate::migrate::v1_12_0_to_v1_13_0::migrate_manifest_v1_12_0_to_v1_13_0;
 use crate::migrate::v1_13_0_to_v1_14_0::migrate_manifest_v1_13_0_to_v1_14_0;
 use crate::migrate::v1_14_0_to_v1_15_0::migrate_manifest_v1_14_0_to_v1_15_0;
+use crate::migrate::v1_15_0_to_v1_16_0::migrate_manifest_v1_15_0_to_v1_16_0;
 use crate::migrate::v1_to_v1_10_0::migrate_manifest_v1_to_v1_10_0;
 use crate::parsed::common::KnownSchemaVersion;
 use crate::raw::SyncTypedToRaw;
@@ -15,6 +16,7 @@ mod v1_11_0_to_v1_12_0;
 mod v1_12_0_to_v1_13_0;
 mod v1_13_0_to_v1_14_0;
 mod v1_14_0_to_v1_15_0;
+mod v1_15_0_to_v1_16_0;
 mod v1_to_v1_10_0;
 
 #[derive(Debug, thiserror::Error)]
@@ -74,11 +76,15 @@ pub(crate) fn migrate_typed_only(
                 let migrated = migrate_manifest_v1_14_0_to_v1_15_0(manifest_v1_14_0)?;
                 inner = Parsed::V1_15_0(migrated);
             },
-            Parsed::V1_15_0(manifest_v1_15_0) => break Parsed::from_latest(manifest_v1_15_0),
+            Parsed::V1_15_0(manifest_v1_15_0) => {
+                let migrated = migrate_manifest_v1_15_0_to_v1_16_0(manifest_v1_15_0)?;
+                inner = Parsed::V1_16_0(migrated);
+            },
+            Parsed::V1_16_0(manifest_v1_16_0) => break Parsed::from_latest(manifest_v1_16_0),
         }
     };
     debug_assert_eq!(inner.schema_version(), KnownSchemaVersion::latest());
-    let Parsed::V1_15_0(migrated_manifest) = inner else {
+    let Parsed::V1_16_0(migrated_manifest) = inner else {
         unreachable!("already checked that manifest was latest schema version")
     };
     let migrated = Manifest {

--- a/cli/flox-manifest/src/migrate/v1_15_0_to_v1_16_0.rs
+++ b/cli/flox-manifest/src/migrate/v1_15_0_to_v1_16_0.rs
@@ -1,0 +1,60 @@
+use crate::migrate::MigrationError;
+use crate::parsed::v1_15_0::ManifestV1_15_0;
+use crate::parsed::v1_16_0::ManifestV1_16_0;
+
+/// Migrate a v1.15.0 manifest to a v1.16.0 manifest.
+///
+/// This is a lossless migration: V1_16_0 adds an optional `[plugin-hooks]`
+/// section. All V1_15_0 manifests are valid V1_16_0 manifests with
+/// `plugin-hooks` unset.
+pub(crate) fn migrate_manifest_v1_15_0_to_v1_16_0(
+    manifest: ManifestV1_15_0,
+) -> Result<ManifestV1_16_0, MigrationError> {
+    Ok(ManifestV1_16_0 {
+        schema_version: "1.16.0".to_string(),
+        minimum_cli_version: manifest.minimum_cli_version,
+        install: manifest.install,
+        vars: manifest.vars,
+        hook: manifest.hook,
+        profile: manifest.profile,
+        options: manifest.options,
+        services: manifest.services,
+        build: manifest.build,
+        containerize: manifest.containerize,
+        include: manifest.include,
+        plugins: manifest.plugins,
+        plugin_hooks: None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+
+    use super::*;
+
+    proptest! {
+        // The migration only sets the new schema version and defaults the new
+        // `[plugin-hooks]` section; everything else is carried over unchanged.
+        #[test]
+        fn migration_v1_15_0_to_v1_16_0_is_lossless(manifest in any::<ManifestV1_15_0>()) {
+            let migrated = migrate_manifest_v1_15_0_to_v1_16_0(manifest.clone()).unwrap();
+            let expected = ManifestV1_16_0 {
+                schema_version: "1.16.0".to_string(),
+                minimum_cli_version: manifest.minimum_cli_version,
+                install: manifest.install,
+                vars: manifest.vars,
+                hook: manifest.hook,
+                profile: manifest.profile,
+                options: manifest.options,
+                services: manifest.services,
+                build: manifest.build,
+                containerize: manifest.containerize,
+                include: manifest.include,
+                plugins: manifest.plugins,
+                plugin_hooks: None,
+            };
+            prop_assert_eq!(migrated, expected);
+        }
+    }
+}

--- a/cli/flox-manifest/src/parsed/common.rs
+++ b/cli/flox-manifest/src/parsed/common.rs
@@ -57,12 +57,13 @@ pub enum KnownSchemaVersion {
     V1_13_0,
     V1_14_0,
     V1_15_0,
+    V1_16_0,
 }
 
 impl KnownSchemaVersion {
     /// Returns the latest schema version.
     pub fn latest() -> Self {
-        KnownSchemaVersion::V1_15_0
+        KnownSchemaVersion::V1_16_0
     }
 
     /// Returns the oldest supported schema version.
@@ -80,6 +81,7 @@ impl KnownSchemaVersion {
             KnownSchemaVersion::V1_13_0,
             KnownSchemaVersion::V1_14_0,
             KnownSchemaVersion::V1_15_0,
+            KnownSchemaVersion::V1_16_0,
         ]
         .into_iter()
     }
@@ -107,6 +109,7 @@ impl TryFrom<VersionKind> for KnownSchemaVersion {
                 "1.13.0" => Ok(KnownSchemaVersion::V1_13_0),
                 "1.14.0" => Ok(KnownSchemaVersion::V1_14_0),
                 "1.15.0" => Ok(KnownSchemaVersion::V1_15_0),
+                "1.16.0" => Ok(KnownSchemaVersion::V1_16_0),
                 _ => Err(ManifestError::InvalidSchemaVersion(v.to_string())),
             },
         }
@@ -123,6 +126,7 @@ impl std::fmt::Display for KnownSchemaVersion {
             KnownSchemaVersion::V1_13_0 => write!(f, "1.13.0"),
             KnownSchemaVersion::V1_14_0 => write!(f, "1.14.0"),
             KnownSchemaVersion::V1_15_0 => write!(f, "1.15.0"),
+            KnownSchemaVersion::V1_16_0 => write!(f, "1.16.0"),
         }
     }
 }

--- a/cli/flox-manifest/src/parsed/latest.rs
+++ b/cli/flox-manifest/src/parsed/latest.rs
@@ -16,8 +16,10 @@ pub use crate::parsed::v1_13_0::BuildSandbox;
 // Hook is version-specific from V1_15_0 on (it adds `on-deactivate`),
 // so the latest schema re-exports that copy rather than common's.
 pub use crate::parsed::v1_15_0::Hook;
+// PluginHooks is introduced in V1_16_0.
+pub use crate::parsed::v1_16_0::PluginHooks;
 use crate::{Manifest, ManifestError, TypedOnly};
-pub type ManifestLatest = crate::parsed::v1_15_0::ManifestV1_15_0;
+pub type ManifestLatest = crate::parsed::v1_16_0::ManifestV1_16_0;
 
 impl ManifestLatest {
     /// Try to return a manifest in its original schema
@@ -88,6 +90,15 @@ impl ManifestLatest {
                 untyped
             },
             KnownSchemaVersion::V1_15_0 => {
+                let mut untyped =
+                    serde_json::to_value(self).map_err(ManifestError::SerializeJson)?;
+                let map = untyped
+                    .as_object_mut()
+                    .expect("all valid manifests should serialize to JSON objects");
+                map.insert("schema-version".into(), "1.15.0".into());
+                untyped
+            },
+            KnownSchemaVersion::V1_16_0 => {
                 return Ok(Some(self.as_typed_only()));
             },
         };
@@ -691,6 +702,64 @@ mod tests {
 
         let compat = manifest
             .as_maybe_backwards_compatible(KnownSchemaVersion::V1_13_0, None)
+            .unwrap();
+
+        assert_eq!(compat.get_schema_version(), KnownSchemaVersion::latest());
+    }
+
+    #[test]
+    fn plugin_hooks_rejected_by_v1_15_0_schema() {
+        let manifest = indoc! {r#"
+            schema-version = "1.15.0"
+
+            [plugin-hooks]
+            session-wrap = "my-plugin"
+        "#};
+
+        let err = Manifest::parse_toml_typed(manifest)
+            .expect_err("'plugin-hooks' should be rejected by the v1.15.0 schema");
+
+        let ManifestError::Invalid(err) = err else {
+            panic!("expected ManifestError::Invalid, got: {err:?}");
+        };
+        assert!(
+            err.message()
+                .starts_with("unknown field `plugin-hooks`, expected one of"),
+            "unexpected error message: {err}",
+        );
+    }
+
+    #[test]
+    fn downgrades_to_v1_15_0_when_plugin_hooks_unused() {
+        let manifest = ManifestLatest {
+            plugins: Plugins(
+                [(
+                    "my-plugin".to_string(),
+                    serde_json::json!({"MY_TOKEN": "demo/my-token"}),
+                )]
+                .into(),
+            ),
+            ..Default::default()
+        };
+
+        let compat = manifest
+            .as_maybe_backwards_compatible(KnownSchemaVersion::V1_15_0, None)
+            .unwrap();
+
+        assert_eq!(compat.get_schema_version(), KnownSchemaVersion::V1_15_0);
+    }
+
+    #[test]
+    fn stays_latest_schema_when_plugin_hooks_used() {
+        let manifest = ManifestLatest {
+            plugin_hooks: Some(PluginHooks {
+                session_wrap: Some("my-plugin".to_string()),
+            }),
+            ..Default::default()
+        };
+
+        let compat = manifest
+            .as_maybe_backwards_compatible(KnownSchemaVersion::V1_15_0, None)
             .unwrap();
 
         assert_eq!(compat.get_schema_version(), KnownSchemaVersion::latest());

--- a/cli/flox-manifest/src/parsed/mod.rs
+++ b/cli/flox-manifest/src/parsed/mod.rs
@@ -7,6 +7,7 @@ pub mod v1_12_0;
 pub mod v1_13_0;
 pub mod v1_14_0;
 pub mod v1_15_0;
+pub mod v1_16_0;
 
 /// An interface codifying how to access types that are just semantic wrappers
 /// around inner types. This impl may be generated with a macro.

--- a/cli/flox-manifest/src/parsed/v1_16_0/mod.rs
+++ b/cli/flox-manifest/src/parsed/v1_16_0/mod.rs
@@ -1,0 +1,171 @@
+use std::collections::BTreeMap;
+
+#[cfg(any(test, feature = "tests"))]
+use flox_test_utils::proptest::alphanum_string;
+#[cfg(any(test, feature = "tests"))]
+use proptest::prelude::*;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
+
+use crate::interfaces::{AsTypedOnlyManifest, SchemaVersion, impl_pkg_lookup};
+use crate::parsed::common::{Containerize, Include, KnownSchemaVersion, Options, Vars};
+use crate::parsed::v1_10_0::{Install, ManifestPackageDescriptor};
+pub use crate::parsed::v1_11_0::MinimumCliVersion;
+pub use crate::parsed::v1_12_0::Services;
+pub use crate::parsed::v1_13_0::{
+    Build,
+    BuildDescriptor,
+    BuildSandbox,
+    Profile,
+    ProfileDeactivate,
+};
+pub use crate::parsed::v1_14_0::Plugins;
+pub use crate::parsed::v1_15_0::Hook;
+use crate::parsed::{Inner, SkipSerializing};
+use crate::{Manifest, ManifestError, Parsed, TypedOnly};
+
+/// Not meant for writing manifest files, only for reading them.
+/// Modifications should be made using `manifest::raw`.
+
+// We use `skip_serializing_none` and `skip_serializing_if` throughout to reduce
+// the size of the lockfile and improve backwards compatibility when we
+// introduce fields.
+//
+// It would be better if we could deny_unknown_fields when we're deserializing
+// the user provided manifest but allow unknown fields when deserializing the
+// lockfile, but that doesn't seem worth the effort at the moment.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, JsonSchema)]
+#[cfg_attr(any(test, feature = "tests"), derive(proptest_derive::Arbitrary))]
+#[serde(deny_unknown_fields)]
+pub struct ManifestV1_16_0 {
+    /// Which schema version this manifest adheres to.
+    ///
+    /// Must be a valid Flox CLI version listed in [`KnownSchemaVersion`].
+    #[serde(rename = "schema-version")]
+    pub schema_version: String,
+    /// The minimum CLI version that can activate this environment.
+    #[serde(rename = "minimum-cli-version")]
+    pub minimum_cli_version: Option<MinimumCliVersion>,
+    /// The packages to install in the form of a map from install_id
+    /// to package descriptor.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Install::skip_serializing")]
+    pub install: Install,
+    /// Variables that are exported to the shell environment upon activation.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Vars::skip_serializing")]
+    pub vars: Vars,
+    /// Hooks that are run at various times during the lifecycle of the manifest
+    /// in a known shell environment.
+    #[serde(default)]
+    pub hook: Option<Hook>,
+    /// Profile scripts that are run in the user's shell upon activation
+    /// (and, optionally, upon deactivation).
+    #[serde(default)]
+    pub profile: Option<Profile>,
+    /// Options that control the behavior of the manifest.
+    #[serde(default)]
+    pub options: Options,
+    /// Service definitions
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Services::skip_serializing")]
+    pub services: Services,
+    /// Package build definitions
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Build::skip_serializing")]
+    pub build: Build,
+    #[serde(default)]
+    pub containerize: Option<Containerize>,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Include::skip_serializing")]
+    pub include: Include,
+    /// Free-form data provided by installed plugins, keyed by plugin
+    /// package name (`[plugins.<pkg-name>]`). Each plugin defines and
+    /// validates the shape of its own table; Flox does not interpret it.
+    /// The convention for secrets plugins is a flat table of
+    /// `ENV_VAR_NAME = "path/to/secret/in/store"`, read by the plugin's
+    /// `profile.d` script at activation.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Plugins::skip_serializing")]
+    pub plugins: Plugins,
+    /// Which installed plugins participate in lifecycle hooks beyond
+    /// `profile.d` scripts. Participation is consent: only hooks declared
+    /// here run, and only the top-level manifest's declarations are
+    /// effective (declarations in included manifests are ignored with a
+    /// notice). Plugin *data* stays in `[plugins.<name>]`; this section
+    /// is the only part of the plugin surface that Flox interprets.
+    #[serde(default)]
+    #[serde(rename = "plugin-hooks")]
+    pub plugin_hooks: Option<PluginHooks>,
+}
+impl_pkg_lookup!(crate::parsed::v1_10_0, ManifestV1_16_0);
+
+// You can't derive `Default` because `schema-version` is a `String`,
+// which just defaults to an empty string.
+impl Default for ManifestV1_16_0 {
+    fn default() -> Self {
+        Self {
+            schema_version: "1.16.0".into(),
+            minimum_cli_version: Default::default(),
+            install: Default::default(),
+            vars: Default::default(),
+            hook: Default::default(),
+            profile: Default::default(),
+            options: Default::default(),
+            services: Default::default(),
+            build: Default::default(),
+            containerize: Default::default(),
+            include: Default::default(),
+            plugins: Default::default(),
+            plugin_hooks: Default::default(),
+        }
+    }
+}
+
+impl AsTypedOnlyManifest for ManifestV1_16_0 {
+    fn as_typed_only(&self) -> crate::Manifest<TypedOnly> {
+        Manifest {
+            inner: TypedOnly {
+                parsed: Parsed::V1_16_0(self.clone()),
+            },
+        }
+    }
+}
+
+impl SchemaVersion for ManifestV1_16_0 {
+    fn get_schema_version(&self) -> KnownSchemaVersion {
+        KnownSchemaVersion::V1_16_0
+    }
+}
+
+/// Which installed plugin participates in the `session-wrap` lifecycle hook.
+///
+/// The value names a plugin, i.e. the key of its `[plugins.<name>]` table
+/// and the install id of the package that ships the hook file. Declaring
+/// the hook here is what arms it: a hook file shipped by a package that is
+/// not declared is ignored. `session-wrap` is single-valued because exactly
+/// one plugin may wrap the activation — two wrappers are unrepresentable
+/// rather than being an activation-time error. Future hooks add keys here.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, JsonSchema)]
+#[cfg_attr(any(test, feature = "tests"), derive(proptest_derive::Arbitrary))]
+#[serde(rename_all = "kebab-case")]
+#[serde(deny_unknown_fields)]
+pub struct PluginHooks {
+    /// The plugin whose `session-wrap` hook re-enters the activation under
+    /// an enforcement boundary. At most one.
+    #[cfg_attr(
+        any(test, feature = "tests"),
+        proptest(strategy = "proptest::option::of(alphanum_string(5))")
+    )]
+    pub session_wrap: Option<String>,
+}
+
+impl PluginHooks {
+    /// Whether any hook participation is declared at all.
+    pub fn is_empty(&self) -> bool {
+        self.session_wrap.is_none()
+    }
+}

--- a/cli/flox-manifest/src/raw/mod.rs
+++ b/cli/flox-manifest/src/raw/mod.rs
@@ -1032,6 +1032,12 @@ fn update_raw_packages_from_typed_manifest(
             .keys()
             .cloned()
             .collect::<HashSet<String>>(),
+        Parsed::V1_16_0(manifest) => manifest
+            .install
+            .inner()
+            .keys()
+            .cloned()
+            .collect::<HashSet<String>>(),
     };
 
     // Don't create an [install] table if there are no packages in either
@@ -1182,6 +1188,19 @@ fn update_descriptor(
             }
         },
         Parsed::V1_15_0(manifest) => {
+            let typed = manifest
+                .install
+                .inner()
+                .get(install_id)
+                .ok_or(TomlEditError::PackageNotFound(install_id.to_string()))?;
+            use crate::parsed::v1_10_0::ManifestPackageDescriptor::*;
+            match typed {
+                Catalog(d) => update_v1_10_0_catalog_descriptor(raw, d),
+                FlakeRef(d) => update_v1_10_0_flake_descriptor(raw, d),
+                StorePath(d) => update_store_path_descriptor(raw, d),
+            }
+        },
+        Parsed::V1_16_0(manifest) => {
             let typed = manifest
                 .install
                 .inner()
@@ -2229,6 +2248,9 @@ curl.outputs = [\"bin\", \"man\"]
             Parsed::V1_15_0(m) => {
                 m.install.inner_mut().remove(id);
             },
+            Parsed::V1_16_0(m) => {
+                m.install.inner_mut().remove(id);
+            },
         }
     }
 
@@ -2255,6 +2277,9 @@ curl.outputs = [\"bin\", \"man\"]
                 m.install.inner_mut().insert(id.to_string(), descriptor);
             },
             Parsed::V1_15_0(m) => {
+                m.install.inner_mut().insert(id.to_string(), descriptor);
+            },
+            Parsed::V1_16_0(m) => {
                 m.install.inner_mut().insert(id.to_string(), descriptor);
             },
             _ => panic!("expected v1_10_0 or later manifest"),
@@ -2291,6 +2316,10 @@ curl.outputs = [\"bin\", \"man\"]
                 v1_10_0::ManifestPackageDescriptor::Catalog(desc) => Some(desc),
                 _ => None,
             },
+            Parsed::V1_16_0(m) => match m.install.inner_mut().get_mut(id)? {
+                v1_10_0::ManifestPackageDescriptor::Catalog(desc) => Some(desc),
+                _ => None,
+            },
             _ => panic!("expected v1_10_0 or later manifest"),
         }
     }
@@ -2312,7 +2341,7 @@ curl.outputs = [\"bin\", \"man\"]
         manifest.update_raw_packages_from_typed_manifest().unwrap();
         let output = manifest.inner.raw.to_string();
         expect![[r#"
-            schema-version = "1.15.0"
+            schema-version = "1.16.0"
 
             [install]
 
@@ -2350,7 +2379,7 @@ curl.outputs = [\"bin\", \"man\"]
         manifest.update_raw_packages_from_typed_manifest().unwrap();
         let output = manifest.inner.raw.to_string();
         expect![[r#"
-            schema-version = "1.15.0"
+            schema-version = "1.16.0"
 
             [install]
             # my favorite greeting program
@@ -2382,7 +2411,7 @@ curl.outputs = [\"bin\", \"man\"]
         manifest.update_raw_packages_from_typed_manifest().unwrap();
         let output = manifest.inner.raw.to_string();
         expect![[r#"
-            schema-version = "1.15.0"
+            schema-version = "1.16.0"
 
             [install]
             # keep this comment about hello
@@ -2410,7 +2439,7 @@ curl.outputs = [\"bin\", \"man\"]
         manifest.update_raw_packages_from_typed_manifest().unwrap();
         let output = manifest.inner.raw.to_string();
         expect![[r#"
-            schema-version = "1.15.0"
+            schema-version = "1.16.0"
 
             [install]
             hello.pkg-path = "hello" # this is important
@@ -2482,7 +2511,7 @@ curl.outputs = [\"bin\", \"man\"]
         manifest.update_raw_packages_from_typed_manifest().unwrap();
         let output = manifest.inner.raw.to_string();
         expect![[r#"
-            schema-version = "1.15.0"
+            schema-version = "1.16.0"
 
             [install]
             # this comment is above hello
@@ -2528,7 +2557,7 @@ curl.outputs = [\"bin\", \"man\"]
         manifest.update_systems().unwrap();
         let output = manifest.inner.raw.to_string();
         expect![[r#"
-            schema-version = "1.15.0"
+            schema-version = "1.16.0"
 
             [options]
             systems = ["aarch64-darwin", "x86_64-linux"]
@@ -2584,7 +2613,7 @@ curl.outputs = [\"bin\", \"man\"]
         manifest.update_raw_packages_from_typed_manifest().unwrap();
         let output = manifest.inner.raw.to_string();
         expect![[r#"
-            schema-version = "1.15.0"
+            schema-version = "1.16.0"
 
             [install]
             hello.pkg-path = "hello"
@@ -2609,7 +2638,7 @@ curl.outputs = [\"bin\", \"man\"]
         let output = migrated.inner.migrated_raw.to_string();
         expect![[r##"
             # this comment is above version
-            schema-version = "1.15.0"
+            schema-version = "1.16.0"
 
             [install]
             hello.pkg-path = "hello"

--- a/cli/flox-rust-sdk/src/models/environment/mod.rs
+++ b/cli/flox-rust-sdk/src/models/environment/mod.rs
@@ -1649,7 +1649,7 @@ mod migration_tests {
             .to_string();
 
         expect![[r#"
-            schema-version = "1.15.0"
+            schema-version = "1.16.0"
         "#]]
         .assert_eq(&manifest_contents);
     }

--- a/cli/flox-rust-sdk/src/providers/manifest_init.rs
+++ b/cli/flox-rust-sdk/src/providers/manifest_init.rs
@@ -465,7 +465,7 @@ mod tests {
             ##
             ## -------------------------------------------------------------------
             # Flox manifest version managed by Flox CLI
-            schema-version = "1.15.0"
+            schema-version = "1.16.0"
 
 
             ## Install Packages --------------------------------------------------
@@ -589,7 +589,7 @@ mod tests {
             ##
             ## -------------------------------------------------------------------
             # Flox manifest version managed by Flox CLI
-            schema-version = "1.15.0"
+            schema-version = "1.16.0"
 
 
             ## Install Packages --------------------------------------------------
@@ -716,7 +716,7 @@ mod tests {
             ##
             ## -------------------------------------------------------------------
             # Flox manifest version managed by Flox CLI
-            schema-version = "1.15.0"
+            schema-version = "1.16.0"
 
 
             ## Install Packages --------------------------------------------------
@@ -840,7 +840,7 @@ mod tests {
             ##
             ## -------------------------------------------------------------------
             # Flox manifest version managed by Flox CLI
-            schema-version = "1.15.0"
+            schema-version = "1.16.0"
 
 
             ## Install Packages --------------------------------------------------
@@ -953,7 +953,7 @@ mod tests {
             ##
             ## -------------------------------------------------------------------
             # Flox manifest version managed by Flox CLI
-            schema-version = "1.15.0"
+            schema-version = "1.16.0"
 
 
             ## Install Packages --------------------------------------------------

--- a/cli/flox/doc/manifest.toml.md
+++ b/cli/flox/doc/manifest.toml.md
@@ -34,6 +34,7 @@ tables:
 - [`[build]`](#build)
 - [`[options]`](#options)
 - [`[plugins]`](#plugins) - experimental, see below
+- [`[plugin-hooks]`](#plugin-hooks) - experimental, see below
 - [`containerize`] - see [`flox-containerize(1)`](./flox-containerize.md)
 
 ## `schema-version`
@@ -53,6 +54,7 @@ Valid string values are:
 - `1.13.0`: introduced `profile.deactivate` and build `sandbox-allow`
 - `1.14.0`: introduced `plugins`
 - `1.15.0`: introduced `hook.on-deactivate`
+- `1.16.0`: introduced `plugin-hooks`
 
 Existing manifest schemas, including the older `version = 1` format, are
 automatically forward-migrated when using features that require a newer schema
@@ -924,6 +926,39 @@ Flox plugins work by convention:
   If a plugin script exports a variable with the same name as a `[vars]`
   entry, the plugin's value wins;
   use the `hook.on-activate` script to override variables set by a plugin.
+
+## `[plugin-hooks]`
+
+**Experimental: the `[plugin-hooks]` section is under active development
+and its behavior may change.** It requires `schema-version = "1.16.0"`
+and currently has no effect unless the `plugin_hooks` feature flag is
+enabled.
+
+The `[plugin-hooks]` section declares which installed plugin participates
+in the `session-wrap` lifecycle hook.
+Declaring the hook is consent: only the declared plugin's hook runs, and a
+hook file shipped by a package that is not declared is ignored.
+
+```
+[plugin-hooks]
+session-wrap = "my-wrapper"
+```
+
+- `session-wrap`: the plugin that re-enters the activation under an
+  enforcement boundary of its own, such as a container or a
+  policy-enforced session. At most one plugin may wrap the session.
+  The plugin package must provide an executable at
+  `etc/flox/hooks/session-wrap.d/<name>`, which `flox activate` runs
+  after the environment is built and rendered.
+  An environment that declares a wrapper cannot be activated in-place
+  with `eval "$(flox activate)"`.
+
+The value names a plugin, i.e. the key of its `[plugins.<name>]` table
+and the install id of the package in `[install]` that ships the hook.
+Only the top-level manifest's `[plugin-hooks]` section takes effect:
+declarations in included environments are ignored with a notice naming
+the include, and must be restated in the including manifest to enable
+them.
 
 
 # SEE ALSO

--- a/cli/flox/src/commands/activate.rs
+++ b/cli/flox/src/commands/activate.rs
@@ -61,6 +61,7 @@ use crate::commands::{
     SHELL_COMPLETION_FILE,
     ensure_environment_trust,
     render_composition_manifest,
+    session_wrap,
     uninitialized_environment_description,
 };
 use crate::utils::detect_shell::{detect_shell_for_in_place, detect_shell_for_subshell};
@@ -501,6 +502,30 @@ impl ActivateOptions {
             path
         };
 
+        let is_ephemeral = !services_for_ephemeral_activation.is_empty();
+
+        // A `[plugin-hooks].session-wrap` plugin re-enters the activation
+        // under its enforcement boundary: `wrap.exec()` replaces this
+        // process and never returns on success. Dispatch sits after render
+        // (hooks are discovered in the rendered environment) and before any
+        // in-process activation state is touched.
+        match session_wrap::resolve(session_wrap::SessionWrapArgs {
+            manifest: manifest.as_latest_schema(),
+            lockfile: &lockfile,
+            lockfile_path: concrete_environment.lockfile_path(&flox)?,
+            dot_flox_path: concrete_environment.dot_flox_path().to_path_buf(),
+            env_name: now_active.name().as_ref().to_string(),
+            activation_mode: mode.to_string(),
+            rendered_env: store_path.clone(),
+            system: &flox.system,
+            invocation_type: &invocation_type,
+            is_ephemeral,
+            feature_enabled: flox.features.plugin_hooks,
+        })? {
+            session_wrap::SessionWrap::Wrap(wrap) => match wrap.exec(&flox.temp_dir)? {},
+            session_wrap::SessionWrap::NoWrap => {},
+        }
+
         // read the currently active environments from the environment
         let mut flox_active_environments = activated_environments();
 
@@ -569,7 +594,6 @@ impl ActivateOptions {
         let add_sbin = self.add_sbin;
 
         // Determine services to start with a new process-compose
-        let is_ephemeral = !services_for_ephemeral_activation.is_empty();
         let services_to_start = if is_ephemeral {
             services_for_ephemeral_activation
         } else {

--- a/cli/flox/src/commands/hook_env.rs
+++ b/cli/flox/src/commands/hook_env.rs
@@ -1,5 +1,5 @@
 use std::borrow::Cow;
-use std::io::{BufWriter, IsTerminal, Write, stdout};
+use std::io::{BufRead, BufWriter, IsTerminal, Write, stdout};
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
@@ -19,8 +19,10 @@ use flox_core::hook_actions::{
     prompt_hook_version_mismatched,
     take_hook_actions,
 };
+use flox_manifest::interfaces::AsLatestSchema;
+use flox_manifest::{MANIFEST_FILENAME, Manifest};
 use flox_rust_sdk::flox::Flox;
-use flox_rust_sdk::models::environment::find_all_dot_flox;
+use flox_rust_sdk::models::environment::{DOT_FLOX, ENV_DIR_NAME, find_all_dot_flox};
 use indoc::formatdoc;
 use shell_gen::{GenerateShell, SetVar, Shell, ShellWithPath, UnsetVar};
 use tracing::debug;
@@ -143,7 +145,8 @@ impl HookEnv {
             }
         }
 
-        let ctx = gather_auto_activate_context(&config, !actions.is_empty())?;
+        let ctx =
+            gather_auto_activate_context(&config, !actions.is_empty(), flox.features.plugin_hooks)?;
         let plan = plan_auto_activation(&ctx);
 
         // The prompt hook the shell registered is out of sync with this binary
@@ -345,6 +348,50 @@ impl HookEnv {
             }
         }
 
+        // For each environment declaring a session-wrap plugin, prompt for
+        // session-entry consent individually. Accepting starts a blocking
+        // foreground session, so each entry needs its own answer; unlike
+        // plain auto-activation, multiple pending sessions cannot share a
+        // single prompt, and at most one session is entered per hook run.
+        for (path, plugin) in &plan.prompt_wrap {
+            match prompt_for_wrap_session(path, plugin, self.shell)? {
+                WrapSessionConsent::Accept => {
+                    // The session runs as a foreground child of the shell.
+                    // The state exports emitted further below are evaluated
+                    // only after the session ends, so the suppression
+                    // recorded for this path lands once the user is back in
+                    // their original shell. Remaining candidates are
+                    // suppressed below and re-prompt after the directory is
+                    // left and re-entered.
+                    write_wrap_session_command(self.shell, path, &mut writer)?;
+                    break;
+                },
+                // Suppress for this shell session (recorded below for every
+                // candidate); the next shell or re-entry asks again.
+                WrapSessionConsent::Decline => {},
+                WrapSessionConsent::NoTerminal | WrapSessionConsent::UnsupportedShell => {
+                    // Cannot start a wrapped session without an interactive
+                    // tty, or from this shell's prompt hook. Emit a notice
+                    // pointing at 'flox activate'.
+                    message::info(formatdoc! {"
+                        Run 'flox activate --dir {dir}' to enter this environment (activation is handled by plugin '{plugin}').",
+                        dir = path.display(),
+                    });
+                },
+            }
+        }
+        // Mark every candidate as suppressed for this shell session, entered
+        // paths included: the wrapped session runs as a foreground child of
+        // the interactive shell, so the shell survives the session and its
+        // prompt hook would immediately re-prompt for the same directory
+        // without the suppression. Leaving the directory clears it, so
+        // re-entering prompts again.
+        for (path, _) in &plan.prompt_wrap {
+            if !suppressed.contains(path) {
+                suppressed.push(path.clone());
+            }
+        }
+
         // Commit the re-insertion target, if any, between the deactivations and
         // the reactivate replay so the diff chain rebuilds in ancestor order:
         // deactivate(descendants) -> activate(target) -> reactivate(descendants).
@@ -459,6 +506,13 @@ struct AutoActivateContext {
     cwd: PathBuf,
     /// Project directories with a discoverable `.flox`, outermost-first.
     discovered: Vec<PathBuf>,
+    /// The session-wrap plugin declared by each discovered directory's
+    /// user-authored manifest, parallel to `discovered`. `None` when the
+    /// manifest declares no wrapper, cannot be read, or the `plugin_hooks`
+    /// feature is off (the gate is applied at gather time so the planner
+    /// stays feature-agnostic). Reading the user manifest alone is correct
+    /// by construction: include-carried declarations are inert.
+    discovered_wrapping: Vec<Option<String>>,
     /// Project directories of active environments, most recently activated
     /// first. `None` for environments without a local directory (remote).
     active: Vec<Option<PathBuf>>,
@@ -491,6 +545,12 @@ struct AutoActivatePlan {
     /// Unregistered project directories to prompt the user about before
     /// activating, outermost-first. Empty unless `auto_activate = "prompt"`.
     prompt: Vec<PathBuf>,
+    /// Project directories declaring a session-wrap plugin, paired with the
+    /// plugin name, outermost-first. These are never in-place activated:
+    /// entering one starts a blocking foreground session, which needs
+    /// explicit consent on every entry — even for allowed directories, since
+    /// a prior allow may predate the wrap declaration.
+    prompt_wrap: Vec<(PathBuf, String)>,
     /// Project directories to deactivate, front of stack first. Includes both
     /// true leavers (gone for good) and survivors that are torn down only to
     /// insert or remove a layer beneath them; the survivors are listed in
@@ -529,6 +589,7 @@ impl AutoActivatePlan {
         !self.deactivate.is_empty()
             || !self.activate.is_empty()
             || !self.prompt.is_empty()
+            || !self.prompt_wrap.is_empty()
             || !self.reactivate.is_empty()
             || self.reinsert.is_some()
             || !self.abandoned.is_empty()
@@ -624,6 +685,7 @@ fn plan_auto_activation(ctx: &AutoActivateContext) -> AutoActivatePlan {
         return AutoActivatePlan {
             activate: Vec::new(),
             prompt: Vec::new(),
+            prompt_wrap: Vec::new(),
             deactivate: Vec::new(),
             reactivate: Vec::new(),
             reinsert: None,
@@ -701,7 +763,17 @@ fn plan_auto_activation(ctx: &AutoActivateContext) -> AutoActivatePlan {
     let unwinding = !reactivate.is_empty() || auto_activated.iter().any(|path| !inside(path));
     let mut activate = Vec::new();
     let mut prompt = Vec::new();
+    let mut prompt_wrap: Vec<(PathBuf, String)> = Vec::new();
     let mut reinsert: Option<PathBuf> = None;
+
+    // The session-wrap plugin declared for a discovered directory, if any.
+    let wrap_plugin = |path: &PathBuf| -> Option<String> {
+        ctx.discovered
+            .iter()
+            .position(|discovered| discovered == path)
+            .and_then(|i| ctx.discovered_wrapping.get(i))
+            .and_then(|plugin| plugin.clone())
+    };
 
     // Whether `path` can be re-inserted in ancestor order this run, and the
     // descendants that would have to be popped to do so.
@@ -769,6 +841,16 @@ fn plan_auto_activation(ctx: &AutoActivateContext) -> AutoActivatePlan {
             {
                 continue;
             }
+            // A directory declaring a session-wrap plugin is never in-place
+            // activated: queue it for session-entry consent instead — even
+            // when allowed, since a prior allow may predate the declaration.
+            // Denied and suppressed directories were already skipped above.
+            if let Some(plugin) = wrap_plugin(path) {
+                if is_allowed(path) || prompt_unregistered {
+                    prompt_wrap.push((path.clone(), plugin));
+                }
+                continue;
+            }
             // An allowed environment with tracked descendants stacked above it
             // (e.g. it was denied, the shell entered a child, then it was
             // re-allowed) must be re-inserted in ancestor order, not activated
@@ -817,6 +899,7 @@ fn plan_auto_activation(ctx: &AutoActivateContext) -> AutoActivatePlan {
     AutoActivatePlan {
         activate,
         prompt,
+        prompt_wrap,
         deactivate,
         reactivate,
         reinsert,
@@ -833,9 +916,10 @@ fn plan_auto_activation(ctx: &AutoActivateContext) -> AutoActivatePlan {
 fn gather_auto_activate_context(
     config: &Config,
     pending_deactivations: bool,
+    plugin_hooks_enabled: bool,
 ) -> Result<AutoActivateContext> {
     let cwd = std::env::current_dir().context("failed to read current directory")?;
-    let discovered = find_all_dot_flox(&cwd)
+    let discovered: Vec<PathBuf> = find_all_dot_flox(&cwd)
         .context("failed to discover environments for auto-activation")?
         .into_iter()
         .filter_map(|dot_flox| dot_flox.path.parent().map(Path::to_path_buf))
@@ -870,9 +954,15 @@ fn gather_auto_activate_context(
     let allowed = preference(AutoActivationPreference::Allow);
     let denied = preference(AutoActivationPreference::Deny);
     let auto_activate = config.flox.auto_activate.clone().unwrap_or_default();
+    let discovered_wrapping = if plugin_hooks_enabled {
+        discovered.iter().map(|dir| read_wrap_plugin(dir)).collect()
+    } else {
+        vec![None; discovered.len()]
+    };
     Ok(AutoActivateContext {
         cwd,
         discovered,
+        discovered_wrapping,
         active,
         auto_activated: read_path_list_var(FLOX_AUTO_ACTIVATED_ENVIRONMENTS_VAR),
         suppressed: read_path_list_var(FLOX_SUPPRESSED_ENVIRONMENTS_VAR),
@@ -881,6 +971,29 @@ fn gather_auto_activate_context(
         auto_activate,
         pending_deactivations,
     })
+}
+
+/// Read the user-authored manifest at `<project_dir>/.flox/env/manifest.toml`
+/// and return its declared session-wrap plugin, if any.
+///
+/// Only the manifest file is consulted — no lockfile migration — which is
+/// correct by construction: `[plugin-hooks]` declarations in included
+/// manifests are stripped during composition, so the user-authored manifest
+/// is the sole source of hook participation. Falls back to `None` on any I/O
+/// or parse error so a broken manifest does not make every prompt fail.
+fn read_wrap_plugin(project_dir: &Path) -> Option<String> {
+    let manifest_path = project_dir
+        .join(DOT_FLOX)
+        .join(ENV_DIR_NAME)
+        .join(MANIFEST_FILENAME);
+    let contents = std::fs::read_to_string(&manifest_path).ok()?;
+    let manifest = Manifest::parse_and_migrate(&contents, None).ok()?;
+    manifest
+        .as_latest_schema()
+        .plugin_hooks
+        .as_ref()?
+        .session_wrap
+        .clone()
 }
 
 /// Read a JSON array of paths from an environment variable, treating an
@@ -969,6 +1082,112 @@ async fn prompt_for_auto_activation(project_dirs: &[PathBuf]) -> Result<AutoActi
     }
 }
 
+/// The user's answer to the wrapped-session consent prompt.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum WrapSessionConsent {
+    /// Enter the wrapped session now.
+    Accept,
+    /// Don't enter; suppress re-prompting for this shell session only.
+    Decline,
+    /// `/dev/tty` is unavailable, so no prompt was possible.
+    NoTerminal,
+    /// Shell does not support starting the session from the prompt hook
+    /// (fish, tcsh).
+    UnsupportedShell,
+}
+
+/// Ask the user, on the controlling terminal, whether to enter an environment
+/// as a wrapped session run as a foreground child of the current shell.
+///
+/// This is a stronger action than plain auto-activation because it hands the
+/// terminal to a process tree controlled by the plugin for the duration of
+/// the session. The prompt is therefore shown even when the directory is
+/// already on the auto-activate allow list (a prior allow may predate the
+/// declaration), and bare Enter declines: handing over the terminal must be
+/// an affirmative choice.
+fn prompt_for_wrap_session(
+    project_dir: &Path,
+    plugin: &str,
+    shell: Shell,
+) -> Result<WrapSessionConsent> {
+    // Starting an interactive session from the fish and tcsh prompt-hook
+    // eval contexts is not supported. Report the gap and fall back to the
+    // non-tty notice path.
+    if matches!(shell, Shell::Fish | Shell::Tcsh) {
+        return Ok(WrapSessionConsent::UnsupportedShell);
+    }
+
+    let Ok(tty) = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open("/dev/tty")
+    else {
+        return Ok(WrapSessionConsent::NoTerminal);
+    };
+
+    let question = format!(
+        "Enter '{}'? Activation hands this session to plugin '{plugin}'. [y/N] ",
+        project_dir.display(),
+    );
+
+    let mut tty_writer = &tty;
+    tty_writer
+        .write_all(question.as_bytes())
+        .context("failed to write the wrapped-session consent prompt")?;
+    tty_writer
+        .flush()
+        .context("failed to flush the wrapped-session consent prompt")?;
+
+    let mut answer = String::new();
+    std::io::BufReader::new(&tty)
+        .read_line(&mut answer)
+        .context("failed to read the wrapped-session consent response")?;
+    let answer = answer.trim();
+
+    if answer.eq_ignore_ascii_case("y") || answer.eq_ignore_ascii_case("yes") {
+        Ok(WrapSessionConsent::Accept)
+    } else {
+        Ok(WrapSessionConsent::Decline)
+    }
+}
+
+/// Emit a command that runs a wrapped activation of the environment in
+/// `project_dir` as a foreground child of the current shell.
+///
+/// Unlike [`write_activate_command`] (which emits `eval "$(flox activate)"`
+/// for in-place activation), this emits a plain `flox activate --dir <path>`
+/// invocation: the wrapped session takes over the terminal for its duration,
+/// and when it exits the user returns to their original shell. The
+/// environment is never activated unwrapped in the host shell — once the
+/// session ends the host shell has nothing activated, the same posture as
+/// declining.
+///
+/// Only bash and zsh are supported: [`prompt_for_wrap_session`] answers
+/// `UnsupportedShell` for fish and tcsh before this is reached, and the
+/// caller emits a notice instead.
+fn write_wrap_session_command(
+    shell: Shell,
+    project_dir: &Path,
+    writer: &mut impl Write,
+) -> Result<()> {
+    let flox_bin = std::env::current_exe().context("failed to determine flox executable path")?;
+    let flox_bin = flox_bin.to_string_lossy().to_string();
+    let escaped_bin = shell_escape::escape(Cow::Borrowed(&*flox_bin));
+    let dir = project_dir.to_string_lossy().to_string();
+    let escaped_dir = shell_escape::escape(Cow::Borrowed(&*dir));
+    match shell {
+        Shell::Bash | Shell::Zsh => {
+            writeln!(writer, "{escaped_bin} activate --dir {escaped_dir};")?;
+        },
+        // An in-place activation of a wrapping environment is refused by
+        // `flox activate`, so there is no correct command to emit here.
+        Shell::Fish | Shell::Tcsh => {
+            bail!("Wrapped sessions cannot be started from the fish or tcsh prompt hook.");
+        },
+    }
+    Ok(())
+}
+
 /// Emit a command that activates the environment in `project_dir` in place.
 ///
 /// The emitted command is itself evaluated by the shell's prompt hook, and
@@ -1038,6 +1257,9 @@ mod tests {
         AutoActivateContext {
             cwd: PathBuf::from(cwd),
             discovered: Vec::new(),
+            // Shorter than `discovered` in most tests; `wrap_plugin` treats a
+            // missing entry as "no wrapper declared".
+            discovered_wrapping: Vec::new(),
             active: Vec::new(),
             auto_activated: Vec::new(),
             suppressed: Vec::new(),
@@ -1056,6 +1278,7 @@ mod tests {
         AutoActivatePlan {
             activate: Vec::new(),
             prompt: Vec::new(),
+            prompt_wrap: Vec::new(),
             deactivate: Vec::new(),
             reactivate: Vec::new(),
             reinsert: None,
@@ -1063,6 +1286,90 @@ mod tests {
             auto_activated: Vec::new(),
             suppressed: Vec::new(),
         }
+    }
+
+    /// A context discovering one directory that declares `wrapper-plugin`
+    /// as its session-wrap plugin.
+    fn wrapping_ctx(cwd: &str, path: &str) -> AutoActivateContext {
+        AutoActivateContext {
+            discovered: paths(&[path]),
+            discovered_wrapping: vec![Some("wrapper-plugin".to_string())],
+            ..empty_ctx(cwd)
+        }
+    }
+
+    // ── Session-wrap decision table ─────────────────────────────────────────
+
+    #[test]
+    fn wrapping_allowed_env_goes_to_prompt_wrap_not_activate() {
+        // An allowed environment declaring a session-wrap plugin is never
+        // in-place activated; it needs session-entry consent on every entry
+        // even though the directory is already on the allow list.
+        let ctx = AutoActivateContext {
+            allowed: paths(&["/tmp/proj"]),
+            ..wrapping_ctx("/tmp/proj", "/tmp/proj")
+        };
+        assert_eq!(plan_auto_activation(&ctx), AutoActivatePlan {
+            prompt_wrap: vec![(PathBuf::from("/tmp/proj"), "wrapper-plugin".to_string())],
+            ..noop_plan()
+        });
+    }
+
+    #[test]
+    fn wrapping_unregistered_env_prompts_in_prompt_mode() {
+        let ctx = AutoActivateContext {
+            auto_activate: AutoActivate::Prompt,
+            ..wrapping_ctx("/tmp/proj", "/tmp/proj")
+        };
+        assert_eq!(plan_auto_activation(&ctx), AutoActivatePlan {
+            prompt_wrap: vec![(PathBuf::from("/tmp/proj"), "wrapper-plugin".to_string())],
+            ..noop_plan()
+        });
+    }
+
+    #[test]
+    fn wrapping_unregistered_env_skipped_in_allowlist_mode() {
+        let ctx = wrapping_ctx("/tmp/proj", "/tmp/proj");
+        assert_eq!(plan_auto_activation(&ctx), noop_plan());
+    }
+
+    #[test]
+    fn wrapping_denied_env_never_prompts() {
+        let ctx = AutoActivateContext {
+            denied: paths(&["/tmp/proj"]),
+            ..wrapping_ctx("/tmp/proj", "/tmp/proj")
+        };
+        assert_eq!(plan_auto_activation(&ctx), noop_plan());
+    }
+
+    #[test]
+    fn wrapping_suppressed_env_never_prompts() {
+        let ctx = AutoActivateContext {
+            allowed: paths(&["/tmp/proj"]),
+            suppressed: paths(&["/tmp/proj"]),
+            ..wrapping_ctx("/tmp/proj", "/tmp/proj")
+        };
+        assert_eq!(plan_auto_activation(&ctx), AutoActivatePlan {
+            suppressed: paths(&["/tmp/proj"]),
+            ..noop_plan()
+        });
+    }
+
+    #[test]
+    fn no_wrapper_declared_takes_the_plain_activation_path() {
+        // With the feature off (or no declaration), gather passes `None` and
+        // the planner takes today's in-place path.
+        let ctx = AutoActivateContext {
+            discovered: paths(&["/tmp/proj"]),
+            discovered_wrapping: vec![None],
+            allowed: paths(&["/tmp/proj"]),
+            ..empty_ctx("/tmp/proj")
+        };
+        assert_eq!(plan_auto_activation(&ctx), AutoActivatePlan {
+            activate: paths(&["/tmp/proj"]),
+            auto_activated: paths(&["/tmp/proj"]),
+            ..noop_plan()
+        });
     }
 
     #[test]

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -26,6 +26,7 @@ mod run;
 mod search;
 mod services;
 mod services_socket;
+mod session_wrap;
 mod show;
 mod uninstall;
 mod upgrade;

--- a/cli/flox/src/commands/session_wrap.rs
+++ b/cli/flox/src/commands/session_wrap.rs
@@ -1,0 +1,386 @@
+//! Session-wrap plugin hook dispatch.
+//!
+//! A plugin declared under `[plugin-hooks].session-wrap` re-enters the
+//! activation under an enforcement boundary of its choosing: after the
+//! environment is locked, built, and rendered — hooks are discovered in the
+//! rendered `$FLOX_ENV`, so render-before-wrap is a hard requirement — the
+//! CLI execs the plugin's hook executable, which never returns on success.
+//! The hook receives a serialized [`SessionWrapCtx`] and either re-execs the
+//! host-side `inner_argv` under a host boundary (same-filesystem wrappers)
+//! or composes its own in-boundary command from `invocation_type`
+//! (container and remote wrappers).
+//!
+//! Re-entry is cooperative: the hook exports [`SESSION_WRAPPED_VAR`] set to
+//! the ctx's `wrap_scope` on the wrapped process, and dispatch is skipped
+//! only when the marker matches the environment being activated. A mismatch
+//! means an activation of a *different* wrapping environment inside an
+//! existing boundary, which is a nested-boundary error rather than a silent
+//! unwrapped activation. The marker is re-entry detection, not boundary
+//! integrity — integrity must come from the boundary itself.
+//!
+//! Design: docs/plugin-lifecycle-hooks.md.
+
+use std::convert::Infallible;
+use std::io::{BufWriter, IsTerminal};
+use std::os::unix::fs::PermissionsExt;
+use std::os::unix::process::CommandExt;
+use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
+
+use anyhow::{Context, Result, bail};
+use flox_core::activate::context::InvocationType;
+use flox_core::path_hash;
+use flox_manifest::lockfile::{LockedPackage, Lockfile};
+use flox_manifest::parsed::Inner;
+use flox_manifest::parsed::latest::ManifestLatest;
+use indoc::formatdoc;
+use serde::Serialize;
+use tracing::debug;
+
+use crate::utils::message;
+
+/// Environment variable holding the path to the serialized [`SessionWrapCtx`].
+pub const FLOX_HOOK_CTX_VAR: &str = "FLOX_HOOK_CTX";
+/// Environment variable naming the hook being invoked (`session-wrap`).
+pub const FLOX_HOOK_VAR: &str = "FLOX_HOOK";
+/// Environment variable naming the plugin whose hook is invoked.
+pub const FLOX_PLUGIN_NAME_VAR: &str = "FLOX_PLUGIN_NAME";
+/// Environment variable pointing at the invoking flox binary.
+pub const FLOX_BIN_VAR: &str = "FLOX_BIN";
+/// Environment variable pointing at a jq the hook may rely on for parsing
+/// its ctx, so shell-scripted hooks need not depend on one themselves.
+pub const FLOX_HOOK_JQ_VAR: &str = "FLOX_HOOK_JQ";
+
+/// Marker exported by a session-wrap hook on the wrapped (inner) process.
+///
+/// Its value is the ctx's `wrap_scope`; dispatch is skipped on a match and
+/// errors on a mismatch. Living here rather than in plugin code makes the
+/// cross-plugin protocol visible in one place.
+pub const SESSION_WRAPPED_VAR: &str = "_FLOX_SESSION_WRAPPED";
+
+/// Hook directory inside the rendered environment, relative to `$FLOX_ENV`.
+const SESSION_WRAP_HOOK_DIR: &str = "etc/flox/hooks/session-wrap.d";
+
+/// jq bundled at build time for hook consumption (`FLOX_HOOK_JQ`), following
+/// the `PROCESS_COMPOSE_BIN` pattern of using our own binaries by absolute
+/// path rather than relying on the user's `PATH`. `JQ_BIN` is exported by
+/// `pkgs/rust-internal-deps` (and therefore the dev shell), so a missing
+/// bake fails at compile time instead of silently handing hooks a bare
+/// `jq`.
+static JQ_BIN: LazyLock<String> =
+    LazyLock::new(|| std::env::var("JQ_BIN").unwrap_or(env!("JQ_BIN").to_string()));
+
+/// Everything a session-wrap hook needs to re-enter the activation under its
+/// boundary. Serialized as JSON to a `0600` file whose path is passed via
+/// [`FLOX_HOOK_CTX_VAR`]; the schema is versioned via `ctx_version`.
+#[derive(Debug, Clone, Serialize)]
+pub struct SessionWrapCtx {
+    /// Version of this context schema. Bump on breaking shape changes.
+    pub ctx_version: u32,
+    /// Absolute path to the `.flox` directory of the environment.
+    pub dot_flox_path: PathBuf,
+    /// Short environment name, for image tags and messages.
+    pub env_name: String,
+    /// Activation mode (`dev` or `run`).
+    pub activation_mode: String,
+    /// Store path of the rendered environment for the activation mode.
+    pub rendered_env: PathBuf,
+    /// Path to the environment's lockfile. Its schema is published at
+    /// `cli/schemas/lockfile-v1.schema.json`.
+    pub lockfile_path: PathBuf,
+    /// The plugin's own `[plugins.<name>]` table, verbatim. `null` when the
+    /// manifest carries no table for the plugin.
+    pub plugin_table: serde_json::Value,
+    /// How the user invoked `flox activate`, with its full payload (the
+    /// command vector for `-- <cmd>`, the shell string for `-c`). Container
+    /// and remote wrappers compose their in-boundary command from this.
+    pub invocation_type: InvocationType,
+    /// Whether stdin/stdout are terminals. Stdio is inherited, not
+    /// guaranteed a tty: a hook that prompts must write to stderr or
+    /// `/dev/tty`, never stdout.
+    pub stdin_is_tty: bool,
+    pub stdout_is_tty: bool,
+    /// Host-side re-entry argv: the invocation to re-exec under a host
+    /// boundary. Only meaningful for wrappers that share the host
+    /// filesystem; container wrappers must use `invocation_type` instead.
+    pub inner_argv: Vec<String>,
+    /// Value the hook must export as [`SESSION_WRAPPED_VAR`] on the wrapped
+    /// process so re-entry skips dispatch.
+    pub wrap_scope: String,
+}
+
+/// A resolved, validated session-wrap dispatch, ready to exec.
+#[derive(Debug)]
+pub struct SessionWrapExec {
+    hook_path: PathBuf,
+    plugin_name: String,
+    ctx: SessionWrapCtx,
+}
+
+/// Outcome of session-wrap resolution for this activation.
+#[derive(Debug)]
+pub enum SessionWrap {
+    /// No wrapping: nothing declared, the feature is off, re-entry, or an
+    /// ephemeral activation.
+    NoWrap,
+    /// Exec the hook; never returns on success.
+    Wrap(Box<SessionWrapExec>),
+}
+
+/// Inputs to [`resolve`] that activate.rs already has in scope.
+pub struct SessionWrapArgs<'a> {
+    pub manifest: &'a ManifestLatest,
+    pub lockfile: &'a Lockfile,
+    pub lockfile_path: PathBuf,
+    pub dot_flox_path: PathBuf,
+    pub env_name: String,
+    pub activation_mode: String,
+    pub rendered_env: PathBuf,
+    pub system: &'a str,
+    pub invocation_type: &'a InvocationType,
+    pub is_ephemeral: bool,
+    pub feature_enabled: bool,
+}
+
+/// The scope value identifying "this environment, wrapped by this plugin".
+fn wrap_scope(dot_flox_path: &Path, plugin_name: &str) -> String {
+    path_hash(dot_flox_path.join(plugin_name))
+}
+
+/// Store paths provided by a locked package, used to verify that the hook
+/// file the rendered environment links actually comes from the declared
+/// plugin's package rather than another install shadowing its filename.
+fn package_store_paths(package: &LockedPackage) -> Vec<PathBuf> {
+    match package {
+        LockedPackage::Catalog(pkg) => pkg.outputs.values().map(PathBuf::from).collect(),
+        LockedPackage::Flake(pkg) => pkg
+            .locked_installable
+            .outputs
+            .values()
+            .map(PathBuf::from)
+            .collect(),
+        LockedPackage::StorePath(pkg) => vec![PathBuf::from(&pkg.store_path)],
+    }
+}
+
+/// Warn about session-wrap hook files shipped by installed packages that are
+/// not armed by a `[plugin-hooks]` declaration. Ignoring them is what makes
+/// declarations meaningful; saying so keeps it from looking like breakage.
+fn warn_undeclared_hook_files(hook_dir: &Path, declared: Option<&str>) {
+    let Ok(entries) = std::fs::read_dir(hook_dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if Some(name.as_ref()) != declared {
+            message::warning(formatdoc! {"
+                Ignored session-wrap hook '{name}' shipped by an installed package.
+                Declare it under [plugin-hooks] in the manifest to enable it."});
+        }
+    }
+}
+
+/// Decide whether this activation is wrapped, enforcing the declaration
+/// cross-checks. See the module docs for the rules' rationale.
+pub fn resolve(args: SessionWrapArgs<'_>) -> Result<SessionWrap> {
+    let declared = args
+        .manifest
+        .plugin_hooks
+        .as_ref()
+        .and_then(|hooks| hooks.session_wrap.as_deref());
+
+    if !args.feature_enabled {
+        if declared.is_some() {
+            message::warning(formatdoc! {"
+                Ignored [plugin-hooks] because the 'plugin_hooks' feature is not enabled.
+                Enable it with 'flox config --set features.plugin_hooks true'."});
+        }
+        return Ok(SessionWrap::NoWrap);
+    }
+
+    let hook_dir = args.rendered_env.join(SESSION_WRAP_HOOK_DIR);
+    warn_undeclared_hook_files(&hook_dir, declared);
+
+    let Some(plugin_name) = declared else {
+        return Ok(SessionWrap::NoWrap);
+    };
+
+    let scope = wrap_scope(&args.dot_flox_path, plugin_name);
+    match std::env::var(SESSION_WRAPPED_VAR) {
+        Ok(marker) if marker == scope => {
+            debug!(
+                plugin = plugin_name,
+                "session already wrapped; skipping session-wrap dispatch"
+            );
+            return Ok(SessionWrap::NoWrap);
+        },
+        Ok(_) => {
+            bail!(formatdoc! {"
+                Cannot activate this environment inside another environment's session-wrap boundary.
+                Exit the wrapped session first, then run 'flox activate' again."});
+        },
+        Err(_) => {},
+    }
+
+    if args.is_ephemeral {
+        debug!(
+            plugin = plugin_name,
+            "ephemeral activation skips session-wrap dispatch"
+        );
+        return Ok(SessionWrap::NoWrap);
+    }
+
+    if args.invocation_type.is_in_place() {
+        bail!(formatdoc! {"
+            Cannot activate in-place an environment that declares a session-wrap plugin.
+            An 'eval \"$(flox activate)\"' cannot hand the current shell to plugin '{plugin_name}'.
+            Run 'flox activate' to enter a wrapped session instead."});
+    }
+
+    let hook_path = hook_dir.join(plugin_name);
+    if !hook_path.is_file() {
+        bail!(formatdoc! {"
+            Plugin '{plugin_name}' declares a session-wrap hook but the environment provides none.
+            Expected an executable at {path}.
+            Ensure the plugin package is installed and provides the hook, or remove the [plugin-hooks] declaration.",
+        path = hook_path.display()});
+    }
+
+    let package = args
+        .lockfile
+        .packages
+        .iter()
+        .filter(|package| package.system() == args.system)
+        .find(|package| package.install_id() == plugin_name);
+    let Some(package) = package else {
+        bail!(formatdoc! {"
+            Plugin '{plugin_name}' is declared in [plugin-hooks] but not installed in this environment.
+            Add a package with install id '{plugin_name}' to [install] before declaring its hooks."});
+    };
+
+    let canonical_hook = hook_path.canonicalize().with_context(|| {
+        format!(
+            "could not resolve the session-wrap hook at {}",
+            hook_path.display()
+        )
+    })?;
+    let store_paths = package_store_paths(package);
+    if !store_paths
+        .iter()
+        .any(|store_path| canonical_hook.starts_with(store_path))
+    {
+        bail!(formatdoc! {"
+            The session-wrap hook for plugin '{plugin_name}' is provided by a different package.
+            Hooks must be shipped by the declared plugin's own package.
+            Remove the conflicting package or fix the [plugin-hooks] declaration."});
+    }
+
+    let metadata = canonical_hook.metadata().with_context(|| {
+        format!(
+            "could not read the session-wrap hook at {}",
+            canonical_hook.display()
+        )
+    })?;
+    if metadata.permissions().mode() & 0o111 == 0 {
+        bail!(formatdoc! {"
+            The session-wrap hook for plugin '{plugin_name}' is not executable.
+            The plugin package must ship {SESSION_WRAP_HOOK_DIR}/{plugin_name} with the executable bit set."});
+    }
+
+    let plugin_table = args
+        .manifest
+        .plugins
+        .inner()
+        .get(plugin_name)
+        .cloned()
+        .unwrap_or(serde_json::Value::Null);
+
+    let inner_argv = std::iter::once(
+        std::env::current_exe()
+            .ok()
+            .and_then(|p| p.to_str().map(String::from))
+            .unwrap_or_else(|| "flox".to_string()),
+    )
+    .chain(std::env::args().skip(1))
+    .collect();
+
+    let ctx = SessionWrapCtx {
+        ctx_version: 1,
+        dot_flox_path: args.dot_flox_path,
+        env_name: args.env_name,
+        activation_mode: args.activation_mode,
+        rendered_env: args.rendered_env,
+        lockfile_path: args.lockfile_path,
+        plugin_table,
+        invocation_type: args.invocation_type.clone(),
+        stdin_is_tty: std::io::stdin().is_terminal(),
+        stdout_is_tty: std::io::stdout().is_terminal(),
+        inner_argv,
+        wrap_scope: scope,
+    };
+
+    Ok(SessionWrap::Wrap(Box::new(SessionWrapExec {
+        hook_path: canonical_hook,
+        plugin_name: plugin_name.to_string(),
+        ctx,
+    })))
+}
+
+impl SessionWrapExec {
+    /// Exec the hook, which re-enters the activation under its boundary and
+    /// never returns on success. `Infallible` makes that contract visible in
+    /// the type; an `Err` means the launch itself failed.
+    ///
+    /// The ctx file is `0600` in flox's temp dir. The hook execs away, so
+    /// nothing can delete it deterministically; it is cleaned up with the
+    /// temp dir rather than by its consumer.
+    pub fn exec(self, temp_dir: &Path) -> Result<Infallible> {
+        let tempfile = tempfile::NamedTempFile::new_in(temp_dir)
+            .context("could not create the session-wrap ctx file")?;
+        let writer = BufWriter::new(&tempfile);
+        serde_json::to_writer_pretty(writer, &self.ctx)
+            .context("could not serialize the session-wrap ctx")?;
+        let (_, ctx_path) = tempfile
+            .keep()
+            .context("could not persist the session-wrap ctx file")?;
+
+        let flox_bin = std::env::current_exe().unwrap_or_else(|_| PathBuf::from("flox"));
+
+        debug!(
+            plugin = self.plugin_name,
+            hook = %self.hook_path.display(),
+            "exec'ing session-wrap hook"
+        );
+        let mut command = std::process::Command::new(&self.hook_path);
+        command
+            .env(FLOX_HOOK_CTX_VAR, &ctx_path)
+            .env(FLOX_HOOK_VAR, "session-wrap")
+            .env(FLOX_PLUGIN_NAME_VAR, &self.plugin_name)
+            .env(FLOX_BIN_VAR, &flox_bin)
+            .env(FLOX_HOOK_JQ_VAR, &*JQ_BIN);
+
+        // exec never returns on success
+        let err = command.exec();
+        Err(err).with_context(|| {
+            format!(
+                "failed to execute the session-wrap hook for plugin '{}' at {}",
+                self.plugin_name,
+                self.hook_path.display()
+            )
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wrap_scope_is_stable_and_distinguishes_plugin_and_path() {
+        let scope = wrap_scope(Path::new("/proj/.flox"), "openshell");
+        assert_eq!(scope, wrap_scope(Path::new("/proj/.flox"), "openshell"));
+        assert_ne!(scope, wrap_scope(Path::new("/proj/.flox"), "other"));
+        assert_ne!(scope, wrap_scope(Path::new("/other/.flox"), "openshell"));
+    }
+}

--- a/cli/flox/src/utils/message.rs
+++ b/cli/flox/src/utils/message.rs
@@ -318,6 +318,19 @@ pub(crate) fn print_overridden_manifest_fields(lockfile: &Lockfile) {
         };
         info(message);
     }
+
+    // Hook participation is consent and must be authored in the top-level
+    // manifest, so include-declared `[plugin-hooks]` sections are dropped
+    // during composition; tell the user how to opt in deliberately.
+    for warning_context in &compose.warnings {
+        if matches!(warning_context.warning, Warning::IgnoredPluginHooks(_)) {
+            info(formatdoc! {"
+                Ignored [plugin-hooks] declared by included environment '{}'.
+                Declare plugin hooks in this environment's manifest to enable them.",
+                warning_context.higher_priority_name
+            });
+        }
+    }
 }
 
 /// Report when re-locking changed the implicit default systems the environment

--- a/cli/schemas/lockfile-v1.schema.json
+++ b/cli/schemas/lockfile-v1.schema.json
@@ -1454,6 +1454,102 @@
           ],
           "type": "object"
         },
+        "ManifestV1_16_0": {
+          "additionalProperties": false,
+          "description": "Not meant for writing manifest files, only for reading them.\nModifications should be made using `manifest::raw`.",
+          "properties": {
+            "build": {
+              "$ref": "#/$defs/Build2",
+              "description": "Package build definitions"
+            },
+            "containerize": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Containerize"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "hook": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Hook2"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Hooks that are run at various times during the lifecycle of the manifest\nin a known shell environment."
+            },
+            "include": {
+              "$ref": "#/$defs/Include"
+            },
+            "install": {
+              "$ref": "#/$defs/Install2",
+              "description": "The packages to install in the form of a map from install_id\nto package descriptor."
+            },
+            "minimum-cli-version": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/MinimumCliVersion"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The minimum CLI version that can activate this environment."
+            },
+            "options": {
+              "$ref": "#/$defs/Options",
+              "default": {},
+              "description": "Options that control the behavior of the manifest."
+            },
+            "plugin-hooks": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/PluginHooks"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Which installed plugins participate in lifecycle hooks beyond\n`profile.d` scripts. Participation is consent: only hooks declared\nhere run, and only the top-level manifest's declarations are\neffective (declarations in included manifests are ignored with a\nwarning). Plugin *data* stays in `[plugins.<name>]`; this section\nis the only part of the plugin surface that Flox interprets."
+            },
+            "plugins": {
+              "$ref": "#/$defs/Plugins",
+              "description": "Free-form data provided by installed plugins, keyed by plugin\npackage name (`[plugins.<pkg-name>]`). Each plugin defines and\nvalidates the shape of its own table; Flox does not interpret it.\nThe convention for secrets plugins is a flat table of\n`ENV_VAR_NAME = \"path/to/secret/in/store\"`, read by the plugin's\n`profile.d` script at activation."
+            },
+            "profile": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Profile2"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Profile scripts that are run in the user's shell upon activation\n(and, optionally, upon deactivation)."
+            },
+            "schema-version": {
+              "description": "Which schema version this manifest adheres to.\n\nMust be a valid Flox CLI version listed in [`KnownSchemaVersion`].",
+              "type": "string"
+            },
+            "services": {
+              "$ref": "#/$defs/Services2",
+              "description": "Service definitions"
+            },
+            "vars": {
+              "$ref": "#/$defs/Vars",
+              "description": "Variables that are exported to the shell environment upon activation."
+            }
+          },
+          "required": [
+            "schema-version"
+          ],
+          "type": "object"
+        },
         "ManifestVersion": {
           "format": "uint8",
           "maximum": 255,
@@ -1705,6 +1801,20 @@
           "required": [
             "store-path"
           ],
+          "type": "object"
+        },
+        "PluginHooks": {
+          "additionalProperties": false,
+          "description": "Which installed plugin participates in the `session-wrap` lifecycle hook.\n\nThe value names a plugin, i.e. the key of its `[plugins.<name>]` table\nand the install id of the package that ships the hook file. Declaring\nthe hook here is what arms it: a hook file shipped by a package that is\nnot declared is ignored. `session-wrap` is single-valued because exactly\none plugin may wrap the activation — two wrappers are unrepresentable\nrather than being an activation-time error. Future hooks add keys here.",
+          "properties": {
+            "session-wrap": {
+              "description": "The plugin whose `session-wrap` hook re-enters the activation under\nan enforcement boundary. At most one.",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
           "type": "object"
         },
         "Plugins": {
@@ -2515,6 +2625,9 @@
         },
         {
           "$ref": "#/$defs/ManifestV1_15_0"
+        },
+        {
+          "$ref": "#/$defs/ManifestV1_16_0"
         }
       ],
       "description": "A validated, typed manifest with a known schema.",
@@ -2532,6 +2645,19 @@
           },
           "required": [
             "Overriding"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "description": "An included manifest declared `[plugin-hooks]`, which is ignored:\nhook participation is consent and must be authored in the top-level\nmanifest. The accompanying [`WarningWithContext`] names the include\nwhose declaration was ignored.",
+          "properties": {
+            "IgnoredPluginHooks": {
+              "$ref": "#/$defs/KeyPath"
+            }
+          },
+          "required": [
+            "IgnoredPluginHooks"
           ],
           "type": "object"
         }

--- a/cli/schemas/manifest-v1.schema.json
+++ b/cli/schemas/manifest-v1.schema.json
@@ -1057,6 +1057,102 @@
       ],
       "type": "object"
     },
+    "ManifestV1_16_0": {
+      "additionalProperties": false,
+      "description": "Not meant for writing manifest files, only for reading them.\nModifications should be made using `manifest::raw`.",
+      "properties": {
+        "build": {
+          "$ref": "#/$defs/Build2",
+          "description": "Package build definitions"
+        },
+        "containerize": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Containerize"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "hook": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Hook2"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Hooks that are run at various times during the lifecycle of the manifest\nin a known shell environment."
+        },
+        "include": {
+          "$ref": "#/$defs/Include"
+        },
+        "install": {
+          "$ref": "#/$defs/Install2",
+          "description": "The packages to install in the form of a map from install_id\nto package descriptor."
+        },
+        "minimum-cli-version": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/MinimumCliVersion"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The minimum CLI version that can activate this environment."
+        },
+        "options": {
+          "$ref": "#/$defs/Options",
+          "default": {},
+          "description": "Options that control the behavior of the manifest."
+        },
+        "plugin-hooks": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PluginHooks"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Which installed plugins participate in lifecycle hooks beyond\n`profile.d` scripts. Participation is consent: only hooks declared\nhere run, and only the top-level manifest's declarations are\neffective (declarations in included manifests are ignored with a\nwarning). Plugin *data* stays in `[plugins.<name>]`; this section\nis the only part of the plugin surface that Flox interprets."
+        },
+        "plugins": {
+          "$ref": "#/$defs/Plugins",
+          "description": "Free-form data provided by installed plugins, keyed by plugin\npackage name (`[plugins.<pkg-name>]`). Each plugin defines and\nvalidates the shape of its own table; Flox does not interpret it.\nThe convention for secrets plugins is a flat table of\n`ENV_VAR_NAME = \"path/to/secret/in/store\"`, read by the plugin's\n`profile.d` script at activation."
+        },
+        "profile": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Profile2"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Profile scripts that are run in the user's shell upon activation\n(and, optionally, upon deactivation)."
+        },
+        "schema-version": {
+          "description": "Which schema version this manifest adheres to.\n\nMust be a valid Flox CLI version listed in [`KnownSchemaVersion`].",
+          "type": "string"
+        },
+        "services": {
+          "$ref": "#/$defs/Services2",
+          "description": "Service definitions"
+        },
+        "vars": {
+          "$ref": "#/$defs/Vars",
+          "description": "Variables that are exported to the shell environment upon activation."
+        }
+      },
+      "required": [
+        "schema-version"
+      ],
+      "type": "object"
+    },
     "ManifestVersion": {
       "format": "uint8",
       "maximum": 255,
@@ -1308,6 +1404,20 @@
       "required": [
         "store-path"
       ],
+      "type": "object"
+    },
+    "PluginHooks": {
+      "additionalProperties": false,
+      "description": "Which installed plugin participates in the `session-wrap` lifecycle hook.\n\nThe value names a plugin, i.e. the key of its `[plugins.<name>]` table\nand the install id of the package that ships the hook file. Declaring\nthe hook here is what arms it: a hook file shipped by a package that is\nnot declared is ignored. `session-wrap` is single-valued because exactly\none plugin may wrap the activation — two wrappers are unrepresentable\nrather than being an activation-time error. Future hooks add keys here.",
+      "properties": {
+        "session-wrap": {
+          "description": "The plugin whose `session-wrap` hook re-enters the activation under\nan enforcement boundary. At most one.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
       "type": "object"
     },
     "Plugins": {
@@ -2118,6 +2228,9 @@
     },
     {
       "$ref": "#/$defs/ManifestV1_15_0"
+    },
+    {
+      "$ref": "#/$defs/ManifestV1_16_0"
     }
   ],
   "description": "A validated, typed manifest with a known schema.",

--- a/cli/tests/session_wrap.bats
+++ b/cli/tests/session_wrap.bats
@@ -1,0 +1,208 @@
+#! /usr/bin/env bats
+# -*- mode: bats; -*-
+# ============================================================================ #
+#
+# End-to-end tests for `[plugin-hooks].session-wrap`: the full path from a
+# manifest declaration through hook discovery in the rendered environment to
+# exec'ing the plugin's wrapper, which re-enters the activation via the
+# ctx's `inner_argv` with the `_FLOX_SESSION_WRAPPED` marker set.
+#
+# The fixture plugin is a package built on the fly with `nix store add`,
+# whose hook logs its invocation, snapshots its ctx for assertions, and
+# re-execs the inner activation — the host-boundary consumption style.
+#
+# ---------------------------------------------------------------------------- #
+
+load test_support.bash
+
+# bats file_tags=session-wrap
+
+# ---------------------------------------------------------------------------- #
+
+setup_file() {
+  common_file_setup
+}
+
+project_setup() {
+  export PROJECT_DIR="${BATS_TEST_TMPDIR?}/project-${BATS_TEST_NUMBER?}"
+  export PROJECT_NAME="${PROJECT_DIR##*/}"
+  rm -rf "$PROJECT_DIR"
+  mkdir -p "$PROJECT_DIR"
+  pushd "$PROJECT_DIR" >/dev/null || return
+  "$FLOX_BIN" init -d "$PROJECT_DIR"
+}
+
+project_teardown() {
+  popd >/dev/null || return
+  rm -rf "${PROJECT_DIR?}"
+  unset PROJECT_DIR
+  unset PROJECT_NAME
+}
+
+setup() {
+  common_test_setup
+  home_setup test
+  setup_isolated_flox
+  export _FLOX_USE_CATALOG_MOCK="$GENERATED_DATA/empty.yaml"
+  export FLOX_FEATURES_PLUGIN_HOOKS=true
+  export WRAP_LOG="${BATS_TEST_TMPDIR?}/wrapper-log"
+}
+
+teardown() {
+  unset FLOX_FEATURES_PLUGIN_HOOKS
+  if [ -n "${PROJECT_DIR:-}" ]; then
+    wait_for_activations "$PROJECT_DIR" || return 1
+    project_teardown
+  fi
+  common_test_teardown
+}
+
+# ---------------------------------------------------------------------------- #
+
+# Build and install a minimal wrapper plugin package into the current
+# project. Its session-wrap hook records that it ran, snapshots its ctx,
+# exports the re-entry marker, and re-execs the host-side inner argv.
+setup_wrapper_plugin() {
+  mkdir -p "$BATS_TEST_TMPDIR/test-wrapper/etc/flox/hooks/session-wrap.d"
+  cat > "$BATS_TEST_TMPDIR/test-wrapper/etc/flox/hooks/session-wrap.d/test-wrapper" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "wrapper-ran plugin=${FLOX_PLUGIN_NAME}" >> "$WRAP_LOG"
+cp "$FLOX_HOOK_CTX" "$WRAP_LOG.ctx"
+_FLOX_SESSION_WRAPPED="$("$FLOX_HOOK_JQ" -r '.wrap_scope' "$FLOX_HOOK_CTX")"
+export _FLOX_SESSION_WRAPPED
+inner_argv=()
+while IFS= read -r arg; do
+  inner_argv+=("$arg")
+done < <("$FLOX_HOOK_JQ" -r '.inner_argv[]' "$FLOX_HOOK_CTX")
+exec "${inner_argv[@]}"
+EOF
+  chmod +x "$BATS_TEST_TMPDIR/test-wrapper/etc/flox/hooks/session-wrap.d/test-wrapper"
+  pkg_store_path="$("$NIX_BIN" --extra-experimental-features nix-command \
+    store add --name test-wrapper "$BATS_TEST_TMPDIR/test-wrapper")"
+  run "$FLOX_BIN" install "$pkg_store_path"
+  assert_success
+}
+
+declare_wrapper() {
+  {
+    cat "$PROJECT_DIR/.flox/env/manifest.toml"
+    echo
+    echo '[plugin-hooks]'
+    echo 'session-wrap = "test-wrapper"'
+  } | "$FLOX_BIN" edit -f -
+}
+
+# ---------------------------------------------------------------------------- #
+
+# bats test_tags=session-wrap:wraps
+@test "session-wrap: declared hook wraps the activation and re-enters via inner_argv" {
+  project_setup
+  setup_wrapper_plugin
+  declare_wrapper
+
+  run "$FLOX_BIN" activate -- true
+  assert_success
+
+  # The wrapper ran exactly once: the marker made the re-entered activation
+  # skip dispatch instead of recursing.
+  run cat "$WRAP_LOG"
+  assert_success
+  assert_output "wrapper-ran plugin=test-wrapper"
+}
+
+# bats test_tags=session-wrap:ctx
+@test "session-wrap: the ctx carries the invocation payload and scope" {
+  project_setup
+  setup_wrapper_plugin
+  declare_wrapper
+
+  run "$FLOX_BIN" activate -- echo hook-ctx-probe
+  assert_success
+  assert_output --partial "hook-ctx-probe"
+
+  run jq -r '.ctx_version' "$WRAP_LOG.ctx"
+  assert_success
+  assert_output "1"
+
+  # The full exec-command payload is serialized so container-style wrappers
+  # can compose their own in-boundary command.
+  run jq -r '.invocation_type | to_entries[0].value | join(" ")' "$WRAP_LOG.ctx"
+  assert_success
+  assert_output "echo hook-ctx-probe"
+
+  run jq -r '.wrap_scope | length' "$WRAP_LOG.ctx"
+  assert_success
+  refute_output "0"
+
+  run jq -r '.plugin_table' "$WRAP_LOG.ctx"
+  assert_success
+  assert_output "null"
+}
+
+# bats test_tags=session-wrap:feature-off
+@test "session-wrap: without the feature flag the declaration warns and is ignored" {
+  project_setup
+  setup_wrapper_plugin
+  declare_wrapper
+
+  unset FLOX_FEATURES_PLUGIN_HOOKS
+  run "$FLOX_BIN" activate -- true
+  assert_success
+  assert_output --partial "Ignored [plugin-hooks]"
+  assert [ ! -e "$WRAP_LOG" ]
+}
+
+# bats test_tags=session-wrap:undeclared
+@test "session-wrap: a shipped but undeclared hook is ignored with a warning" {
+  project_setup
+  setup_wrapper_plugin
+
+  run "$FLOX_BIN" activate -- true
+  assert_success
+  assert_output --partial "Ignored session-wrap hook 'test-wrapper'"
+  assert [ ! -e "$WRAP_LOG" ]
+}
+
+# bats test_tags=session-wrap:in-place
+@test "session-wrap: in-place activation of a wrapping environment errors" {
+  project_setup
+  setup_wrapper_plugin
+  declare_wrapper
+
+  # stdout is not a tty under bats, so a bare `flox activate` plans an
+  # in-place activation.
+  run "$FLOX_BIN" activate
+  assert_failure
+  assert_output --partial "Cannot activate in-place"
+  assert [ ! -e "$WRAP_LOG" ]
+}
+
+# bats test_tags=session-wrap:nested
+@test "session-wrap: activating inside a foreign wrap boundary errors" {
+  project_setup
+  setup_wrapper_plugin
+  declare_wrapper
+
+  _FLOX_SESSION_WRAPPED="some-other-scope" run "$FLOX_BIN" activate -- true
+  assert_failure
+  assert_output --partial "inside another environment's session-wrap boundary"
+  assert [ ! -e "$WRAP_LOG" ]
+}
+
+# bats test_tags=session-wrap:missing-hook
+@test "session-wrap: declaring a plugin that ships no hook errors" {
+  project_setup
+  setup_wrapper_plugin
+
+  {
+    cat "$PROJECT_DIR/.flox/env/manifest.toml"
+    echo
+    echo '[plugin-hooks]'
+    echo 'session-wrap = "no-such-plugin"'
+  } | "$FLOX_BIN" edit -f -
+
+  run "$FLOX_BIN" activate -- true
+  assert_failure
+  assert_output --partial "declares a session-wrap hook but the environment provides none"
+}

--- a/cli/tests/test_support.bash
+++ b/cli/tests/test_support.bash
@@ -398,9 +398,9 @@ ensure_remote_environment_built() {
 with_latest_schema() {
   body="$1"
   if [ -z "$body" ]; then
-    printf "schema-version = \"1.15.0\"\n"
+    printf "schema-version = \"1.16.0\"\n"
   else
-    printf "schema-version = \"1.15.0\"\n\n%s" "$body"
+    printf "schema-version = \"1.16.0\"\n\n%s" "$body"
   fi
 }
 

--- a/docs/plugin-lifecycle-hooks.md
+++ b/docs/plugin-lifecycle-hooks.md
@@ -1,0 +1,317 @@
+# Plugin lifecycle hooks: `session-wrap`
+
+Status: DESIGN — scoped branch `daniel/session-wrap-hook`.
+Author: Daniel Sauble, 2026-08-27; scoped 2026-09-01.
+
+The `prototype/sandbox-plugins` branch designed a complete set of
+extension points ("hooks") across the lifecycle of a Flox environment
+(building on the experimental `[plugins]` mechanism of schema v1.14.0)
+and validated it by carrying sandboxed activation entirely as plugins.
+This branch scopes that design down to what shipping a
+**session-boundary plugin** such as OpenShell requires from flox core:
+one hook (`session-wrap`, dispatched from `flox activate`), one typed
+manifest section (`[plugin-hooks]`, with one key), one feature flag
+(`features.plugin_hooks`), include-stripping during composition, and a
+consent prompt in the auto-activation planner. Everything else stays
+on the prototype branch until a consumer ships (§2). Core never says
+the word "sandbox": the hook is generic session capture, and OpenShell
+is its first consumer.
+
+## 1. What a plugin is
+
+Unchanged from the v1.14.0 convention established in
+`flox/flox-plugins`: **a plugin is an ordinary package** installed via
+`[install]`, whose files are merged into the rendered environment by
+the buildenv symlink forest. Today the only recognized payload is
+`etc/profile.d/*.sh`, sourced during activation by the interpreter,
+with per-plugin manifest data readable via `flox_plugin_data`.
+
+This design adds one payload path (the `session-wrap.d` hook
+directory, §4) and one piece of typed manifest surface (the
+`[plugin-hooks]` section, §5). Each plugin's `[plugins.<name>]` table
+remains opaque to Flox: "Flox stores the data without interpreting it."
+
+### Threat model
+
+Installing any package already concedes arbitrary code execution at
+activation: every installed package's `etc/profile.d/*.sh` is sourced
+into the activation shell, runs with the user's privileges, and its
+env mutations replay into every attaching shell. The `[plugin-hooks]`
+declaration is therefore **not** a code-execution boundary. What it
+gates is exactly one power today: **session capture** — a
+`session-wrap` hook execs the user's terminal session under code the
+plugin controls.
+
+A shipped-but-undeclared hook file is ignored with a warning rather
+than an error, and that is sound: ignoring the file removes exactly
+the power the declaration guards. (It cannot remove code execution —
+nothing can, short of not installing the package.)
+
+## 2. Where `session-wrap` sits in the lifecycle
+
+| Phase | Driven by | Extension points today | Added here |
+|---|---|---|---|
+| activate: resolve & render | `commands/activate.rs` | none | **`session-wrap`** — after lock, build, and render; before the exec into `flox-activations` |
+| activate: start | interpreter `activate` script | interpreter profile.d → `[vars]` → plugin `etc/profile.d` → `hook.on-activate` | — |
+| activate: per-shell attach | `flox-activations` `gen_rc/*` | `[profile]` scripts, prompt hooks | — |
+| in-session | executive daemon, `hook-env` prompt hook | auto-activate allow/deny config | consent prompt for wrapping environments (§3.2) |
+| deactivate / exit | emitted teardown scripts; executive | `[profile.deactivate]`, `hook.on-deactivate` | — |
+
+Every other extension point — `env` and `sidecar` hooks, plugin
+`on-deactivate.d` scripts, and the init/lock/push/pull/containerize/
+services hooks — was designed or prototyped on `prototype/sandbox-plugins`
+and is deferred until a consumer ships: an extension point with no
+consumer is speculative API we would have to support forever.
+
+## 3. The `session-wrap` hook
+
+### 3.1 Contract
+
+Runs in `flox activate` **after lock, build, and render**, immediately
+before the CLI would exec into `flox-activations activate`. Hooks are
+discovered in the rendered `$FLOX_ENV`, so render-before-wrap is a
+hard requirement (a bake-style plugin re-uses that render, and the
+remote-include trust prompt runs before the wrap rather than inside
+it). The hook executable receives a serialized context and **execs
+the activation under its boundary; on success it never returns.**
+
+Payload path: `etc/flox/hooks/session-wrap.d/<plugin-name>`
+(executable).
+
+Protocol:
+
+- Core writes a versioned JSON context file (mode `0600`, in flox's
+  temp dir) and invokes the hook with `FLOX_HOOK_CTX=<path>`,
+  `FLOX_HOOK=session-wrap`, `FLOX_PLUGIN_NAME=<name>`,
+  `FLOX_BIN=<current flox>`, and `FLOX_HOOK_JQ=<store path of jq>`
+  (so shell-scripted hooks have guaranteed JSON tooling). The hook
+  inherits the invoking user's full environment, cwd, and stdio.
+- **Stdio is inherited, not guaranteed a tty.** `flox activate -- cmd
+  | tee` reaches the hook with stdout a pipe. A hook that wants to
+  prompt must write to stderr or `/dev/tty` — never stdout. The ctx
+  carries `stdin_is_tty` / `stdout_is_tty` so hooks need not probe.
+- The ctx contains: `ctx_version`, `dot_flox_path`, `env_name`,
+  `activation_mode` (`dev` or `run`), `rendered_env` (store path),
+  `lockfile_path`, `plugin_table` (the plugin's own `[plugins.<name>]`
+  value, verbatim JSON; `null` when absent), `invocation_type` **with
+  its full payload** (the command vector for `-- cmd`, the shell
+  string for `-c`), `stdin_is_tty`, `stdout_is_tty`, `inner_argv`, and
+  `wrap_scope`.
+- `inner_argv` is the **host-side re-entry argv** — sufficient for
+  wrappers that re-exec the whole activation under a boundary on the
+  host filesystem. Wrappers that run the session elsewhere — in a
+  container or a guest, as OpenShell does — must instead compose their
+  own in-boundary command from `invocation_type` plus their image's
+  entrypoint; a single argv cannot express that. The bats fixture
+  (`cli/tests/session_wrap.bats`) exercises the re-exec style.
+- Re-entry: the hook sets `_FLOX_SESSION_WRAPPED=<wrap_scope>` in the
+  wrapped process's environment, where `wrap_scope` is a core-defined
+  digest of (`dot_flox_path`, plugin name) provided in the ctx. Core
+  skips dispatch only when the marker **matches** the environment
+  being activated; a mismatch — activating env B (which declares its
+  own wrapper) inside env A's boundary — is the nested-boundary error
+  of §8. The marker is cooperative re-entry detection, not boundary
+  integrity; integrity must come from the boundary itself.
+- The hook **replaces** the flox process (`exec`), so its exit status
+  is the activation's exit status. A hook that cannot hand off must
+  exit non-zero and say why on stderr (which reaches the user via
+  inherited stdio); a hook that exits 0 without exec'ing produces a
+  silent no-op activation, which is a plugin bug rather than a state
+  core can detect. There is no "decline and continue unwrapped" path
+  while the feature is on — an environment that declares a
+  session-wrap plugin either activates wrapped or not at all (the
+  escape hatches are editing the manifest or declining the consent
+  prompt).
+
+Rules enforced by core:
+
+- **Single wrapper.** `[plugin-hooks].session-wrap` is single-valued
+  (§5), so two wrappers are unrepresentable in one manifest;
+  composition cannot smuggle a second one in (include declarations are
+  inert, §3.2).
+- **Declaration↔payload binding.** Core resolves the declared plugin
+  name to its locked install (install-id → store path) and verifies
+  the discovered hook file's realpath lives inside that package's
+  store path. A declaration with no matching install, a hook file
+  shipped by a *different* package (shadowing, typo-squatting a plugin
+  name), a declared-but-missing hook file, or a non-executable hook
+  file is an activation error.
+- **No in-place wrapping.** `eval "$(flox activate)"` cannot exec-wrap
+  the caller's shell; declaring a session-wrap plugin makes in-place
+  activation an error.
+- **Ephemeral activations skip the hook.** The synthetic activation
+  that `flox services start` builds must not recurse into a wrapper.
+- **Feature-gated** behind a dedicated `features.plugin_hooks` flag
+  (§5.1).
+
+### 3.2 The consent anchor: top-level `[plugin-hooks]`
+
+The auto-activation planner (`hook-env`) must classify "entering this
+directory hands your session to a wrapper" **without executing any
+plugin code** — it runs on every prompt render. And the consent signal
+must be something the top-level author actually wrote: `[include]`
+composition unions included environments' `[plugins.*]` tables, so a
+declaration living *inside* plugin tables could arrive from an
+included manifest the user never read. That is not consent. Therefore:
+
+- Hook participation is declared in a **typed, top-level manifest
+  section** (§5), separate from the opaque plugin data tables.
+- **Only the top-level (user-authored) manifest's `[plugin-hooks]` is
+  effective.** An included manifest's section is stripped during
+  composition with a notice naming the include; an environment whose
+  *include* declares a wrapper activates unwrapped, with the
+  shipped-but-undeclared warning pointing at the fix.
+- At activation, core cross-checks declarations against the rendered
+  environment (declared-but-missing hook file = error; the binding
+  rule of §3.1 covers the reverse direction).
+- The planner classifies from the user-authored `manifest.toml`
+  alone — a cheap TOML parse, and *correct by construction* because
+  include-carried declarations are inert anyway.
+- The consent prompt (core-owned, generically worded) offers a
+  foreground wrapped session, once per shell visit, clearing on
+  leaving the directory, with a **default of No** — bare Enter
+  declines; handing the terminal to third-party code from a `cd` must
+  be an affirmative choice. It is asked even for directories on the
+  allow list, since a prior allow may predate the declaration:
+
+  ```
+  Enter '<path>'? Activation hands this session to plugin '<name>'. [y/N]
+  ```
+
+- On fish, tcsh, or without a tty, auto-activation of a wrapping
+  environment emits a notice pointing at `flox activate` — no prompt.
+
+## 4. Hook tree layout and rendering
+
+```
+<plugin package>/
+├── etc/profile.d/1000_<name>.sh            # existing: activation env setup
+└── etc/flox/hooks/
+    └── session-wrap.d/<name>               # executable
+```
+
+The buildenv symlink forest merges nested package directories at
+arbitrary depth (`pathsToLink = "/"`), so per-plugin files inside the
+hook directory merge exactly like profile.d. One caveat is
+load-bearing: an identical *leaf filename* from two packages is a hard
+build failure, so the `<plugin-name>` naming convention is a
+requirement, not tidiness. Discovery at dispatch time is a directory
+listing of `$FLOX_ENV/etc/flox/hooks/session-wrap.d/`, cross-checked
+against the `[plugin-hooks]` declaration (§3.1–3.2).
+
+Other contract details plugin authors need on day one:
+
+- **Execution environment:** hooks run with the invoking user's
+  environment and `PATH`, before any activation setup. On macOS
+  `/usr/bin/env bash` can resolve to the system bash 3.2, so shell
+  hooks must stay 3.2-compatible — notably, bash 3.2 cannot parse a
+  heredoc inside `$(...)` when the body has unbalanced parentheses
+  (policy files often do); write such payloads to a temp file instead.
+- **Cache/state:** blessed location is
+  `<project>/.flox/cache/plugins/<plugin-name>/`.
+- **Ctx schema:** the ctx JSON is versioned (`ctx_version`, currently
+  `1`); publishing its schema under `cli/schemas/` is a follow-up.
+- **Local dev loop:** hooks are testable without publishing — build
+  the plugin package and path-install it (store-path installs are the
+  mechanism main's own bats suite uses to exercise `[plugins]`).
+
+## 5. Manifest schema: the `[plugin-hooks]` section
+
+A **new typed, top-level section** — not a reserved key inside the
+opaque plugin tables, whose `serde_json::Value` content can't trip
+`deny_unknown_fields` on older schemas (hooks-bearing manifests would
+silently activate unwrapped on every released CLI). A new section makes
+released CLIs reject it wholesale and blocks downgrade while present.
+
+```toml
+[plugin-hooks]
+session-wrap = "plugin-openshell"   # at most one — single-wrapper rule is structural
+```
+
+- Typed as `PluginHooks { session_wrap: Option<String> }` with
+  `deny_unknown_fields`, so an unknown hook kind fails at parse time
+  (lock/edit), not activation time. Future hooks add keys here.
+- The value names a plugin, i.e. the key of its `[plugins.<name>]`
+  table and the install id of the package that ships the hook file;
+  the activation-time binding check (§3.1) ties the name to the locked
+  install.
+- Introduced in schema **v1.16.0**.
+- Migration to/from the previous version is lossless when the section
+  is absent; a manifest using it does not downgrade (new-field
+  precedent, same as the `[plugins]` introduction).
+- Composition: included manifests' `[plugin-hooks]` sections are
+  stripped with a notice (§3.2). `[plugins.<name>]` data tables keep
+  their existing whole-table merge — data flows through includes,
+  *participation* does not.
+
+### 5.1 Feature gating
+
+A dedicated `features.plugin_hooks` flag (env:
+`FLOX_FEATURES_PLUGIN_HOOKS`), not `features.beta` — enabling beta to
+try subcommand extensions must not silently arm session handoff.
+
+- **Flag off (the default):** hooks-declaring manifests
+  **warn-and-ignore** — the activation proceeds unwrapped with a
+  warning naming the flag, so a shared environment stays usable for
+  teammates who haven't opted in. Asymmetry to revisit before the flag
+  defaults on: *released* CLIs reject the manifest at parse
+  (fail-closed); *flag-off* CLIs warn-and-ignore (fail-open, loudly).
+- The gate is evaluated in the `flox` CLI only. Session-wrap dispatch
+  runs before the CLI hands off to `flox-activations`, which has no
+  config plumbing and gains none.
+
+## 6. What OpenShell becomes
+
+An ordinary package, `plugin-openshell`, developed in
+`flox/flox-plugins` and shipping the `session-wrap.d/plugin-openshell`
+hook. The hook bakes the rendered environment into a guest image via
+`flox containerize`, compiles its network policy per activation from
+its own `[plugins.plugin-openshell]` table (`autobake`, `allow-stale`,
+`image`, and `[[plugins.plugin-openshell.network]]` entries with
+`endpoint`, `access`, `protocol`, `binary`), and composes the in-guest
+command from `invocation_type`. It is intended to be the first plugin
+released to the Flox Catalog (`flox` org) for internal and user
+testing; until then it is built from `flox/flox-plugins` and installed
+by store path.
+
+## 7. Branches
+
+| Repo | Branch | Carries |
+|---|---|---|
+| `flox/flox` | `daniel/session-wrap-hook` (this one) | this design; `[plugin-hooks]` schema v1.16.0 + `features.plugin_hooks`; session-wrap dispatch in `activate.rs`; include-stripping in composition; the consent leg in `hook_env.rs`; `cli/tests/session_wrap.bats` |
+| `flox/flox-plugins` | `daniel/openshell-plugin` | the `plugin-openshell` package (§6) |
+| `flox/docs` | `daniel/session-wrap-openshell` | plugin-hook and OpenShell documentation |
+
+## 8. Open questions / future work
+
+- **Run-mode plugins**: profile.d (and thus plugin env setup) is
+  skipped in run mode today; session-wrap is mode-independent by
+  design, but a wrapped run-mode env whose plugin needs profile.d data
+  must carry everything in the ctx. Revisit if a real case appears.
+- **Remote/managed environments**: consent semantics for
+  `flox activate -r` pulling a manifest that declares session-wrap —
+  the remote-env trust prompt and the hook consent prompt should
+  compose, not stack. (Include-stripping already prevents *transitive*
+  arrival; this is about the remote env's own top-level declaration.)
+- **Nested boundaries**: a scope-mismatched `_FLOX_SESSION_WRAPPED`
+  (env B activating inside env A's boundary) errors, per §3.1.
+  Composing boundaries is future work.
+- **Catalog metadata**: a catalog-side "this package declares hooks X"
+  signal could let `flox install` surface consent before activation.
+- **Ctx cleanup**: the hook execs away, so nobody deletes its 0600 ctx
+  file deterministically; it is cleaned with flox's temp dir. If that
+  proves unsatisfying, hand the ctx on an inherited fd instead.
+- **Duplicate warnings on re-entry**: the wrapped inner activation
+  re-runs session-wrap resolution (skipping via the marker), so the
+  undeclared-hook warning prints twice. Cosmetic; dedupe if it grates.
+- **Double-counted activation events for same-filesystem wrappers**:
+  the outer process records its `activate` metrics and events before
+  dispatch execs the hook, and a wrapper that re-enters via
+  `inner_argv` records them again. Container wrappers such as
+  OpenShell run no flox CLI in the guest, so they count once. Fix when
+  a same-filesystem wrapper ships: record events after dispatch, or
+  skip them in the outer process when it is about to exec.
+- **Flag-off is fail-open**: with `features.plugin_hooks` off a
+  declaring manifest activates unwrapped with a warning (§5.1). For an
+  isolation consumer that may be the wrong default; failing closed is
+  fewer lines. Decide before the flag defaults on.

--- a/pkgs/flox/default.nix
+++ b/pkgs/flox/default.nix
@@ -9,6 +9,7 @@
   flox-nix-plugins,
   flox-cli,
   flox-manpages,
+  jq,
   process-compose,
   pkgsFor,
   SENTRY_DSN ? null,
@@ -46,6 +47,7 @@ symlinkJoin {
       --set BUILDENV_NIX        "${flox-buildenv}/lib/buildenv.nix" \
       --set NIX_PLUGINS         "${flox-nix-plugins}/lib/nix-plugins" \
       --set PROCESS_COMPOSE_BIN "${process-compose}/bin/process-compose" \
+      --set JQ_BIN              "${jq}/bin/jq" \
       --set FLOX_VERSION        "${version}"
 
     # make sure that version can be parsed

--- a/pkgs/rust-internal-deps/default.nix
+++ b/pkgs/rust-internal-deps/default.nix
@@ -12,6 +12,7 @@
   glibcLocalesUtf8,
   gnumake,
   inputs,
+  jq,
   lib,
   nixpkgsInputLockedURL,
   nix,
@@ -39,6 +40,7 @@ let
       NIX_VERSION = nix.version;
       GNUMAKE_BIN = "${gnumake}/bin/make";
       SLEEP_BIN = "${coreutils}/bin/sleep";
+      JQ_BIN = "${jq}/bin/jq";
       PROCESS_COMPOSE_BIN = "${process-compose}/bin/process-compose";
       FLOX_ACTIVATIONS_BIN = "${flox-activations}/libexec/flox-activations";
       # used internally to ensure CA certificates are available


### PR DESCRIPTION
## Proposed Changes

Tightly-scoped cut of `prototype/sandbox-plugins`: **only the core surface a session-boundary plugin such as OpenShell needs**, so the Q4 effort can be t-shirt sized. Tracking: [OpenShell Sandbox Plugin](https://linear.app/floxdotdev/project/openshell-sandbox-plugin-ca88a8ab0737) (Linear). Sibling drafts: flox/flox-plugins#25 (the OpenShell plugin) and flox/docs#86 (concept docs).

Core never says "sandbox". What it gains is one generic extension point, gated behind a dedicated feature flag:

1. **`docs(plugins)`** — a 300-line design doc for the `session-wrap` hook (contract, consent anchor, hook tree, schema, open questions). The full lifecycle design (env/sidecar hooks, `on-deactivate.d`, 14 other backends) stays on `prototype/sandbox-plugins`.
2. **`feat(manifest)`** — schema **v1.16.0** minting a typed, top-level `[plugin-hooks]` section with exactly one key, `session-wrap = "<plugin>"` (so two wrappers are unrepresentable), plus `features.plugin_hooks`. Included manifests' declarations are stripped during composition with a notice — hook participation is consent and must be authored in the top-level manifest.
3. **`feat(activate)`** — dispatch in `flox activate` after lock/build/render: discover `etc/flox/hooks/session-wrap.d/<plugin>` in the rendered env, verify the declaration↔package binding (installed, shipped by the declared package's own store path, executable), write a `0600` JSON ctx, and `exec` the hook with `FLOX_HOOK_CTX`/`FLOX_HOOK`/`FLOX_PLUGIN_NAME`/`FLOX_BIN`/`FLOX_HOOK_JQ`. Re-entry marker `_FLOX_SESSION_WRAPPED=<wrap_scope>` (match skips, mismatch errors); in-place and ephemeral activations are guarded.
4. **`test(activate)`** — 7 end-to-end bats tests with a store-path-installed fixture plugin.
5. **`feat(hook-env)`** — auto-activation consent: entering a wrapping directory prompts (`[y/N]`, default No) and starts a foreground `flox activate --dir` session instead of an in-place activation; fish/tcsh/no-tty get a notice. *Separable*: OpenShell's activation path does not need it, but the project's stated DX goal ("as seamless as `cd`-ing into the directory") does. Happy to split it into a follow-up PR if that helps sizing.

### Surface-area inventory (for sizing)

| Component | Lines | Needed by OpenShell? |
|---|---|---|
| Schema mint + `PluginHooks` type (14 manifest files, ~120 of it proptest/expect churn) | ~440 | yes |
| Generated JSON schemas | ~240 | yes (generated) |
| Include-stripping + notice | ~130 (~70 are tests) | consent guarantee; keep |
| Feature flag | 5 | policy |
| `session_wrap.rs` (resolve, validate, ctx, exec) + `activate.rs` call site | ~420 | yes |
| Auto-activation consent leg (`hook_env.rs`) | ~310 (~90 tests) | no (DX goal) |
| bats | ~210 | merge requirement |
| Design doc + man page | ~350 | — |

Roughly 60% is mechanical or prose; the behavioral core is ~560 lines. Dropped relative to the prototype: `env`/`sidecar` hooks, plugin `on-deactivate.d`, the macOS `proc_status` fix (only Seatbelt wrappers needed it), and all wave notes.

### Verification

- `cargo fmt --check`, `cargo clippy --all` (clean), `just gen-schemas` leaves the tree clean.
- Unit: `flox-manifest` 149/149; `flox` (session_wrap, hook_env) 54/54.
- Integration: `session_wrap.bats` 7/7, `include.bats` 8/8, `init.bats`, `list.bats`, the `plugins:` subset of `activate.bats`.
- **End to end with the real plugin** (this build + flox-plugins `daniel/openshell-plugin`, macOS, Docker, local OpenShell gateway): wrapped session runs as the unprivileged sandbox user in a Linux guest with the re-entry marker set, project mounted at its host path, host home absent, granted endpoint 200 / everything else 403, live policy edits apply without a rebake, flag-off degrades with a warning, in-place activation refused. Transcript in the flox-plugins PR.

### Decisions to confirm during review

- **Flag-off is fail-open**: a declaring manifest activates unwrapped with a warning when `features.plugin_hooks` is off (keeps shared envs usable for teammates without the flag). For an isolation consumer, fail-closed may be the better default and is fewer lines.
- **New schema version for one flagged key**: every `flox init`/edit now writes 1.16.0, which released CLIs reject wholesale; VERSION stays 1.15.0 following the 1.15.0-mint precedent.
- **ctx v1 carries fields OpenShell doesn't read** (`inner_argv`, `rendered_env`, `activation_mode`, `stdout_is_tty`) for same-filesystem wrappers; adding later is free, removing later costs a version bump.
- Known and documented in §8 of the design doc: same-filesystem wrappers double-count `activate` metrics (container wrappers don't); the undeclared-hook warning prints twice on re-entry.

## Release Notes

N/A — everything is behind `features.plugin_hooks` (default off) and a new manifest schema version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPagejDEz6zqZRXJQZp4Zr
