### PR TITLE
fix(catalog): honor retry-after for unavailable responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -742,6 +742,7 @@ dependencies = [
  "serde",
  "serde_json",
  "syn 2.0.114",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -743,6 +743,7 @@ dependencies = [
  "serde_json",
  "syn 2.0.114",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/cli/catalog-api-v1/Cargo.toml
+++ b/cli/catalog-api-v1/Cargo.toml
@@ -16,6 +16,7 @@ regress.workspace = true
 regex = { workspace = true, optional = true }
 httpmock = { workspace = true, optional = true }
 tokio.workspace = true
+tracing.workspace = true
 
 [build-dependencies]
 prettyplease.workspace = true

--- a/cli/catalog-api-v1/Cargo.toml
+++ b/cli/catalog-api-v1/Cargo.toml
@@ -15,6 +15,7 @@ chrono.workspace = true
 regress.workspace = true
 regex = { workspace = true, optional = true }
 httpmock = { workspace = true, optional = true }
+tokio.workspace = true
 
 [build-dependencies]
 prettyplease.workspace = true

--- a/cli/catalog-api-v1/src/hooks.rs
+++ b/cli/catalog-api-v1/src/hooks.rs
@@ -1,6 +1,36 @@
 use std::sync::Arc;
+use std::time::Duration;
 
-use progenitor_client::{ClientHooks, Error, OperationInfo};
+use chrono::{DateTime, Utc};
+use progenitor_client::{ClientHooks, ClientInfo, Error, OperationInfo};
+use reqwest::StatusCode;
+use reqwest::header::RETRY_AFTER;
+
+const MAX_SERVICE_UNAVAILABLE_RETRIES: usize = 2;
+
+fn parse_retry_after(value: &str, now: DateTime<Utc>) -> Duration {
+    if let Ok(seconds) = value.parse::<u64>() {
+        return Duration::from_secs(seconds);
+    }
+
+    let Ok(retry_at) = DateTime::parse_from_rfc2822(value) else {
+        return Duration::ZERO;
+    };
+    retry_at
+        .with_timezone(&Utc)
+        .signed_duration_since(now)
+        .to_std()
+        .unwrap_or_default()
+}
+
+fn retry_after_delay(response: &reqwest::Response) -> Duration {
+    response
+        .headers()
+        .get(RETRY_AFTER)
+        .and_then(|value| value.to_str().ok())
+        .map(|value| parse_retry_after(value, Utc::now()))
+        .unwrap_or_default()
+}
 
 /// Per-instance request hooks embedded in the generated `Client` via
 /// `with_inner_type`.
@@ -52,5 +82,70 @@ impl ClientHooks<RequestHooks> for crate::Client {
     ) -> Result<(), Error<E>> {
         (self.inner.pre_request)(request);
         Ok(())
+    }
+
+    async fn exec(
+        &self,
+        request: reqwest::Request,
+        _info: &OperationInfo,
+    ) -> reqwest::Result<reqwest::Response> {
+        let mut request = request;
+        for attempt in 0..=MAX_SERVICE_UNAVAILABLE_RETRIES {
+            let retry_request = request.try_clone();
+            let response = self.client().execute(request).await?;
+            if response.status() != StatusCode::SERVICE_UNAVAILABLE
+                || attempt == MAX_SERVICE_UNAVAILABLE_RETRIES
+            {
+                return Ok(response);
+            }
+
+            let Some(next_request) = retry_request else {
+                return Ok(response);
+            };
+            tokio::time::sleep(retry_after_delay(&response)).await;
+            request = next_request;
+        }
+
+        unreachable!("retry loop always returns on its final attempt")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::TimeZone;
+
+    use super::*;
+
+    #[test]
+    fn retry_after_parses_seconds() {
+        let now = Utc.with_ymd_and_hms(2026, 9, 4, 12, 0, 0).unwrap();
+
+        assert_eq!(
+            parse_retry_after("12", now),
+            Duration::from_secs(12)
+        );
+    }
+
+    #[test]
+    fn retry_after_parses_http_date() {
+        let now = Utc.with_ymd_and_hms(2026, 9, 4, 12, 0, 0).unwrap();
+
+        assert_eq!(
+            parse_retry_after("Fri, 04 Sep 2026 12:00:12 GMT", now),
+            Duration::from_secs(12)
+        );
+    }
+
+    #[test]
+    fn retry_after_defaults_to_zero_for_past_dates_and_invalid_values() {
+        let now = Utc.with_ymd_and_hms(2026, 9, 4, 12, 0, 0).unwrap();
+
+        assert_eq!(
+            (
+                parse_retry_after("Fri, 04 Sep 2026 11:59:59 GMT", now),
+                parse_retry_after("not a delay", now),
+            ),
+            (Duration::ZERO, Duration::ZERO)
+        );
     }
 }

--- a/cli/catalog-api-v1/src/hooks.rs
+++ b/cli/catalog-api-v1/src/hooks.rs
@@ -5,31 +5,46 @@ use chrono::{DateTime, Utc};
 use progenitor_client::{ClientHooks, ClientInfo, Error, OperationInfo};
 use reqwest::StatusCode;
 use reqwest::header::RETRY_AFTER;
+use tracing::warn;
 
 const MAX_SERVICE_UNAVAILABLE_RETRIES: usize = 2;
+const DEFAULT_SERVICE_UNAVAILABLE_RETRY_DELAY: Duration = Duration::from_secs(2);
 
-fn parse_retry_after(value: &str, now: DateTime<Utc>) -> Duration {
+fn parse_retry_after(value: &str, now: DateTime<Utc>) -> Option<Duration> {
     if let Ok(seconds) = value.parse::<u64>() {
-        return Duration::from_secs(seconds);
+        return Some(Duration::from_secs(seconds));
     }
 
     let Ok(retry_at) = DateTime::parse_from_rfc2822(value) else {
-        return Duration::ZERO;
+        return None;
     };
-    retry_at
-        .with_timezone(&Utc)
-        .signed_duration_since(now)
-        .to_std()
-        .unwrap_or_default()
+    Some(
+        retry_at
+            .with_timezone(&Utc)
+            .signed_duration_since(now)
+            .to_std()
+            .unwrap_or_default(),
+    )
 }
 
 fn retry_after_delay(response: &reqwest::Response) -> Duration {
-    response
-        .headers()
-        .get(RETRY_AFTER)
-        .and_then(|value| value.to_str().ok())
-        .map(|value| parse_retry_after(value, Utc::now()))
-        .unwrap_or_default()
+    let Some(value) = response.headers().get(RETRY_AFTER) else {
+        return DEFAULT_SERVICE_UNAVAILABLE_RETRY_DELAY;
+    };
+    let Ok(value) = value.to_str() else {
+        warn!(
+            retry_after = ?value,
+            "Retry-After header is not valid text; using the default retry delay"
+        );
+        return DEFAULT_SERVICE_UNAVAILABLE_RETRY_DELAY;
+    };
+    parse_retry_after(value, Utc::now()).unwrap_or_else(|| {
+        warn!(
+            retry_after = value,
+            "Could not parse Retry-After header; using the default retry delay"
+        );
+        DEFAULT_SERVICE_UNAVAILABLE_RETRY_DELAY
+    })
 }
 
 /// Per-instance request hooks embedded in the generated `Client` via
@@ -122,7 +137,7 @@ mod tests {
 
         assert_eq!(
             parse_retry_after("12", now),
-            Duration::from_secs(12)
+            Some(Duration::from_secs(12))
         );
     }
 
@@ -132,12 +147,12 @@ mod tests {
 
         assert_eq!(
             parse_retry_after("Fri, 04 Sep 2026 12:00:12 GMT", now),
-            Duration::from_secs(12)
+            Some(Duration::from_secs(12))
         );
     }
 
     #[test]
-    fn retry_after_defaults_to_zero_for_past_dates_and_invalid_values() {
+    fn retry_after_distinguishes_past_dates_from_invalid_values() {
         let now = Utc.with_ymd_and_hms(2026, 9, 4, 12, 0, 0).unwrap();
 
         assert_eq!(
@@ -145,7 +160,7 @@ mod tests {
                 parse_retry_after("Fri, 04 Sep 2026 11:59:59 GMT", now),
                 parse_retry_after("not a delay", now),
             ),
-            (Duration::ZERO, Duration::ZERO)
+            (Some(Duration::ZERO), None)
         );
     }
 }

--- a/cli/floxhub-client/src/client.rs
+++ b/cli/floxhub-client/src/client.rs
@@ -969,20 +969,6 @@ pub(crate) fn build_http_client(
     base_url: &str,
 ) -> Result<reqwest::Client, String> {
     let headers = build_header_map(extra_headers)?;
-    let retry_host = Url::parse(base_url)
-        .map_err(|error| format!("invalid base URL '{base_url}': {error}"))?
-        .host_str()
-        .ok_or_else(|| format!("base URL '{base_url}' has no host"))?
-        .to_string();
-    let retry_policy = reqwest::retry::for_host(retry_host)
-        .max_retries_per_request(2)
-        .classify_fn(|request| {
-            if request.status() == Some(StatusCode::SERVICE_UNAVAILABLE) {
-                request.retryable()
-            } else {
-                request.success()
-            }
-        });
 
     debug!(
         base_url = %base_url,
@@ -993,8 +979,7 @@ pub(crate) fn build_http_client(
     let client_builder = reqwest::Client::builder()
         .default_headers(headers)
         .connect_timeout(Duration::from_secs(15))
-        .timeout(Duration::from_secs(60))
-        .retry(retry_policy);
+        .timeout(Duration::from_secs(60));
 
     let client_builder = if let Some(ua) = user_agent {
         client_builder.user_agent(ua)
@@ -1196,6 +1181,7 @@ pub mod tests {
         let mock = server.mock(|when, then| {
             when.method("POST").path("/api/v1/catalog/resolve");
             then.status(StatusCode::SERVICE_UNAVAILABLE.as_u16())
+                .header("retry-after", "0")
                 .json_body(json!({"detail": "try again"}));
         });
         let client = FloxhubClient::new(client_config(&server.base_url())).unwrap();
@@ -1234,21 +1220,6 @@ pub mod tests {
         };
         assert_eq!(error.status(), Some(StatusCode::INTERNAL_SERVER_ERROR));
         mock.assert_calls(1);
-    }
-
-    #[tokio::test]
-    async fn accounts_requests_retry_service_unavailable_responses() {
-        let server = MockServer::start_async().await;
-        let mock = server.mock(|when, then| {
-            when.method("GET").path("/accounts/api/v1/accounts/me");
-            then.status(StatusCode::SERVICE_UNAVAILABLE.as_u16());
-        });
-        let client = FloxhubClient::new(client_config(&server.base_url())).unwrap();
-
-        let result = client.resolve_identity("flox_pat_retry-test").await;
-
-        assert!(result.is_err());
-        mock.assert_calls(3);
     }
 
     /// `resolve()` applies `FloxhubClientConfig::stability` to every

--- a/cli/floxhub-client/src/client.rs
+++ b/cli/floxhub-client/src/client.rs
@@ -969,6 +969,22 @@ pub(crate) fn build_http_client(
     base_url: &str,
 ) -> Result<reqwest::Client, String> {
     let headers = build_header_map(extra_headers)?;
+    let retry_host = Url::parse(base_url)
+        .map_err(|error| format!("invalid base URL '{base_url}': {error}"))?
+        .host_str()
+        .ok_or_else(|| format!("base URL '{base_url}' has no host"))?
+        .to_string();
+    let retry_policy = reqwest::retry::for_host(retry_host)
+        .max_retries_per_request(2)
+        .classify_fn(|request| {
+            if request.status() == Some(StatusCode::SERVICE_UNAVAILABLE)
+                && request.uri().path().starts_with("/api/v1/catalog/")
+            {
+                request.retryable()
+            } else {
+                request.success()
+            }
+        });
 
     debug!(
         base_url = %base_url,
@@ -979,7 +995,8 @@ pub(crate) fn build_http_client(
     let client_builder = reqwest::Client::builder()
         .default_headers(headers)
         .connect_timeout(Duration::from_secs(15))
-        .timeout(Duration::from_secs(60));
+        .timeout(Duration::from_secs(60))
+        .retry(retry_policy);
 
     let client_builder = if let Some(ua) = user_agent {
         client_builder.user_agent(ua)
@@ -1173,6 +1190,52 @@ pub mod tests {
             },
         };
         mock.assert();
+    }
+
+    #[tokio::test]
+    async fn resolve_retries_service_unavailable_responses() {
+        let server = MockServer::start_async().await;
+        let mock = server.mock(|when, then| {
+            when.method("POST").path("/api/v1/catalog/resolve");
+            then.status(StatusCode::SERVICE_UNAVAILABLE.as_u16())
+                .json_body(json!({"detail": "try again"}));
+        });
+        let client = FloxhubClient::new(client_config(&server.base_url())).unwrap();
+
+        let result = client
+            .resolve(vec![PackageGroup {
+                name: "group".to_string(),
+                descriptors: vec![],
+            }])
+            .await;
+
+        assert!(result.is_err());
+        mock.assert_calls(3);
+    }
+
+    #[tokio::test]
+    async fn resolve_returns_other_error_responses_without_retrying() {
+        let server = MockServer::start_async().await;
+        let mock = server.mock(|when, then| {
+            when.method("POST").path("/api/v1/catalog/resolve");
+            then.status(StatusCode::INTERNAL_SERVER_ERROR.as_u16())
+                .json_body(json!({"detail": "internal error"}));
+        });
+        let client = FloxhubClient::new(client_config(&server.base_url())).unwrap();
+
+        let result = client
+            .resolve(vec![PackageGroup {
+                name: "group".to_string(),
+                descriptors: vec![],
+            }])
+            .await;
+
+        let error = match result.unwrap_err() {
+            ResolveError::FloxhubClientError(FloxhubClientError::APIError(error)) => error,
+            other => panic!("expected an API error, got {other:?}"),
+        };
+        assert_eq!(error.status(), Some(StatusCode::INTERNAL_SERVER_ERROR));
+        mock.assert_calls(1);
     }
 
     /// `resolve()` applies `FloxhubClientConfig::stability` to every

--- a/cli/floxhub-client/src/client.rs
+++ b/cli/floxhub-client/src/client.rs
@@ -977,9 +977,7 @@ pub(crate) fn build_http_client(
     let retry_policy = reqwest::retry::for_host(retry_host)
         .max_retries_per_request(2)
         .classify_fn(|request| {
-            if request.status() == Some(StatusCode::SERVICE_UNAVAILABLE)
-                && request.uri().path().starts_with("/api/v1/catalog/")
-            {
+            if request.status() == Some(StatusCode::SERVICE_UNAVAILABLE) {
                 request.retryable()
             } else {
                 request.success()
@@ -1236,6 +1234,21 @@ pub mod tests {
         };
         assert_eq!(error.status(), Some(StatusCode::INTERNAL_SERVER_ERROR));
         mock.assert_calls(1);
+    }
+
+    #[tokio::test]
+    async fn accounts_requests_retry_service_unavailable_responses() {
+        let server = MockServer::start_async().await;
+        let mock = server.mock(|when, then| {
+            when.method("GET").path("/accounts/api/v1/accounts/me");
+            then.status(StatusCode::SERVICE_UNAVAILABLE.as_u16());
+        });
+        let client = FloxhubClient::new(client_config(&server.base_url())).unwrap();
+
+        let result = client.resolve_identity("flox_pat_retry-test").await;
+
+        assert!(result.is_err());
+        mock.assert_calls(3);
     }
 
     /// `resolve()` applies `FloxhubClientConfig::stability` to every


### PR DESCRIPTION
## Proposed Changes

- Retry catalog `503 Service Unavailable` responses up to twice in the generated client's execution hook.
- Honor `Retry-After` delays expressed as either seconds or an HTTP date.
- Preserve reqwest's default transport behavior and existing handling for all non-503 responses.

Resolves https://linear.app/floxdotdev/issue/CLI-167/flox-cli-does-not-retry-catalog-503s-server-side-load-shedding-is

## Release Notes

Catalog requests now wait for the server-requested delay and retry when the service is temporarily unavailable.
