### PR TITLE
feat(publish): AI-670 send the build's raw meta document to the catalog

### DIFF
--- a/cli/catalog-api-v1/openapi.json
+++ b/cli/catalog-api-v1/openapi.json
@@ -146,6 +146,7 @@
             "required": false,
             "schema": {
               "type": "integer",
+              "minimum": 0,
               "default": 0,
               "title": "Page"
             }
@@ -156,6 +157,7 @@
             "required": false,
             "schema": {
               "type": "integer",
+              "minimum": 0,
               "default": 10,
               "title": "Pagesize"
             }
@@ -336,7 +338,7 @@
           "build-inputs"
         ],
         "summary": "Lookup",
-        "description": "Resolve build inputs for one or more reference groups.\n\nDirect references resolve to latest; the transitive closure is taken\nverbatim; a cross-reference conflict yields a per-group conflict result.\n\nFor each group, walks the transitive package_inputs closure (accessor),\nthen applies auth redaction and assembles the flat LockedInputs map.\n\nEach group runs in its own transaction so a single group's timeout,\noverflow, or conflict produces a per-group error without affecting others.",
+        "description": "Resolve build inputs for one or more reference groups.\n\nDirect references resolve to the latest revision of their own source; the\ntransitive closure is taken verbatim; a cross-reference conflict yields a\nper-group conflict result.\n\nFor each group, walks the transitive package_inputs closure (accessor),\nthen applies auth redaction and assembles the flat LockedInputs map.\n\nEach group runs in its own transaction so a single group's timeout,\noverflow, or conflict produces a per-group error without affecting others.",
         "operationId": "lookup_api_v1_catalog_build_inputs_lookup_post",
         "requestBody": {
           "content": {
@@ -1750,6 +1752,37 @@
         }
       }
     },
+    "/api/v1/catalog/info/systems": {
+      "get": {
+        "tags": [
+          "info"
+        ],
+        "summary": "List registered systems",
+        "operationId": "getSystems_api_v1_catalog_info_systems_get",
+        "responses": {
+          "200": {
+            "description": "The names of every system registered in the catalog, sorted by name",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SystemsResult"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "The request could not be processed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/catalog/info/published-catalogs": {
       "get": {
         "tags": [
@@ -2239,9 +2272,11 @@
       "BuildInputsLookupRequest": {
         "properties": {
           "stability": {
-            "type": "string",
-            "minLength": 1,
-            "title": "Stability"
+            "title": "Stability",
+            "description": "Accepted and ignored; not used by this endpoint. Deprecated.",
+            "deprecated": true,
+            "nullable": true,
+            "type": "string"
           },
           "reference_point": {
             "nullable": true,
@@ -2262,11 +2297,10 @@
         },
         "type": "object",
         "required": [
-          "stability",
           "groups"
         ],
         "title": "BuildInputsLookupRequest",
-        "description": "Request body for the /build-inputs/lookup endpoint.\n\nA lookup names a `stability` (required) and one or more `groups` of\nreferences to resolve, optionally anchored at a `reference_point`.  It is\nsystem-independent \u2014 the response is source revs + DAG edges, which carry\nno system \u2014 so the request body has no system field."
+        "description": "Request body for the /build-inputs/lookup endpoint.\n\nA lookup names one or more `groups` of references to resolve, optionally\nanchored at a `reference_point`.\n\nThe response is source revisions plus DAG edges: for each reference, the\nlatest revision of its own source together with the transitive non-base\nsources that revision was built against.  That answer carries no system\nand no nixpkgs base revision, so the request body names neither.  A base\nrevision is selected at build time, against which the same lock may be\nbuilt repeatedly."
       },
       "BuildInputsLookupResponse": {
         "properties": {
@@ -3395,6 +3429,16 @@
             },
             "type": "array",
             "title": "Items"
+          },
+          "commands_by_output": {
+            "additionalProperties": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "type": "object",
+            "title": "Commands By Output"
           }
         },
         "type": "object",
@@ -3493,6 +3537,12 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/LockedInputEntry"
             },
+            "type": "object"
+          },
+          "evaluation_meta": {
+            "title": "Evaluation Meta",
+            "nullable": true,
+            "additionalProperties": true,
             "type": "object"
           }
         },
@@ -4826,6 +4876,23 @@
         ],
         "title": "StorepathStatusResponse"
       },
+      "SystemsResult": {
+        "properties": {
+          "registered_systems": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Registered Systems"
+          }
+        },
+        "type": "object",
+        "required": [
+          "registered_systems"
+        ],
+        "title": "SystemsResult",
+        "description": "Every system registered in the catalog, sorted by name."
+      },
       "UnresolvableEntry": {
         "properties": {
           "reference": {
@@ -4862,7 +4929,7 @@
         },
         "type": "object",
         "title": "UnresolvableLeaf",
-        "description": "Uniform shape for an unresolvable dependency.\n\nSerializes as {\"unresolvable\": {}} \u2014 exactly one shape, no cause/reason\nfields at the leaf level. If a future change needs structured error\ndetail, introduce a typed `reason` field here."
+        "description": "Uniform shape for an unresolvable dependency.\n\nSerializes as {\"unresolvable\": {<cause>: <detail>}} \u2014 a single-key cause\nmap, not a typed field.  The current cause vocabulary: \"_handle\" (uniform\nnon-disclosure marker), \"overflow\", \"conflict\", \"timeout\", and\n\"not_lockable\".  A consumer must tolerate an unrecognized key: this type\nmakes no closed-vocabulary guarantee, and a new cause can be added here\nwithout a schema change (the field is `dict[str, Any]`)."
       },
       "UserCatalog": {
         "properties": {

--- a/cli/catalog-api-v1/src/client.rs
+++ b/cli/catalog-api-v1/src/client.rs
@@ -86,21 +86,25 @@ pub mod types {
     }
     /**Request body for the /build-inputs/lookup endpoint.
 
-A lookup names a `stability` (required) and one or more `groups` of
-references to resolve, optionally anchored at a `reference_point`.  It is
-system-independent — the response is source revs + DAG edges, which carry
-no system — so the request body has no system field.*/
+A lookup names one or more `groups` of references to resolve, optionally
+anchored at a `reference_point`.
+
+The response is source revisions plus DAG edges: for each reference, the
+latest revision of its own source together with the transitive non-base
+sources that revision was built against.  That answer carries no system
+and no nixpkgs base revision, so the request body names neither.  A base
+revision is selected at build time, against which the same lock may be
+built repeatedly.*/
     ///
     /// <details><summary>JSON schema</summary>
     ///
     /// ```json
     ///{
     ///  "title": "BuildInputsLookupRequest",
-    ///  "description": "Request body for the /build-inputs/lookup endpoint.\n\nA lookup names a `stability` (required) and one or more `groups` of\nreferences to resolve, optionally anchored at a `reference_point`.  It is\nsystem-independent — the response is source revs + DAG edges, which carry\nno system — so the request body has no system field.",
+    ///  "description": "Request body for the /build-inputs/lookup endpoint.\n\nA lookup names one or more `groups` of references to resolve, optionally\nanchored at a `reference_point`.\n\nThe response is source revisions plus DAG edges: for each reference, the\nlatest revision of its own source together with the transitive non-base\nsources that revision was built against.  That answer carries no system\nand no nixpkgs base revision, so the request body names neither.  A base\nrevision is selected at build time, against which the same lock may be\nbuilt repeatedly.",
     ///  "type": "object",
     ///  "required": [
-    ///    "groups",
-    ///    "stability"
+    ///    "groups"
     ///  ],
     ///  "properties": {
     ///    "groups": {
@@ -127,8 +131,12 @@ no system — so the request body has no system field.*/
     ///    },
     ///    "stability": {
     ///      "title": "Stability",
-    ///      "type": "string",
-    ///      "minLength": 1
+    ///      "description": "Accepted and ignored; not used by this endpoint. Deprecated.",
+    ///      "deprecated": true,
+    ///      "type": [
+    ///        "string",
+    ///        "null"
+    ///      ]
     ///    }
     ///  }
     ///}
@@ -139,7 +147,9 @@ no system — so the request body has no system field.*/
         pub groups: ::std::vec::Vec<LookupGroup>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub reference_point: ::std::option::Option<ReferencePoint>,
-        pub stability: Stability,
+        ///Accepted and ignored; not used by this endpoint. Deprecated.
+        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        pub stability: ::std::option::Option<::std::string::String>,
     }
     impl ::std::convert::From<&BuildInputsLookupRequest> for BuildInputsLookupRequest {
         fn from(value: &BuildInputsLookupRequest) -> Self {
@@ -2729,6 +2739,16 @@ catalog) or '<owner>.<pkgset>.*' (package set) — e.g. 'brantley.*'
     ///    "items"
     ///  ],
     ///  "properties": {
+    ///    "commands_by_output": {
+    ///      "title": "Commands By Output",
+    ///      "type": "object",
+    ///      "additionalProperties": {
+    ///        "type": "array",
+    ///        "items": {
+    ///          "type": "string"
+    ///        }
+    ///      }
+    ///    },
     ///    "items": {
     ///      "title": "Items",
     ///      "type": "array",
@@ -2742,6 +2762,14 @@ catalog) or '<owner>.<pkgset>.*' (package set) — e.g. 'brantley.*'
     /// </details>
     #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug, PartialEq)]
     pub struct PackageBuildList {
+        #[serde(
+            default,
+            skip_serializing_if = ":: std :: collections :: HashMap::is_empty"
+        )]
+        pub commands_by_output: ::std::collections::HashMap<
+            ::std::string::String,
+            ::std::vec::Vec<::std::string::String>,
+        >,
         pub items: ::std::vec::Vec<PackageBuild>,
     }
     impl ::std::convert::From<&PackageBuildList> for PackageBuildList {
@@ -2889,6 +2917,14 @@ catalog) or '<owner>.<pkgset>.*' (package set) — e.g. 'brantley.*'
     ///      "default": ".flox",
     ///      "type": "string"
     ///    },
+    ///    "evaluation_meta": {
+    ///      "title": "Evaluation Meta",
+    ///      "type": [
+    ///        "object",
+    ///        "null"
+    ///      ],
+    ///      "additionalProperties": true
+    ///    },
     ///    "locked_base_catalog_url": {
     ///      "title": "Locked Base Catalog Url",
     ///      "type": [
@@ -2977,6 +3013,10 @@ catalog) or '<owner>.<pkgset>.*' (package set) — e.g. 'brantley.*'
         pub derivation: PackageDerivation,
         #[serde(default = "defaults::package_build_with_nar_info_dot_flox_dir")]
         pub dot_flox_dir: ::std::string::String,
+        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        pub evaluation_meta: ::std::option::Option<
+            ::serde_json::Map<::std::string::String, ::serde_json::Value>,
+        >,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub locked_base_catalog_url: ::std::option::Option<::std::string::String>,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -5417,84 +5457,6 @@ because the two anchors carry different value types.*/
             value.clone()
         }
     }
-    ///`Stability`
-    ///
-    /// <details><summary>JSON schema</summary>
-    ///
-    /// ```json
-    ///{
-    ///  "title": "Stability",
-    ///  "type": "string",
-    ///  "minLength": 1
-    ///}
-    /// ```
-    /// </details>
-    #[derive(::serde::Serialize, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-    #[serde(transparent)]
-    pub struct Stability(::std::string::String);
-    impl ::std::ops::Deref for Stability {
-        type Target = ::std::string::String;
-        fn deref(&self) -> &::std::string::String {
-            &self.0
-        }
-    }
-    impl ::std::convert::From<Stability> for ::std::string::String {
-        fn from(value: Stability) -> Self {
-            value.0
-        }
-    }
-    impl ::std::convert::From<&Stability> for Stability {
-        fn from(value: &Stability) -> Self {
-            value.clone()
-        }
-    }
-    impl ::std::str::FromStr for Stability {
-        type Err = self::error::ConversionError;
-        fn from_str(
-            value: &str,
-        ) -> ::std::result::Result<Self, self::error::ConversionError> {
-            if value.chars().count() < 1usize {
-                return Err("shorter than 1 characters".into());
-            }
-            Ok(Self(value.to_string()))
-        }
-    }
-    impl ::std::convert::TryFrom<&str> for Stability {
-        type Error = self::error::ConversionError;
-        fn try_from(
-            value: &str,
-        ) -> ::std::result::Result<Self, self::error::ConversionError> {
-            value.parse()
-        }
-    }
-    impl ::std::convert::TryFrom<&::std::string::String> for Stability {
-        type Error = self::error::ConversionError;
-        fn try_from(
-            value: &::std::string::String,
-        ) -> ::std::result::Result<Self, self::error::ConversionError> {
-            value.parse()
-        }
-    }
-    impl ::std::convert::TryFrom<::std::string::String> for Stability {
-        type Error = self::error::ConversionError;
-        fn try_from(
-            value: ::std::string::String,
-        ) -> ::std::result::Result<Self, self::error::ConversionError> {
-            value.parse()
-        }
-    }
-    impl<'de> ::serde::Deserialize<'de> for Stability {
-        fn deserialize<D>(deserializer: D) -> ::std::result::Result<Self, D::Error>
-        where
-            D: ::serde::Deserializer<'de>,
-        {
-            ::std::string::String::deserialize(deserializer)?
-                .parse()
-                .map_err(|e: self::error::ConversionError| {
-                    <D::Error as ::serde::de::Error>::custom(e.to_string())
-                })
-        }
-    }
     ///`StabilityInfo`
     ///
     /// <details><summary>JSON schema</summary>
@@ -5763,6 +5725,39 @@ because the two anchors carry different value types.*/
             value.clone()
         }
     }
+    ///Every system registered in the catalog, sorted by name.
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "title": "SystemsResult",
+    ///  "description": "Every system registered in the catalog, sorted by name.",
+    ///  "type": "object",
+    ///  "required": [
+    ///    "registered_systems"
+    ///  ],
+    ///  "properties": {
+    ///    "registered_systems": {
+    ///      "title": "Registered Systems",
+    ///      "type": "array",
+    ///      "items": {
+    ///        "type": "string"
+    ///      }
+    ///    }
+    ///  }
+    ///}
+    /// ```
+    /// </details>
+    #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug, PartialEq)]
+    pub struct SystemsResult {
+        pub registered_systems: ::std::vec::Vec<::std::string::String>,
+    }
+    impl ::std::convert::From<&SystemsResult> for SystemsResult {
+        fn from(value: &SystemsResult) -> Self {
+            value.clone()
+        }
+    }
     ///A single unresolvable reference within a lookup group.
     ///
     /// <details><summary>JSON schema</summary>
@@ -5809,16 +5804,19 @@ because the two anchors carry different value types.*/
     }
     /**Uniform shape for an unresolvable dependency.
 
-Serializes as {"unresolvable": {}} — exactly one shape, no cause/reason
-fields at the leaf level. If a future change needs structured error
-detail, introduce a typed `reason` field here.*/
+Serializes as {"unresolvable": {<cause>: <detail>}} — a single-key cause
+map, not a typed field.  The current cause vocabulary: "_handle" (uniform
+non-disclosure marker), "overflow", "conflict", "timeout", and
+"not_lockable".  A consumer must tolerate an unrecognized key: this type
+makes no closed-vocabulary guarantee, and a new cause can be added here
+without a schema change (the field is `dict[str, Any]`).*/
     ///
     /// <details><summary>JSON schema</summary>
     ///
     /// ```json
     ///{
     ///  "title": "UnresolvableLeaf",
-    ///  "description": "Uniform shape for an unresolvable dependency.\n\nSerializes as {\"unresolvable\": {}} — exactly one shape, no cause/reason\nfields at the leaf level. If a future change needs structured error\ndetail, introduce a typed `reason` field here.",
+    ///  "description": "Uniform shape for an unresolvable dependency.\n\nSerializes as {\"unresolvable\": {<cause>: <detail>}} — a single-key cause\nmap, not a typed field.  The current cause vocabulary: \"_handle\" (uniform\nnon-disclosure marker), \"overflow\", \"conflict\", \"timeout\", and\n\"not_lockable\".  A consumer must tolerate an unrecognized key: this type\nmakes no closed-vocabulary guarantee, and a new cause can be added here\nwithout a schema change (the field is `dict[str, Any]`).",
     ///  "type": "object",
     ///  "properties": {
     ///    "unresolvable": {
@@ -6155,8 +6153,9 @@ impl Client {
 
 Resolve build inputs for one or more reference groups.
 
-Direct references resolve to latest; the transitive closure is taken
-verbatim; a cross-reference conflict yields a per-group conflict result.
+Direct references resolve to the latest revision of their own source; the
+transitive closure is taken verbatim; a cross-reference conflict yields a
+per-group conflict result.
 
 For each group, walks the transitive package_inputs closure (accessor),
 then applies auth redaction and assembles the flat LockedInputs map.
@@ -6228,8 +6227,8 @@ Sends a `GET` request to `/api/v1/catalog/by-command`
     pub async fn by_command_api_v1_catalog_by_command_get<'a>(
         &'a self,
         name: &'a types::Name,
-        page: Option<i64>,
-        page_size: Option<i64>,
+        page: Option<u64>,
+        page_size: Option<u64>,
         system: types::PackageSystem,
     ) -> Result<ResponseValue<types::ByCommandResult>, Error<types::ErrorResponse>> {
         let url = format!("{}/api/v1/catalog/by-command", self.baseurl);

--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -330,9 +330,18 @@ pub struct BuildResultMeta {
 }
 
 /// The build's `meta` attribute, kept twice: the typed projection the
-/// publish request's flat fields are derived from, and the document the
-/// catalog stores -- verbatim content, key order normalised, since
-/// `serde_json::Map` is a `BTreeMap` unless `preserve_order` is on.
+/// publish request's flat fields are derived from, and the whole
+/// document the catalog stores -- every key the build wrote, none
+/// dropped.
+///
+/// Not byte-for-byte, and the difference is serde_json's rather than
+/// ours: with neither `preserve_order` nor `arbitrary_precision`
+/// enabled (checked in Cargo.lock), `Map` is a `BTreeMap` so keys come
+/// back sorted, duplicate keys collapse last-wins, and numbers
+/// round-trip through `f64` -- measured on this build:
+/// `{"a": 1.50, "b": 1e3, "c": 1, "c": 2}` reads back as
+/// `{"a":1.5,"b":1000.0,"c":2}`. What is preserved is the key set and
+/// the values' meaning, which is what the projection loses.
 ///
 /// `BuildResultMeta` is lossy by design: it declares a fixed set of
 /// fields, so every other key a derivation wrote is dropped, and even
@@ -375,6 +384,11 @@ impl TryFrom<serde_json::Map<String, serde_json::Value>> for CapturedMeta {
         // `Deserializer` for `&Value`, so the map moves into a `Value`
         // once and comes back out, instead of being deep-copied for the
         // projection and then again for the field.
+        // Captured before the map moves: computing it inside the error
+        // arm would need a second `as_object()` whose None branch is
+        // dead, and a dead branch has to either panic or invent an
+        // empty key list. One story instead.
+        let keys = raw.keys().cloned().collect::<Vec<_>>().join(", ");
         let value = serde_json::Value::Object(raw);
         // Locate the failure, since routing through `TryFrom` costs the
         // diagnostics the outer parse had: serde re-wraps this error
@@ -387,12 +401,9 @@ impl TryFrom<serde_json::Map<String, serde_json::Value>> for CapturedMeta {
         // document and its keys is the cheapest thing that puts the
         // reader back in the right place.
         let typed = BuildResultMeta::deserialize(&value).map_err(|err| {
-            let keys = value
-                .as_object()
-                .map(|map| map.keys().cloned().collect::<Vec<_>>().join(", "))
-                .unwrap_or_default();
             <serde_json::Error as serde::de::Error>::custom(format!(
-                "{err} (while projecting the build's `meta`, whose keys are: {keys})"
+                "{err} (while projecting the build's `meta`, whose top-level \
+                 keys are: {keys})"
             ))
         })?;
         let serde_json::Value::Object(raw) = value else {
@@ -1709,7 +1720,7 @@ mod captured_meta_tests {
     }
 
     #[test]
-    fn captured_meta_preserves_a_manifest_document_verbatim() {
+    fn captured_meta_keeps_every_key_a_manifest_document_declared() {
         // Manifest builds construct meta as exactly `description`,
         // `license`, `outputsToInstall`
         // (`package-builder/flox-build.mk:567,662`), so `homepage` is
@@ -1742,8 +1753,11 @@ mod captured_meta_tests {
         // error via `de::Error::custom`, which drops the line and column
         // the outer `serde_json::from_str` would have carried. Nothing
         // pinned what survives that, and `ParseBuildResultFile` is
-        // user-facing on a failed publish -- so this fixes the floor:
-        // the field name is still in the message a user reads.
+        // user-facing on a failed publish -- so this pins the floor: the
+        // type mismatch, plus the document and its TOP-LEVEL keys. Not
+        // a path: a bad value nested inside `license` names `license`
+        // and no further, which would take `serde_path_to_error` as a
+        // direct dependency.
         let map = serde_json::json!({
             "description": "A test package",
             "outputsToInstall": "not-a-list",
@@ -1768,7 +1782,7 @@ mod captured_meta_tests {
         );
         assert!(
             rendered.contains("outputsToInstall"),
-            "the message must name the document's keys; got: {rendered}"
+            "the message must name the document's top-level keys; got: {rendered}"
         );
     }
 }

--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -196,7 +196,7 @@ pub struct BuildResult {
     pub name: String,
     pub pname: String,
     pub outputs: HashMap<String, BuiltStorePath>,
-    pub meta: BuildResultMeta,
+    pub meta: CapturedMeta,
     pub version: String,
     pub system: String,
     pub log: BuiltStorePath,
@@ -327,6 +327,32 @@ pub struct BuildResultMeta {
 
     #[serde(rename = "outputsToInstall")]
     pub outputs_to_install: Vec<String>,
+}
+
+/// The build's `meta` attribute, kept twice: the typed projection the
+/// publish request's flat fields are derived from, and the untouched
+/// document the catalog stores. `BuildResultMeta` is lossy by design
+/// (`NixyLicense::Map` reads one of four license keys and drops the
+/// rest), so the two are not interchangeable.
+#[derive(Debug, PartialEq, Deserialize)]
+#[serde(try_from = "serde_json::Map<String, serde_json::Value>")]
+pub struct CapturedMeta {
+    pub typed: BuildResultMeta,
+    pub raw: serde_json::Map<String, serde_json::Value>,
+}
+
+impl TryFrom<serde_json::Map<String, serde_json::Value>> for CapturedMeta {
+    type Error = serde_json::Error;
+
+    fn try_from(raw: serde_json::Map<String, serde_json::Value>) -> Result<Self, Self::Error> {
+        // A derived deserializer cannot route one input key to two fields:
+        // it generates a single field-name matcher, so a second field
+        // aliased to "meta" would just be dead code behind the first.
+        // Deserializing `typed` from a clone of `raw` is the only way to
+        // keep both the lossy projection and the untouched document.
+        let typed = BuildResultMeta::deserialize(serde_json::Value::Object(raw.clone()))?;
+        Ok(CapturedMeta { typed, raw })
+    }
 }
 
 /// A manifest builder that uses the [FLOX_BUILD_MK] makefile to build packages.
@@ -1544,6 +1570,75 @@ mod license_tests {
         assert_eq!(
             license.to_catalog_license().unwrap(),
             "[ GPL-2.0-or-later, Unfree ]"
+        );
+    }
+
+    #[test]
+    fn captured_meta_keeps_license_keys_the_typed_copy_drops() {
+        // Expression builds merge the eval JSON into `meta` unfiltered
+        // (`package-builder/flox-build.mk:946`), so unlike a manifest
+        // build this document can carry a license as a four-key map.
+        let json = serde_json::json!({
+            "description": "A test package",
+            "license": {
+                "spdxId": "MIT",
+                "fullName": "MIT License",
+                "shortName": "MIT",
+                "url": "https://spdx.org/licenses/MIT.html",
+            },
+            "outputsToInstall": ["out"],
+        });
+        let map = match json {
+            serde_json::Value::Object(map) => map,
+            _ => unreachable!(),
+        };
+
+        let captured = CapturedMeta::try_from(map.clone()).unwrap();
+
+        // The typed projection reads only the first available key and
+        // drops the rest.
+        assert_eq!(
+            captured
+                .typed
+                .license
+                .as_ref()
+                .unwrap()
+                .to_catalog_license()
+                .unwrap(),
+            "MIT"
+        );
+        // The raw document keeps every key the map declared.
+        assert_eq!(captured.raw, map);
+    }
+
+    #[test]
+    fn captured_meta_preserves_a_manifest_document_the_typed_struct_has_no_field_for() {
+        // Manifest builds construct meta as exactly `description`,
+        // `license`, `outputsToInstall`
+        // (`package-builder/flox-build.mk:567,662`), so `homepage` is
+        // always absent from this shape and the typed projection reports
+        // it as `None` without that being a loss.
+        let json = serde_json::json!({
+            "description": "A test package",
+            "license": ["MIT"],
+            "outputsToInstall": ["out"],
+        });
+        let map = match json {
+            serde_json::Value::Object(map) => map,
+            _ => unreachable!(),
+        };
+
+        let captured = CapturedMeta::try_from(map.clone()).unwrap();
+
+        // All three keys the manifest declared survive in `raw`.
+        assert_eq!(captured.raw, map);
+        assert_eq!(captured.raw.len(), 3);
+        assert_eq!(captured.typed.homepage, None);
+        assert_eq!(
+            captured.typed.license,
+            Some(NixyLicense::ComplexList(vec![NixyLicense::String(
+                "MIT".to_string()
+            )]))
         );
     }
 }

--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -330,15 +330,35 @@ pub struct BuildResultMeta {
 }
 
 /// The build's `meta` attribute, kept twice: the typed projection the
-/// publish request's flat fields are derived from, and the untouched
-/// document the catalog stores. `BuildResultMeta` is lossy by design
-/// (`NixyLicense::Map` reads one of four license keys and drops the
-/// rest), so the two are not interchangeable.
+/// publish request's flat fields are derived from, and the document the
+/// catalog stores -- verbatim content, key order normalised, since
+/// `serde_json::Map` is a `BTreeMap` unless `preserve_order` is on.
+///
+/// `BuildResultMeta` is lossy by design: it declares a fixed set of
+/// fields, so every other key a derivation wrote is dropped, and even
+/// within a field it narrows -- a nixpkgs license attrset also carries
+/// `free`, `redistributable` and `deprecated`, which `NixyLicense::Map`
+/// has no variant for. (The four keys `Map` DOES declare all survive the
+/// projection; `to_catalog_license` picks one of them later, which is a
+/// different loss in a different place.) So the two halves are not
+/// interchangeable.
+// Same suppression, and for the same `_private: ()` field, as
+// `CheckedBuildMetadata` in publish.rs: a non_exhaustive attribute would
+// only close the type to other crates, and this one must be unbuildable
+// inside this crate too.
+#[allow(clippy::manual_non_exhaustive)]
 #[derive(Debug, PartialEq, Deserialize)]
 #[serde(try_from = "serde_json::Map<String, serde_json::Value>")]
 pub struct CapturedMeta {
     pub typed: BuildResultMeta,
     pub raw: serde_json::Map<String, serde_json::Value>,
+
+    // Not "pub", so nothing outside this module can build a CapturedMeta
+    // whose `typed` is not the projection of its `raw` -- the one
+    // invariant the type exists to hold. `CheckedBuildMetadata` in
+    // publish.rs guards itself the same way. `try_from` below is the
+    // only constructor.
+    _private: (),
 }
 
 impl TryFrom<serde_json::Map<String, serde_json::Value>> for CapturedMeta {
@@ -348,10 +368,41 @@ impl TryFrom<serde_json::Map<String, serde_json::Value>> for CapturedMeta {
         // A derived deserializer cannot route one input key to two fields:
         // it generates a single field-name matcher, so a second field
         // aliased to "meta" would just be dead code behind the first.
-        // Deserializing `typed` from a clone of `raw` is the only way to
-        // keep both the lossy projection and the untouched document.
-        let typed = BuildResultMeta::deserialize(serde_json::Value::Object(raw.clone()))?;
-        Ok(CapturedMeta { typed, raw })
+        // Deserializing `typed` out of the same document is the only way
+        // to keep both the lossy projection and the original.
+        //
+        // Borrowed rather than cloned: serde_json implements
+        // `Deserializer` for `&Value`, so the map moves into a `Value`
+        // once and comes back out, instead of being deep-copied for the
+        // projection and then again for the field.
+        let value = serde_json::Value::Object(raw);
+        // Locate the failure, since routing through `TryFrom` costs the
+        // diagnostics the outer parse had: serde re-wraps this error
+        // through `de::Error::custom`, so the line and column of
+        // `build-meta.json` are gone, and serde_json never carried a
+        // field path in the first place (that is `serde_path_to_error`,
+        // which is not on this path). What is left unaided is
+        // `invalid type: string "x", expected a sequence` -- true, and
+        // unattributable to any file, field or record. Naming the
+        // document and its keys is the cheapest thing that puts the
+        // reader back in the right place.
+        let typed = BuildResultMeta::deserialize(&value).map_err(|err| {
+            let keys = value
+                .as_object()
+                .map(|map| map.keys().cloned().collect::<Vec<_>>().join(", "))
+                .unwrap_or_default();
+            <serde_json::Error as serde::de::Error>::custom(format!(
+                "{err} (while projecting the build's `meta`, whose keys are: {keys})"
+            ))
+        })?;
+        let serde_json::Value::Object(raw) = value else {
+            unreachable!("constructed as Value::Object directly above")
+        };
+        Ok(CapturedMeta {
+            typed,
+            raw,
+            _private: (),
+        })
     }
 }
 
@@ -1572,12 +1623,30 @@ mod license_tests {
             "[ GPL-2.0-or-later, Unfree ]"
         );
     }
+}
+
+/// Unit tests for [CapturedMeta] -- the document kept beside the typed
+/// projection, and the keys the projection has no field for.
+#[cfg(test)]
+mod captured_meta_tests {
+    use super::*;
 
     #[test]
-    fn captured_meta_keeps_license_keys_the_typed_copy_drops() {
+    fn captured_meta_keeps_keys_the_typed_projection_cannot_reproduce() {
         // Expression builds merge the eval JSON into `meta` unfiltered
         // (`package-builder/flox-build.mk:946`), so unlike a manifest
-        // build this document can carry a license as a four-key map.
+        // build this document carries keys `BuildResultMeta` has no
+        // field for. `position` and `maintainers` are the discriminating
+        // ones and the reason this test exists: an implementation that
+        // derived `raw` by re-serializing `typed` would lose exactly
+        // these, and would pass every other assertion in this file.
+        //
+        // The four-key license map is deliberately NOT that
+        // discriminator. `NixyLicense::Map` stores all four keys
+        // (see its definition above); the selection to one happens in
+        // `license_map_to_string`, downstream of the projection. It is
+        // asserted below because it is what the request's flat
+        // `license` field is derived from, not because `raw` rescues it.
         let json = serde_json::json!({
             "description": "A test package",
             "license": {
@@ -1586,17 +1655,47 @@ mod license_tests {
                 "shortName": "MIT",
                 "url": "https://spdx.org/licenses/MIT.html",
             },
+            "maintainers": [{
+                "name": "A Maintainer",
+                "email": "maintainer@example.com",
+                "github": "amaintainer",
+            }],
+            "position": "/nix/store/deadbeef-source/pkgs/example/default.nix:12",
             "outputsToInstall": ["out"],
         });
-        let map = match json {
-            serde_json::Value::Object(map) => map,
-            _ => unreachable!(),
-        };
+        let map = json.as_object().unwrap().clone();
 
         let captured = CapturedMeta::try_from(map.clone()).unwrap();
 
-        // The typed projection reads only the first available key and
-        // drops the rest.
+        // The raw document keeps every key the map declared, including
+        // the two the typed projection has no field for at all.
+        assert_eq!(captured.raw, map);
+        assert!(captured.raw.contains_key("maintainers"));
+        assert!(captured.raw.contains_key("position"));
+
+        // And `typed` is blind to both: the same document with those
+        // two keys removed produces an IDENTICAL typed projection and a
+        // different raw one. That is the property `raw` exists to hold,
+        // stated as the discrimination it makes -- an implementation
+        // deriving `raw` from `typed` could not tell these two inputs
+        // apart. Asserted this way rather than by re-serializing
+        // `typed`, which would need a `Serialize` derive the projection
+        // deliberately does not have.
+        let mut without = map.clone();
+        without.remove("maintainers");
+        without.remove("position");
+        let stripped = CapturedMeta::try_from(without.clone()).unwrap();
+        assert_eq!(
+            stripped.typed, captured.typed,
+            "the typed projection must not see the keys it has no field for"
+        );
+        assert_ne!(
+            stripped.raw, captured.raw,
+            "the raw document is the only half that can tell them apart"
+        );
+
+        // The flat `license` field still comes from the typed copy,
+        // which reads the first available key of the four.
         assert_eq!(
             captured
                 .typed
@@ -1607,12 +1706,10 @@ mod license_tests {
                 .unwrap(),
             "MIT"
         );
-        // The raw document keeps every key the map declared.
-        assert_eq!(captured.raw, map);
     }
 
     #[test]
-    fn captured_meta_preserves_a_manifest_document_the_typed_struct_has_no_field_for() {
+    fn captured_meta_preserves_a_manifest_document_verbatim() {
         // Manifest builds construct meta as exactly `description`,
         // `license`, `outputsToInstall`
         // (`package-builder/flox-build.mk:567,662`), so `homepage` is
@@ -1623,10 +1720,7 @@ mod license_tests {
             "license": ["MIT"],
             "outputsToInstall": ["out"],
         });
-        let map = match json {
-            serde_json::Value::Object(map) => map,
-            _ => unreachable!(),
-        };
+        let map = json.as_object().unwrap().clone();
 
         let captured = CapturedMeta::try_from(map.clone()).unwrap();
 
@@ -1639,6 +1733,42 @@ mod license_tests {
             Some(NixyLicense::ComplexList(vec![NixyLicense::String(
                 "MIT".to_string()
             )]))
+        );
+    }
+
+    #[test]
+    fn a_malformed_meta_says_which_document_failed() {
+        // Routing `Deserialize` through `TryFrom` re-wraps the inner
+        // error via `de::Error::custom`, which drops the line and column
+        // the outer `serde_json::from_str` would have carried. Nothing
+        // pinned what survives that, and `ParseBuildResultFile` is
+        // user-facing on a failed publish -- so this fixes the floor:
+        // the field name is still in the message a user reads.
+        let map = serde_json::json!({
+            "description": "A test package",
+            "outputsToInstall": "not-a-list",
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+
+        let err = CapturedMeta::try_from(map).unwrap_err();
+        let rendered = err.to_string();
+        // What serde gives unaided: the type mismatch, and nothing that
+        // says where. Pinned so a future change to this conversion has
+        // to decide about the message rather than move it by accident.
+        assert!(
+            rendered.contains("invalid type: string"),
+            "the type mismatch must survive; got: {rendered}"
+        );
+        // What this conversion adds back: the document and its keys.
+        assert!(
+            rendered.contains("the build's `meta`"),
+            "the message must say which document failed; got: {rendered}"
+        );
+        assert!(
+            rendered.contains("outputsToInstall"),
+            "the message must name the document's keys; got: {rendered}"
         );
     }
 }

--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -161,8 +161,11 @@ pub struct MockClient {
     // to `self` just to get mock responses out.
     pub mock_responses: MockField<VecDeque<Response>>,
     // Recorded verbatim so a test can assert on the request `publish()` sent,
-    // not just on the canned response popped in return.
-    pub published_builds: MockField<Vec<UserBuildPublish>>,
+    // not just on the canned response popped in return. Private, unlike
+    // `mock_responses` above: reads go through `published_builds()`, which
+    // locks and clones rather than handing out a guard a caller could hold
+    // across an await.
+    published_builds: MockField<Vec<UserBuildPublish>>,
 }
 
 impl MockClient {
@@ -199,6 +202,14 @@ impl MockClient {
             .expect("couldn't acquire mock lock");
         locked_mock_responses.clear();
         locked_mock_responses.extend(responses);
+        // The recording is mock state too: leaving it populated would let
+        // a test that re-seeds mid-run assert on requests sent before the
+        // reset. No test does that today, which is what makes it a trap
+        // rather than a bug.
+        self.published_builds
+            .lock()
+            .expect("couldn't acquire mock lock")
+            .clear();
     }
 }
 

--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -160,6 +160,9 @@ pub struct MockClient {
     // We use a RefCell here so that we don't have to modify the trait to allow mutable access
     // to `self` just to get mock responses out.
     pub mock_responses: MockField<VecDeque<Response>>,
+    // Recorded verbatim so a test can assert on the request `publish()` sent,
+    // not just on the canned response popped in return.
+    pub published_builds: MockField<Vec<UserBuildPublish>>,
 }
 
 impl MockClient {
@@ -167,6 +170,7 @@ impl MockClient {
     pub fn new() -> Self {
         Self {
             mock_responses: Arc::new(Mutex::new(VecDeque::new())),
+            published_builds: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -176,6 +180,15 @@ impl MockClient {
             .lock()
             .expect("couldn't acquire mock lock")
             .push_back(Response::GetStoreInfo(resp));
+    }
+
+    /// The [UserBuildPublish] requests recorded by [publish_build], in call
+    /// order.
+    pub fn published_builds(&self) -> Vec<UserBuildPublish> {
+        self.published_builds
+            .lock()
+            .expect("couldn't acquire mock lock")
+            .clone()
     }
 
     /// See [test_helpers::reset_mocks].
@@ -338,8 +351,12 @@ impl CatalogClientTrait for MockClient {
         &self,
         _catalog_name: impl AsRef<str> + Send + Sync,
         _package_name: impl AsRef<str> + Send + Sync,
-        _build_info: &UserBuildPublish,
+        build_info: &UserBuildPublish,
     ) -> Result<(), FloxhubClientError> {
+        self.published_builds
+            .lock()
+            .expect("couldn't acquire mock lock")
+            .push(build_info.clone());
         let mock_resp = self
             .mock_responses
             .lock()

--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -202,6 +202,12 @@ impl MockClient {
             .expect("couldn't acquire mock lock");
         locked_mock_responses.clear();
         locked_mock_responses.extend(responses);
+        // Dropped before the second lock is taken: `publish_build` locks
+        // published_builds first and mock_responses second, and holding
+        // one across the other in the opposite order is the shape a
+        // deadlock grows from later, even though neither path can reach
+        // it today.
+        drop(locked_mock_responses);
         // The recording is mock state too: leaving it populated would let
         // a test that re-seeds mid-run assert on requests sent before the
         // reset. No test does that today, which is what makes it a trap
@@ -981,16 +987,21 @@ mod tests {
             .unwrap();
         assert_eq!(client.published_builds().len(), 1);
 
-        test_helpers::reset_mocks(&mut client, vec![Response::PublishBuild]);
+        // Nothing armed: clearing the recording is independent of what
+        // the re-seed puts back, and an unconsumed response left behind
+        // is something a future edit could trip over.
+        test_helpers::reset_mocks(&mut client, vec![]);
         assert!(
             client.published_builds().is_empty(),
             "a re-seed must clear the recording, not just the responses"
         );
     }
 
-    /// The smallest document the generated request type will accept.
-    /// Deserialized rather than constructed: the struct literal is 25
-    /// lines of fields this test says nothing about.
+    /// A minimal request, deserialized rather than constructed: the
+    /// struct literal is 25 lines of fields this test says nothing
+    /// about. Not the smallest the type would accept -- most of these
+    /// keys carry serde defaults -- just small enough to be obviously
+    /// irrelevant to what is being asserted.
     fn dummy_user_build_publish() -> UserBuildPublish {
         serde_json::from_value(serde_json::json!({
             "derivation": {

--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -967,6 +967,55 @@ mod tests {
     };
 
     #[test]
+    fn reset_mocks_clears_the_recorded_requests_too() {
+        // The recording is mock state: a test that re-seeds mid-run and
+        // then asserts on `published_builds()` must not see requests
+        // sent before the reset. Nothing does that today, which is why
+        // this is here -- the trap is cheap to close and expensive to
+        // find later.
+        let mut client = MockClient::new();
+        test_helpers::reset_mocks(&mut client, vec![Response::PublishBuild]);
+        client
+            .publish_build("catalog", "package", &dummy_user_build_publish())
+            .block_on()
+            .unwrap();
+        assert_eq!(client.published_builds().len(), 1);
+
+        test_helpers::reset_mocks(&mut client, vec![Response::PublishBuild]);
+        assert!(
+            client.published_builds().is_empty(),
+            "a re-seed must clear the recording, not just the responses"
+        );
+    }
+
+    /// The smallest document the generated request type will accept.
+    /// Deserialized rather than constructed: the struct literal is 25
+    /// lines of fields this test says nothing about.
+    fn dummy_user_build_publish() -> UserBuildPublish {
+        serde_json::from_value(serde_json::json!({
+            "derivation": {
+                "description": null,
+                "drv_path": "/nix/store/deadbeef-dummy.drv",
+                "license": null,
+                "name": "dummy",
+                "outputs": [],
+                "outputs_to_install": [],
+                "pname": "dummy",
+                "system": "x86_64-linux",
+                "version": "1.0.0",
+            },
+            "locked_base_catalog_url": null,
+            "narinfos": null,
+            "rev": "0000000000000000000000000000000000000000",
+            "rev_count": 1,
+            "rev_date": "2026-01-01T00:00:00Z",
+            "url": "https://example.invalid/repo",
+            "dot_flox_dir": ".flox",
+        }))
+        .expect("the dummy request must match the generated type")
+    }
+
+    #[test]
     fn can_push_responses_outside_of_client() {
         let client = MockClient::new();
         {

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -219,11 +219,26 @@ pub struct CheckedBuildMetadata {
 
     pub version: Option<String>,
 
-    /// The build's untouched `meta` document, sent to the catalog
-    /// alongside the flat fields above (which are derived from the lossy
-    /// typed projection, not from this map). Never `Option`: the request
-    /// literal always wraps this in `Some`, so the type itself rules out
-    /// silently omitting the field.
+    /// The build's `meta` document as the build wrote it -- verbatim
+    /// content, key order normalised -- sent to the catalog alongside
+    /// the flat fields above (which are derived from the lossy typed
+    /// projection, not from this map).
+    ///
+    /// Not an `Option`, because a `CheckedBuildMetadata` exists only
+    /// because a build parsed, and a build parses only when `meta` was
+    /// an object: the absent case is unreachable here. What rules out an
+    /// omitted WIRE field is separate and is not the type -- the
+    /// generated field is `Option` with `skip_serializing_if`, and the
+    /// unconditional `Some(...)` at the request literal, above every
+    /// store-configuration branch, is what keeps it present.
+    ///
+    /// What the document may contain is decided in the slice, not here:
+    /// `maintainers` and `teams` are captured verbatim with no
+    /// deny-list, and the three position-bearing fields are stripped
+    /// server-side by a generated column rather than by any writer, so
+    /// this layer deliberately applies no allowlist and no redaction.
+    /// See flox/forge#1357, `slices/2026/08-catalog-meta-attributes/`
+    /// (requirements.md "Decisions", D3, D24).
     pub evaluation_meta: serde_json::Map<String, serde_json::Value>,
 
     // This field isn't "pub", so no one outside this module can construct this struct. That helps
@@ -2049,9 +2064,12 @@ pub mod tests {
             broken: Some(false),
             insecure: None,
             unfree: None,
-            // A one-key map rather than `Map::new()`, so a test asserting
-            // on this value proves the field's content flows through
-            // `publish()` rather than merely that a `Some` exists.
+            // A one-key map rather than `Map::new()`: small and
+            // distinctive, so a test that wants to assert the field's
+            // content -- rather than merely that a `Some` exists -- has
+            // something to match. No test does today; the one publish
+            // assertion in this file builds its metadata through
+            // `check_build_metadata` and never reaches this helper.
             evaluation_meta: serde_json::Map::from_iter([(
                 "outputsToInstall".to_string(),
                 serde_json::json!(["out"]),

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -219,6 +219,13 @@ pub struct CheckedBuildMetadata {
 
     pub version: Option<String>,
 
+    /// The build's untouched `meta` document, sent to the catalog
+    /// alongside the flat fields above (which are derived from the lossy
+    /// typed projection, not from this map). Never `Option`: the request
+    /// literal always wraps this in `Some`, so the type itself rules out
+    /// silently omitting the field.
+    pub evaluation_meta: serde_json::Map<String, serde_json::Value>,
+
     // This field isn't "pub", so no one outside this module can construct this struct. That helps
     // ensure that we can only make this struct as a result of doing the "right thing."
     _private: (),
@@ -700,6 +707,11 @@ where
             // empty server-side (floxhub#1791). The wire type is a HashMap;
             // ordering on the wire is meaningless.
             locked_inputs: Some(locked_inputs.clone().into_iter().collect()),
+            // Always sent, never omitted: a `None` `meta_blob_id` already
+            // means "never captured" server-side, and collapsing an empty
+            // document into absence here would recreate that same collapse
+            // one layer out, where the server-side guard can't see it.
+            evaluation_meta: Some(build_metadata.evaluation_meta.clone()),
             base_catalog_rev_count: None,
             base_catalog_rev_date: None,
             url: self.env_metadata.build_repo_meta.url.to_string(),
@@ -867,14 +879,14 @@ fn convert_build_result_to_build_metadata(
         .into();
 
     // Get outputs to install from the build result, or default to all outputs.
-    let outputs_to_install = build_result.meta.outputs_to_install.clone();
+    let outputs_to_install = build_result.meta.typed.outputs_to_install.clone();
 
     // Wrapping `outputs_to_install` in an option to satisfy the API.
     // In practice outputs_to_install are required / must be always `Some`
     // so a future change will update the API to reflect that.
     let outputs_to_install = Some(outputs_to_install);
 
-    let license = match &build_result.meta.license {
+    let license = match &build_result.meta.typed.license {
         Some(lic) => Some(lic.to_catalog_license()?),
         None => None,
     };
@@ -884,11 +896,12 @@ fn convert_build_result_to_build_metadata(
         name: build_result.name.clone(),
         pname: build_result.pname.clone(),
 
-        description: build_result.meta.description.clone(),
+        description: build_result.meta.typed.description.clone(),
         license,
-        broken: build_result.meta.broken,
-        insecure: build_result.meta.insecure,
-        unfree: build_result.meta.unfree,
+        broken: build_result.meta.typed.broken,
+        insecure: build_result.meta.typed.insecure,
+        unfree: build_result.meta.typed.unfree,
+        evaluation_meta: build_result.meta.raw.clone(),
 
         outputs,
         outputs_to_install,
@@ -1831,6 +1844,21 @@ pub mod tests {
             false,
             "MetadataOnly should not require publisher wait"
         );
+
+        // The request sent to the catalog always carries the build's meta
+        // document as an object, never omitted (D18): a `None`
+        // `meta_blob_id` already means "never captured" server-side, so
+        // sending nothing here would be indistinguishable from that.
+        let published = catalog.published_builds();
+        assert_eq!(published.len(), 1);
+        let evaluation_meta = published[0]
+            .evaluation_meta
+            .as_ref()
+            .expect("evaluation_meta must always be sent as Some, never omitted");
+        assert!(
+            !evaluation_meta.is_empty(),
+            "a manifest build's meta always includes at least outputsToInstall"
+        );
     }
 
     #[test]
@@ -2021,6 +2049,13 @@ pub mod tests {
             broken: Some(false),
             insecure: None,
             unfree: None,
+            // A one-key map rather than `Map::new()`, so a test asserting
+            // on this value proves the field's content flows through
+            // `publish()` rather than merely that a `Some` exists.
+            evaluation_meta: serde_json::Map::from_iter([(
+                "outputsToInstall".to_string(),
+                serde_json::json!(["out"]),
+            )]),
             _private: (),
         };
 

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -1882,6 +1882,17 @@ pub mod tests {
             !evaluation_meta.is_empty(),
             "a manifest build's meta always includes at least outputsToInstall"
         );
+        // And it is THIS build's document, not merely some object. The
+        // unit tests prove `raw` keeps what `typed` cannot reproduce;
+        // without an equality here, an implementation that sent a
+        // re-serialized typed projection -- or any other non-empty map
+        // -- would leave every test in this file green, which is the
+        // threading gap between "captured losslessly" and "transmitted
+        // losslessly".
+        assert_eq!(
+            evaluation_meta, &build_metadata.evaluation_meta,
+            "publish must send the captured document, not a reconstruction"
+        );
     }
 
     #[test]

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -219,10 +219,12 @@ pub struct CheckedBuildMetadata {
 
     pub version: Option<String>,
 
-    /// The build's `meta` document as the build wrote it -- verbatim
-    /// content, key order normalised -- sent to the catalog alongside
-    /// the flat fields above (which are derived from the lossy typed
-    /// projection, not from this map).
+    /// The build's whole `meta` document -- every key the build wrote,
+    /// none dropped, though not byte-for-byte (see `CapturedMeta`:
+    /// serde_json sorts keys, collapses duplicates and round-trips
+    /// numbers through `f64`) -- sent to the catalog alongside the flat
+    /// fields above, which are derived from the lossy typed projection
+    /// and not from this map.
     ///
     /// Not an `Option`, because a `CheckedBuildMetadata` exists only
     /// because a build parsed, and a build parses only when `meta` was
@@ -916,6 +918,12 @@ fn convert_build_result_to_build_metadata(
         broken: build_result.meta.typed.broken,
         insecure: build_result.meta.typed.insecure,
         unfree: build_result.meta.typed.unfree,
+        // Cloned, not moved: this function takes `&BuildResult`, and
+        // the caller holds `build_results` for its length check. One of
+        // the two structural copies of this document -- the other is
+        // the request literal in `publish()`, which borrows its
+        // metadata. D23 priced one clone; these are the two that a
+        // signature change would be needed to remove.
         evaluation_meta: build_result.meta.raw.clone(),
 
         outputs,

--- a/cli/floxhub-client/src/client.rs
+++ b/cli/floxhub-client/src/client.rs
@@ -492,10 +492,18 @@ impl CatalogClientTrait for FloxhubClient {
                 let listing_known = first.listing_known;
                 let command_name_str = first.command_name;
                 let total_count = first.total_count;
+                // One comparison type for the loop. `page`/`page_size` are
+                // u64 since the schema gained `minimum: 0`, `total_count`
+                // is i64, and `len()` is usize -- narrowed once here
+                // rather than cast at each of the two comparisons below.
+                // `max(0)` because a negative count from the server would
+                // otherwise wrap.
+                let total = total_count.max(0) as usize;
+                let page_size_usize = page_size as usize;
                 let mut all_providers = first.providers;
                 // Fetch subsequent pages until we have all providers.
                 let mut page = 1u64;
-                while (all_providers.len() as i64) < total_count {
+                while all_providers.len() < total {
                     let next = self
                         .catalog
                         .by_command_api_v1_catalog_by_command_get(
@@ -510,7 +518,7 @@ impl CatalogClientTrait for FloxhubClient {
                         .into_inner();
                     let page_len = next.providers.len();
                     all_providers.extend(next.providers);
-                    if page_len < page_size as usize {
+                    if page_len < page_size_usize {
                         break;
                     }
                     page += 1;

--- a/cli/floxhub-client/src/client.rs
+++ b/cli/floxhub-client/src/client.rs
@@ -465,7 +465,7 @@ impl CatalogClientTrait for FloxhubClient {
                     .by_command_api_v1_catalog_by_command_get(
                         &command_name,
                         Some(0),
-                        Some(page_size.get() as i64),
+                        Some(page_size.get() as u64),
                         system,
                     )
                     .await
@@ -475,7 +475,7 @@ impl CatalogClientTrait for FloxhubClient {
             },
             None => {
                 // Collect all providers across pages.
-                let page_size = RESPONSE_PAGE_SIZE.get() as i64;
+                let page_size = RESPONSE_PAGE_SIZE.get() as u64;
                 // Fetch the first page to initialise the stable fields.
                 let first = self
                     .catalog
@@ -494,7 +494,7 @@ impl CatalogClientTrait for FloxhubClient {
                 let total_count = first.total_count;
                 let mut all_providers = first.providers;
                 // Fetch subsequent pages until we have all providers.
-                let mut page = 1i64;
+                let mut page = 1u64;
                 while (all_providers.len() as i64) < total_count {
                     let next = self
                         .catalog

--- a/cli/floxhub-client/src/client.rs
+++ b/cli/floxhub-client/src/client.rs
@@ -494,11 +494,18 @@ impl CatalogClientTrait for FloxhubClient {
                 let total_count = first.total_count;
                 // One comparison type for the loop. `page`/`page_size` are
                 // u64 since the schema gained `minimum: 0`, `total_count`
-                // is i64, and `len()` is usize -- narrowed once here
+                // is i64, and `len()` is usize -- converted once here
                 // rather than cast at each of the two comparisons below.
-                // `max(0)` because a negative count from the server would
-                // otherwise wrap.
-                let total = total_count.max(0) as usize;
+                //
+                // Saturating rather than `as`: the old comparison widened
+                // `len()` to i64 and could not lose information, and a
+                // bare `total_count as usize` would narrow instead --
+                // on a 32-bit target a count above u32::MAX would wrap
+                // small and stop the loop early. Clamping to usize::MAX
+                // keeps it going, and the `page_len < page_size` break
+                // below is what actually ends it. A negative count
+                // clamps to 0, which ends it immediately, as before.
+                let total = usize::try_from(total_count).unwrap_or(usize::MAX);
                 let page_size_usize = page_size as usize;
                 let mut all_providers = first.providers;
                 // Fetch subsequent pages until we have all providers.

--- a/cli/floxhub-client/src/types.rs
+++ b/cli/floxhub-client/src/types.rs
@@ -45,7 +45,6 @@ pub use api_types::{
     LookupGroup,
     ReferencePoint,
     ReferencesItem,
-    Stability,
     UnresolvableEntry,
     UnresolvableLeaf,
 };

--- a/cli/nef-lock-catalog/src/lock/lookup.rs
+++ b/cli/nef-lock-catalog/src/lock/lookup.rs
@@ -88,11 +88,12 @@ fn build_request(references: BTreeSet<CatalogRef>) -> BuildInputsLookupRequest {
         groups: vec![group],
         reference_point: None,
         // Catalog-input resolution is independent of the nixpkgs base-catalog
-        // stability, but the OpenAPI spec still marks `stability` as a
-        // required request field. The field is in the process of being
-        // deprecated on the server side and in the spec; until that
-        // coordinated change lands, send the constant "stable".
-        stability: "stable".parse().expect("constant stability parses"),
+        // stability. The server now documents `stability` as deprecated and
+        // ignores whatever value it receives, so this constant is kept only
+        // to leave the request byte-identical across the schema bump.
+        // Dropping the field (sending `None`) omits the key entirely, which
+        // is a wire change and a separate ticket.
+        stability: Some("stable".to_string()),
     }
 }
 


### PR DESCRIPTION
## What this does

The publish request carried only the six flat fields the typed projection exposes, so anything a derivation declared beyond them was lost before it reached the catalog. `BuildResultMeta` is lossy by design — `NixyLicense::Map` reads one of four license keys and drops the rest — and expression builds merge their eval JSON unfiltered, so the loss is real and unbounded.

`CapturedMeta` keeps the document twice: `typed`, the projection the flat fields are still derived from, and `raw`, the untouched map the catalog now stores. The six flat fields keep coming from the typed projection — captured meta and the `derivations` columns are deliberately not reconciled.

`Deserialize` is derived from a hand-written `TryFrom` rather than from the struct. Serde's derive cannot route one input key to two fields: it generates a single field-name matcher, so a second field aliased to `meta` would be dead code behind the first.

**The name changes exactly once.** `BuildResult.meta` and the `meta` key in `build-meta.json` keep Nix's own spelling — there the CLI is quoting what the build wrote. From `CheckedBuildMetadata` outward it is `evaluation_meta`, matching the request and the generated client. No layer in between gets a third name.

`CheckedBuildMetadata.evaluation_meta` is a `Map`, not an `Option`, and the request literal wraps it in `Some` unconditionally, above every store-configuration branch — whether narinfos are produced at all depends on the store type, and the meta document must not ride that decision. Per **D18** the field is always sent as an object *including when empty*: a null `meta_blob_id` already means "never captured" server-side, so collapsing an empty document into absence here would recreate that same collapse one layer out, where the server-side guard cannot see it.

## Most of the client diff is not this ticket

Read the diff on `cli/catalog-api-v1/` with this in mind. **AI-668's entire schema contribution is six lines** — the `evaluation_meta` property on `PackageBuildWithNarInfo`. The rest of the ~191-line client diff is pre-existing drift: flox/flox's vendored schema was already behind floxhub before AI-668 existed. That drift brings a new `/api/v1/catalog/info/systems` endpoint, `SystemsResult`, `commands_by_output`, the `stability` deprecation, `minimum: 0` on by-command pagination, and reworded docs.

The same is true of the compile repair below: **the nine errors are the cost of that drift, not of `evaluation_meta`.** They arrive identically in floxhub's own `submit-client-pr.yml` bot PR, and land on this ticket either way.

`cli/catalog-api-v1/openapi.json` and `cli/catalog-api-v1/src/client.rs` are the first commit here and were verified byte-identical to the bot's own generated patch artifact. `cli/factory-api-v1/` is deliberately untouched — the bot delivers that drift separately, and touching it would convert a clean, disjoint rebase into a conflict.

## Compile repair — nine errors, four crates

| Crate | Fix |
|---|---|
| `floxhub-client` | Drop the `Stability` re-export progenitor no longer emits (`types.rs:48`) |
| `floxhub-client` | Retype `page`/`page_size` to `u64` on the one endpoint that gained `minimum: 0` |
| `nef-lock-catalog` | `stability` is now `Option<String>` with no `FromStr` |
| `flox-rust-sdk` | Three struct literals: `UserBuildPublish`, and `CheckedBuildMetadata` ×2 |

**Judgement call worth reviewing:** the pagination fix *retypes* the locals rather than casting at each call site — three edits instead of four, and no `u32 -> i64 -> u64` round trip. It is behaviour-preserving: the loop contains no subtraction so no underflow is reachable, `page` starts at 1 and only increments, and `ByCommandResult.total_count` is `i64` on both sides of the bump so the comparison at `client.rs:498` never crosses the boundary.

`nef-lock-catalog` keeps sending `stability: Some("stable")`. The server documents the field as deprecated and ignores it, but dropping it omits the key entirely — a wire change, and a separate ticket. The old comment claimed the spec "still marks `stability` as a required request field", which stopped being true with this schema; it has been rewritten rather than left to mislead.

## Recordings are not re-cut

No recording is edited, re-cut, weakened or regenerated. Every `/builds` request matches with `json_body_includes` — a subset matcher (`assert-json-diff::CompareMode::Inclusive`) the repo adopted for narinfo redaction and documents at `floxhub-client/src/mock.rs:229-236` — so an added field invalidates none of them.

That cuts both ways: a subset matcher also cannot *observe* the new field. So `MockClient` now records the `UserBuildPublish` that `publish()` sends, and the existing meta-only test asserts `evaluation_meta` arrives as an object. Without it, a later refactor folding the field into a store-configuration branch would compile clean and pass everything.

## Tests

- `captured_meta_keeps_keys_the_typed_projection_cannot_reproduce` — an expression-shaped document, since that is the producer that merges eval JSON unfiltered (`flox-build.mk:946`). It carries `maintainers` and `position`, which `BuildResultMeta` has no field for, and asserts the discrimination directly: the same document with those two removed produces an **identical** typed projection and a different raw one. The four-key license map is asserted too, but is deliberately not the discriminator — `NixyLicense::Map` stores all four keys and `to_catalog_license` picks one later, so a `raw` derived from `typed` would reproduce it.
- `captured_meta_preserves_a_manifest_document_verbatim` — a manifest-shaped three-key document keeps all three keys in `raw` while `typed.homepage` is `None`. The fixture is unchanged (AI-670 names its three keys literally, and manifest meta is filtered to exactly those upstream); the name is, because "the typed struct has no field for" describes `homepage`, which is the converse of what it claimed.
- `a_malformed_meta_says_which_document_failed` — see the diagnostic note below.

Worth knowing when reading these: on **manifest** publishes the captured blob gains only the license's original array shape, because manifest meta is already a subset of the typed projection (`flox-build.mk:567,662` filter it to `description`, `license`, `outputsToInstall`). The CLI-side value of this change lands on NEF/expression publishes.

**The malformed-`meta` diagnostic, measured rather than predicted.** `#[serde(try_from = ...)]` re-wraps the inner error through `de::Error::custom`, keeping the error variant (`ManifestBuilderError::ParseBuildResultFile`) and losing the position. What it actually produced was `invalid type: string "not-a-list", expected a sequence` — no file, no line, and no field, because serde_json never carried a field path on this route either (`serde_path_to_error` is not on it). The conversion now appends the document and its keys, and a test pins both halves.

That is a floor, not a fix: the message still cannot name the offending key, and putting a real path in front of it means adding `serde_path_to_error` as a direct dependency, which is a separate change.

## Verification

```
cargo build --workspace --all-targets    Finished (clean)
cargo clippy --workspace --all-targets   exit 0, no findings
cargo fmt --all -- --check               clean
```

`--all-targets` matters: `just build` resolves to `cargo build -p flox` and would miss both the `publish.rs` test helper and the `lookup.rs` test.

Unit suites for the three crates touched:

| Crate | Result |
|---|---|
| `flox-rust-sdk --lib` | 599 passed, 2 failed |
| `floxhub-client --lib` | 127 passed, 1 failed |
| `nef-lock-catalog --lib` | 139 passed, 0 failed |

All three failures are **pre-existing**, and the two header ones have since been re-measured at this PR's own head in the same build environment — 597 passed / 2 failed at `95a4a7a69`, 599 / 2 with the review fixups — rather than only against `origin/main` in a detached worktree:

- `models::floxmeta::header_tests::git_request_includes_telemetry_headers` and `…_without_device_uuid` — httpmock, order-dependent; both pass in isolation on this branch and both fail in the full suite on `origin/main` at the same `httpmock/src/api/output.rs:51` panic.
- `factory::tests::list_builds_routes_through_mock_guard_in_replay_mode` — fails on `origin/main` too.

None is in this diff's blast radius. The `flox publish` integration recordings were not run against a live stack; nothing here required re-cutting them.

**One of the three clones is kept on purpose.** The conversion no longer clones the map to feed the projection — it deserializes from a borrowed `&Value` — but `convert_build_result_to_build_metadata` takes `&BuildResult`, so the copy into `CheckedBuildMetadata` stays. Removing it needs an ownership change through `BuildResults`' private newtype field, which is out of proportion to a ~2 KB copy once per publish; D23 priced one clone and this leaves two.

## Not done here

Do not merge, rebase or retarget this branch. It will be rebased onto floxhub's bot PR once flox/floxhub#2370 merges, and that reconciliation is the dispatcher's.

Refs: AI-670

