### PR TITLE
perf(auth): cache identity and defer credential loading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1838,6 +1838,7 @@ version = "0.0.0"
 dependencies = [
  "async-stream",
  "base64",
+ "blake3",
  "catalog-api-v1",
  "chrono",
  "derive_more",

--- a/cli/flox-rust-sdk/src/flox.rs
+++ b/cli/flox-rust-sdk/src/flox.rs
@@ -6,7 +6,7 @@ use flox_core::features::Features;
 use flox_core::floxhub::Floxhub;
 use flox_core::vars::FLOX_VERSION_STRING;
 pub use floxhub_client::{AccessToken, AuthContext, AuthFailure, FloxhubToken, UserIdentity};
-use floxhub_client::{FloxhubClient, FloxhubClientError, IdentityError};
+use floxhub_client::{FloxhubClient, FloxhubClientError};
 use url::Url;
 use uuid::Uuid;
 
@@ -54,7 +54,7 @@ pub struct Flox {
 
     pub floxhub: Floxhub,
 
-    /// The current authentication credential.
+    /// Authentication with deferred credential loading and cached identity lookup.
     pub auth_context: AuthContext,
 
     /// Shared HTTP client for both the catalog and factory API surfaces.
@@ -86,64 +86,6 @@ impl Flox {
             config.auth_context = auth_context;
         })?;
         Ok(())
-    }
-
-    /// The identity behind the current credential — the one uniform way to
-    /// answer "who is authenticated": JWT claims for an Auth0-shaped token,
-    /// the accounts service's `GET /api/v1/accounts/me` for any credential
-    /// that doesn't identify its owner — a bare JWT or an opaque access token
-    /// (a successful resolution is cached for the process) — and the principal
-    /// for Kerberos. The public gateway exposes that endpoint at
-    /// `/accounts/api/v1/accounts/me`.
-    ///
-    /// - `Ok(Some(identity))` — authenticated. Expiry is reported *in* the
-    ///   identity ([`UserIdentity::is_expired`]), not as a failure — what
-    ///   expiry means is each caller's decision.
-    /// - `Ok(None)` — the identity is unknown: there is a credential, but it
-    ///   could not be verified (e.g. FloxHub was unreachable). Typically not
-    ///   fatal: the server stays the authority for whether the credential
-    ///   actually authenticates requests, so callers usually degrade rather
-    ///   than block.
-    /// - `Err(failure)` — affirmatively unauthenticated: no credential
-    ///   ([`AuthFailure::NotLoggedIn`]), no Kerberos ticket
-    ///   ([`AuthFailure::NoKerberosTicket`]), or the server rejected the
-    ///   token ([`AuthFailure::TokenExpired`]).
-    pub async fn get_identity(&self) -> Result<Option<UserIdentity>, AuthFailure> {
-        match &self.auth_context {
-            AuthContext::Auth0(Some(token)) => Ok(Some(UserIdentity {
-                handle: token.handle().to_string(),
-                sub: token.sub().map(str::to_owned),
-                expires_at: Some(token.expires_at()),
-            })),
-            AuthContext::Auth0(None) => Err(AuthFailure::NotLoggedIn),
-            // A bare token resolves from /me like an opaque access token.
-            // Its own exp claim wins over the server's expires_at — /me
-            // describes stored credentials like PATs, while a JWT carries
-            // its expiry with it.
-            AuthContext::Bare(token) => {
-                match self.floxhub_client.resolve_identity(token.secret()).await {
-                    Ok(identity) => Ok(Some(UserIdentity {
-                        expires_at: token.expires_at().or(identity.expires_at),
-                        ..identity
-                    })),
-                    Err(IdentityError::Unauthorized) => Err(AuthFailure::TokenExpired),
-                    Err(_) => Ok(None),
-                }
-            },
-            AuthContext::AccessToken(token) => {
-                match self.floxhub_client.resolve_identity(token.secret()).await {
-                    Ok(identity) => Ok(Some(identity)),
-                    Err(IdentityError::Unauthorized) => Err(AuthFailure::TokenExpired),
-                    Err(_) => Ok(None),
-                }
-            },
-            AuthContext::Kerberos(Some(material)) => Ok(Some(UserIdentity {
-                handle: material.principal.clone(),
-                sub: None,
-                expires_at: None,
-            })),
-            AuthContext::Kerberos(None) => Err(AuthFailure::NoKerberosTicket),
-        }
     }
 }
 

--- a/cli/flox-rust-sdk/src/flox.rs
+++ b/cli/flox-rust-sdk/src/flox.rs
@@ -124,7 +124,7 @@ pub mod test_helpers {
     /// Set a pre-existing token on a [Flox] instance and rebuild the auth
     /// strategy so that `auth_context.handle()` and friends see it immediately.
     pub fn set_test_token(flox: &mut Flox, token: FloxhubToken) {
-        let _ = flox.set_auth_context(AuthContext::Auth0(Some(token)));
+        let _ = flox.set_auth_context(AuthContext::from_auth0_token(Some(token)));
     }
 
     /// Set up test authentication on a [Flox] instance.
@@ -261,6 +261,7 @@ pub mod test_helpers {
 
 #[cfg(test)]
 pub mod tests {
+    use floxhub_client::auth::storage::AuthContextStorageExt;
     use floxhub_client::test_helpers::{
         FAKE_EXPIRED_TOKEN,
         FAKE_TOKEN,
@@ -289,23 +290,26 @@ pub mod tests {
     }
 
     #[tokio::test]
-    async fn get_identity_without_token_is_not_logged_in() {
+    async fn identity_without_token_is_not_logged_in() {
         let (flox, _temp_dir) = flox_instance();
         assert!(matches!(
-            flox.get_identity().await,
+            flox.auth_context.identity(&flox.floxhub_client).await,
             Err(AuthFailure::NotLoggedIn)
         ));
     }
 
     #[tokio::test]
-    async fn get_identity_derives_jwt_identity_from_claims() {
+    async fn identity_derives_jwt_identity_from_claims() {
         let (mut flox, _temp_dir) = flox_instance();
         let token: FloxhubToken = FAKE_TOKEN.parse().unwrap();
         let expires_at = token.expires_at();
-        let _ = flox.set_auth_context(AuthContext::Auth0(Some(token)));
+        let _ = flox.set_auth_context(AuthContext::from_auth0_token(Some(token)));
 
         assert_eq!(
-            flox.get_identity().await.unwrap(),
+            flox.auth_context
+                .identity(&flox.floxhub_client)
+                .await
+                .unwrap(),
             Some(UserIdentity {
                 handle: "test".to_string(),
                 sub: None,
@@ -315,13 +319,18 @@ pub mod tests {
     }
 
     #[tokio::test]
-    async fn get_identity_reports_expiry_in_the_identity() {
+    async fn identity_reports_expiry_in_the_identity() {
         let (mut flox, _temp_dir) = flox_instance();
-        let _ = flox.set_auth_context(AuthContext::Auth0(Some(
+        let _ = flox.set_auth_context(AuthContext::from_auth0_token(Some(
             FAKE_EXPIRED_TOKEN.parse().unwrap(),
         )));
 
-        let identity = flox.get_identity().await.unwrap().unwrap();
+        let identity = flox
+            .auth_context
+            .identity(&flox.floxhub_client)
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(identity.handle, "test");
         assert!(identity.is_expired(), "expiry is data, not an error");
     }
@@ -330,7 +339,7 @@ pub mod tests {
     /// identity from /me, with the token's own exp claim carried into the
     /// identity over the server's null.
     #[tokio::test(flavor = "multi_thread")]
-    async fn get_identity_resolves_bare_token_via_me() {
+    async fn identity_resolves_bare_token_via_me() {
         let server = httpmock::MockServer::start();
         server.mock(|when, then| {
             when.method(httpmock::Method::GET)
@@ -348,16 +357,16 @@ pub mod tests {
             floxhub_client::client::test_helpers::client_config(&server.base_url()),
         )
         .unwrap();
-        let AuthContext::Bare(token) = AuthContext::new_from_token(Some(FAKE_TOKEN_NO_HANDLE))
-        else {
-            panic!("a claim-less JWT routes to Bare");
-        };
-        let expires_at = token.expires_at();
+        let token = AuthContext::new_from_token(Some(FAKE_TOKEN_NO_HANDLE));
+        let expires_at = token.cached_facts().expires_at;
         assert!(expires_at.is_some(), "test premise: the token carries exp");
-        let _ = flox.set_auth_context(AuthContext::Bare(token));
+        let _ = flox.set_auth_context(token);
 
         assert_eq!(
-            flox.get_identity().await.unwrap(),
+            flox.auth_context
+                .identity(&flox.floxhub_client)
+                .await
+                .unwrap(),
             Some(UserIdentity {
                 handle: "dexter".to_string(),
                 sub: Some("oidc|dexter".to_string()),
@@ -369,7 +378,7 @@ pub mod tests {
     /// The server rejecting a claim-less token is affirmative: the login is
     /// expired or revoked, not merely unverifiable.
     #[tokio::test(flavor = "multi_thread")]
-    async fn get_identity_maps_401_for_bare_token_to_token_expired() {
+    async fn identity_maps_401_for_bare_token_to_token_expired() {
         let server = httpmock::MockServer::start();
         server.mock(|when, then| {
             when.method(httpmock::Method::GET)
@@ -385,10 +394,12 @@ pub mod tests {
         // A unique sub keeps the token's secret unique: the process-wide
         // identity cache would otherwise satisfy the resolve after another
         // test cached this token.
-        let _ = flox.set_auth_context(AuthContext::Bare(test_bare_token("identity-401-test")));
+        let _ = flox.set_auth_context(AuthContext::from_bare_token(test_bare_token(
+            "identity-401-test",
+        )));
 
         assert!(matches!(
-            flox.get_identity().await,
+            flox.auth_context.identity(&flox.floxhub_client).await,
             Err(AuthFailure::TokenExpired)
         ));
     }

--- a/cli/flox-rust-sdk/src/models/floxmeta.rs
+++ b/cli/flox-rust-sdk/src/models/floxmeta.rs
@@ -321,8 +321,12 @@ mod header_tests {
 
             let owner = "testowner";
             let server_url = Url::parse(&server.base_url()).unwrap();
-            let options =
-                floxmeta_git_options(&server_url, owner, &AuthContext::Auth0(None), Some(&uuid));
+            let options = floxmeta_git_options(
+                &server_url,
+                owner,
+                &AuthContext::from_auth0_token(None),
+                Some(&uuid),
+            );
             clone_against_mock(&server, owner, options);
             mock.assert();
         });
@@ -344,7 +348,12 @@ mod header_tests {
 
             let owner = "testowner";
             let server_url = Url::parse(&server.base_url()).unwrap();
-            let options = floxmeta_git_options(&server_url, owner, &AuthContext::Auth0(None), uuid);
+            let options = floxmeta_git_options(
+                &server_url,
+                owner,
+                &AuthContext::from_auth0_token(None),
+                uuid,
+            );
             clone_against_mock(&server, owner, options);
             mock.assert();
         });

--- a/cli/flox-rust-sdk/src/providers/buildenv.rs
+++ b/cli/flox-rust-sdk/src/providers/buildenv.rs
@@ -1633,8 +1633,10 @@ mod test_helpers {
 
     pub(super) fn buildenv_instance() -> BuildEnvNix<NixAuth> {
         init_tracing();
-        let auth =
-            NixAuth::from_tempdir_and_context(TempDir::new().unwrap(), AuthContext::Auth0(None));
+        let auth = NixAuth::from_tempdir_and_context(
+            TempDir::new().unwrap(),
+            AuthContext::from_auth0_token(None),
+        );
         BuildEnvNix::new(auth)
     }
 

--- a/cli/flox-rust-sdk/src/providers/catalog.rs
+++ b/cli/flox-rust-sdk/src/providers/catalog.rs
@@ -649,7 +649,7 @@ pub mod test_helpers {
             filename,
             DEFAULT_CATALOG_URL,
             PublishTestUser::Unauthenticated,
-            &AuthContext::Auth0(None),
+            &AuthContext::from_auth0_token(None),
             record,
         )
     }
@@ -913,7 +913,7 @@ pub mod test_helpers {
             base_url: base_url.to_string(),
             extra_headers: Default::default(),
             mock_mode: FloxhubMockMode::None,
-            auth_context: AuthContext::Auth0(Some(admin_token)),
+            auth_context: AuthContext::from_auth0_token(Some(admin_token)),
             user_agent: None,
             stability: None,
             on_unauthenticated_resolve: None,

--- a/cli/flox-rust-sdk/src/providers/git_auth.rs
+++ b/cli/flox-rust-sdk/src/providers/git_auth.rs
@@ -1,3 +1,4 @@
+use floxhub_client::auth::Credential;
 use floxhub_client::{AuthContext, CredentialKind};
 use url::Url;
 
@@ -15,9 +16,9 @@ pub trait GitCommandOptionsExt {
 
 impl GitCommandOptionsExt for GitCommandOptions {
     fn authenticate(&mut self, auth_context: &AuthContext, git_url: &Url) {
-        if auth_context.kind() == CredentialKind::Kerberos {
+        if let Credential::Kerberos(material) = auth_context.credential() {
             self.add_config_flag("http.emptyAuth", "true");
-            match auth_context.kerberos_principal() {
+            match material {
                 Some(_) => {
                     tracing::debug!("Kerberos mode — git auth handled natively via ccache");
                 },
@@ -30,9 +31,9 @@ impl GitCommandOptionsExt for GitCommandOptions {
             return;
         }
         let token = auth_context.token_secret().unwrap_or("");
-        // Read the token first so diagnostics describe the loaded credential,
-        // not potentially stale startup facts. For these JWT kinds, a present
-        // token is locally unauthenticated only when it has expired.
+        // The credential is loaded, so diagnostics use its actual facts.
+        // For these JWT kinds, a present token is locally unauthenticated only
+        // when it has expired.
         match auth_context.kind() {
             CredentialKind::Auth0 if auth_context.is_unauthenticated() => {
                 tracing::debug!("FloxHub token is expired, sending for identification");
@@ -45,6 +46,14 @@ impl GitCommandOptionsExt for GitCommandOptions {
             },
             CredentialKind::Bare => {
                 tracing::debug!("using bare FloxHub token");
+            },
+            CredentialKind::PersonalAccessToken
+            | CredentialKind::ServiceAccountToken
+            | CredentialKind::OpaqueToken => {
+                tracing::debug!(kind = ?auth_context.kind(), "using FloxHub access token");
+            },
+            CredentialKind::NotLoggedIn => {
+                tracing::debug!("no credential available for git auth");
             },
             _ => {},
         }
@@ -213,7 +222,7 @@ mod tests {
     #[test]
     fn auth0_with_token_sets_credential_helper() {
         let token = create_test_token("testuser");
-        let auth = AuthContext::Auth0(Some(token.clone()));
+        let auth = AuthContext::from_auth0_token(Some(token.clone()));
         let mut options = GitCommandOptions::default();
 
         let mut expected = GitCommandOptions::default();
@@ -231,7 +240,7 @@ mod tests {
 
     #[test]
     fn auth0_without_token_sets_empty_credential_helper() {
-        let auth = AuthContext::Auth0(None);
+        let auth = AuthContext::from_auth0_token(None);
         let mut options = GitCommandOptions::default();
 
         let mut expected = GitCommandOptions::default();
@@ -250,7 +259,7 @@ mod tests {
     #[test]
     fn pat_sets_credential_helper_with_secret() {
         let token = floxhub_client::AccessToken::new("flox_pat_secret".to_string());
-        let auth = AuthContext::AccessToken(token.clone());
+        let auth = AuthContext::from_access_token(token.clone());
         let mut options = GitCommandOptions::default();
 
         let mut expected = GitCommandOptions::default();
@@ -268,7 +277,7 @@ mod tests {
 
     #[test]
     fn kerberos_with_material_sets_empty_auth() {
-        let auth = AuthContext::Kerberos(Some(floxhub_client::KerberosMaterial {
+        let auth = AuthContext::from_kerberos(Some(floxhub_client::KerberosMaterial {
             principal: "user@REALM".to_string(),
             generate_token: std::sync::Arc::new(|_| Ok("token".to_string())),
         }));
@@ -283,7 +292,7 @@ mod tests {
 
     #[test]
     fn kerberos_without_material_sets_empty_auth() {
-        let auth = AuthContext::Kerberos(None);
+        let auth = AuthContext::from_kerberos(None);
         let mut options = GitCommandOptions::default();
 
         let mut expected = GitCommandOptions::default();

--- a/cli/flox-rust-sdk/src/providers/git_auth.rs
+++ b/cli/flox-rust-sdk/src/providers/git_auth.rs
@@ -1,4 +1,4 @@
-use floxhub_client::AuthContext;
+use floxhub_client::{AuthContext, CredentialKind};
 use url::Url;
 
 use crate::models::floxmeta::FLOXHUB_TOKEN_ENV_VAR;
@@ -8,91 +8,206 @@ use crate::providers::git::GitCommandOptions;
 pub trait GitCommandOptionsExt {
     /// Apply authentication based on the [`AuthContext`].
     ///
-    /// Matches on the variant because git genuinely needs different behavior
-    /// per auth type:
-    /// - Auth0 (bearer): inline credential helper with the token
-    /// - Kerberos: set `http.emptyAuth=true` so libcurl performs the SPNEGO
-    ///   Negotiate handshake against the remote; credentials themselves come
-    ///   from the ccache
-    /// - No material: empty credential helper to prevent pinentry fallback
+    /// Bearer credentials use an inline helper. Kerberos delegates to git's
+    /// native ccache support via `http.emptyAuth`.
     fn authenticate(&mut self, auth_context: &AuthContext, git_url: &Url);
 }
 
 impl GitCommandOptionsExt for GitCommandOptions {
     fn authenticate(&mut self, auth_context: &AuthContext, git_url: &Url) {
-        match auth_context {
-            AuthContext::Auth0(maybe_token) => {
-                let token = match maybe_token {
-                    Some(token) => {
-                        if token.is_expired() {
-                            tracing::debug!("FloxHub token is expired, sending for identification");
-                        } else {
-                            tracing::debug!("using valid FloxHub token");
-                        }
-                        token.secret()
-                    },
-                    None => {
-                        tracing::debug!("no credential available for git auth");
-                        ""
-                    },
-                };
-
-                self.add_env_var(FLOXHUB_TOKEN_ENV_VAR, token);
-                self.add_config_flag(
-                    &format!("credential.{git_url}.helper"),
-                    format!(
-                        r#"!f(){{ echo "username=oauth"; echo "password=${FLOXHUB_TOKEN_ENV_VAR}"; }}; f"#
-                    ),
-                );
-            },
-            AuthContext::Bare(token) => {
-                if token.is_expired() {
-                    tracing::debug!("bare FloxHub token is expired, sending for identification");
-                } else {
-                    tracing::debug!("using bare FloxHub token");
-                }
-                self.add_env_var(FLOXHUB_TOKEN_ENV_VAR, token.secret());
-                self.add_config_flag(
-                    &format!("credential.{git_url}.helper"),
-                    format!(
-                        r#"!f(){{ echo "username=oauth"; echo "password=${FLOXHUB_TOKEN_ENV_VAR}"; }}; f"#
-                    ),
-                );
-            },
-            AuthContext::AccessToken(token) => {
-                tracing::debug!("using FloxHub personal access token");
-                self.add_env_var(FLOXHUB_TOKEN_ENV_VAR, token.secret());
-                self.add_config_flag(
-                    &format!("credential.{git_url}.helper"),
-                    format!(
-                        r#"!f(){{ echo "username=oauth"; echo "password=${FLOXHUB_TOKEN_ENV_VAR}"; }}; f"#
-                    ),
-                );
-            },
-            AuthContext::Kerberos(material) => {
-                match material {
-                    Some(_) => {
-                        tracing::debug!("Kerberos mode — git auth handled natively via ccache");
-                    },
-                    None => {
-                        tracing::warn!(
-                            "Kerberos mode but no ticket available — git operations will likely fail; run 'kinit'"
-                        );
-                    },
-                }
-                self.add_config_flag("http.emptyAuth", "true");
-            },
+        if auth_context.kind() == CredentialKind::Kerberos {
+            self.add_config_flag("http.emptyAuth", "true");
+            match auth_context.kerberos_principal() {
+                Some(_) => {
+                    tracing::debug!("Kerberos mode — git auth handled natively via ccache");
+                },
+                None => {
+                    tracing::warn!(
+                        "Kerberos mode but no ticket available — git operations will likely fail; run 'kinit'"
+                    );
+                },
+            }
+            return;
         }
+        let token = auth_context.token_secret().unwrap_or("");
+        // Read the token first so diagnostics describe the loaded credential,
+        // not potentially stale startup facts. For these JWT kinds, a present
+        // token is locally unauthenticated only when it has expired.
+        match auth_context.kind() {
+            CredentialKind::Auth0 if auth_context.is_unauthenticated() => {
+                tracing::debug!("FloxHub token is expired, sending for identification");
+            },
+            CredentialKind::Auth0 => {
+                tracing::debug!("using valid FloxHub token");
+            },
+            CredentialKind::Bare if auth_context.is_unauthenticated() => {
+                tracing::debug!("bare FloxHub token is expired, sending for identification");
+            },
+            CredentialKind::Bare => {
+                tracing::debug!("using bare FloxHub token");
+            },
+            _ => {},
+        }
+        self.add_env_var(FLOXHUB_TOKEN_ENV_VAR, token);
+        self.add_config_flag(
+            &format!("credential.{git_url}.helper"),
+            format!(
+                r#"!f(){{ echo "username=oauth"; echo "password=${FLOXHUB_TOKEN_ENV_VAR}"; }}; f"#
+            ),
+        );
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use floxhub_client::KerberosMaterial;
+    use floxhub_client::auth::storage::{AuthContextStorageExt, CachedFacts};
+
     use super::*;
     use crate::flox::test_helpers::create_test_token;
 
     fn test_url() -> Url {
         Url::parse("https://git.floxhub.com").unwrap()
+    }
+
+    fn capture_logs(f: impl FnOnce()) -> String {
+        let log = tempfile::NamedTempFile::new().unwrap();
+        let writer = log.reopen().unwrap();
+        let subscriber = tracing_subscriber::fmt()
+            .without_time()
+            .with_ansi(false)
+            .with_target(false)
+            .with_max_level(tracing::Level::DEBUG)
+            .with_writer(move || writer.try_clone().unwrap())
+            .finish();
+        tracing::subscriber::with_default(subscriber, f);
+        std::fs::read_to_string(log.path()).unwrap()
+    }
+
+    #[test]
+    fn jwt_git_diagnostics_use_loaded_expiry_and_still_send_expired_tokens() {
+        for (kind, expiry, expected_log) in [
+            (
+                CredentialKind::Auth0,
+                Some(1),
+                "DEBUG FloxHub token is expired, sending for identification\n",
+            ),
+            (
+                CredentialKind::Auth0,
+                Some(9999999999_i64),
+                "DEBUG using valid FloxHub token\n",
+            ),
+            (
+                CredentialKind::Bare,
+                Some(1),
+                "DEBUG bare FloxHub token is expired, sending for identification\n",
+            ),
+            (
+                CredentialKind::Bare,
+                Some(9999999999_i64),
+                "DEBUG using bare FloxHub token\n",
+            ),
+            (
+                CredentialKind::Bare,
+                None,
+                "DEBUG using bare FloxHub token\n",
+            ),
+        ] {
+            let mut claims = serde_json::json!({});
+            if let Some(expiry) = expiry {
+                claims["exp"] = serde_json::json!(expiry);
+            }
+            if kind == CredentialKind::Auth0 {
+                claims["https://flox.dev/handle"] = serde_json::json!("testuser");
+            }
+            let secret = jsonwebtoken::encode(
+                &jsonwebtoken::Header::default(),
+                &claims,
+                &jsonwebtoken::EncodingKey::from_secret(b"secret"),
+            )
+            .unwrap();
+            let resolved = AuthContext::new_from_token(Some(&secret));
+            let mut recorded = resolved.cached_facts();
+            // Both the kind and expiry can change before a deferred read.
+            recorded.kind = if kind == CredentialKind::Auth0 {
+                CredentialKind::Bare
+            } else {
+                CredentialKind::Auth0
+            };
+            recorded.expires_at =
+                chrono::DateTime::from_timestamp(if expiry == Some(1) { 9999999999 } else { 1 }, 0);
+            let calls = Arc::new(AtomicUsize::new(0));
+            let counter = Arc::clone(&calls);
+            let credential = resolved.clone();
+            let deferred = AuthContext::deferred(recorded, move || {
+                counter.fetch_add(1, Ordering::SeqCst);
+                credential.clone()
+            });
+            assert_eq!(calls.load(Ordering::SeqCst), 0);
+
+            for context in [resolved, deferred.clone(), deferred] {
+                let mut options = GitCommandOptions::default();
+                let logs = capture_logs(|| options.authenticate(&context, &test_url()));
+                assert_eq!(logs, expected_log);
+
+                let mut expected = GitCommandOptions::default();
+                expected.add_env_var(FLOXHUB_TOKEN_ENV_VAR, &secret);
+                expected.add_config_flag(
+                    &format!("credential.{}.helper", test_url()),
+                    format!(
+                        r#"!f(){{ echo "username=oauth"; echo "password=${FLOXHUB_TOKEN_ENV_VAR}"; }}; f"#
+                    ),
+                );
+                assert_eq!(options, expected);
+            }
+            assert_eq!(calls.load(Ordering::SeqCst), 1);
+        }
+    }
+
+    #[test]
+    fn kerberos_git_diagnostics_check_deferred_credentials_once_across_clones() {
+        for principal in [Some("user@REALM"), None] {
+            let calls = Arc::new(AtomicUsize::new(0));
+            let counter = Arc::clone(&calls);
+            let auth = AuthContext::deferred(
+                CachedFacts {
+                    kind: CredentialKind::Kerberos,
+                    // Advisory facts must not decide whether a ticket exists.
+                    handle: principal.is_none().then(|| "stale@REALM".to_string()),
+                    ..Default::default()
+                },
+                move || {
+                    counter.fetch_add(1, Ordering::SeqCst);
+                    AuthContext::from_kerberos(principal.map(|principal| KerberosMaterial {
+                        principal: principal.to_string(),
+                        generate_token: Arc::new(|_| {
+                            panic!("git must use native ccache authentication")
+                        }),
+                    }))
+                },
+            );
+            assert_eq!(calls.load(Ordering::SeqCst), 0);
+
+            for context in [&auth, &auth.clone()] {
+                let mut options = GitCommandOptions::default();
+                let logs = capture_logs(|| options.authenticate(context, &test_url()));
+                let expected_log = match principal {
+                    Some(_) => "DEBUG Kerberos mode — git auth handled natively via ccache\n",
+                    None => {
+                        " WARN Kerberos mode but no ticket available — git operations will likely fail; run 'kinit'\n"
+                    },
+                };
+                assert_eq!(logs, expected_log);
+                assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+                let mut expected = GitCommandOptions::default();
+                expected.add_config_flag("http.emptyAuth", "true");
+                assert_eq!(options, expected);
+            }
+        }
     }
 
     #[test]

--- a/cli/flox-rust-sdk/src/providers/nix_auth.rs
+++ b/cli/flox-rust-sdk/src/providers/nix_auth.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
-use floxhub_client::AuthContext;
+use floxhub_client::{AuthContext, CredentialKind};
 use indoc::formatdoc;
 use tempfile::{NamedTempFile, TempDir, TempPath, tempdir_in};
 
@@ -92,11 +92,10 @@ pub struct NixAuth {
 impl NixAuth {
     /// Construct a new auth provider from a Flox instance
     pub fn from_flox(flox: &Flox) -> Result<Self, AuthError> {
-        let netrc_tempdir = match &flox.auth_context {
-            AuthContext::Auth0(_) | AuthContext::Bare(_) | AuthContext::AccessToken(_) => {
-                Some(tempdir_in(&flox.temp_dir).map_err(AuthError::CreateTempDir)?)
-            },
-            AuthContext::Kerberos(_) => None,
+        let netrc_tempdir = if flox.auth_context.kind() == CredentialKind::Kerberos {
+            None
+        } else {
+            Some(tempdir_in(&flox.temp_dir).map_err(AuthError::CreateTempDir)?)
         };
         Ok(Self {
             netrc_tempdir,
@@ -181,7 +180,10 @@ mod tests {
 
     fn test_auth() -> NixAuth {
         let token = FloxhubToken::new(FAKE_TOKEN.to_string()).expect("token parses");
-        NixAuth::from_tempdir_and_context(tempdir().unwrap(), AuthContext::Auth0(Some(token)))
+        NixAuth::from_tempdir_and_context(
+            tempdir().unwrap(),
+            AuthContext::from_auth0_token(Some(token)),
+        )
     }
 
     /// create_netrc returns a TempPath whose underlying file exists while held
@@ -226,7 +228,10 @@ mod tests {
     /// try_create_netrc returns None when no token is present.
     #[test]
     fn try_create_netrc_returns_none_without_token() {
-        let auth = NixAuth::from_tempdir_and_context(tempdir().unwrap(), AuthContext::Auth0(None));
+        let auth = NixAuth::from_tempdir_and_context(
+            tempdir().unwrap(),
+            AuthContext::from_auth0_token(None),
+        );
         assert!(auth.try_create_netrc().is_none());
     }
 }

--- a/cli/flox-rust-sdk/src/providers/publish.rs
+++ b/cli/flox-rust-sdk/src/providers/publish.rs
@@ -1376,6 +1376,7 @@ pub mod tests {
     use flox_manifest::interfaces::{AsWritableManifest, WriteManifest};
     use flox_test_utils::GENERATED_DATA;
     use floxhub_client::AuthContext;
+    use floxhub_client::auth::Credential;
     use pretty_assertions::assert_eq;
 
     use super::*;
@@ -1450,8 +1451,11 @@ pub mod tests {
         let cache_url = format!("file://{}", temp_dir.path().display());
         let parsed_cache_url = Url::parse(&cache_url).unwrap();
         let key_file_path = temp_key_file.path().to_path_buf();
-        let auth_file =
-            write_floxhub_netrc(temp_dir.path(), &AuthContext::Auth0(Some(token.clone()))).unwrap();
+        let auth_file = write_floxhub_netrc(
+            temp_dir.path(),
+            &AuthContext::from_auth0_token(Some(token.clone())),
+        )
+        .unwrap();
         let catalog_store = ClientSideCatalogStoreConfig::NixCopy {
             ingress_uri: parsed_cache_url.clone(),
             egress_uri: parsed_cache_url.clone(),
@@ -2207,13 +2211,10 @@ pub mod tests {
         )
         .unwrap();
 
-        let (_key_file, cache) = local_nix_cache(
-            match &flox.auth_context {
-                AuthContext::Auth0(t) => t.as_ref(),
-                _ => None,
-            }
-            .unwrap(),
-        );
+        let Credential::Auth0(Some(token)) = flox.auth_context.credential() else {
+            panic!("expected an Auth0 credential");
+        };
+        let (_key_file, cache) = local_nix_cache(token);
         let auth = NixAuth::from_flox(&flox).unwrap();
         let publish_provider = PublishProvider::new(env_metadata, package_metadata, auth);
 
@@ -2435,7 +2436,7 @@ pub mod tests {
         let (flox, _temp_dir_handle) = flox_instance();
         let auth_file = write_floxhub_netrc(
             flox.temp_dir.as_path(),
-            &AuthContext::Auth0(Some(token.clone())),
+            &AuthContext::from_auth0_token(Some(token.clone())),
         )
         .unwrap();
 
@@ -2516,7 +2517,13 @@ pub mod tests {
             PublishTestUser::PersonalCatalogOnly,
             recording_name,
         );
-        let user_handle = flox.auth_context.handle().unwrap();
+        let user_handle = flox
+            .auth_context
+            .identity(&flox.floxhub_client)
+            .await
+            .unwrap()
+            .unwrap()
+            .handle;
         let publish_provider = PublishProvider::new(env_meta, pkg_meta, auth);
         let packaged_created_guard = publish_provider
             .create_package_and_possibly_user_catalog(&flox.floxhub_client, &user_handle)
@@ -2680,7 +2687,13 @@ pub mod tests {
             PublishTestUser::WithOrgCatalogs,
             recording_name,
         );
-        let user_handle = flox.auth_context.handle().unwrap();
+        let user_handle = flox
+            .auth_context
+            .identity(&flox.floxhub_client)
+            .await
+            .unwrap()
+            .unwrap()
+            .handle;
         let publish_provider = PublishProvider::new(env_meta, pkg_meta, auth);
         let err = publish_provider
             .publish(

--- a/cli/flox/src/commands/auth.rs
+++ b/cli/flox/src/commands/auth.rs
@@ -369,20 +369,15 @@ impl Auth {
             Auth::Logout => {
                 let span = tracing::info_span!("logout");
                 let _guard = span.enter();
-                if config.flox.floxhub_token.is_none() {
+                let stores = CredentialStores::from_flox(&flox);
+                let source = stores
+                    .logout(&config)
+                    .context("Could not remove the stored token")?;
+
+                if source == CredentialSource::None {
                     message::warning("You are not logged in");
                     return Ok(());
                 }
-
-                let stores = CredentialStores::from_flox(&flox);
-                // Probe before removal: this identifies which source supplies
-                // the active token, so logout can say when clearing the stores
-                // is not enough to end the session.
-                let source = stores.probe_source(&config);
-
-                stores
-                    .remove_all()
-                    .context("Could not remove the stored token")?;
 
                 match source {
                     CredentialSource::Env => message::warning(indoc! {"
@@ -404,7 +399,17 @@ impl Auth {
                 // guard avoids an *additional* keyring read (and a possible
                 // unlock prompt) during source probing when the user is not
                 // logged in.
-                match flox.get_identity().await {
+                //
+                // Ask the server rather than reciting a cached answer. Nothing
+                // else expires the recorded identity, so a handle renamed
+                // server-side would otherwise be reported wrong indefinitely;
+                // `status` exists to report the truth about a credential, and
+                // it is the one command that can afford the round trip.
+                let identity = flox
+                    .auth_context
+                    .refresh_identity(&flox.floxhub_client)
+                    .await;
+                match identity {
                     Ok(Some(identity)) => {
                         message::plain(format!(
                             "You are logged in as {} on {}",
@@ -554,11 +559,6 @@ fn complete_login(
     once: bool,
     storage_pref: TokenStorageMode,
 ) -> Result<String> {
-    let secret = auth_context
-        .token_secret()
-        .expect("login completes with a bearer credential")
-        .to_string();
-
     // `--insecure-storage` forces plain text for this login; otherwise honor the
     // standing storage preference.
     let target = if insecure_storage {
@@ -572,7 +572,7 @@ fn complete_login(
     // (explicit 0600).
     let stores = CredentialStores::from_flox(flox);
     let storage = stores
-        .persist_login_token(&secret, target)
+        .persist_login(&auth_context, target)
         .context("Could not store token")?;
 
     // Persist the plain-text choice as a standing preference only when
@@ -734,6 +734,8 @@ mod tests {
     use flox_events::{CredentialType, EventsBuffer, EventsClient, SharedMetadataTemplate};
     use flox_rust_sdk::flox::FloxhubToken;
     use flox_rust_sdk::flox::test_helpers::{create_test_token, flox_instance};
+    use flox_rust_sdk::models::floxmeta::FLOXHUB_TOKEN_ENV_VAR;
+    use floxhub_client::auth::storage::credential_fingerprint;
     use floxhub_client::test_helpers::{FAKE_EXPIRED_TOKEN, FAKE_TOKEN_WITH_SUB};
     use httpmock::MockServer;
     use serial_test::serial;
@@ -1095,6 +1097,74 @@ mod tests {
             );
             assert!(matches!(&flox.auth_context, AuthContext::AccessToken(_)));
         })
+        .await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn plaintext_logins_persist_resolved_identity() {
+        temp_env::async_with_vars(
+            [
+                ("_FLOX_DISABLE_KEYRING", Some("true")),
+                (FLOXHUB_TOKEN_ENV_VAR, None),
+            ],
+            async {
+                for (prefix, storage_pref) in [
+                    ("pat", TokenStorageMode::Plaintext),
+                    ("sat", TokenStorageMode::Plaintext),
+                    ("pat", TokenStorageMode::Keyring),
+                    ("sat", TokenStorageMode::Keyring),
+                ] {
+                    let secret = format!("flox_{prefix}_plaintext-{storage_pref:?}");
+                    let server = MockServer::start();
+                    let request = server.mock(|when, then| {
+                        when.method(httpmock::Method::GET)
+                            .path("/accounts/api/v1/accounts/me")
+                            .header("authorization", format!("bearer {secret}"));
+                        then.status(200).json_body(serde_json::json!({
+                            "user_id": "account|plaintext",
+                            "handle": "plaintext-user",
+                            "expires_at": null,
+                        }));
+                    });
+                    let (mut flox, _temp_dir) = flox_instance();
+                    override_client(&mut flox, &server);
+                    let token_file = flox.temp_dir.join("token");
+                    fs::write(&token_file, &secret).unwrap();
+
+                    login_with_token_file(&mut flox, &token_file, false, false, storage_pref)
+                        .await
+                        .unwrap();
+
+                    request.assert_calls(1);
+                    let record_path = fs::read_dir(&flox.cache_dir)
+                        .unwrap()
+                        .map(|entry| entry.unwrap().path())
+                        .find(|path| {
+                            path.file_name()
+                                .unwrap()
+                                .to_string_lossy()
+                                .starts_with("auth-state-")
+                        })
+                        .expect("login must persist the resolved identity");
+                    let record: serde_json::Value =
+                        serde_json::from_str(&fs::read_to_string(record_path).unwrap()).unwrap();
+                    assert_eq!(
+                        record,
+                        serde_json::json!({
+                            "version": 1,
+                            "account": flox.floxhub.base_url().as_str(),
+                            "storage": TokenStorage::Plaintext,
+                            "logged_in": true,
+                            "kind": flox.auth_context.kind(),
+                            "requires_login": false,
+                            "subject": "account|plaintext",
+                            "handle": "plaintext-user",
+                            "fingerprint": credential_fingerprint(&secret),
+                        })
+                    );
+                }
+            },
+        )
         .await;
     }
 

--- a/cli/flox/src/commands/auth.rs
+++ b/cli/flox/src/commands/auth.rs
@@ -525,7 +525,11 @@ pub async fn login_flox(
     // credential, and every handle consumer needs the same server.
     let auth_context = AuthContext::new_from_token(Some(&cred.token));
     let _ = flox.set_auth_context(auth_context.clone());
-    let handle = match flox.get_identity().await {
+    let handle = match flox
+        .auth_context
+        .refresh_identity(&flox.floxhub_client)
+        .await
+    {
         Ok(Some(identity)) => identity.handle,
         Ok(None) => bail!(indoc! {"
             Could not reach FloxHub to verify the login.
@@ -694,8 +698,13 @@ pub async fn login_with_token_file(
     // where a 401 covers expired and revoked tokens alike.
     // Elsewhere an unresolvable identity degrades to the UNKNOWN handle, but
     // login exists to verify-and-store the credential — an unverifiable
-    // token is a failure here, not a success.
-    let handle = match flox.get_identity().await {
+    // token is a failure here, not a success. Startup may have seeded a saved
+    // identity for this token, so explicitly refresh it before accepting login.
+    let handle = match flox
+        .auth_context
+        .refresh_identity(&flox.floxhub_client)
+        .await
+    {
         Ok(Some(identity)) if identity.is_expired() => bail!(indoc! {"
             The provided token is expired.
             Obtain a fresh token from FloxHub and try again."
@@ -735,7 +744,12 @@ mod tests {
     use flox_rust_sdk::flox::FloxhubToken;
     use flox_rust_sdk::flox::test_helpers::{create_test_token, flox_instance};
     use flox_rust_sdk::models::floxmeta::FLOXHUB_TOKEN_ENV_VAR;
-    use floxhub_client::auth::storage::credential_fingerprint;
+    use floxhub_client::auth::Credential as AuthCredential;
+    use floxhub_client::auth::storage::{
+        AuthContextStorageExt,
+        CachedFacts,
+        credential_fingerprint,
+    };
     use floxhub_client::test_helpers::{FAKE_EXPIRED_TOKEN, FAKE_TOKEN_WITH_SUB};
     use httpmock::MockServer;
     use serial_test::serial;
@@ -935,7 +949,7 @@ mod tests {
                 Some(token.secret()),
                 "the config stores exactly the provided token"
             );
-            let AuthContext::Auth0(Some(stored)) = &flox.auth_context else {
+            let AuthCredential::Auth0(Some(stored)) = flox.auth_context.credential() else {
                 panic!("expected an Auth0 auth context with a token");
             };
             assert_eq!(stored.secret(), token.secret());
@@ -952,7 +966,7 @@ mod tests {
 
             complete_login(
                 &mut flox,
-                AuthContext::Auth0(Some(
+                AuthContext::from_auth0_token(Some(
                     FloxhubToken::new(FAKE_TOKEN_WITH_SUB.to_string()).expect("token parses"),
                 )),
                 "test".to_string(),
@@ -1095,7 +1109,10 @@ mod tests {
                 Some("flox_pat_secret"),
                 "the config stores exactly the provided token"
             );
-            assert!(matches!(&flox.auth_context, AuthContext::AccessToken(_)));
+            assert_eq!(
+                flox.auth_context.kind(),
+                floxhub_client::CredentialKind::PersonalAccessToken
+            );
         })
         .await;
     }
@@ -1197,6 +1214,59 @@ mod tests {
             "Could not reach FloxHub to verify the token.\nTry again."
         );
         assert!(!flox.config_dir.join(FLOX_CONFIG_FILE).exists());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn login_with_token_file_refreshes_cached_identity() {
+        temp_env::async_with_vars(
+            [("_FLOX_DISABLE_KEYRING", Some("true")), (FLOXHUB_TOKEN_ENV_VAR, None)],
+            async {
+                for (status, expected) in [
+                    (401, Err("FloxHub rejected the provided token: it is invalid, expired, or revoked.\nObtain a fresh token from FloxHub and try again.".to_string())),
+                    (500, Err("Could not reach FloxHub to verify the token.\nTry again.".to_string())),
+                    (200, Ok("current-user".to_string())),
+                ] {
+                    let server = MockServer::start();
+                    let request = server.mock(|when, then| {
+                        when.method(httpmock::Method::GET)
+                            .path("/accounts/api/v1/accounts/me");
+                        then.status(status).json_body(serde_json::json!({
+                            "user_id": "account|current",
+                            "handle": "current-user",
+                            "expires_at": null,
+                        }));
+                    });
+                    let (mut flox, _temp_dir) = flox_instance();
+                    override_client(&mut flox, &server);
+                    let secret = format!("flox_pat_login-cached-identity-{status}");
+                    let context = AuthContext::new_from_token(Some(&secret));
+                    // Configured tokens are seeded from disk during startup,
+                    // before the login command creates its own auth context.
+                    context.seed_from(&CachedFacts {
+                        handle: Some("cached-user".into()),
+                        subject: Some("account|cached".into()),
+                        ..context.cached_facts()
+                    });
+                    flox.set_auth_context(context).unwrap();
+                    let token_file = flox.temp_dir.join("token");
+                    fs::write(&token_file, &secret).unwrap();
+
+                    let result = login_with_token_file(
+                        &mut flox,
+                        &token_file,
+                        false,
+                        false,
+                        TokenStorageMode::Plaintext,
+                    )
+                    .await
+                    .map_err(|error| error.to_string());
+
+                    assert_eq!(result, expected);
+                    request.assert_calls(1);
+                }
+            },
+        )
+        .await;
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/cli/flox/src/commands/containerize/macos_containerize_proxy.rs
+++ b/cli/flox/src/commands/containerize/macos_containerize_proxy.rs
@@ -7,11 +7,12 @@ use std::sync::LazyLock;
 use flox_config::FLOX_CONFIG_FILE;
 use flox_core::activate::context::ActivateMode;
 use flox_core::vars::FLOX_DISABLE_METRICS_VAR;
-use flox_rust_sdk::flox::{AuthContext, FLOX_VERSION, Flox};
+use flox_rust_sdk::flox::{FLOX_VERSION, Flox};
 use flox_rust_sdk::models::floxmeta::FLOXHUB_TOKEN_ENV_VAR;
 use flox_rust_sdk::providers::container_builder::{ContainerBuilder, ContainerSource};
 use flox_rust_sdk::providers::nix::{NIX_VERSION, NixSubstituterConfig};
 use flox_rust_sdk::utils::ReaderExt;
+use floxhub_client::auth::Credential;
 use indoc::formatdoc;
 use thiserror::Error;
 use tracing::{debug, info, instrument};
@@ -187,7 +188,7 @@ impl ContainerizeProxy {
         // highest precedence (bypassing both stores), restoring prior behaviour
         // regardless of where the host stores the token. Only set when a token
         // is present (skipped in Kerberos mode / logged out).
-        if let AuthContext::Auth0(Some(token)) = &flox.auth_context {
+        if let Credential::Auth0(Some(token)) = flox.auth_context.credential() {
             add_floxhub_token_env(command, token.secret());
         }
 

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -79,7 +79,7 @@ use crate::utils::active_environments::{
     activated_environments,
     last_activated_environment,
 };
-use crate::utils::credential_store::{CredentialStores, ResolveOutcome};
+use crate::utils::credential_store::{CredentialMigration, CredentialStores};
 use crate::utils::dialog::{Dialog, Select};
 use crate::utils::errors::display_chain;
 use crate::utils::events::{build_events_client, resolve_invocation_id};
@@ -261,7 +261,7 @@ pub struct Interrupted;
 
 impl FloxArgs {
     /// Initialize the command line by creating an initial FloxBuilder
-    pub async fn handle(self, mut config: Config) -> Result<()> {
+    pub async fn handle(self, config: Config) -> Result<()> {
         // ensure xdg dirs exist
         tokio::fs::create_dir_all(&config.flox.config_dir).await?;
         tokio::fs::create_dir_all(&config.flox.data_dir).await?;
@@ -359,44 +359,38 @@ impl FloxArgs {
 
         let floxhub = Floxhub::new(floxhub_url, api_url_override, git_url_override)?;
 
-        // Resolve the token string once, upstream: opportunistically migrate an
-        // existing plaintext token into the OS keyring, then — when the merged
-        // config supplied no token — populate it from the keyring so the loud
-        // `resolve_auth_context`, the silent `init_floxhub_client`, and the
-        // v2-events client's `auth_subject` snapshot all see the keyring
-        // value. This block must stay ahead of the token resolution and the
-        // events-client install below.
-        //
-        // Store credentials only in Auth0 mode and outside the prompt/hook
-        // flow: in other modes (e.g. Kerberos) the token is not used for
-        // authentication, so a legacy `floxhub_token` must not be silently
-        // moved or read, and the prompt/hook flow must do no keyring I/O.
-        // `resolve_auth_context` is deliberately not behind this gate — it
-        // still runs in the hook flow (returning the token, suppressing
-        // messages) and gates on the auth mode alone. Consequently, hook-flow
-        // invocations by keyring-storage users emit with `auth_subject` absent
-        // and `credential_type` set to `none` — an accepted gap; a prompt hook
-        // must never trigger a keyring unlock.
-        let stores = CredentialStores::new(floxhub.base_url(), &config.flox.config_dir);
-        let is_auth0 = !matches!(
+        // Share one auth context across warnings, requests, and telemetry.
+        // Prompt hooks must never access the keyring, and Kerberos must not
+        // migrate an unrelated token left in configuration.
+        let stores = CredentialStores::new(
+            floxhub.base_url(),
+            &config.flox.config_dir,
+            &config.flox.cache_dir,
+        );
+        let uses_token_auth = !matches!(
             config.flox.floxhub_authn_mode,
             Some(flox_config::AuthnMode::Kerberos)
         );
-        let should_store_credentials = is_auth0 && !self.is_prompt_hook_flow();
-        if should_store_credentials {
-            match stores.resolve_into(&mut config) {
-                ResolveOutcome::Migrated => message::info(
+        let should_store_credentials = uses_token_auth && !self.is_prompt_hook_flow();
+        let credential = if should_store_credentials {
+            let resolved = stores.resolve(&config);
+            match resolved.migration {
+                Some(CredentialMigration::Migrated) => message::info(
                     "Moved your FloxHub credential from plain text into your system keyring.",
                 ),
-                ResolveOutcome::MigratedButPlaintextRemains => message::warning(indoc! {"
+                Some(CredentialMigration::PlaintextRemains) => message::warning(indoc! {"
                     Stored your credential in the system keyring.
                     The plain-text copy in flox.toml could not be removed.
                     Remove 'floxhub_token' from flox.toml so it does not shadow the keyring."}),
-                ResolveOutcome::PopulatedFromKeyring | ResolveOutcome::Unchanged => {},
+                None => {},
             }
-        }
+            resolved.context
+        } else {
+            auth_context_from_config(&config)
+        };
 
-        let credential = self.resolve_auth_context(&config);
+        self.warn_if_logged_out(&config, &credential);
+
         let invocation_id = resolve_invocation_id();
 
         let metrics_device_uuid = (!config.flox.disable_metrics)
@@ -412,7 +406,7 @@ impl FloxArgs {
         // the user never saw.
         //
         // This deliberately coexists with the once-per-shell-session
-        // logged-out reminder from `resolve_auth_context`: the reminder
+        // logged-out reminder from `warn_if_logged_out`: the reminder
         // reports current status on every command, while this warning fires
         // only on the resolve that will start failing once catalog auth
         // gating is enforced — at which point it becomes an error (or an
@@ -453,7 +447,7 @@ impl FloxArgs {
         // "Dispatch start" sits after credential resolution and best-effort
         // PAT/SAT subject resolution so the event carries `auth_subject` and
         // `credential_type`. The cost: an invocation that dies upstream — on
-        // fallible FloxHub setup, killed while `resolve_into` waits on an OS
+        // fallible FloxHub setup, killed while credential resolution waits on an OS
         // keyring unlock, or killed during credential resolution (e.g.
         // kerberos ticket I/O) — records neither `cli.command_run` nor the
         // matching `cli.command_completed` (no client installs, so the
@@ -600,49 +594,30 @@ impl FloxArgs {
         )
     }
 
-    /// Build the [AuthContext] from the configured `floxhub_token`, emitting
-    /// any user-facing warnings as a side effect.
+    /// Remind a user who is not logged in — no credential, or one whose `exp`
+    /// claim has passed — to run 'flox auth login'. The reminder is suppressed
+    /// for `flox auth` subcommands, the prompt-hook flow, invocations nested
+    /// inside an activation, and when the `auth_notifications` config key is
+    /// set to `false`.
     ///
-    /// A user who is not logged in — no token, or a token whose `exp` claim
-    /// has passed — is reminded to run 'flox auth login'. The reminder is
-    /// suppressed for `flox auth` subcommands, the prompt-hook flow,
-    /// invocations nested inside an activation, and when the
-    /// `auth_notifications` config key is set to `false`.
+    /// The credential is not consumed when the configured authn mode does not
+    /// use it (e.g. Kerberos), so warning about its state never happens there.
     ///
-    /// The token is not consumed when the configured authn mode does not use
-    /// it (e.g. Kerberos), so warning about the token's state never happens
-    /// there.
+    /// For `flox hook-env` the state is reported by the next user-invoked
+    /// command instead; see [Self::is_prompt_hook_flow].
     ///
-    /// For `flox hook-env` the token state is reported by the next
-    /// user-invoked command instead; see [Self::is_prompt_hook_flow].
+    /// No credential can be rejected locally: a `flox_pat_` token is opaque by
+    /// design, and any other string may be an issuer's opaque access token, so
+    /// both count as logged in until the server says otherwise. Expiry is only
+    /// known locally for a token carrying the `exp` claim.
     ///
-    /// No token can be rejected locally: a `flox_pat_` token is opaque by
-    /// design, and any other string may be an issuer's opaque access token,
-    /// so both count as logged in until the server says otherwise. Expiry is
-    /// only known locally for a token carrying the `exp` claim.
-    fn resolve_auth_context(&self, config: &Config) -> AuthContext {
-        // Kerberos does not use FloxHub tokens; the stored token is not
-        // consumed (and none of the token warnings below apply).
-        if let Some(flox_config::AuthnMode::Kerberos) = config.flox.floxhub_authn_mode {
-            return AuthContext::new_kerberos();
-        }
-
-        let raw = config
-            .flox
-            .floxhub_token
-            .as_deref()
-            .filter(|s| !s.is_empty());
-
-        let auth_context = AuthContext::new_from_token(raw);
-        let logged_out = match &auth_context {
-            AuthContext::Auth0(None) => true,
-            AuthContext::Auth0(Some(token)) => token.is_expired(),
-            // A bare token's expiry is known locally only when it carries
-            // the exp claim; an opaque token's never is (like a PAT's).
-            AuthContext::Bare(token) => token.is_expired(),
-            _ => false,
-        };
-        if logged_out {
+    /// This asks [AuthContext] rather than the credential itself, so a
+    /// deferred credential is not read just to decide whether to print a
+    /// reminder. The answer then comes from a record an earlier invocation
+    /// wrote, and a record that disagrees with the keyring misses or invents
+    /// one reminder.
+    fn warn_if_logged_out(&self, config: &Config, credential: &AuthContext) {
+        if credential.is_unauthenticated() {
             // Every `flox auth` subcommand either logs the user in
             // (`login`) or already reports the logged-out state itself
             // (`status`, `logout`, `token`), so the reminder would be
@@ -665,8 +640,32 @@ impl FloxArgs {
                 );
             }
         }
-        auth_context
     }
+}
+
+/// The credential named by the already-merged config.
+///
+/// Kerberos ignores the FloxHub token entirely and resolves a principal from
+/// the ccache instead; every other mode routes the merged `floxhub_token` by
+/// its form (see [AuthContext::new_from_token]). An empty token is treated as
+/// absent — an explicit empty `FLOX_FLOXHUB_TOKEN` masks saved credentials for
+/// one invocation.
+///
+/// Only Kerberos is deferred here. A token is already in hand — the merge read
+/// it from the environment or a config file — so there is nothing to defer;
+/// the keyring is the expensive case and it is handled by
+/// [CredentialStores::resolve].
+fn auth_context_from_config(config: &Config) -> AuthContext {
+    if let Some(flox_config::AuthnMode::Kerberos) = config.flox.floxhub_authn_mode {
+        return AuthContext::new_kerberos();
+    }
+    AuthContext::new_from_token(
+        config
+            .flox
+            .floxhub_token
+            .as_deref()
+            .filter(|token| !token.is_empty()),
+    )
 }
 
 /// Print general welcome message with short usage instructions
@@ -1652,14 +1651,22 @@ pub(super) async fn ensure_environment_trust(
         return Ok(());
     }
 
-    let handle = flox.auth_context.handle();
-    if handle.as_deref() == Some(env_ref.owner().as_str()) {
-        debug!("{env_prefixed_name} is trusted by auth handle");
+    // Configured trust does not depend on the current credential or FloxHub
+    // availability, so honor it before loading credentials or resolving identity.
+    if matches!(trust, Some(EnvironmentTrust::Trust)) {
+        debug!("{env_prefixed_name} is trusted by config");
         return Ok(());
     }
 
-    if matches!(trust, Some(EnvironmentTrust::Trust)) {
-        debug!("{env_prefixed_name} is trusted by config");
+    let handle = flox
+        .auth_context
+        .identity(&flox.floxhub_client)
+        .await
+        .ok()
+        .flatten()
+        .map(|identity| identity.handle);
+    if handle.as_deref() == Some(env_ref.owner().as_str()) {
+        debug!("{env_prefixed_name} is trusted by auth handle");
         return Ok(());
     }
 
@@ -1865,7 +1872,7 @@ pub(super) async fn ensure_auth(flox: &mut Flox) -> Result<String> {
 /// the user's handle.
 ///
 /// Unlike [`ensure_auth`], an expired Auth0 token is not a hard failure: the
-/// handle is still readable from the token, and [`FloxArgs::resolve_auth_context`]
+/// handle is still readable from the token, and [`FloxArgs::warn_if_logged_out`]
 /// has already warned that the user is not logged in, so activation proceeds
 /// with the handle rather than blocking. FloxHub still validates the token on
 /// the actual request. Missing credentials (not logged in / no Kerberos ticket) fall back
@@ -2120,8 +2127,45 @@ mod subcommand_name_tests {
 mod wildcard_trust_tests {
     use std::collections::HashMap;
 
-    use flox_config::EnvironmentTrust;
+    use flox_config::{Config, EnvironmentTrust};
     use flox_core::data::environment_ref::RemoteEnvironmentRef;
+    use flox_rust_sdk::flox::test_helpers::flox_instance;
+    use floxhub_client::auth::storage::{AuthContextStorageExt, CachedFacts};
+    use floxhub_client::client::test_helpers::client_config;
+    use floxhub_client::{AuthContext, FloxhubClient};
+    use httpmock::MockServer;
+
+    #[tokio::test]
+    async fn configured_trust_does_not_load_credentials_or_resolve_identity() {
+        let server = MockServer::start();
+        let request = server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path("/accounts/api/v1/accounts/me");
+            then.status(500);
+        });
+        let (mut flox, _temp_dir) = flox_instance();
+        flox.floxhub_client = FloxhubClient::new(client_config(&server.base_url())).unwrap();
+        let env_ref = RemoteEnvironmentRef::new("trusted-owner", "env").unwrap();
+        for name in ["env", "*"] {
+            let mut config = Config::default();
+            config.flox.trusted_environments.insert(
+                RemoteEnvironmentRef::new("trusted-owner", name).unwrap(),
+                EnvironmentTrust::Trust,
+            );
+            for context in [
+                AuthContext::new_from_token(Some("flox_pat_configured-trust")),
+                AuthContext::deferred(CachedFacts::default(), || {
+                    panic!("configured trust must not load the credential")
+                }),
+            ] {
+                flox.set_auth_context(context).unwrap();
+                super::ensure_environment_trust(&mut config, &flox, &env_ref, true, &String::new())
+                    .await
+                    .unwrap();
+            }
+        }
+        request.assert_calls(0);
+    }
 
     #[test]
     fn wildcard_trust_matches_any_env_from_owner() {
@@ -2185,5 +2229,68 @@ mod wildcard_trust_tests {
             super::resolve_trust(&map, &env_ref),
             Some(&EnvironmentTrust::Trust)
         );
+    }
+}
+
+#[cfg(test)]
+mod auth_context_from_config_tests {
+    use floxhub_client::auth::storage::{AuthContextStorageExt, CachedFacts};
+
+    use super::*;
+
+    fn kerberos_config() -> Config {
+        let mut config = Config::default();
+        config.flox.floxhub_authn_mode = Some(flox_config::AuthnMode::Kerberos);
+        config
+    }
+
+    /// Kerberos answers every startup question without a ticket, so the GSSAPI
+    /// acquire must not happen until something needs a SPNEGO token. Reaching
+    /// the ccache here would also make the test depend on a Kerberized host.
+    #[test]
+    fn kerberos_defers_the_ccache_read() {
+        let credential = auth_context_from_config(&kerberos_config());
+
+        assert_eq!(credential.cached_facts(), CachedFacts {
+            logged_in: false,
+            // Stated up front rather than read: both Kerberos arms agree, so
+            // the ccache has nothing to add to the startup facts.
+            kind: floxhub_client::CredentialKind::Kerberos,
+            requires_login: false,
+            expires_at: None,
+            subject: None,
+            // A principal would be a handle, but reading one is exactly the
+            // ccache round trip this defers.
+            handle: None,
+            fingerprint: None,
+        });
+        // The reminder is about logging in to FloxHub, which kerberos mode
+        // never does; answering it must not have cost a ticket.
+        assert!(!credential.is_unauthenticated());
+    }
+
+    /// A token from the merged config is already in hand, so there is nothing
+    /// to defer — deferring it would only add a layer over a value we hold.
+    #[test]
+    fn a_config_token_is_resolved_already() {
+        let mut config = Config::default();
+        config.flox.floxhub_token = Some("flox_pat_config-token".to_string());
+
+        let credential = auth_context_from_config(&config);
+
+        assert_eq!(credential.token_secret(), Some("flox_pat_config-token"));
+    }
+
+    /// An explicit empty `FLOX_FLOXHUB_TOKEN` masks saved credentials for one
+    /// invocation, so an empty merged token is absent, not a credential.
+    #[test]
+    fn an_empty_config_token_is_not_logged_in() {
+        let mut config = Config::default();
+        config.flox.floxhub_token = Some(String::new());
+
+        let credential = auth_context_from_config(&config);
+
+        assert!(!credential.cached_facts().logged_in);
+        assert!(credential.is_unauthenticated());
     }
 }

--- a/cli/flox/src/commands/mod.rs
+++ b/cli/flox/src/commands/mod.rs
@@ -62,7 +62,7 @@ use flox_rust_sdk::models::environment::{
     find_dot_flox,
     open_path,
 };
-use floxhub_client::UnauthenticatedResolveHook;
+use floxhub_client::{CredentialKind, UnauthenticatedResolveHook};
 use indoc::{formatdoc, indoc};
 use tempfile::TempDir;
 use thiserror::Error;
@@ -301,7 +301,10 @@ impl FloxArgs {
                 && let Some(events_client) = build_events_client(
                     &config,
                     resolve_invocation_id(),
-                    &AuthContext::new_from_token(None),
+                    // This path runs before any credential is resolved, and
+                    // the event carries none: `AuthContext::default` is
+                    // the not-logged-in credential, already resolved.
+                    &AuthContext::default(),
                     None,
                 )
                 .await
@@ -1658,6 +1661,8 @@ pub(super) async fn ensure_environment_trust(
         return Ok(());
     }
 
+    // Load the credential before trusting its identity: a saved handle alone
+    // may belong to a different token. A matching cache avoids the /me request.
     let handle = flox
         .auth_context
         .identity(&flox.floxhub_client)
@@ -1800,7 +1805,7 @@ pub(super) async fn ensure_auth(flox: &mut Flox) -> Result<String> {
 
     // Gating authentication is the caller that treats an expired identity
     // as a failure.
-    let identity = match flox.get_identity().await {
+    let identity = match flox.auth_context.identity(&flox.floxhub_client).await {
         Ok(Some(identity)) if identity.is_expired() => Err(AuthFailure::TokenExpired),
         other => other,
     };
@@ -1816,7 +1821,12 @@ pub(super) async fn ensure_auth(flox: &mut Flox) -> Result<String> {
         // cannot mint a new PAT anyway. Warn and let the actual request be
         // the authority.
         Err(AuthFailure::TokenExpired)
-            if matches!(flox.auth_context, AuthContext::AccessToken(_)) =>
+            if matches!(
+                flox.auth_context.kind(),
+                CredentialKind::PersonalAccessToken
+                    | CredentialKind::ServiceAccountToken
+                    | CredentialKind::OpaqueToken
+            ) =>
         {
             message::warning(
                 "Your FloxHub token could not be verified and may be expired or revoked.",
@@ -1881,7 +1891,7 @@ async fn ensure_auth_allowing_expired(flox: &mut Flox) -> Result<String> {
     // An expired identity still carries its handle; only a missing identity
     // (not logged in, no ticket, or a server-rejected token) falls back to
     // the recovery flow.
-    match flox.get_identity().await {
+    match flox.auth_context.identity(&flox.floxhub_client).await {
         Ok(Some(identity)) => Ok(identity.handle),
         // Identity unknown: proceed under the UNKNOWN display handle.
         Ok(None) => Ok(floxhub_client::UNKNOWN_HANDLE.to_string()),

--- a/cli/flox/src/commands/pull.rs
+++ b/cli/flox/src/commands/pull.rs
@@ -707,7 +707,7 @@ impl Pull {
 
         // Check if the token is expired (resolving a personal access token's
         // identity if needed) - this might be why authentication failed.
-        let token_expired = match flox.get_identity().await {
+        let token_expired = match flox.auth_context.identity(&flox.floxhub_client).await {
             Ok(Some(identity)) => identity.is_expired(),
             // An unknown identity is not "expired".
             Ok(None) => false,

--- a/cli/flox/src/commands/push.rs
+++ b/cli/flox/src/commands/push.rs
@@ -123,8 +123,7 @@ async fn handle_path_environment_push(
         owner
     } else {
         EnvironmentOwner::from_str(
-            &flox
-                .get_identity()
+            &flox.auth_context.identity(&flox.floxhub_client)
                 .await
                 .ok()
                 .flatten()

--- a/cli/flox/src/utils/credential_store/auth_cache.rs
+++ b/cli/flox/src/utils/credential_store/auth_cache.rs
@@ -1,0 +1,633 @@
+//! A non-secret note of what the last credential read found.
+//!
+//! Reading the OS keyring is the most expensive thing an invocation does
+//! before it knows what it was asked to do: a macOS Keychain read measures
+//! ~9.5 ms, most of the ~12 ms it takes the process to start at all. Yet the
+//! only questions the startup path asks of the credential are "is one
+//! stored", "has it expired", and "which pseudonymous subject metrics are
+//! attributed to".
+//!
+//! Recording the summary beside the credential turns those questions into a
+//! ~2 µs file read and leaves the keyring for the invocations that actually
+//! send a FloxHub request. See [super::CredentialStores::resolve].
+//!
+//! The record also carries the user's handle, which for an opaque token costs
+//! a `/me` round trip rather than a keyring read. That half is keyed the same
+//! way — by FloxHub instance — because the point is to answer before the
+//! credential has been loaded, and keying on the secret would gate the cheap
+//! fact behind the costly one. A caller that *does* hold the secret checks the
+//! recorded `fingerprint` against it before believing the handle; see
+//! [AuthContextStorageExt::seed_from].
+//! Identity records cover both keyring and plaintext credentials. Only a
+//! keyring record may defer a keyring read; a plaintext record supplies identity
+//! only after its fingerprint matches the token loaded from configuration.
+//!
+//! **Nothing here is secret, and nothing secret may be added.** Writing the
+//! token to a plain file would undo the reason it lives in the keyring at all.
+//! The subject claim and the handle identify a user across sessions, so the
+//! file is written `0600` like the plain-text credential, and the fingerprint
+//! is a blake3 digest that names the credential without revealing it.
+//!
+//! The record is a claim about a credential this invocation has not read. It
+//! goes stale whenever the keychain changes behind our back — another `flox`
+//! version, another machine syncing the keychain, Keychain Access, a direct
+//! `security` invocation. The blast radius is bounded: a missing or spurious
+//! "not logged in" reminder, and one telemetry event attributed to the wrong
+//! subject. A recorded handle is also advisory until the credential is loaded;
+//! identity lookups check its fingerprint before reusing it. The first invocation
+//! that actually needs the token reads the keyring and rewrites the record, so a
+//! stale one does not survive use.
+
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+use flox_rust_sdk::models::floxmeta::FLOXHUB_TOKEN_ENV_VAR;
+use floxhub_client::auth::storage::{AuthContextStorageExt, CachedFacts};
+use floxhub_client::{AuthContext, CredentialKind};
+use serde::{Deserialize, Serialize};
+use tracing::debug;
+use url::Url;
+
+use super::TokenStorage;
+
+/// Bumped when the on-disk shape changes. A record written by a different
+/// version is ignored rather than migrated — the cost of a miss is one
+/// keyring read.
+const AUTH_STATE_VERSION: u32 = 1;
+
+/// The on-disk form of a [CachedFacts].
+///
+/// `expires_at` is stored as a Unix timestamp rather than a formatted date so
+/// the file does not depend on chrono's serde feature, and `account` is
+/// repeated inside the file so a record can be rejected when it does not
+/// belong to the FloxHub instance being asked about — the filename is derived
+/// from the URL and is not injective.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct AuthStateRecord {
+    version: u32,
+    account: String,
+    storage: TokenStorage,
+    logged_in: bool,
+    kind: CredentialKind,
+    requires_login: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    expires_at: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    subject: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    handle: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    fingerprint: Option<String>,
+}
+
+/// The recorded summary of the credential stored for one FloxHub instance.
+#[derive(Debug, Clone)]
+pub(super) struct AuthCache {
+    path: PathBuf,
+    account: String,
+}
+
+impl AuthCache {
+    /// The record for `account`, kept in `cache_dir`.
+    ///
+    /// The cache dir rather than the runtime dir: the record describes a
+    /// credential that outlives the login session, so tying the record to the
+    /// session would discard it while the thing it describes is still there.
+    /// It relies on being rewritten for invalidation instead — see the module
+    /// docs.
+    pub(super) fn new(cache_dir: impl AsRef<Path>, account: &Url) -> Self {
+        let account = account.as_str().to_string();
+        Self {
+            path: cache_dir
+                .as_ref()
+                .join(format!("auth-state-{}.json", filename_slug(&account))),
+            account,
+        }
+    }
+
+    /// The recorded summary, or `None` when there is nothing usable to read.
+    ///
+    /// Every failure — no file yet, a truncated write, a record from another
+    /// version or another FloxHub instance — is a miss, and a miss simply
+    /// costs the keyring read this record exists to avoid.
+    fn read(&self) -> Option<AuthStateRecord> {
+        let contents = match fs::read_to_string(&self.path) {
+            Ok(contents) => contents,
+            Err(err) => {
+                debug!(path = ?self.path, error = %err, "no recorded auth state");
+                return None;
+            },
+        };
+        let record: AuthStateRecord = match serde_json::from_str(&contents) {
+            Ok(record) => record,
+            Err(err) => {
+                debug!(path = ?self.path, error = %err, "could not parse the recorded auth state");
+                return None;
+            },
+        };
+        if record.version != AUTH_STATE_VERSION || record.account != self.account {
+            debug!(
+                path = ?self.path,
+                version = record.version,
+                "recorded auth state does not describe this credential"
+            );
+            return None;
+        }
+        Some(record)
+    }
+
+    /// Defer a keyring read only when the record describes keyring state.
+    /// A plaintext record cannot establish whether a keyring credential exists.
+    pub(super) fn defer_or_resolve(
+        &self,
+        resolve: impl Fn() -> AuthContext + Send + Sync + 'static,
+    ) -> AuthContext {
+        let context = match self
+            .read()
+            .filter(|record| record.storage == TokenStorage::Keyring)
+        {
+            Some(record) => AuthContext::deferred(record.into(), resolve),
+            None => resolve(),
+        };
+        self.configure(context, TokenStorage::Keyring)
+    }
+
+    /// The recorded facts, or `None` on a miss.
+    fn recorded_facts(&self) -> Option<CachedFacts> {
+        self.read().map(Into::into)
+    }
+
+    /// Attach this record to a credential and persist successful identity lookups.
+    /// Environment overrides may read a matching record but never overwrite it.
+    pub(super) fn configure(&self, context: AuthContext, storage: TokenStorage) -> AuthContext {
+        if let Some(facts) = self.recorded_facts() {
+            context.seed_from(&facts);
+        }
+        if std::env::var(FLOXHUB_TOKEN_ENV_VAR).is_ok() {
+            return context;
+        }
+        let cache = self.clone();
+        context.with_identity_recorder(move |facts| cache.write_facts(facts, storage))
+    }
+
+    /// Record a credential's non-secret properties.
+    ///
+    /// Best effort: a command must not fail because a cache could not be
+    /// written. The write goes to a sibling temp file and is renamed into
+    /// place so a concurrent reader sees either the old record or the new one.
+    pub(super) fn write(&self, context: &AuthContext, storage: TokenStorage) {
+        self.write_facts(&context.cached_facts(), storage);
+    }
+
+    fn write_facts(&self, facts: &CachedFacts, storage: TokenStorage) {
+        if let Err(err) = self.try_write(facts, storage) {
+            debug!(path = ?self.path, error = %err, "could not record auth state");
+        }
+    }
+
+    /// Drop the record, at logout or whenever the credential's fate is
+    /// unknown. Best effort, and a missing record is already the state we
+    /// want.
+    pub(super) fn remove(&self) {
+        match fs::remove_file(&self.path) {
+            Ok(()) => {},
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {},
+            Err(err) => {
+                debug!(path = ?self.path, error = %err, "could not drop recorded auth state")
+            },
+        }
+    }
+
+    fn try_write(&self, facts: &CachedFacts, storage: TokenStorage) -> Result<(), anyhow::Error> {
+        let record = AuthStateRecord {
+            version: AUTH_STATE_VERSION,
+            account: self.account.clone(),
+            storage,
+            logged_in: facts.logged_in,
+            kind: facts.kind,
+            requires_login: facts.requires_login,
+            expires_at: facts.expires_at.map(|expiry| expiry.timestamp()),
+            subject: facts.subject.clone(),
+            handle: facts.handle.clone(),
+            fingerprint: facts.fingerprint.clone(),
+        };
+        let contents = serde_json::to_string(&record)?;
+
+        if let Some(parent) = self.path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        // NamedTempFile creates a private file and removes it on error. Keeping
+        // it beside the record lets persist atomically replace the old contents.
+        let mut temp = tempfile::NamedTempFile::new_in(
+            self.path
+                .parent()
+                .expect("auth state has a parent directory"),
+        )?;
+        temp.write_all(contents.as_bytes())?;
+        temp.persist(&self.path)?;
+        Ok(())
+    }
+}
+
+impl From<AuthStateRecord> for CachedFacts {
+    fn from(record: AuthStateRecord) -> Self {
+        Self {
+            logged_in: record.logged_in,
+            kind: record.kind,
+            requires_login: record.requires_login,
+            expires_at: record
+                .expires_at
+                .and_then(|seconds| DateTime::<Utc>::from_timestamp(seconds, 0)),
+            subject: record.subject,
+            handle: record.handle,
+            fingerprint: record.fingerprint,
+        }
+    }
+}
+
+/// A filename-safe rendering of a FloxHub URL, e.g. `https-hub.flox.dev`.
+///
+/// Readable rather than hashed: there is nothing secret about which FloxHub
+/// instance a user talks to, and a name that says which record is which is
+/// worth more than injectivity. Two URLs can collide here; [AuthCache::read]
+/// rejects a record whose `account` does not match.
+fn filename_slug(account: &str) -> String {
+    let mut slug = String::with_capacity(account.len());
+    for character in account.chars() {
+        match character {
+            'a'..='z' | 'A'..='Z' | '0'..='9' | '.' | '_' => slug.push(character),
+            // Collapse runs of separators, so `https://host` reads as
+            // `https-host` rather than `https---host`.
+            _ if !slug.ends_with('-') => slug.push('-'),
+            _ => {},
+        }
+    }
+    slug.trim_matches('-').to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::os::unix::fs::PermissionsExt;
+
+    use chrono::TimeDelta;
+    use floxhub_client::auth::storage::credential_fingerprint;
+    use pretty_assertions::assert_eq;
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn account() -> Url {
+        Url::parse("https://hub.flox.dev").unwrap()
+    }
+
+    fn facts() -> CachedFacts {
+        CachedFacts {
+            logged_in: true,
+            kind: CredentialKind::Auth0,
+            requires_login: true,
+            expires_at: Some(
+                DateTime::<Utc>::from_timestamp(1_788_000_000, 0).expect("valid timestamp"),
+            ),
+            subject: Some("auth0|cache-round-trip".to_string()),
+            handle: Some("testuser".to_string()),
+            fingerprint: Some(credential_fingerprint("cache-round-trip-secret")),
+        }
+    }
+
+    fn context() -> AuthContext {
+        AuthContext::deferred(facts(), || {
+            panic!("cache tests must not resolve the credential")
+        })
+    }
+
+    #[test]
+    fn records_and_reads_back_auth_state() {
+        let dir = TempDir::new().unwrap();
+        let cache = AuthCache::new(dir.path(), &account());
+
+        cache.write(&context(), TokenStorage::Keyring);
+
+        assert_eq!(
+            cache.read(),
+            Some(AuthStateRecord {
+                version: AUTH_STATE_VERSION,
+                account: account().to_string(),
+                storage: TokenStorage::Keyring,
+                logged_in: true,
+                kind: CredentialKind::Auth0,
+                requires_login: true,
+                expires_at: Some(1_788_000_000),
+                subject: Some("auth0|cache-round-trip".to_string()),
+                handle: Some("testuser".to_string()),
+                fingerprint: Some(credential_fingerprint("cache-round-trip-secret")),
+            })
+        );
+    }
+
+    /// The record names the credential without carrying it: the fingerprint
+    /// is the whole point, and the secret must never reach the file.
+    #[test]
+    fn the_record_names_the_credential_without_carrying_it() {
+        let dir = TempDir::new().unwrap();
+        let cache = AuthCache::new(dir.path(), &account());
+        let secret = "flox_pat_never-on-disk";
+
+        cache.write(
+            &AuthContext::new_from_token(Some(secret)),
+            TokenStorage::Keyring,
+        );
+
+        let contents = fs::read_to_string(&cache.path).unwrap();
+        assert!(
+            !contents.contains(secret),
+            "the record carried the secret: {contents}"
+        );
+        assert!(
+            contents.contains(&credential_fingerprint(secret)),
+            "the record should name the credential by fingerprint: {contents}"
+        );
+    }
+
+    /// The seeding path end to end: a handle recorded for one credential is
+    /// adopted by that credential and by no other.
+    #[test]
+    fn seeding_adopts_a_handle_recorded_for_the_same_credential() {
+        let dir = TempDir::new().unwrap();
+        let cache = AuthCache::new(dir.path(), &account());
+        let secret = "flox_pat_cache-seed-test";
+        cache.write(
+            &AuthContext::deferred(
+                CachedFacts {
+                    handle: Some("seeded-user".to_string()),
+                    fingerprint: Some(credential_fingerprint(secret)),
+                    ..CachedFacts::default()
+                },
+                || panic!("cache tests must not resolve the credential"),
+            ),
+            TokenStorage::Keyring,
+        );
+
+        let same = AuthContext::new_from_token(Some(secret));
+        let other = AuthContext::new_from_token(Some("flox_pat_cache-seed-test-other"));
+        let same = cache.configure(same, TokenStorage::Plaintext);
+        let other = cache.configure(other, TokenStorage::Plaintext);
+
+        assert_eq!(same.handle(), Some("seeded-user".to_string()));
+        assert_eq!(
+            other.handle(),
+            None,
+            "a record for a different credential must be ignored"
+        );
+    }
+
+    /// The facts survive the round trip through the file, not just the
+    /// on-disk shape: this is what the startup path actually reads back.
+    #[test]
+    fn deferring_from_a_record_reproduces_the_facts() {
+        let dir = TempDir::new().unwrap();
+        let cache = AuthCache::new(dir.path(), &account());
+        cache.write(&context(), TokenStorage::Keyring);
+
+        let deferred =
+            cache.defer_or_resolve(|| panic!("a valid record must not resolve the credential"));
+
+        assert_eq!(deferred.cached_facts(), facts());
+    }
+
+    #[test]
+    fn plaintext_identity_does_not_stand_in_for_a_keyring_credential() {
+        let dir = TempDir::new().unwrap();
+        let cache = AuthCache::new(dir.path(), &account());
+        cache.write(&context(), TokenStorage::Plaintext);
+
+        let context = cache.defer_or_resolve(AuthContext::default);
+
+        assert_eq!(
+            context.cached_facts(),
+            AuthContext::default().cached_facts()
+        );
+    }
+
+    #[test]
+    fn plaintext_identity_is_reused_for_the_matching_configured_token() {
+        let dir = TempDir::new().unwrap();
+        let cache = AuthCache::new(dir.path(), &account());
+        let credential = AuthContext::new_from_token(Some("flox_pat_plaintext-reuse"));
+        let facts = CachedFacts {
+            handle: Some("plaintext-user".into()),
+            subject: Some("account|plaintext".into()),
+            ..credential.cached_facts()
+        };
+        cache.write(
+            &AuthContext::deferred(facts.clone(), || {
+                panic!("recording must not load the credential")
+            }),
+            TokenStorage::Plaintext,
+        );
+
+        let context = cache.configure(credential, TokenStorage::Plaintext);
+
+        assert_eq!(context.handle(), Some("plaintext-user".into()));
+        assert_eq!(context.cached_facts(), facts);
+    }
+
+    #[test]
+    fn a_record_without_storage_provenance_is_a_miss() {
+        let dir = TempDir::new().unwrap();
+        let cache = AuthCache::new(dir.path(), &account());
+        cache.write(&context(), TokenStorage::Keyring);
+        let mut record: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&cache.path).unwrap()).unwrap();
+        record.as_object_mut().unwrap().remove("storage");
+        fs::write(&cache.path, serde_json::to_string(&record).unwrap()).unwrap();
+
+        assert_eq!(cache.read(), None);
+    }
+
+    #[test]
+    fn no_record_reads_as_a_miss() {
+        let dir = TempDir::new().unwrap();
+
+        assert_eq!(AuthCache::new(dir.path(), &account()).read(), None);
+    }
+
+    /// The record is written before the command that could leak it exists, so
+    /// the mode is checked rather than assumed.
+    #[test]
+    fn record_is_owner_only() {
+        let dir = TempDir::new().unwrap();
+        let cache = AuthCache::new(dir.path(), &account());
+
+        cache.write(&context(), TokenStorage::Keyring);
+
+        let mode = fs::metadata(&cache.path).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o600);
+    }
+
+    #[test]
+    fn failed_replacement_removes_the_temporary_file() {
+        let dir = TempDir::new().unwrap();
+        let cache = AuthCache::new(dir.path(), &account());
+        // A directory at the destination makes the final rename fail.
+        fs::create_dir(&cache.path).unwrap();
+
+        assert!(cache.try_write(&facts(), TokenStorage::Keyring).is_err());
+
+        let remaining: Vec<_> = fs::read_dir(dir.path())
+            .unwrap()
+            .map(|entry| entry.unwrap().path())
+            .collect();
+        assert_eq!(remaining, vec![cache.path]);
+    }
+
+    /// The filename is derived from the URL and is not injective — a trailing
+    /// path separator is one way two instances land on the same name — so the
+    /// account is checked against the record's own copy.
+    #[test]
+    fn record_for_another_floxhub_sharing_a_filename_is_a_miss() {
+        let dir = TempDir::new().unwrap();
+        let hub = Url::parse("https://flox.example/hub").unwrap();
+        let sibling = Url::parse("https://flox.example/hub/").unwrap();
+        AuthCache::new(dir.path(), &hub).write(&context(), TokenStorage::Keyring);
+
+        let colliding = AuthCache::new(dir.path(), &sibling);
+        assert_eq!(
+            colliding.path,
+            AuthCache::new(dir.path(), &hub).path,
+            "the two URLs must actually share a filename for this to test anything"
+        );
+
+        assert_eq!(colliding.read(), None);
+    }
+
+    #[test]
+    fn record_from_another_version_is_a_miss() {
+        let dir = TempDir::new().unwrap();
+        let cache = AuthCache::new(dir.path(), &account());
+        cache.write(&context(), TokenStorage::Keyring);
+
+        let contents = fs::read_to_string(&cache.path).unwrap();
+        fs::write(
+            &cache.path,
+            contents.replace(
+                &format!("\"version\":{AUTH_STATE_VERSION}"),
+                "\"version\":999",
+            ),
+        )
+        .unwrap();
+
+        assert_eq!(cache.read(), None);
+    }
+
+    #[test]
+    fn a_truncated_record_is_a_miss() {
+        let dir = TempDir::new().unwrap();
+        let cache = AuthCache::new(dir.path(), &account());
+        cache.write(&context(), TokenStorage::Keyring);
+        let contents = fs::read_to_string(&cache.path).unwrap();
+        fs::write(&cache.path, &contents[..contents.len() / 2]).unwrap();
+
+        assert_eq!(cache.read(), None);
+    }
+
+    #[test]
+    fn removing_a_record_leaves_a_miss_and_removing_nothing_is_fine() {
+        let dir = TempDir::new().unwrap();
+        let cache = AuthCache::new(dir.path(), &account());
+        cache.write(&context(), TokenStorage::Keyring);
+
+        cache.remove();
+        assert_eq!(cache.read(), None);
+
+        cache.remove();
+        assert_eq!(cache.read(), None);
+    }
+
+    /// `FLOX_FLOXHUB_TOKEN` is a one-invocation override, so recording what
+    /// it resolved would leave the record describing a credential the next
+    /// invocation will not have.
+    #[test]
+    fn an_env_credential_is_not_recorded() {
+        let dir = TempDir::new().unwrap();
+        let cache = AuthCache::new(dir.path(), &account());
+        let secret = floxhub_client::auth::test_helpers::FAKE_TOKEN;
+
+        temp_env::with_var(FLOXHUB_TOKEN_ENV_VAR, Some(secret), || {
+            let context = cache.configure(
+                AuthContext::new_from_token(Some(secret)),
+                TokenStorage::Plaintext,
+            );
+            tokio::runtime::Runtime::new().unwrap().block_on(async {
+                let client = floxhub_client::client::test_helpers::new_noop();
+                context.identity(&client).await.unwrap().unwrap();
+            });
+        });
+
+        assert_eq!(cache.read(), None);
+    }
+
+    /// Every other source persists, so the record describes what a later
+    /// invocation will actually find. The rule is about lifetime, not about
+    /// which backend holds the credential.
+    #[test]
+    fn a_stored_credential_is_recorded() {
+        let dir = TempDir::new().unwrap();
+        let cache = AuthCache::new(dir.path(), &account());
+        let secret = floxhub_client::auth::test_helpers::FAKE_TOKEN;
+
+        temp_env::with_var(FLOXHUB_TOKEN_ENV_VAR, None::<&str>, || {
+            let context = cache.configure(
+                AuthContext::new_from_token(Some(secret)),
+                TokenStorage::Plaintext,
+            );
+            tokio::runtime::Runtime::new().unwrap().block_on(async {
+                let client = floxhub_client::client::test_helpers::new_noop();
+                context.identity(&client).await.unwrap().unwrap();
+            });
+        });
+
+        assert_eq!(
+            cache.read().and_then(|record| record.fingerprint),
+            Some(credential_fingerprint(secret))
+        );
+    }
+
+    /// Expiry is stored as a timestamp and evaluated on read, so a record
+    /// written while the credential was valid reports it as expired once the
+    /// moment passes.
+    #[test]
+    fn an_expired_record_reads_as_unauthenticated() {
+        let dir = TempDir::new().unwrap();
+        let cache = AuthCache::new(dir.path(), &account());
+        cache.write(
+            &AuthContext::deferred(
+                CachedFacts {
+                    expires_at: Some(Utc::now() - TimeDelta::hours(1)),
+                    ..facts()
+                },
+                || panic!("cache tests must not resolve the credential"),
+            ),
+            TokenStorage::Keyring,
+        );
+
+        let deferred = cache.defer_or_resolve(|| panic!("a valid record must be a cache hit"));
+        assert!(deferred.is_unauthenticated());
+    }
+
+    /// A credential that is not login-gated — Kerberos, or an opaque token —
+    /// records `logged_in: false` yet must not read back as unauthenticated.
+    #[test]
+    fn a_record_without_login_gating_is_not_unauthenticated() {
+        let dir = TempDir::new().unwrap();
+        let cache = AuthCache::new(dir.path(), &account());
+        cache.write(
+            &floxhub_client::AuthContext::from_kerberos(None),
+            TokenStorage::Keyring,
+        );
+
+        let deferred = cache.defer_or_resolve(|| panic!("a valid record must be a cache hit"));
+        assert!(!deferred.is_unauthenticated());
+    }
+}

--- a/cli/flox/src/utils/credential_store/keyring.rs
+++ b/cli/flox/src/utils/credential_store/keyring.rs
@@ -74,12 +74,12 @@ fn classify_keyring_error(error: keyring_core::Error) -> CredentialStoreError {
 /// The entry is keyed by [KEYRING_SERVICE] plus the FloxHub base URL as the
 /// account, so distinct FloxHub instances do not collide.
 #[derive(Debug, Clone)]
-pub struct KeyringStore {
+pub(super) struct KeyringStore {
     account: String,
 }
 
 impl KeyringStore {
-    pub fn new(floxhub_url: &Url) -> Self {
+    pub(super) fn new(floxhub_url: &Url) -> Self {
         Self {
             account: floxhub_url.as_str().to_string(),
         }

--- a/cli/flox/src/utils/credential_store/mock.rs
+++ b/cli/flox/src/utils/credential_store/mock.rs
@@ -6,7 +6,7 @@ use super::{CredentialStore, CredentialStoreError};
 
 /// In-memory credential store for tests, with optional error injection.
 #[derive(Debug, Clone, Default)]
-pub struct MockStore {
+pub(super) struct MockStore {
     inner: Arc<Mutex<MockState>>,
 }
 
@@ -22,13 +22,13 @@ impl MockStore {
     // and this module's tests. `cli/flox` is a binary crate, so `pub` does not
     // exempt it from dead-code analysis (mirrors `set_lock_results` in the SDK).
     #[allow(dead_code)]
-    pub fn new() -> Self {
+    pub(super) fn new() -> Self {
         Self::default()
     }
 
     /// Inject an error returned by the next `get`/`set`/`remove` call.
     #[allow(dead_code)]
-    pub fn set_error(&self, message: impl Into<String>) {
+    pub(super) fn set_error(&self, message: impl Into<String>) {
         self.inner.lock().unwrap().error = Some(message.into());
     }
 
@@ -37,7 +37,7 @@ impl MockStore {
     /// fails — the shape of a plaintext file that is readable but cannot be
     /// rewritten.
     #[allow(dead_code)]
-    pub fn set_remove_error(&self, message: impl Into<String>) {
+    pub(super) fn set_remove_error(&self, message: impl Into<String>) {
         self.inner.lock().unwrap().remove_error = Some(message.into());
     }
 

--- a/cli/flox/src/utils/credential_store/mod.rs
+++ b/cli/flox/src/utils/credential_store/mod.rs
@@ -1,41 +1,35 @@
-//! Storage backend abstraction for the FloxHub auth token.
+//! Prepare and persist authentication for one FloxHub instance.
 //!
-//! The token's runtime representation (`Option<String>` in [Config] → parsed
-//! `FloxhubToken` → `AuthContext`) is unchanged; this module owns only the
-//! *source* of the string and the *destination* of writes.
+//! [CredentialStores] selects credentials, migrates storage, and coordinates
+//! the private non-secret cache. Consumers receive a ready-to-use [AuthContext];
+//! they do not need to coordinate deferred loading or cache updates.
 //!
-//! The abstraction follows the `enum_dispatch` + `Mock`-arm pattern used by
-//! `InstallableLockerImpl`
-//! (`cli/flox-rust-sdk/src/providers/flake_installable_locker.rs`), and the
-//! typed-error convention used by `AuthError`
-//! (`cli/flox-rust-sdk/src/providers/nix_auth.rs`): any "no backend" or
-//! credential-redaction concern lives in the error type rather than at call
-//! sites.
-//!
-//! Each backend lives in its own file — [keyring], [plaintext], and [mock] —
-//! while this module holds the shared [CredentialStore] trait, the error type,
-//! and the [CredentialStores] orchestration.
+//! Secret backends live in [keyring], [plaintext], and [mock].
 
+mod auth_cache;
 mod keyring;
 mod mock;
 mod plaintext;
 
 use std::path::{Path, PathBuf};
 
+use auth_cache::AuthCache;
 use enum_dispatch::enum_dispatch;
 use flox_config::{Config, FLOX_CONFIG_FILE, TokenStorageMode};
 use flox_rust_sdk::flox::Flox;
 use flox_rust_sdk::models::floxmeta::FLOXHUB_TOKEN_ENV_VAR;
+use floxhub_client::AuthContext;
 use indoc::indoc;
-pub use keyring::KeyringStore;
-pub use mock::MockStore;
-pub use plaintext::PlaintextStore;
+use keyring::KeyringStore;
+use mock::MockStore;
+use plaintext::PlaintextStore;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use url::Url;
 
 use crate::utils::message;
 
-/// Errors returned by a [CredentialStore].
+/// Errors from credential storage operations.
 ///
 /// Per the project conventions, credential redaction and backend-availability
 /// classification belong here rather than at call sites. The underlying writes
@@ -78,7 +72,7 @@ pub enum CredentialStoreError {
     #[error("the OS keyring is disabled")]
     Disabled,
 
-    /// An error injected by [MockStore] for testing.
+    /// An error injected by `MockStore` for testing.
     #[error("{0}")]
     Mock(String),
 }
@@ -137,7 +131,7 @@ impl CredentialSource {
 
 /// Storage backend for the FloxHub auth token.
 #[enum_dispatch]
-pub trait CredentialStore {
+trait CredentialStore {
     /// Return the stored token, or `None` when this backend has no token.
     fn get(&self) -> Result<Option<String>, CredentialStoreError>;
     /// Store `token`, replacing any previously stored value.
@@ -149,7 +143,7 @@ pub trait CredentialStore {
 /// The concrete credential backends.
 #[enum_dispatch(CredentialStore)]
 #[derive(Debug, Clone)]
-pub enum CredentialStoreImpl {
+enum CredentialStoreImpl {
     /// OS-native encrypted credential store (macOS Keychain / Linux Secret
     /// Service), keyed by the FloxHub base URL.
     Keyring(KeyringStore),
@@ -159,67 +153,68 @@ pub enum CredentialStoreImpl {
     Mock(MockStore),
 }
 
-/// Where a freshly-logged-in token was written.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// The storage backend for a persistent credential.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum TokenStorage {
     /// Stored in the OS keyring.
     Keyring,
-    /// Stored in the plaintext `flox.toml` file (the fallback).
+    /// Stored in plaintext configuration, explicitly or as a keyring fallback.
     Plaintext,
 }
 
-/// What the upstream resolver did, so the caller can emit the right message.
+/// A storage migration to report to the user.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ResolveOutcome {
-    /// An existing plaintext token was moved into the keyring and removed from
-    /// the plaintext file. The caller emits the one-time migration note.
+pub enum CredentialMigration {
+    /// The plaintext token was moved into the keyring.
     Migrated,
-    /// The token was written to the keyring, but the plaintext copy could not be
-    /// removed (e.g. an unwritable `flox.toml`). The keyring now holds the token,
-    /// but the plaintext secret lingers and shadows it (user file > keyring), so
-    /// the caller warns the user rather than letting this fail silently.
-    MigratedButPlaintextRemains,
-    /// `config.flox.floxhub_token` was empty and was populated from the keyring.
-    PopulatedFromKeyring,
-    /// Nothing changed (env/system token present, no plaintext to migrate, or
-    /// the keyring is empty).
-    Unchanged,
+    /// The keyring write succeeded, but the plaintext copy could not be removed.
+    PlaintextRemains,
 }
 
-/// The keyring + plaintext credential-store pair for a single FloxHub instance.
+/// Ready-to-use authentication and any migration notice for this invocation.
+#[derive(Debug, Clone)]
+pub struct AuthResolution {
+    pub context: AuthContext,
+    pub migration: Option<CredentialMigration>,
+}
+
+/// Credential storage and its non-secret cache for one FloxHub instance.
 ///
-/// The two backends are derived once from the FloxHub base URL and the user
-/// config directory, then shared by every credential operation — login,
-/// logout, `status`, and the startup resolver — so the inputs have a single
-/// derivation point and no call site rebuilds its own bare stores.
+/// Startup, login, and logout coordinate credentials and their cached identity
+/// here. Callers use the resulting [AuthContext] and report storage notices.
 #[derive(Debug, Clone)]
 pub struct CredentialStores {
     keyring: CredentialStoreImpl,
     plaintext: CredentialStoreImpl,
+    cache: AuthCache,
     /// The user config directory, retained for user-facing messages that name
     /// the plaintext file path.
     config_dir: PathBuf,
 }
 
 impl CredentialStores {
-    /// Build the store pair from the FloxHub base URL and the user config
-    /// directory.
+    /// Build storage and caching from the FloxHub URL and CLI directories.
     ///
     /// Used at startup, before a [Flox] exists; [Self::from_flox] is the
     /// convenience for the command handlers that already hold one.
-    pub fn new(floxhub_url: &Url, config_dir: impl Into<PathBuf>) -> Self {
+    pub fn new(
+        floxhub_url: &Url,
+        config_dir: impl Into<PathBuf>,
+        cache_dir: impl AsRef<Path>,
+    ) -> Self {
         let config_dir = config_dir.into();
         Self {
             keyring: CredentialStoreImpl::Keyring(KeyringStore::new(floxhub_url)),
             plaintext: CredentialStoreImpl::Plaintext(PlaintextStore::new(config_dir.clone())),
+            cache: AuthCache::new(cache_dir, floxhub_url),
             config_dir,
         }
     }
 
-    /// Build the store pair from a [Flox], using its FloxHub base URL and
-    /// config directory.
+    /// Build storage and caching for an existing [Flox].
     pub fn from_flox(flox: &Flox) -> Self {
-        Self::new(flox.floxhub.base_url(), &flox.config_dir)
+        Self::new(flox.floxhub.base_url(), &flox.config_dir, &flox.cache_dir)
     }
 
     /// Path to the plaintext `flox.toml`, for user-facing messages about where
@@ -230,20 +225,12 @@ impl CredentialStores {
 
     /// Determine where the active FloxHub credential comes from.
     ///
-    /// Pure: no migration or other side effects. Shared by the startup resolver
-    /// and `flox auth status`.
+    /// Read-only, but may access the keyring. Used by logout and auth status.
     ///
-    /// Precedence: `FLOX_FLOXHUB_TOKEN` env > user-file plaintext > keyring >
-    /// system config > none.
-    ///
-    /// The keyring branch is value-aware: the keyring is the source only when
-    /// the merged `config.flox.floxhub_token` is empty (the resolver would
-    /// populate it from the keyring) or equals the keyring entry (the resolver
-    /// already did). A non-empty merged token that differs from the keyring
-    /// entry is not being read from the keyring at all — it came from
-    /// `/etc/flox.toml` — and must report `SystemConfig` even when the keyring
-    /// also holds an unrelated entry, so messaging about a system-supplied
-    /// token never points at the user's saved keyring credential.
+    /// Environment and user-file tokens are identified first. Otherwise, a
+    /// keyring entry is reported only if the merged token is absent or matches
+    /// it. A differing configured token comes from the system configuration,
+    /// so messages must not point at an unrelated saved keyring credential.
     pub fn probe_source(&self, config: &Config) -> CredentialSource {
         let env_token = std::env::var(FLOXHUB_TOKEN_ENV_VAR).ok();
         if env_token.is_some_and(|t| !t.is_empty()) {
@@ -276,6 +263,23 @@ impl CredentialStores {
         CredentialSource::None
     }
 
+    /// Persist a bearer credential and its resolved identity.
+    ///
+    /// Cache writes are best effort and happen only after credential storage
+    /// succeeds. The returned backend lets the caller explain plaintext storage.
+    pub fn persist_login(
+        &self,
+        context: &AuthContext,
+        target: TokenStorageMode,
+    ) -> Result<TokenStorage, CredentialStoreError> {
+        let token = context
+            .token_secret()
+            .expect("login completes with a bearer credential");
+        let storage = self.persist_login_token(token, target)?;
+        self.cache.write(context, storage);
+        Ok(storage)
+    }
+
     /// Persist a logged-in token according to `target`.
     ///
     /// `Keyring`: attempt the keyring first (try-then-confirm); on success
@@ -284,7 +288,7 @@ impl CredentialStores {
     /// plaintext file (`0600`). `Plaintext`: write the plaintext file and drop
     /// any existing keyring entry (best effort). The returned [TokenStorage]
     /// tells the caller whether to warn the user.
-    pub fn persist_login_token(
+    fn persist_login_token(
         &self,
         token: &str,
         target: TokenStorageMode,
@@ -326,114 +330,121 @@ impl CredentialStores {
         Ok(TokenStorage::Plaintext)
     }
 
-    /// Resolve the FloxHub credential for this invocation: opportunistically
-    /// migrate an existing plaintext token into the keyring, and populate
-    /// `config.flox.floxhub_token` from the keyring when the merged config
-    /// supplied no token.
+    /// Prepare bearer authentication, including storage migration and caching.
     ///
-    /// This is the single upstream resolution step (Q8, Option C): both the loud
-    /// `resolve_auth_context` and the silent `init_floxhub_client` read the same
-    /// field, so resolving it once here lets both see the keyring value with no
-    /// change to their internals.
-    ///
-    /// The caller gates this on "Auth0 mode, outside the prompt/hook flow": in
-    /// other modes (e.g. Kerberos) the token is not used for authentication, so
-    /// a legacy `floxhub_token` left in `flox.toml` must not be silently moved or
-    /// read, and the prompt/hook flow does no keyring I/O. This method assumes
-    /// that gate has already passed and performs the I/O unconditionally.
-    ///
-    /// Migration (additive over Phase 2) runs only when all of these hold, so it
-    /// is correct rather than merely convenient:
-    /// - `FLOX_FLOXHUB_TOKEN` is not present in the environment — a transient
-    ///   CI token is never persisted, and an explicit *empty* export (used to
-    ///   mask saved credentials for one invocation) blocks the stores entirely.
-    /// - the *user file* (`PlaintextStore::get`) holds a token — the system
-    ///   `/etc/flox.toml` token never appears here, so it is never migrated.
-    /// - the storage preference (`config.flox.floxhub_token_storage`) is
-    ///   `Keyring` — when the user has chosen plain-text storage, a plaintext
-    ///   token is left in place rather than moved.
-    ///
-    /// The migration moves the token store-to-store only; it never writes
-    /// `config.flox.floxhub_token`. The merge already populated that field with
-    /// the user-file value, and rewriting it would corrupt precedence in the
-    /// env-unset / system-token edge case (where the user-file token differs from
-    /// the merged system token) and would disturb the loud/silent dual-parse this
-    /// same invocation performs.
-    ///
-    /// On any keyring failure the plaintext file is left untouched: no data loss,
-    /// no migration. Precedence is otherwise preserved by only consulting the
-    /// keyring for a *read* when the merged value (env > user file > system) is
-    /// empty.
-    pub fn resolve_into(&self, config: &mut Config) -> ResolveOutcome {
-        // Any explicit `FLOX_FLOXHUB_TOKEN` — including an *empty* export used
-        // to mask saved credentials for one invocation — takes precedence over
-        // both stores: never migrate the plaintext token, and never populate
-        // the config from the keyring. Presence is what matters here; whether
-        // the value is a usable token is validated downstream.
-        if std::env::var(FLOXHUB_TOKEN_ENV_VAR).is_ok() {
-            return ResolveOutcome::Unchanged;
-        }
-
-        // Opportunistic migration: only the user-file token is eligible, and
-        // only when the standing preference is keyring storage — a chosen
-        // plain-text token is left in place rather than moved. Probe the
-        // plaintext file directly (provenance-aware) rather than trusting the
-        // merged config field, which may hold a system token instead.
-        if config.flox.floxhub_token_storage == TokenStorageMode::Keyring
-            && let Ok(Some(token)) = self.plaintext.get()
-        {
-            // Try-then-confirm: only after the keyring write succeeds do we
-            // remove the plaintext token. On any keyring failure the plaintext
-            // file is left exactly as it was.
-            if self.keyring.set(&token).is_ok() {
-                return match self.plaintext.remove() {
-                    Ok(()) => ResolveOutcome::Migrated,
-                    // The keyring now holds the token, so this is not a no-op: do
-                    // not return `Unchanged` (which would be silent and re-attempt
-                    // every command). Report the partial migration so the caller
-                    // warns; the lingering plaintext token still shadows the
-                    // keyring.
-                    Err(e) => {
-                        tracing::warn!(
-                            error = %e,
-                            "could not remove the plaintext credential after migrating it to the keyring"
-                        );
-                        ResolveOutcome::MigratedButPlaintextRemains
-                    },
-                };
-            }
-            return ResolveOutcome::Unchanged;
-        }
-
-        if config
+    /// Call only in token-auth mode and outside prompt hooks. An explicit
+    /// environment override, including an empty one, bypasses both secret stores.
+    /// Only user-file tokens are eligible for migration; the merged configuration
+    /// is never rewritten. Keyring reads are deferred when a usable record exists.
+    pub fn resolve(&self, config: &Config) -> AuthResolution {
+        let token = config
             .flox
             .floxhub_token
             .as_deref()
-            .is_some_and(|t| !t.is_empty())
+            .filter(|token| !token.is_empty());
+        let configured = || AuthContext::new_from_token(token);
+
+        if std::env::var(FLOXHUB_TOKEN_ENV_VAR).is_ok() {
+            return AuthResolution {
+                context: self.cache.configure(configured(), TokenStorage::Plaintext),
+                migration: None,
+            };
+        }
+
+        if config.flox.floxhub_token_storage == TokenStorageMode::Keyring
+            && let Ok(Some(token)) = self.plaintext.get()
         {
-            return ResolveOutcome::Unchanged;
+            let migration = self.migrate_plaintext(&token);
+            let storage = if migration.is_some() {
+                TokenStorage::Keyring
+            } else {
+                TokenStorage::Plaintext
+            };
+            let context = self.cache.configure(configured(), storage);
+            if migration.is_some() {
+                self.cache.write(&context, storage);
+            }
+            return AuthResolution { context, migration };
         }
 
-        if let Ok(Some(token)) = self.keyring.get() {
-            config.flox.floxhub_token = Some(token);
-            return ResolveOutcome::PopulatedFromKeyring;
+        let context = if token.is_some() {
+            self.cache.configure(configured(), TokenStorage::Plaintext)
+        } else {
+            self.defer_to_keyring()
+        };
+        AuthResolution {
+            context,
+            migration: None,
         }
+    }
 
-        ResolveOutcome::Unchanged
+    fn migrate_plaintext(&self, token: &str) -> Option<CredentialMigration> {
+        // Confirm the keyring write before removing the only persistent copy.
+        self.keyring.set(token).ok()?;
+        Some(match self.plaintext.remove() {
+            Ok(()) => CredentialMigration::Migrated,
+            Err(err) => {
+                tracing::warn!(
+                    error = %err,
+                    "could not remove the plaintext credential after migrating it to the keyring"
+                );
+                CredentialMigration::PlaintextRemains
+            },
+        })
+    }
+
+    /// A keyring record can answer startup checks without reading the secret.
+    /// On a miss, read immediately so the context describes actual credentials.
+    fn defer_to_keyring(&self) -> AuthContext {
+        let cache = &self.cache;
+        let keyring = self.keyring.clone();
+        let cache_for_resolver = cache.clone();
+        let read_keyring = move || {
+            let token = match keyring.get() {
+                Ok(token) => token,
+                Err(err) => {
+                    tracing::debug!(error = %err, "could not read the credential from the keyring");
+                    // A failed read says nothing about the stored credential.
+                    // Retry next invocation instead of caching a logged-out state.
+                    cache_for_resolver.remove();
+                    return AuthContext::default();
+                },
+            };
+            let context = cache_for_resolver.configure(
+                AuthContext::new_from_token(token.as_deref()),
+                TokenStorage::Keyring,
+            );
+            cache_for_resolver.write(&context, TokenStorage::Keyring);
+            context
+        };
+
+        cache.defer_or_resolve(read_keyring)
+    }
+
+    /// Clear saved authentication and report the source that was active.
+    ///
+    /// Invalidate the record even when no credential remains or removal fails.
+    /// Environment and system-config tokens are not removed; the caller uses
+    /// the returned source to explain how to finish logging out.
+    pub fn logout(&self, config: &Config) -> Result<CredentialSource, CredentialStoreError> {
+        let source = self.probe_source(config);
+        self.cache.remove();
+        if source != CredentialSource::None {
+            self.remove_all()?;
+        }
+        Ok(source)
     }
 
     /// Remove the token from both stores, for logout.
     ///
-    /// The resolver may have populated the token from the keyring, and a
-    /// plaintext token may also linger from before migration, so both are
-    /// cleared. Both removals are idempotent, so this succeeds when nothing is
-    /// stored.
+    /// A plaintext token may linger alongside a keyring credential, so both
+    /// stores are cleared. Both removals are idempotent.
     ///
     /// Both removals are always attempted: a keyring platform error (e.g. a
     /// locked Secret Service session) must not short-circuit logout and leave
     /// the plaintext secret on disk. A plaintext failure is reported first —
     /// that is the copy sitting in a file.
-    pub fn remove_all(&self) -> Result<(), CredentialStoreError> {
+    fn remove_all(&self) -> Result<(), CredentialStoreError> {
         let keyring_result = self.keyring.remove();
         self.plaintext.remove()?;
         keyring_result
@@ -462,21 +473,33 @@ pub(crate) mod test_helpers {
 mod tests {
     use std::env;
 
+    use floxhub_client::auth::storage::{AuthContextStorageExt, CachedFacts};
     use pretty_assertions::assert_eq;
+    use tempfile::TempDir;
 
     use super::test_helpers::{TOKEN, write_flox_toml};
     use super::*;
+
+    /// The FloxHub instance the deferred-resolution tests key their record on.
+    fn test_account() -> Url {
+        Url::parse("https://hub.flox.dev").unwrap()
+    }
 
     impl CredentialStores {
         /// Assemble the pair from arbitrary backends (typically [MockStore]) so
         /// the orchestration methods can be exercised without a real keyring or
         /// FloxHub URL. `config_dir` is left empty because these tests do not
         /// exercise the path-bearing messages.
-        fn from_stores(keyring: CredentialStoreImpl, plaintext: CredentialStoreImpl) -> Self {
+        fn from_stores(
+            keyring: CredentialStoreImpl,
+            plaintext: CredentialStoreImpl,
+            cache_dir: &Path,
+        ) -> Self {
             Self {
                 keyring,
                 plaintext,
                 config_dir: PathBuf::new(),
+                cache: AuthCache::new(cache_dir, &test_account()),
             }
         }
     }
@@ -518,7 +541,8 @@ mod tests {
                 let plaintext =
                     CredentialStoreImpl::Plaintext(PlaintextStore::new(user_dir.path()));
                 let keyring = CredentialStoreImpl::Mock(MockStore::new());
-                let stores = CredentialStores::from_stores(keyring, plaintext);
+                let cache_dir = TempDir::new().unwrap();
+                let stores = CredentialStores::from_stores(keyring, plaintext, cache_dir.path());
                 assert_eq!(stores.probe_source(&config), CredentialSource::None);
                 unsafe { env::remove_var("FLOX_CONFIG_DIR") };
             },
@@ -546,7 +570,8 @@ mod tests {
                 let plaintext =
                     CredentialStoreImpl::Plaintext(PlaintextStore::new(user_dir.path()));
                 let keyring = CredentialStoreImpl::Mock(MockStore::new());
-                let stores = CredentialStores::from_stores(keyring, plaintext);
+                let cache_dir = TempDir::new().unwrap();
+                let stores = CredentialStores::from_stores(keyring, plaintext, cache_dir.path());
                 assert_eq!(stores.probe_source(&config), CredentialSource::Env);
                 unsafe { env::remove_var("FLOX_CONFIG_DIR") };
             },
@@ -568,7 +593,8 @@ mod tests {
                 let plaintext =
                     CredentialStoreImpl::Plaintext(PlaintextStore::new(user_dir.path()));
                 let keyring = CredentialStoreImpl::Mock(MockStore::new());
-                let stores = CredentialStores::from_stores(keyring, plaintext);
+                let cache_dir = TempDir::new().unwrap();
+                let stores = CredentialStores::from_stores(keyring, plaintext, cache_dir.path());
                 assert_eq!(
                     stores.probe_source(&config),
                     CredentialSource::UserConfigPlaintext
@@ -600,7 +626,8 @@ mod tests {
                     CredentialStoreImpl::Plaintext(PlaintextStore::new(user_dir.path()));
                 assert_eq!(plaintext.get().unwrap(), None);
                 let keyring = CredentialStoreImpl::Mock(MockStore::new());
-                let stores = CredentialStores::from_stores(keyring, plaintext);
+                let cache_dir = TempDir::new().unwrap();
+                let stores = CredentialStores::from_stores(keyring, plaintext, cache_dir.path());
                 assert_eq!(stores.probe_source(&config), CredentialSource::SystemConfig);
                 unsafe { env::remove_var("FLOX_CONFIG_DIR") };
             },
@@ -626,28 +653,26 @@ mod tests {
                     CredentialStoreImpl::Plaintext(PlaintextStore::new(user_dir.path()));
                 let keyring = CredentialStoreImpl::Mock(MockStore::new());
                 keyring.set(TOKEN).unwrap();
-                let stores = CredentialStores::from_stores(keyring, plaintext);
+                let cache_dir = TempDir::new().unwrap();
+                let stores = CredentialStores::from_stores(keyring, plaintext, cache_dir.path());
                 assert_eq!(stores.probe_source(&config), CredentialSource::Keyring);
                 unsafe { env::remove_var("FLOX_CONFIG_DIR") };
             },
         );
     }
 
-    /// Reproduce the real `status` call order: the resolver populates
-    /// `config.flox.floxhub_token` from the keyring, then `probe` runs on that
-    /// mutated config. The keyring branch must win over the `SystemConfig`
-    /// inference — otherwise a keyring-sourced token misreports as system
-    /// config. (`Config::parse()` is unnecessary here: the resolver works on
-    /// the merged field directly, which is what the bug hinges on.)
+    /// Source probing recognizes a keyring credential even though resolution
+    /// leaves it out of the merged configuration.
     #[test]
     fn probe_after_resolver_reports_keyring_not_system_config() {
         let keyring = CredentialStoreImpl::Mock(MockStore::new());
         keyring.set(TOKEN).unwrap();
         let plaintext = CredentialStoreImpl::Mock(MockStore::new());
-        let stores = CredentialStores::from_stores(keyring, plaintext);
+        let cache_dir = TempDir::new().unwrap();
+        let stores = CredentialStores::from_stores(keyring, plaintext, cache_dir.path());
 
-        let mut config = config_with_token(None);
-        stores.resolve_into(&mut config);
+        let config = config_with_token(None);
+        stores.resolve(&config);
 
         assert_eq!(stores.probe_source(&config), CredentialSource::Keyring);
     }
@@ -662,12 +687,14 @@ mod tests {
             let keyring = CredentialStoreImpl::Mock(MockStore::new());
             keyring.set("keyring-token").unwrap();
             let plaintext = CredentialStoreImpl::Mock(MockStore::new());
-            let stores = CredentialStores::from_stores(keyring.clone(), plaintext);
+            let cache_dir = TempDir::new().unwrap();
+            let stores =
+                CredentialStores::from_stores(keyring.clone(), plaintext, cache_dir.path());
 
             // Mirror the merge: the system config supplied the (invalid) token,
             // and the resolver leaves a non-empty merged token untouched.
-            let mut config = config_with_token(Some("invalid-system-token"));
-            assert_eq!(stores.resolve_into(&mut config), ResolveOutcome::Unchanged);
+            let config = config_with_token(Some("invalid-system-token"));
+            assert_eq!(stores.resolve(&config).migration, None);
 
             let source = stores.probe_source(&config);
             assert_eq!(source, CredentialSource::SystemConfig);
@@ -687,7 +714,9 @@ mod tests {
 
         let keyring = CredentialStoreImpl::Mock(MockStore::new());
         let plaintext = CredentialStoreImpl::Plaintext(PlaintextStore::new(dir.path()));
-        let stores = CredentialStores::from_stores(keyring.clone(), plaintext.clone());
+        let cache_dir = TempDir::new().unwrap();
+        let stores =
+            CredentialStores::from_stores(keyring.clone(), plaintext.clone(), cache_dir.path());
 
         let storage = stores
             .persist_login_token(TOKEN, TokenStorageMode::Keyring)
@@ -707,7 +736,9 @@ mod tests {
         keyring_mock.set_error("no backend");
         let keyring = CredentialStoreImpl::Mock(keyring_mock);
         let plaintext = CredentialStoreImpl::Plaintext(PlaintextStore::new(dir.path()));
-        let stores = CredentialStores::from_stores(keyring.clone(), plaintext.clone());
+        let cache_dir = TempDir::new().unwrap();
+        let stores =
+            CredentialStores::from_stores(keyring.clone(), plaintext.clone(), cache_dir.path());
 
         let storage = stores
             .persist_login_token(TOKEN, TokenStorageMode::Keyring)
@@ -728,7 +759,8 @@ mod tests {
         let plaintext_mock = MockStore::new();
         plaintext_mock.set_error("config file is unreadable");
         let plaintext = CredentialStoreImpl::Mock(plaintext_mock);
-        let stores = CredentialStores::from_stores(keyring.clone(), plaintext);
+        let cache_dir = TempDir::new().unwrap();
+        let stores = CredentialStores::from_stores(keyring.clone(), plaintext, cache_dir.path());
 
         let storage = stores
             .persist_login_token(TOKEN, TokenStorageMode::Keyring)
@@ -745,7 +777,9 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let keyring = CredentialStoreImpl::Mock(MockStore::new());
         let plaintext = CredentialStoreImpl::Plaintext(PlaintextStore::new(dir.path()));
-        let stores = CredentialStores::from_stores(keyring.clone(), plaintext.clone());
+        let cache_dir = TempDir::new().unwrap();
+        let stores =
+            CredentialStores::from_stores(keyring.clone(), plaintext.clone(), cache_dir.path());
 
         let storage = stores
             .persist_login_token(TOKEN, TokenStorageMode::Plaintext)
@@ -765,7 +799,9 @@ mod tests {
         let keyring = CredentialStoreImpl::Mock(MockStore::new());
         keyring.set("stale-keyring-token").unwrap();
         let plaintext = CredentialStoreImpl::Plaintext(PlaintextStore::new(dir.path()));
-        let stores = CredentialStores::from_stores(keyring.clone(), plaintext.clone());
+        let cache_dir = TempDir::new().unwrap();
+        let stores =
+            CredentialStores::from_stores(keyring.clone(), plaintext.clone(), cache_dir.path());
 
         let storage = stores
             .persist_login_token(TOKEN, TokenStorageMode::Plaintext)
@@ -776,7 +812,7 @@ mod tests {
         assert_eq!(plaintext.get().unwrap(), Some(TOKEN.to_string()));
     }
 
-    // --- CredentialStores::resolve_into: the upstream read resolver ---
+    // --- CredentialStores::resolve: the upstream read resolver ---
 
     fn config_with_token(token: Option<&str>) -> Config {
         let mut config = Config::default();
@@ -784,22 +820,194 @@ mod tests {
         config
     }
 
-    /// When the merged config supplied no token, the keyring value populates it.
+    /// Without a configured token or a record, resolve the keyring credential.
     #[test]
-    fn resolve_populates_token_from_keyring_when_config_empty() {
+    fn resolve_reads_the_keyring_when_config_and_cache_are_empty() {
         temp_env::with_var(FLOXHUB_TOKEN_ENV_VAR, None::<&str>, || {
             let keyring = CredentialStoreImpl::Mock(MockStore::new());
             keyring.set(TOKEN).unwrap();
             // Empty plaintext store: nothing to migrate, so the read path runs.
             let plaintext = CredentialStoreImpl::Mock(MockStore::new());
-            let stores = CredentialStores::from_stores(keyring, plaintext);
+            let cache_dir = TempDir::new().unwrap();
+            let stores = CredentialStores::from_stores(keyring, plaintext, cache_dir.path());
 
-            let mut config = config_with_token(None);
-            let outcome = stores.resolve_into(&mut config);
+            let config = config_with_token(None);
+            let outcome = stores.resolve(&config);
 
-            assert_eq!(outcome, ResolveOutcome::PopulatedFromKeyring);
-            assert_eq!(config.flox.floxhub_token.as_deref(), Some(TOKEN));
+            assert_eq!(
+                (outcome.context.token_secret(), outcome.migration),
+                (Some(TOKEN), None),
+            );
+            assert_eq!(config.flox.floxhub_token.as_deref(), None);
         });
+    }
+
+    #[test]
+    fn keyring_read_failure_is_retried_on_the_next_invocation() {
+        temp_env::with_var(FLOXHUB_TOKEN_ENV_VAR, None::<&str>, || {
+            for cached in [false, true] {
+                let cache_dir = TempDir::new().unwrap();
+                let keyring = MockStore::new();
+                keyring.set(TOKEN).unwrap();
+                keyring.set_error("keyring is locked");
+                let stores = CredentialStores::from_stores(
+                    CredentialStoreImpl::Mock(keyring),
+                    CredentialStoreImpl::Mock(MockStore::new()),
+                    cache_dir.path(),
+                );
+                let expected = AuthContext::new_from_token(Some(TOKEN));
+                if cached {
+                    stores.cache.write(&expected, TokenStorage::Keyring);
+                }
+
+                let failed = stores.resolve(&config_with_token(None)).context;
+                assert_eq!(failed.token_secret(), None);
+                assert_eq!(failed.cached_facts(), AuthContext::default().cached_facts());
+
+                let probe = AuthContext::new_from_token(Some("flox_pat_cache-miss-probe"));
+                assert_eq!(
+                    stores
+                        .cache
+                        .defer_or_resolve(|| {
+                            AuthContext::new_from_token(Some("flox_pat_cache-miss-probe"))
+                        })
+                        .cached_facts(),
+                    probe.cached_facts(),
+                    "a failed read must leave a cache miss"
+                );
+
+                // Startup facts alone must retry, without asking for the secret.
+                let recovered = stores.resolve(&config_with_token(None)).context;
+                assert_eq!(recovered.cached_facts(), expected.cached_facts());
+                assert_eq!(
+                    stores
+                        .cache
+                        .defer_or_resolve(|| panic!("successful read was not cached"))
+                        .cached_facts(),
+                    expected.cached_facts()
+                );
+            }
+        });
+    }
+
+    #[test]
+    fn an_empty_keyring_is_cached_as_logged_out() {
+        temp_env::with_var(FLOXHUB_TOKEN_ENV_VAR, None::<&str>, || {
+            let cache_dir = TempDir::new().unwrap();
+            let stores = CredentialStores::from_stores(
+                CredentialStoreImpl::Mock(MockStore::new()),
+                CredentialStoreImpl::Mock(MockStore::new()),
+                cache_dir.path(),
+            );
+
+            let context = stores.resolve(&config_with_token(None)).context;
+            assert_eq!(
+                context.cached_facts(),
+                AuthContext::default().cached_facts()
+            );
+            assert_eq!(
+                stores
+                    .cache
+                    .defer_or_resolve(|| panic!("empty keyring was not cached"))
+                    .cached_facts(),
+                AuthContext::default().cached_facts()
+            );
+        });
+    }
+
+    /// With nothing recorded, the deferred credential still resolves — the
+    /// keyring is read straight away and the summary recorded, so only the
+    /// first invocation pays.
+    #[test]
+    fn deferring_without_a_record_reads_the_keyring_and_records_it() {
+        let cache_dir = TempDir::new().unwrap();
+        let cache = AuthCache::new(cache_dir.path(), &test_account());
+        let keyring = CredentialStoreImpl::Mock(MockStore::new());
+        keyring.set(TOKEN).unwrap();
+        let stores = CredentialStores::from_stores(
+            keyring,
+            CredentialStoreImpl::Mock(MockStore::new()),
+            cache_dir.path(),
+        );
+
+        let credential = stores.resolve(&config_with_token(None)).context;
+
+        assert_eq!(credential.token_secret(), Some(TOKEN));
+        let recorded =
+            cache.defer_or_resolve(|| panic!("the keyring read should have populated the cache"));
+        assert!(recorded.cached_facts().logged_in);
+        assert_eq!(recorded.cached_facts().expires_at, None);
+        assert_eq!(recorded.user_subject(), None);
+        assert_eq!(
+            recorded.kind(),
+            floxhub_client::CredentialKind::OpaqueToken,
+            "the mock keyring holds an opaque, prefix-less token"
+        );
+    }
+
+    /// With a record in hand the keyring is not touched at all: the recorded
+    /// answer stands even though the store here holds nothing.
+    #[test]
+    fn a_record_answers_without_reading_the_keyring() {
+        let cache_dir = TempDir::new().unwrap();
+        let cache = AuthCache::new(cache_dir.path(), &test_account());
+        cache.write(
+            &AuthContext::deferred(
+                CachedFacts {
+                    logged_in: true,
+                    kind: floxhub_client::CredentialKind::Auth0,
+                    requires_login: true,
+                    subject: Some("auth0|deferred".to_string()),
+                    ..CachedFacts::default()
+                },
+                || panic!("recording cached properties must not resolve the credential"),
+            ),
+            TokenStorage::Keyring,
+        );
+        let stores = CredentialStores::from_stores(
+            CredentialStoreImpl::Mock(MockStore::new()),
+            CredentialStoreImpl::Mock(MockStore::new()),
+            cache_dir.path(),
+        );
+
+        let credential = stores.resolve(&config_with_token(None)).context;
+
+        assert!(!credential.is_unauthenticated());
+        assert_eq!(
+            credential.user_subject(),
+            Some("auth0|deferred".to_string())
+        );
+    }
+
+    #[test]
+    fn a_keyring_read_preserves_matching_plaintext_identity() {
+        let cache_dir = TempDir::new().unwrap();
+        let cache = AuthCache::new(cache_dir.path(), &test_account());
+        let secret = "flox_pat_plaintext-to-keyring";
+        let facts = CachedFacts {
+            handle: Some("migrated-user".into()),
+            subject: Some("account|migrated".into()),
+            ..AuthContext::new_from_token(Some(secret)).cached_facts()
+        };
+        cache.write(
+            &AuthContext::deferred(facts.clone(), || {
+                panic!("recording must not load the credential")
+            }),
+            TokenStorage::Plaintext,
+        );
+        let keyring = CredentialStoreImpl::Mock(MockStore::new());
+        keyring.set(secret).unwrap();
+        let stores = CredentialStores::from_stores(
+            keyring,
+            CredentialStoreImpl::Mock(MockStore::new()),
+            cache_dir.path(),
+        );
+
+        let context = stores.resolve(&config_with_token(None)).context;
+
+        assert_eq!(context.cached_facts(), facts);
+        let next = cache.defer_or_resolve(|| panic!("the record now describes the keyring"));
+        assert_eq!(next.cached_facts(), facts);
     }
 
     /// A non-empty merged token wins: env > user file > system all flow through this
@@ -812,17 +1020,18 @@ mod tests {
             // Empty plaintext store: no migration, so only the read path could
             // touch the config — and it must not, because the token is set.
             let plaintext = CredentialStoreImpl::Mock(MockStore::new());
-            let stores = CredentialStores::from_stores(keyring, plaintext);
+            let cache_dir = TempDir::new().unwrap();
+            let stores = CredentialStores::from_stores(keyring, plaintext, cache_dir.path());
 
-            let mut config = config_with_token(Some("config-token"));
-            let outcome = stores.resolve_into(&mut config);
+            let config = config_with_token(Some("config-token"));
+            let outcome = stores.resolve(&config);
 
-            assert_eq!(outcome, ResolveOutcome::Unchanged);
+            assert_eq!(outcome.migration, None);
             assert_eq!(config.flox.floxhub_token.as_deref(), Some("config-token"));
         });
     }
 
-    // --- CredentialStores::resolve_into: opportunistic plaintext → keyring migration ---
+    // --- CredentialStores::resolve: opportunistic plaintext → keyring migration ---
 
     /// A user-file plaintext token is moved into the keyring and removed from
     /// the file once the keyring write confirms.
@@ -834,13 +1043,15 @@ mod tests {
             let plaintext = CredentialStoreImpl::Plaintext(PlaintextStore::new(dir.path()));
             let keyring = CredentialStoreImpl::Mock(MockStore::new());
 
-            let stores = CredentialStores::from_stores(keyring.clone(), plaintext.clone());
+            let cache_dir = TempDir::new().unwrap();
+            let stores =
+                CredentialStores::from_stores(keyring.clone(), plaintext.clone(), cache_dir.path());
 
             // Mirror the merge: the user-file token is already in the config.
-            let mut config = config_with_token(Some(TOKEN));
-            let outcome = stores.resolve_into(&mut config);
+            let config = config_with_token(Some(TOKEN));
+            let outcome = stores.resolve(&config);
 
-            assert_eq!(outcome, ResolveOutcome::Migrated);
+            assert_eq!(outcome.migration, Some(CredentialMigration::Migrated));
             assert_eq!(keyring.get().unwrap(), Some(TOKEN.to_string()));
             assert_eq!(plaintext.get().unwrap(), None);
             // Migration is store-to-store only: the config field is left as the
@@ -859,13 +1070,15 @@ mod tests {
             write_flox_toml(dir.path(), &format!("floxhub_token = \"{TOKEN}\"\n"));
             let plaintext = CredentialStoreImpl::Plaintext(PlaintextStore::new(dir.path()));
             let keyring = CredentialStoreImpl::Mock(MockStore::new());
-            let stores = CredentialStores::from_stores(keyring.clone(), plaintext.clone());
+            let cache_dir = TempDir::new().unwrap();
+            let stores =
+                CredentialStores::from_stores(keyring.clone(), plaintext.clone(), cache_dir.path());
 
             let mut config = config_with_token(Some(TOKEN));
             config.flox.floxhub_token_storage = TokenStorageMode::Plaintext;
-            let outcome = stores.resolve_into(&mut config);
+            let outcome = stores.resolve(&config);
 
-            assert_eq!(outcome, ResolveOutcome::Unchanged);
+            assert_eq!(outcome.migration, None);
             assert_eq!(keyring.get().unwrap(), None);
             assert_eq!(plaintext.get().unwrap(), Some(TOKEN.to_string()));
         });
@@ -881,12 +1094,14 @@ mod tests {
             let plaintext = CredentialStoreImpl::Plaintext(PlaintextStore::new(dir.path()));
             let keyring = CredentialStoreImpl::Mock(MockStore::new());
 
-            let stores = CredentialStores::from_stores(keyring.clone(), plaintext.clone());
+            let cache_dir = TempDir::new().unwrap();
+            let stores =
+                CredentialStores::from_stores(keyring.clone(), plaintext.clone(), cache_dir.path());
 
-            let mut config = config_with_token(Some("env-token"));
-            let outcome = stores.resolve_into(&mut config);
+            let config = config_with_token(Some("env-token"));
+            let outcome = stores.resolve(&config);
 
-            assert_eq!(outcome, ResolveOutcome::Unchanged);
+            assert_eq!(outcome.migration, None);
             assert_eq!(keyring.get().unwrap(), None);
             assert_eq!(plaintext.get().unwrap(), Some(TOKEN.to_string()));
         });
@@ -903,14 +1118,16 @@ mod tests {
             keyring.set("keyring-token").unwrap();
             let plaintext = CredentialStoreImpl::Mock(MockStore::new());
             plaintext.set(TOKEN).unwrap();
-            let stores = CredentialStores::from_stores(keyring.clone(), plaintext.clone());
+            let cache_dir = TempDir::new().unwrap();
+            let stores =
+                CredentialStores::from_stores(keyring.clone(), plaintext.clone(), cache_dir.path());
 
             // Mirror the merge: the empty env override yields an empty merged
             // token.
-            let mut config = config_with_token(Some(""));
-            let outcome = stores.resolve_into(&mut config);
+            let config = config_with_token(Some(""));
+            let outcome = stores.resolve(&config);
 
-            assert_eq!(outcome, ResolveOutcome::Unchanged);
+            assert_eq!(outcome.migration, None);
             // No migration: both stores are exactly as they were.
             assert_eq!(keyring.get().unwrap(), Some("keyring-token".to_string()));
             assert_eq!(plaintext.get().unwrap(), Some(TOKEN.to_string()));
@@ -932,12 +1149,14 @@ mod tests {
             // migration branch never calls `keyring.get()` first.
             keyring_mock.set_error("no backend");
             let keyring = CredentialStoreImpl::Mock(keyring_mock);
-            let stores = CredentialStores::from_stores(keyring.clone(), plaintext.clone());
+            let cache_dir = TempDir::new().unwrap();
+            let stores =
+                CredentialStores::from_stores(keyring.clone(), plaintext.clone(), cache_dir.path());
 
-            let mut config = config_with_token(Some(TOKEN));
-            let outcome = stores.resolve_into(&mut config);
+            let config = config_with_token(Some(TOKEN));
+            let outcome = stores.resolve(&config);
 
-            assert_eq!(outcome, ResolveOutcome::Unchanged);
+            assert_eq!(outcome.migration, None);
             assert_eq!(keyring.get().unwrap(), None);
             assert_eq!(plaintext.get().unwrap(), Some(TOKEN.to_string()));
         });
@@ -945,8 +1164,7 @@ mod tests {
 
     /// Keyring write succeeds but the plaintext removal fails (e.g. an unwritable
     /// `flox.toml`). The token is now in the keyring, but the plaintext copy
-    /// lingers, so the resolver reports `MigratedButPlaintextRemains` (not a
-    /// silent `Unchanged`) and the caller warns instead of looping silently.
+    /// lingers, so the caller must report the incomplete migration.
     #[test]
     fn resolve_reports_plaintext_remains_when_remove_fails_after_keyring_write() {
         temp_env::with_var(FLOXHUB_TOKEN_ENV_VAR, None::<&str>, || {
@@ -955,12 +1173,17 @@ mod tests {
             plaintext_mock.set_remove_error("flox.toml is not writable");
             let plaintext = CredentialStoreImpl::Mock(plaintext_mock);
             let keyring = CredentialStoreImpl::Mock(MockStore::new());
-            let stores = CredentialStores::from_stores(keyring.clone(), plaintext.clone());
+            let cache_dir = TempDir::new().unwrap();
+            let stores =
+                CredentialStores::from_stores(keyring.clone(), plaintext.clone(), cache_dir.path());
 
-            let mut config = config_with_token(Some(TOKEN));
-            let outcome = stores.resolve_into(&mut config);
+            let config = config_with_token(Some(TOKEN));
+            let outcome = stores.resolve(&config);
 
-            assert_eq!(outcome, ResolveOutcome::MigratedButPlaintextRemains);
+            assert_eq!(
+                outcome.migration,
+                Some(CredentialMigration::PlaintextRemains)
+            );
             // The keyring received the token; the plaintext copy still lingers.
             assert_eq!(keyring.get().unwrap(), Some(TOKEN.to_string()));
             assert_eq!(plaintext.get().unwrap(), Some(TOKEN.to_string()));
@@ -968,6 +1191,161 @@ mod tests {
     }
 
     // --- CredentialStores::remove_all: logout removal ---
+
+    #[test]
+    fn logout_drops_stale_identity_when_credentials_are_already_gone() {
+        temp_env::with_var(FLOXHUB_TOKEN_ENV_VAR, None::<&str>, || {
+            let cache_dir = TempDir::new().unwrap();
+            let stores = CredentialStores::from_stores(
+                CredentialStoreImpl::Mock(MockStore::new()),
+                CredentialStoreImpl::Mock(MockStore::new()),
+                cache_dir.path(),
+            );
+            stores.cache.write(
+                &AuthContext::new_from_token(Some(TOKEN)),
+                TokenStorage::Keyring,
+            );
+
+            let source = stores.logout(&config_with_token(None)).unwrap();
+
+            assert_eq!(
+                (
+                    source,
+                    stores
+                        .cache
+                        .defer_or_resolve(AuthContext::default)
+                        .cached_facts()
+                ),
+                (
+                    CredentialSource::None,
+                    AuthContext::default().cached_facts()
+                ),
+            );
+        });
+    }
+
+    #[test]
+    fn logout_invalidates_identity_even_when_a_store_cannot_be_cleared() {
+        temp_env::with_var(FLOXHUB_TOKEN_ENV_VAR, None::<&str>, || {
+            for failing_store in [TokenStorage::Keyring, TokenStorage::Plaintext] {
+                let cache_dir = TempDir::new().unwrap();
+                let keyring = MockStore::new();
+                let plaintext = MockStore::new();
+                keyring.set(TOKEN).unwrap();
+                plaintext.set(TOKEN).unwrap();
+                match failing_store {
+                    TokenStorage::Keyring => keyring.set_remove_error("keyring is locked"),
+                    TokenStorage::Plaintext => plaintext.set_remove_error("config is read-only"),
+                }
+                let stores = CredentialStores::from_stores(
+                    CredentialStoreImpl::Mock(keyring.clone()),
+                    CredentialStoreImpl::Mock(plaintext.clone()),
+                    cache_dir.path(),
+                );
+                stores.cache.write(
+                    &AuthContext::new_from_token(Some(TOKEN)),
+                    TokenStorage::Keyring,
+                );
+
+                let result = stores.logout(&config_with_token(Some(TOKEN)));
+
+                assert_eq!(
+                    (
+                        result.is_err(),
+                        keyring.get().unwrap(),
+                        plaintext.get().unwrap(),
+                        stores
+                            .cache
+                            .defer_or_resolve(AuthContext::default)
+                            .cached_facts(),
+                    ),
+                    (
+                        true,
+                        (failing_store == TokenStorage::Keyring).then(|| TOKEN.to_string()),
+                        (failing_store == TokenStorage::Plaintext).then(|| TOKEN.to_string()),
+                        AuthContext::default().cached_facts(),
+                    ),
+                );
+            }
+        });
+    }
+
+    #[test]
+    fn failed_login_preserves_the_previous_identity_record() {
+        let cache_dir = TempDir::new().unwrap();
+        let keyring = MockStore::new();
+        let plaintext = MockStore::new();
+        keyring.set_error("keyring is locked");
+        plaintext.set_error("config is read-only");
+        let stores = CredentialStores::from_stores(
+            CredentialStoreImpl::Mock(keyring),
+            CredentialStoreImpl::Mock(plaintext),
+            cache_dir.path(),
+        );
+        let previous = AuthContext::new_from_token(Some(TOKEN));
+        stores.cache.write(&previous, TokenStorage::Keyring);
+
+        let result = stores.persist_login(
+            &AuthContext::new_from_token(Some("flox_pat_cannot-save")),
+            TokenStorageMode::Keyring,
+        );
+
+        assert_eq!(
+            (
+                result.is_err(),
+                stores
+                    .cache
+                    .defer_or_resolve(AuthContext::default)
+                    .cached_facts()
+            ),
+            (true, previous.cached_facts()),
+        );
+    }
+
+    #[test]
+    fn migration_returns_cached_identity_and_records_the_keyring_backend() {
+        temp_env::with_var(FLOXHUB_TOKEN_ENV_VAR, None::<&str>, || {
+            let cache_dir = TempDir::new().unwrap();
+            let stores = CredentialStores::from_stores(
+                CredentialStoreImpl::Mock(MockStore::new()),
+                CredentialStoreImpl::Mock(MockStore::new()),
+                cache_dir.path(),
+            );
+            let secret = "flox_pat_migration-with-identity";
+            let context = AuthContext::new_from_token(Some(secret));
+            let facts = CachedFacts {
+                handle: Some("migration-user".into()),
+                subject: Some("account|migration".into()),
+                ..context.cached_facts()
+            };
+            context.seed_from(&facts);
+            stores
+                .persist_login(&context, TokenStorageMode::Plaintext)
+                .unwrap();
+
+            let resolved = stores.resolve(&config_with_token(Some(secret)));
+
+            assert_eq!(
+                (
+                    resolved.context.cached_facts(),
+                    resolved.migration,
+                    stores.keyring.get().unwrap(),
+                    stores.plaintext.get().unwrap(),
+                    stores
+                        .cache
+                        .defer_or_resolve(|| panic!("migration must record keyring state"))
+                        .cached_facts(),
+                ),
+                (
+                    facts.clone(),
+                    Some(CredentialMigration::Migrated),
+                    Some(secret.to_string()),
+                    None,
+                    facts,
+                ),
+            );
+        });
+    }
 
     /// A keyring platform failure (e.g. a locked Secret Service session) must
     /// not short-circuit logout: the plaintext token is still removed, and the
@@ -979,7 +1357,8 @@ mod tests {
         let keyring = CredentialStoreImpl::Mock(keyring_mock);
         let plaintext = CredentialStoreImpl::Mock(MockStore::new());
         plaintext.set(TOKEN).unwrap();
-        let stores = CredentialStores::from_stores(keyring, plaintext.clone());
+        let cache_dir = TempDir::new().unwrap();
+        let stores = CredentialStores::from_stores(keyring, plaintext.clone(), cache_dir.path());
 
         let result = stores.remove_all();
 

--- a/cli/flox/src/utils/credential_store/plaintext.rs
+++ b/cli/flox/src/utils/credential_store/plaintext.rs
@@ -10,12 +10,12 @@ use crate::commands::general::update_config;
 
 /// Plain-text token storage in `<config_dir>/flox.toml`.
 #[derive(Debug, Clone)]
-pub struct PlaintextStore {
+pub(super) struct PlaintextStore {
     config_dir: PathBuf,
 }
 
 impl PlaintextStore {
-    pub fn new(config_dir: impl Into<PathBuf>) -> Self {
+    pub(super) fn new(config_dir: impl Into<PathBuf>) -> Self {
         Self {
             config_dir: config_dir.into(),
         }

--- a/cli/flox/src/utils/events.rs
+++ b/cli/flox/src/utils/events.rs
@@ -528,7 +528,7 @@ mod tests {
             AuthContext::new_from_token(Some("opaque-access-token")),
             AuthContext::new_from_token(Some("flox_unknown_test")),
             AuthContext::new_from_token(None),
-            AuthContext::Kerberos(None),
+            AuthContext::from_kerberos(None),
         ];
 
         // Routed through `AuthContext::kind` so the credential type comes
@@ -626,7 +626,7 @@ mod tests {
         let uuid = Uuid::new_v4();
         let config = test_config_with_uuid(&tempdir, uuid);
 
-        let auth_context = AuthContext::new_from_token(None);
+        let auth_context = AuthContext::default();
         let client = build_events_client(&config, Uuid::new_v4(), &auth_context, None).await;
         assert!(client.is_some(), "v2 is enabled by default");
         assert_eq!(client.unwrap().device_id, uuid);
@@ -646,7 +646,7 @@ mod tests {
             .expect("client installs");
         assert_eq!(client.auth_subject.as_deref(), Some("github|424242"));
 
-        let unauthenticated = AuthContext::new_from_token(None);
+        let unauthenticated = AuthContext::default();
         let client = build_events_client(&config, Uuid::new_v4(), &unauthenticated, None)
             .await
             .expect("client installs");

--- a/cli/flox/src/utils/events.rs
+++ b/cli/flox/src/utils/events.rs
@@ -17,11 +17,11 @@ use std::sync::{LazyLock, OnceLock};
 
 use flox_config::Config;
 use flox_events::{CredentialType, EnvDetail, EventsClient, EventsHub, SharedMetadataTemplate};
-use flox_rust_sdk::flox::{AuthContext, FLOX_VERSION, Flox};
+use flox_rust_sdk::flox::{FLOX_VERSION, Flox};
 use flox_rust_sdk::models::environment::generations::GenerationsExt;
 use flox_rust_sdk::models::environment::{ConcreteEnvironment, Environment};
 use flox_rust_sdk::utils::INVOCATION_SOURCES;
-use floxhub_client::FloxhubClient;
+use floxhub_client::{AuthContext, CredentialKind, FloxhubClient};
 use tracing::debug;
 use uuid::Uuid;
 
@@ -91,17 +91,19 @@ pub(crate) fn duration_to_ms(elapsed: std::time::Duration) -> u64 {
     u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX)
 }
 
-fn credential_type_from_context(auth_context: &AuthContext) -> CredentialType {
-    match auth_context {
-        AuthContext::Auth0(Some(_)) | AuthContext::Bare(_) => CredentialType::Jwt,
-        AuthContext::AccessToken(token) if token.secret().starts_with("flox_pat_") => {
-            CredentialType::Pat
-        },
-        AuthContext::AccessToken(token) if token.secret().starts_with("flox_sat_") => {
-            CredentialType::Sat
-        },
-        AuthContext::AccessToken(_) => CredentialType::Unknown,
-        AuthContext::Auth0(None) | AuthContext::Kerberos(_) => CredentialType::None,
+/// Map the credential kind onto the wire enum.
+///
+/// Taken from [`CredentialKind`] rather than the [`AuthContext`] variant so
+/// this costs nothing: the kind is a recorded fact, and reading the credential
+/// to learn it would make every invocation pay for the keyring
+/// (see [`floxhub_client::AuthContext`]).
+fn credential_type_from_kind(kind: CredentialKind) -> CredentialType {
+    match kind {
+        CredentialKind::Auth0 | CredentialKind::Bare => CredentialType::Jwt,
+        CredentialKind::OpaqueToken => CredentialType::Unknown,
+        CredentialKind::PersonalAccessToken => CredentialType::Pat,
+        CredentialKind::ServiceAccountToken => CredentialType::Sat,
+        CredentialKind::NotLoggedIn | CredentialKind::Kerberos => CredentialType::None,
     }
 }
 
@@ -194,7 +196,7 @@ pub async fn build_events_client(
         },
     };
 
-    let credential_type = credential_type_from_context(auth_context);
+    let credential_type = credential_type_from_kind(auth_context.kind());
     let auth_subject =
         auth_subject_from_context(auth_context, credential_type, floxhub_client).await;
     Some(EventsClient::new(
@@ -219,6 +221,8 @@ async fn auth_subject_from_context(
     credential_type: CredentialType,
     floxhub_client: Option<&FloxhubClient>,
 ) -> Option<String> {
+    // Return a subject from JWT claims or cached identity facts without loading
+    // credentials or making a request. Deferred facts may be stale.
     if let Some(subject) = auth_context.user_subject() {
         return Some(subject);
     }
@@ -230,15 +234,14 @@ async fn auth_subject_from_context(
         debug!("v2 events: no FloxHub client available to resolve token subject");
         return None;
     };
-    let secret = auth_context.token_secret()?;
 
     match tokio::time::timeout(
         AUTH_SUBJECT_RESOLUTION_TIMEOUT,
-        floxhub_client.resolve_identity(secret),
+        auth_context.identity(floxhub_client),
     )
     .await
     {
-        Ok(Ok(identity)) => identity.sub,
+        Ok(Ok(identity)) => identity.and_then(|identity| identity.sub),
         Ok(Err(err)) => {
             debug!(error = %err, "v2 events: could not resolve token subject");
             None
@@ -528,8 +531,10 @@ mod tests {
             AuthContext::Kerberos(None),
         ];
 
+        // Routed through `AuthContext::kind` so the credential type comes
+        // from a fact a record can carry; the reported values are unchanged.
         assert_eq!(
-            contexts.map(|context| credential_type_from_context(&context)),
+            contexts.map(|context| credential_type_from_kind(context.kind())),
             [
                 CredentialType::Jwt,
                 CredentialType::Jwt,

--- a/cli/flox/src/utils/init/floxhub_client.rs
+++ b/cli/flox/src/utils/init/floxhub_client.rs
@@ -78,7 +78,7 @@ mod tests {
 
         let client = init_floxhub_client(
             server.base_url(),
-            AuthContext::new_from_token(None),
+            AuthContext::default(),
             Some(Uuid::new_v4()),
             invocation_id,
             None,
@@ -99,7 +99,7 @@ mod tests {
 
         let client = init_floxhub_client(
             server.base_url(),
-            AuthContext::new_from_token(None),
+            AuthContext::default(),
             None,
             Uuid::nil(),
             None,

--- a/cli/floxhub-client/Cargo.toml
+++ b/cli/floxhub-client/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 
 [dependencies]
 async-stream.workspace = true
+blake3.workspace = true
 catalog-api-v1.workspace = true
 chrono.workspace = true
 factory-api-v1.workspace = true

--- a/cli/floxhub-client/src/auth/auth_context.rs
+++ b/cli/floxhub-client/src/auth/auth_context.rs
@@ -1,319 +1,313 @@
-//! [`AuthContext`] — the credential threaded through the CLI.
-//!
-//! [`AuthContext`] is the central authentication type threaded through the CLI.
-//! It captures both the *kind* of credential in use — decided by what the
-//! credential answers locally: Auth0-shaped JWT, bare JWT, opaque token, or
-//! Kerberos — and the material available for that kind (which may be
-//! absent — e.g. no token yet, or no Kerberos ticket).
-//!
-//! Transport layers (HTTP catalog client, git credential helper) inspect the
-//! variant to decide how to authenticate requests. "No material" is an
-//! explicit state rather than a separate variant so that the configured auth
-//! mode is always preserved.
+//! Authentication with credential loading and identity caching handled internally.
+
+use std::fmt;
+use std::sync::{Arc, OnceLock};
 
 use url::Url;
 
-use crate::auth::kerberos::KerberosMaterial;
-use crate::auth::token::{ACCESS_TOKEN_PREFIX, AccessToken, BareToken, FloxhubToken};
+use super::credential::Credential;
+use super::storage::{AuthContextStorageExt, CachedFacts};
+use super::{
+    AccessToken,
+    AuthFailure,
+    AuthHeaderError,
+    BareToken,
+    CredentialKind,
+    FloxhubToken,
+    KerberosMaterial,
+    UserIdentity,
+    identity,
+};
+use crate::FloxhubClient;
+use crate::accounts::MeError;
 
-/// Describes why authentication failed.
-///
-/// The CLI layer decides how to present these failures to the user and whether
-/// interactive recovery is possible.
-#[derive(Debug, Clone, thiserror::Error)]
-pub enum AuthFailure {
-    /// Auth0 token exists but has expired.
-    #[error("token expired")]
-    TokenExpired,
-    /// Auth0 mode but no token is available.
-    #[error("not logged in")]
-    NotLoggedIn,
-    /// Kerberos mode but no ticket is available.
-    #[error("no kerberos ticket")]
-    NoKerberosTicket,
+type IdentityRecorder = Arc<dyn Fn(&CachedFacts) + Send + Sync>;
+
+enum CredentialSource {
+    Resolved(Credential),
+    Deferred {
+        recorded: CachedFacts,
+        resolved: OnceLock<Credential>,
+        resolve: Box<dyn Fn() -> AuthContext + Send + Sync>,
+    },
 }
 
-/// Error from producing an authorization header (e.g. SPNEGO token generation).
-#[derive(Debug, Clone, thiserror::Error)]
-#[error("{0}")]
-pub struct AuthHeaderError(pub String);
-
-/// Authentication context threaded through the CLI.
+/// Authentication for one invocation.
 ///
-/// Each variant corresponds to a kind of authentication and wraps an
-/// `Option` of the material for that kind:
-///
-/// - `Auth0(Some(token))` — an Auth0-shaped JWT, identity answered from
-///   its claims; the token may or may not be expired (checked lazily).
-/// - `Auth0(None)` — interactive-login mode but no token yet (not logged
-///   in).
-/// - `Bare(token)` — a decodable JWT without the handle claim (an issuer
-///   other than the Auth0 tenant, e.g. a deployment's Dex); `exp` and
-///   `sub` read from the claims, identity resolved at the point of use
-///   and cached process-wide.
-/// - `AccessToken(token)` — not decodable at all: a `flox_`-prefixed
-///   token (e.g. a `flox_pat_` personal access token) or any opaque
-///   string an issuer mints; identity is resolved at the point of use
-///   and cached process-wide.
-/// - `Kerberos(Some(material))` — Kerberos mode with a resolved principal
-///   and SPNEGO token generator.
-/// - `Kerberos(None)` — Kerberos mode but no ticket available (`kinit`
-///   hasn't been run).
-///
-/// Transport adapters match on the variant to decide how to authenticate:
-/// the HTTP catalog client calls [`authorization_header`](Self::authorization_header)
-/// to get a bearer or Negotiate header, while the git credential helper
-/// uses the variant to decide between an inline credential helper and a
-/// no-op (kerberized git authenticates via the ccache directly).
+/// Startup checks use recorded non-secret facts. Operations that need a secret
+/// or an identity load the credential automatically, at most once across clones.
+/// Identity lookups reuse a fingerprint-checked cache and record successful
+/// resolutions for later invocations.
 #[derive(Clone)]
-pub enum AuthContext {
-    /// Auth0-shaped JWT — identity answered locally from its claims.
-    /// May or may not have a token; the settled server-side direction is
-    /// that identity comes from accounts, so this is the shape being
-    /// retired as issuers stop emitting the handle claim.
-    Auth0(Option<FloxhubToken>),
-    /// Decodable JWT without the handle claim — identity resolved lazily
-    /// via /me and cached process-wide. No `Option`: "logged-in mode with
-    /// no token" remains `Auth0(None)`.
-    Bare(BareToken),
-    /// Opaque token (`flox_`-prefixed, or any string that doesn't decode
-    /// as a JWT) — identity is resolved lazily and cached process-wide.
-    /// No `Option`, as for `Bare`.
-    AccessToken(AccessToken),
-    /// Kerberos authentication — may or may not have a ticket/principal.
-    Kerberos(Option<KerberosMaterial>),
+pub struct AuthContext {
+    source: Arc<CredentialSource>,
+    record_identity: Option<IdentityRecorder>,
 }
 
 impl AuthContext {
-    /// Return the user's handle, when it is known locally: JWT claims, a
-    /// Kerberos principal, or a token whose identity was already resolved
-    /// and cached. Never blocks and never touches the network — for the
-    /// resolved answer use `Flox::get_identity`.
-    pub fn handle(&self) -> Option<String> {
-        match self {
-            AuthContext::Auth0(Some(token)) => Some(token.handle().to_string()),
-            AuthContext::Auth0(None) => None,
-            AuthContext::Bare(token) => token.handle(),
-            AuthContext::AccessToken(token) => token.handle(),
-            AuthContext::Kerberos(Some(material)) => Some(material.principal.clone()),
-            AuthContext::Kerberos(None) => None,
+    fn from_credential(credential: Credential) -> Self {
+        Self {
+            source: Arc::new(CredentialSource::Resolved(credential)),
+            record_identity: None,
         }
     }
 
-    /// Return the pseudonymous subject identifier for telemetry attribution,
-    /// if one is available locally or in the process-wide identity cache.
-    ///
-    /// Auth0 tokens carry the OIDC `sub` claim ([`FloxhubToken::sub`]) —
-    /// opaque and stable across the user's lifetime, so it remains valid
-    /// attribution even when the token has expired. PATs and SATs read the
-    /// `/me.user_id` value after identity resolution has populated the cache.
-    /// Kerberos has no pseudonymous equivalent today (the principal is
-    /// directly identifying), so kerberos-mode invocations return `None`.
-    ///
-    /// [`FloxhubToken::sub`]: crate::auth::token::FloxhubToken::sub
-    pub fn user_subject(&self) -> Option<String> {
-        match self {
-            AuthContext::Auth0(Some(token)) => token.sub().map(str::to_owned),
-            AuthContext::Auth0(None) => None,
-            AuthContext::Bare(token) => token.sub().map(str::to_owned),
-            AuthContext::AccessToken(token) => {
-                crate::auth::identity::cached_identity(token.secret())
-                    .and_then(|identity| identity.sub)
-            },
-            AuthContext::Kerberos(_) => None,
+    /// Parse a token's locally available claims without contacting FloxHub.
+    pub fn new_from_token(token: Option<&str>) -> Self {
+        Self::from_credential(Credential::new_from_token(token))
+    }
+
+    pub fn from_auth0_token(token: Option<FloxhubToken>) -> Self {
+        Self::from_credential(Credential::Auth0(token))
+    }
+
+    pub fn from_bare_token(token: BareToken) -> Self {
+        Self::from_credential(Credential::Bare(token))
+    }
+
+    pub fn from_access_token(token: AccessToken) -> Self {
+        Self::from_credential(Credential::AccessToken(token))
+    }
+
+    pub fn from_kerberos(material: Option<KerberosMaterial>) -> Self {
+        Self::from_credential(Credential::Kerberos(material))
+    }
+
+    /// Acquire the Kerberos credential only when an operation needs it.
+    pub fn new_kerberos() -> Self {
+        Self::deferred(Credential::Kerberos(None).cached_facts(), || {
+            Self::from_credential(Credential::new_kerberos())
+        })
+    }
+
+    /// Return the credential material, loading it once if necessary.
+    pub fn credential(&self) -> &Credential {
+        match self.source.as_ref() {
+            CredentialSource::Resolved(credential) => credential,
+            CredentialSource::Deferred {
+                recorded,
+                resolved,
+                resolve,
+            } => resolved.get_or_init(|| {
+                let credential = resolve().credential().clone();
+                credential.seed_from(recorded);
+                credential
+            }),
         }
+    }
+
+    pub fn is_unauthenticated(&self) -> bool {
+        self.cached_facts().is_unauthenticated()
+    }
+
+    pub fn user_subject(&self) -> Option<String> {
+        self.cached_facts().subject
+    }
+
+    pub fn kind(&self) -> CredentialKind {
+        self.cached_facts().kind
+    }
+
+    /// Return the bearer secret, loading the credential if necessary.
+    pub fn token_secret(&self) -> Option<&str> {
+        self.credential().token_secret()
     }
 
     /// Produce the value for an HTTP Authorization header targeting the given URL.
     pub fn authorization_header(&self, url: &Url) -> Option<Result<String, AuthHeaderError>> {
-        match self {
-            AuthContext::Auth0(_) | AuthContext::Bare(_) | AuthContext::AccessToken(_) => self
+        match self.credential() {
+            Credential::Auth0(_) | Credential::Bare(_) | Credential::AccessToken(_) => self
                 .token_secret()
                 .map(|secret| Ok(format!("bearer {secret}"))),
-            AuthContext::Kerberos(Some(material)) => {
+            Credential::Kerberos(Some(material)) => {
                 Some((material.generate_token)(url).map(|t| format!("Negotiate {t}")))
             },
-            AuthContext::Kerberos(None) => None,
+            Credential::Kerberos(None) => None,
         }
     }
 
-    /// Return the raw token secret, if this credential carries one.
+    /// Return the currently known handle without loading credentials or doing I/O.
     ///
-    /// Kerberos does not use bearer tokens, so it has no secret.
-    pub fn token_secret(&self) -> Option<&str> {
-        match self {
-            AuthContext::Auth0(Some(token)) => Some(token.secret()),
-            AuthContext::Auth0(None) => None,
-            AuthContext::Bare(token) => Some(token.secret()),
-            AuthContext::AccessToken(token) => Some(token.secret()),
-            AuthContext::Kerberos(_) => None,
-        }
+    /// `None` means the handle is unknown, not necessarily that the user is
+    /// unauthenticated. An environment or manually configured token may never
+    /// have had its identity resolved; its saved record may be missing, corrupt,
+    /// unwritable, or describe a different token. Credentials from before
+    /// identity caching, an unloaded Kerberos principal, and missing credentials
+    /// can also leave the handle unknown.
+    ///
+    /// Before the credential is loaded, a recorded handle is advisory and may
+    /// be stale. Use [`Self::identity`] when the operation requires an identity
+    /// checked against the current credential, rather than an optional hint.
+    pub fn handle(&self) -> Option<String> {
+        self.cached_facts().handle
     }
 
-    /// Create an [`AuthContext`] from a stored token, routing by what the
-    /// credential's claims answer locally:
+    /// Resolve the identity, including expiry and the pseudonymous subject.
     ///
-    /// - `flox_`-prefixed token: [`AuthContext::AccessToken`] — opaque by
-    ///   fiat, never decoded.
-    /// - Auth0-shaped JWT (handle claim and expiry): [`AuthContext::Auth0`].
-    /// - Any other decodable JWT: [`AuthContext::Bare`].
-    /// - Anything else: [`AuthContext::AccessToken`] — an issuer may mint
-    ///   opaque access tokens.
-    /// - No token: `Auth0(None)` (not logged in).
+    /// `Ok(None)` means a FloxHub lookup failed for a reason other than
+    /// unauthorized access. Missing credentials and unauthorized responses are
+    /// errors. Local expiry is returned in the identity so callers decide whether
+    /// it blocks their operation.
     ///
-    /// Routing is total: no local check can reject a token, and the
-    /// server's 401 is the authority on validity.
-    pub fn new_from_token(token: Option<&str>) -> Self {
-        let Some(token) = token else {
-            return AuthContext::Auth0(None);
+    /// Successful network lookups update both the process cache and the
+    /// persistent record. A fingerprint-checked cache hit, JWT identity claims,
+    /// and Kerberos principals answer locally. Use [Self::refresh_identity] to
+    /// check for revoked tokens or renamed handles through a fresh lookup.
+    pub async fn identity(
+        &self,
+        client: &FloxhubClient,
+    ) -> Result<Option<UserIdentity>, AuthFailure> {
+        self.resolve_identity(client, false).await
+    }
+
+    /// Fetch identity from `/me` again and update the caches on success.
+    ///
+    /// Auth status uses this to detect revoked tokens and renamed handles.
+    /// This does not reload or renew the credential. JWT identity claims and
+    /// Kerberos principals still answer locally.
+    pub async fn refresh_identity(
+        &self,
+        client: &FloxhubClient,
+    ) -> Result<Option<UserIdentity>, AuthFailure> {
+        self.resolve_identity(client, true).await
+    }
+
+    async fn resolve_identity(
+        &self,
+        client: &FloxhubClient,
+        refresh: bool,
+    ) -> Result<Option<UserIdentity>, AuthFailure> {
+        let credential = self.credential();
+        let identity = match credential {
+            Credential::Auth0(Some(token)) => UserIdentity {
+                handle: token.handle().to_string(),
+                sub: token.sub().map(str::to_owned),
+                expires_at: Some(token.expires_at()),
+            },
+            Credential::Auth0(None) => return Err(AuthFailure::NotLoggedIn),
+            Credential::Kerberos(Some(material)) => UserIdentity {
+                handle: material.principal.clone(),
+                sub: None,
+                expires_at: None,
+            },
+            Credential::Kerberos(None) => return Err(AuthFailure::NoKerberosTicket),
+            Credential::Bare(_) | Credential::AccessToken(_) => {
+                let secret = credential
+                    .token_secret()
+                    .expect("bearer credential has a token");
+                let cached = (!refresh)
+                    .then(|| identity::cached_identity(secret))
+                    .flatten();
+                let mut resolved = match cached {
+                    Some(identity) => identity,
+                    None => match client.accounts().me(secret).await {
+                        Ok(resolved) => {
+                            identity::cache_identity(secret, &resolved);
+                            resolved
+                        },
+                        Err(MeError::Unauthorized) => return Err(AuthFailure::TokenExpired),
+                        Err(err) => {
+                            tracing::debug!(error = %err, "could not resolve identity");
+                            return Ok(None);
+                        },
+                    },
+                };
+                // JWT expiry describes the presenting credential; /me may
+                // describe a stored access token instead.
+                if let Credential::Bare(token) = credential {
+                    resolved.expires_at = token.expires_at().or(resolved.expires_at);
+                }
+                resolved
+            },
         };
-        if token.starts_with(ACCESS_TOKEN_PREFIX) {
-            return AuthContext::AccessToken(AccessToken::new(token.to_string()));
+        if let Some(record) = &self.record_identity {
+            record(&self.cached_facts());
         }
-        match FloxhubToken::new(token.to_string()) {
-            Ok(parsed) => AuthContext::Auth0(Some(parsed)),
-            Err(_) => match BareToken::new(token.to_string()) {
-                Ok(parsed) => AuthContext::Bare(parsed),
-                Err(_) => AuthContext::AccessToken(AccessToken::new(token.to_string())),
+        Ok(Some(identity))
+    }
+}
+
+impl AuthContextStorageExt for AuthContext {
+    fn deferred(
+        recorded: CachedFacts,
+        resolve: impl Fn() -> AuthContext + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            source: Arc::new(CredentialSource::Deferred {
+                recorded,
+                resolved: OnceLock::new(),
+                resolve: Box::new(resolve),
+            }),
+            record_identity: None,
+        }
+    }
+
+    fn with_identity_recorder(
+        mut self,
+        record: impl Fn(&CachedFacts) + Send + Sync + 'static,
+    ) -> Self {
+        self.record_identity = Some(Arc::new(record));
+        self
+    }
+
+    fn cached_facts(&self) -> CachedFacts {
+        match self.source.as_ref() {
+            CredentialSource::Resolved(credential) => credential.cached_facts(),
+            CredentialSource::Deferred {
+                recorded, resolved, ..
+            } => resolved
+                .get()
+                .map(Credential::cached_facts)
+                .unwrap_or_else(|| recorded.clone()),
+        }
+    }
+
+    fn seed_from(&self, recorded: &CachedFacts) {
+        match self.source.as_ref() {
+            CredentialSource::Resolved(credential) => credential.seed_from(recorded),
+            CredentialSource::Deferred { resolved, .. } => {
+                if let Some(credential) = resolved.get() {
+                    credential.seed_from(recorded);
+                }
             },
         }
     }
+}
 
-    /// Returns true when no valid authentication material is available and a
-    /// future catalog-auth-gated call would fail.
-    ///
-    /// `Auth0(None)` (not logged in) and `Auth0(Some(expired))` both count —
-    /// neither carries a credential that will pass once gating is enforced —
-    /// and a bare token counts exactly when its exp claim has passed.
-    /// `Kerberos(..)` does not require a FloxHub login, `AccessToken` is
-    /// opaque (validity unknown until resolved via /me), and a bare token
-    /// without the exp claim is equally unknowable, so none of those are
-    /// treated as unauthenticated here.
-    pub fn is_unauthenticated(&self) -> bool {
-        match self {
-            AuthContext::Auth0(None) => true,
-            AuthContext::Auth0(Some(token)) => token.is_expired(),
-            AuthContext::Bare(token) => token.is_expired(),
-            AuthContext::AccessToken(_) | AuthContext::Kerberos(_) => false,
-        }
-    }
-
-    /// Create a Kerberos [`AuthContext`]: resolves the principal and embeds
-    /// a SPNEGO token generator; returns `Kerberos(None)` (with a warning
-    /// log) if the ticket cannot be resolved. FloxHub tokens are not used.
-    pub fn new_kerberos() -> Self {
-        crate::auth::kerberos::kerberos_credential()
+impl Default for AuthContext {
+    fn default() -> Self {
+        Self::from_auth0_token(None)
     }
 }
 
-impl std::fmt::Debug for AuthContext {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            AuthContext::Auth0(Some(_)) => f.debug_tuple("Auth0").field(&"<token>").finish(),
-            AuthContext::Auth0(None) => f.write_str("Auth0(None)"),
-            AuthContext::Bare(token) => f.debug_tuple("Bare").field(&token).finish(),
-            AuthContext::AccessToken(token) => f.debug_tuple("AccessToken").field(&token).finish(),
-            AuthContext::Kerberos(Some(material)) => f
-                .debug_struct("Kerberos")
-                .field("principal", &material.principal)
-                .finish_non_exhaustive(),
-            AuthContext::Kerberos(None) => f.write_str("Kerberos(None)"),
-        }
+impl fmt::Debug for AuthContext {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AuthContext")
+            .field("facts", &self.cached_facts())
+            .finish_non_exhaustive()
     }
 }
-
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
+    use std::sync::Mutex;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use httpmock::MockServer;
+    use serde_json::json;
 
     use super::*;
-    use crate::auth::identity::test_helpers::test_identity;
-    use crate::auth::token::FloxhubToken;
-    use crate::auth::token::test_helpers::{
-        FAKE_EXPIRED_TOKEN_WITH_SUB,
-        FAKE_TOKEN,
-        FAKE_TOKEN_NO_HANDLE,
-        FAKE_TOKEN_WITH_SUB,
-        test_bare_token,
-    };
+    use crate::auth::token::test_helpers::test_bare_token;
+    use crate::client::test_helpers::client_config;
 
-    #[test]
-    fn user_subject_returns_sub_for_auth0_token() {
-        let token = FloxhubToken::from_str(FAKE_TOKEN_WITH_SUB).expect("token parses");
-        assert_eq!(
-            AuthContext::Auth0(Some(token)).user_subject().as_deref(),
-            Some("github|424242")
-        );
-    }
-
-    /// Expiry gates authentication, not identity — an expired token's `sub`
-    /// is still the correct attribution.
-    #[test]
-    fn user_subject_returns_sub_for_expired_auth0_token() {
-        let token = FloxhubToken::from_str(FAKE_EXPIRED_TOKEN_WITH_SUB).expect("token parses");
-        assert!(token.is_expired(), "test premise: token is expired");
-        assert_eq!(
-            AuthContext::Auth0(Some(token)).user_subject().as_deref(),
-            Some("github|424242")
-        );
-    }
-
-    #[test]
-    fn user_subject_is_none_without_sub_token_or_auth0() {
-        let token = FloxhubToken::from_str(FAKE_TOKEN).expect("token parses");
-        assert_eq!(AuthContext::Auth0(Some(token)).user_subject(), None);
-        assert_eq!(AuthContext::Auth0(None).user_subject(), None);
-        assert_eq!(AuthContext::Kerberos(None).user_subject(), None);
-    }
-
-    #[test]
-    fn is_unauthenticated_covers_missing_and_expired_auth0_tokens() {
-        let valid = FloxhubToken::from_str(FAKE_TOKEN).expect("token parses");
-        let expired = FloxhubToken::from_str(FAKE_EXPIRED_TOKEN_WITH_SUB).expect("token parses");
-        assert!(expired.is_expired(), "test premise: token is expired");
-
-        assert!(AuthContext::Auth0(None).is_unauthenticated());
-        assert!(AuthContext::Auth0(Some(expired)).is_unauthenticated());
-        assert!(!AuthContext::Auth0(Some(valid)).is_unauthenticated());
-        assert!(!pat_unresolved().is_unauthenticated());
-        assert!(!AuthContext::Kerberos(None).is_unauthenticated());
-    }
-
-    fn pat_unresolved() -> AuthContext {
-        AuthContext::AccessToken(AccessToken::new("flox_pat_secret".to_string()))
-    }
-
-    #[test]
-    fn pat_handle_is_unknown_until_resolved() {
-        let auth = pat_unresolved();
-        assert_eq!(auth.handle(), None);
-    }
-
-    #[test]
-    fn pat_handle_reads_the_cached_identity() {
-        let token = AccessToken::new("flox_pat_context-handle-test".to_string());
-        crate::auth::identity::cache_identity(token.secret(), &test_identity("testuser"));
-        let auth = AuthContext::AccessToken(token);
-
-        assert_eq!(auth.handle(), Some("testuser".to_string()));
-    }
-
-    #[test]
-    fn pat_subject_reads_the_cached_identity() {
-        let token = AccessToken::new("flox_pat_context-subject-test".to_string());
-        crate::auth::identity::cache_identity(token.secret(), &crate::auth::UserIdentity {
-            handle: "testuser".to_string(),
-            sub: Some("auth0|123".to_string()),
-            expires_at: None,
-        });
-        let auth = AuthContext::AccessToken(token);
-
-        assert_eq!(auth.user_subject().as_deref(), Some("auth0|123"));
+    /// The record an invocation writes when nobody is logged in: a FloxHub
+    /// login is what would fix it, so `requires_login` is set.
+    fn logged_out() -> CachedFacts {
+        AuthContext::from_auth0_token(None).cached_facts()
     }
 
     #[test]
     fn pat_authorization_header_is_bearer_secret() {
-        let auth = pat_unresolved();
+        let auth = AuthContext::new_from_token(Some("flox_pat_secret"));
         let url = Url::parse("https://api.flox.dev").unwrap();
 
         assert_eq!(
@@ -323,82 +317,242 @@ mod tests {
     }
 
     #[test]
-    fn pat_debug_redacts_the_secret() {
-        let auth = pat_unresolved();
-        assert!(!format!("{auth:?}").contains("flox_pat_secret"));
+    fn deferred_context_is_not_resolved_until_it_is_needed() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let counter = Arc::clone(&calls);
+        let lazy = AuthContext::deferred(logged_out(), move || {
+            counter.fetch_add(1, Ordering::SeqCst);
+            AuthContext::from_auth0_token(None)
+        });
+
+        assert!(!lazy.cached_facts().logged_in);
+        assert!(lazy.is_unauthenticated());
+        assert_eq!(lazy.user_subject(), None);
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+
+        lazy.token_secret();
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    /// Every clone shares one resolution: the handle is threaded through the
+    /// client, the SDK and the transport adapters, and a read per hop would
+    /// defeat the point.
+    #[test]
+    fn clones_share_a_single_resolution() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let counter = Arc::clone(&calls);
+        let lazy = AuthContext::deferred(logged_out(), move || {
+            counter.fetch_add(1, Ordering::SeqCst);
+            AuthContext::from_bare_token(test_bare_token("lazy-clone-test"))
+        });
+
+        lazy.clone().token_secret();
+        lazy.clone().token_secret();
+        lazy.token_secret();
+
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    /// A recorded summary that disagrees with the stored credential is
+    /// superseded once the credential is actually read.
+    #[test]
+    fn resolving_supersedes_stale_recorded_properties() {
+        let lazy = AuthContext::deferred(logged_out(), || {
+            AuthContext::from_bare_token(test_bare_token("lazy-stale-test"))
+        });
+
+        assert!(lazy.is_unauthenticated());
+        lazy.token_secret();
+        assert!(!lazy.is_unauthenticated());
     }
 
     #[test]
-    fn jwt_handle_derives_from_claims() {
-        let auth = AuthContext::Auth0(Some(FAKE_TOKEN.parse().unwrap()));
-        assert_eq!(auth.handle(), Some("test".to_string()));
+    fn deferred_context_exposes_recorded_properties_without_resolving() {
+        let recorded = CachedFacts {
+            logged_in: true,
+            kind: CredentialKind::Auth0,
+            requires_login: true,
+            expires_at: None,
+            subject: Some("cached-subject".to_string()),
+            handle: Some("cached-user".to_string()),
+            fingerprint: Some("cached-fingerprint".to_string()),
+        };
+        let lazy = AuthContext::deferred(recorded.clone(), || {
+            panic!("recorded properties must not resolve the credential")
+        });
+
+        assert_eq!(lazy.handle(), Some("cached-user".into()));
+        assert_eq!(lazy.cached_facts(), recorded);
     }
 
     #[test]
-    fn new_from_token_routes_flox_prefix_to_access_token() {
-        // Any flox_-prefixed token is an opaque access token, including
-        // personal and service account tokens.
-        for secret in ["flox_pat_abc123", "flox_sat_abc123"] {
-            let auth = AuthContext::new_from_token(Some(secret));
-            let AuthContext::AccessToken(token) = auth else {
-                panic!("expected AccessToken, got {auth:?}");
-            };
-            assert_eq!(token.secret(), secret);
+    fn handle_is_none_without_a_known_identity_and_does_not_load_credentials() {
+        let deferred = AuthContext::deferred(logged_out(), || {
+            panic!("reading an optional handle must not load the credential")
+        });
+        for context in [
+            deferred,
+            AuthContext::default(),
+            AuthContext::new_from_token(Some("flox_pat_unknown-handle")),
+            AuthContext::new_from_token(Some("flox_sat_unknown-handle")),
+            AuthContext::from_bare_token(test_bare_token("unknown-handle")),
+            AuthContext::new_kerberos(),
+        ] {
+            assert_eq!(context.handle(), None);
         }
     }
 
+    /// Kerberos carries no bearer secret, so it records `logged_in: false` —
+    /// and without `requires_login` gating the answer that would read as "not
+    /// logged in" for a mode where logging in is not a thing.
     #[test]
-    fn new_from_token_routes_jwt_to_auth0() {
-        let auth = AuthContext::new_from_token(Some(FAKE_TOKEN));
-        let AuthContext::Auth0(Some(token)) = auth else {
-            panic!("expected Auth0, got {auth:?}");
-        };
-        assert_eq!(token.secret(), FAKE_TOKEN);
+    fn kerberos_is_not_unauthenticated_despite_having_no_secret() {
+        let facts = AuthContext::from_kerberos(None).cached_facts();
+
+        assert_eq!(facts, CachedFacts {
+            logged_in: false,
+            kind: CredentialKind::Kerberos,
+            requires_login: false,
+            expires_at: None,
+            subject: None,
+            handle: None,
+            fingerprint: None,
+        });
+        assert!(!facts.is_unauthenticated());
+
+        let lazy = AuthContext::deferred(facts, || {
+            panic!("the recorded facts answer without acquiring a ticket")
+        });
+        assert!(!lazy.is_unauthenticated());
     }
 
-    #[test]
-    fn new_from_token_without_token_is_not_logged_in() {
-        let auth = AuthContext::new_from_token(None);
-        assert!(matches!(auth, AuthContext::Auth0(None)));
+    fn me_response(handle: &str) -> serde_json::Value {
+        json!({"handle": handle, "user_id": "pat|test", "expires_at": null})
     }
 
-    #[test]
-    fn new_from_token_routes_claimless_jwt_to_bare() {
-        let auth = AuthContext::new_from_token(Some(FAKE_TOKEN_NO_HANDLE));
-        let AuthContext::Bare(token) = auth else {
-            panic!("expected Bare, got {auth:?}");
-        };
-        assert_eq!(token.secret(), FAKE_TOKEN_NO_HANDLE);
-    }
+    #[tokio::test]
+    async fn identity_resolves_once_and_records_the_identity() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path("/accounts/api/v1/accounts/me")
+                .header("authorization", "bearer flox_pat_context-record");
+            then.status(200).json_body(me_response("testuser"));
+        });
+        let client = FloxhubClient::new(client_config(&server.base_url())).unwrap();
+        let records = Arc::new(Mutex::new(Vec::new()));
+        let recorded = records.clone();
+        let context = AuthContext::new_from_token(Some("flox_pat_context-record"))
+            .with_identity_recorder(move |facts| recorded.lock().unwrap().push(facts.clone()));
 
-    #[test]
-    fn new_from_token_carries_a_non_jwt_opaquely() {
-        // No local check can reject a token — an issuer may mint opaque
-        // access tokens, so a non-decodable string is a credential whose
-        // validity only the server can judge.
-        let auth = AuthContext::new_from_token(Some("not-a-jwt"));
-        let AuthContext::AccessToken(token) = auth else {
-            panic!("expected AccessToken, got {auth:?}");
-        };
-        assert_eq!(token.secret(), "not-a-jwt");
-    }
-
-    #[test]
-    fn bare_token_subject_and_cached_handle() {
-        // A bare token contributes its sub for telemetry, and its handle
-        // comes from the /me-filled cache, like an opaque token's.
-        let token = test_bare_token("context-bare-handle-test");
-        let auth = AuthContext::Bare(token.clone());
+        assert_eq!(context.handle(), None);
+        let expected_identity = Some(UserIdentity {
+            handle: "testuser".into(),
+            sub: Some("pat|test".into()),
+            expires_at: None,
+        });
+        assert_eq!(context.identity(&client).await.unwrap(), expected_identity);
+        assert_eq!(context.handle(), Some("testuser".into()));
         assert_eq!(
-            auth.user_subject().as_deref(),
-            Some("context-bare-handle-test")
+            context.clone().identity(&client).await.unwrap(),
+            expected_identity
         );
-        assert_eq!(auth.handle(), None);
+        assert_eq!(context.clone().handle(), Some("testuser".into()));
+        mock.assert_calls(1);
+        let expected = context.cached_facts();
+        assert_eq!(*records.lock().unwrap(), vec![expected.clone(), expected]);
+    }
 
-        crate::auth::identity::cache_identity(token.secret(), &test_identity("dexter"));
+    #[tokio::test]
+    async fn refresh_replaces_a_cached_handle() {
+        let server = MockServer::start();
+        let mut stale = server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path("/accounts/api/v1/accounts/me");
+            then.status(200).json_body(me_response("old-handle"));
+        });
+        let client = FloxhubClient::new(client_config(&server.base_url())).unwrap();
+        let context = AuthContext::new_from_token(Some("flox_pat_context-refresh"));
+
+        assert_eq!(context.handle(), None);
+        context.identity(&client).await.unwrap().unwrap();
+        assert_eq!(context.handle(), Some("old-handle".into()));
+        stale.delete();
+        let fresh = server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path("/accounts/api/v1/accounts/me");
+            then.status(200).json_body(me_response("new-handle"));
+        });
+        assert_eq!(context.handle(), Some("old-handle".into()));
+        fresh.assert_calls(0);
         assert_eq!(
-            AuthContext::Bare(token).handle(),
-            Some("dexter".to_string())
+            context.refresh_identity(&client).await.unwrap(),
+            Some(UserIdentity {
+                handle: "new-handle".into(),
+                sub: Some("pat|test".into()),
+                expires_at: None,
+            })
         );
+        assert_eq!(context.handle(), Some("new-handle".into()));
+        fresh.assert_calls(1);
+    }
+
+    #[tokio::test]
+    async fn failed_identity_lookups_are_retried_and_never_recorded() {
+        let server = MockServer::start();
+        let mut failure = server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path("/accounts/api/v1/accounts/me");
+            then.status(500);
+        });
+        let client = FloxhubClient::new(client_config(&server.base_url())).unwrap();
+        let context = AuthContext::new_from_token(Some("flox_pat_context-failure"))
+            .with_identity_recorder(|_| panic!("failed lookups must not be recorded"));
+
+        assert_eq!(context.identity(&client).await.unwrap(), None);
+        assert_eq!(context.identity(&client).await.unwrap(), None);
+        failure.assert_calls(2);
+        failure.delete();
+        server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path("/accounts/api/v1/accounts/me");
+            then.status(401);
+        });
+        assert!(matches!(
+            context.identity(&client).await,
+            Err(AuthFailure::TokenExpired)
+        ));
+    }
+
+    #[tokio::test]
+    async fn identity_checks_the_record_against_the_loaded_credential() {
+        let server = MockServer::start();
+        let request = server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path("/accounts/api/v1/accounts/me")
+                .header("authorization", "bearer flox_pat_context-replaced");
+            then.status(200).json_body(me_response("current-user"));
+        });
+        let client = FloxhubClient::new(client_config(&server.base_url())).unwrap();
+        let stored = AuthContext::new_from_token(Some("flox_pat_context-matched"));
+        let facts = CachedFacts {
+            handle: Some("recorded-user".into()),
+            subject: Some("pat|recorded".into()),
+            ..stored.cached_facts()
+        };
+        let matched = AuthContext::deferred(facts.clone(), move || stored.clone());
+        matched.identity(&client).await.unwrap().unwrap();
+        assert_eq!(matched.handle(), Some("recorded-user".into()));
+        request.assert_calls(0);
+
+        let replaced = AuthContext::deferred(facts, || {
+            AuthContext::new_from_token(Some("flox_pat_context-replaced"))
+        });
+        assert_eq!(replaced.handle(), Some("recorded-user".into()));
+        replaced.token_secret();
+        assert_eq!(replaced.handle(), None);
+        replaced.identity(&client).await.unwrap().unwrap();
+        assert_eq!(replaced.handle(), Some("current-user".into()));
+        request.assert_calls(1);
     }
 }

--- a/cli/floxhub-client/src/auth/credential.rs
+++ b/cli/floxhub-client/src/auth/credential.rs
@@ -1,0 +1,558 @@
+//! Credential material and the facts it can answer locally.
+
+use crate::auth::kerberos::KerberosMaterial;
+use crate::auth::storage::{CachedFacts, credential_fingerprint};
+use crate::auth::token::{
+    ACCESS_TOKEN_PREFIX,
+    AccessToken,
+    BareToken,
+    FloxhubToken,
+    PERSONAL_ACCESS_TOKEN_PREFIX,
+    SERVICE_ACCOUNT_TOKEN_PREFIX,
+};
+
+/// Which kind of credential is in play, without the material.
+///
+/// This is the credential kind with the secret stripped out — the one
+/// part of the variant a record can carry, and the only part a caller needs
+/// when it wants to describe the credential rather than use it. Telemetry is
+/// the caller today: it reports the credential kind on every event, and
+/// deriving that from the variant would mean reading the credential on every
+/// invocation.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CredentialKind {
+    /// No credential is stored.
+    #[default]
+    NotLoggedIn,
+    /// An Auth0-shaped JWT, identity in its claims.
+    Auth0,
+    /// A JWT without the handle claim.
+    Bare,
+    /// An opaque `flox_pat_` personal access token.
+    PersonalAccessToken,
+    /// An opaque `flox_sat_` service account token.
+    ServiceAccountToken,
+    /// An opaque token matching no known prefix — an issuer may mint one.
+    OpaqueToken,
+    /// Kerberos, which uses no FloxHub token at all.
+    Kerberos,
+}
+
+/// Describes why authentication failed.
+///
+/// The CLI layer decides how to present these failures to the user and whether
+/// interactive recovery is possible.
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum AuthFailure {
+    /// Auth0 token exists but has expired.
+    #[error("token expired")]
+    TokenExpired,
+    /// Auth0 mode but no token is available.
+    #[error("not logged in")]
+    NotLoggedIn,
+    /// Kerberos mode but no ticket is available.
+    #[error("no kerberos ticket")]
+    NoKerberosTicket,
+}
+
+/// Error from producing an authorization header (e.g. SPNEGO token generation).
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("{0}")]
+pub struct AuthHeaderError(pub String);
+
+/// Credential material resolved by `AuthContext`.
+///
+/// Each variant corresponds to a kind of authentication and wraps an
+/// `Option` of the material for that kind:
+///
+/// - `Auth0(Some(token))` — an Auth0-shaped JWT, identity answered from
+///   its claims; the token may or may not be expired (checked lazily).
+/// - `Auth0(None)` — interactive-login mode but no token yet (not logged
+///   in).
+/// - `Bare(token)` — a decodable JWT without the handle claim (an issuer
+///   other than the Auth0 tenant, e.g. a deployment's Dex); `exp` and
+///   `sub` read from the claims, identity resolved at the point of use
+///   and cached process-wide.
+/// - `AccessToken(token)` — not decodable at all: a `flox_`-prefixed
+///   token (e.g. a `flox_pat_` personal access token) or any opaque
+///   string an issuer mints; identity is resolved at the point of use
+///   and cached process-wide.
+/// - `Kerberos(Some(material))` — Kerberos mode with a resolved principal
+///   and SPNEGO token generator.
+/// - `Kerberos(None)` — Kerberos mode but no ticket available (`kinit`
+///   hasn't been run).
+///
+/// Callers needing a specific token format can inspect this through
+/// `AuthContext::credential`.
+#[derive(Clone)]
+pub enum Credential {
+    /// Auth0-shaped JWT — identity answered locally from its claims.
+    /// May or may not have a token; the settled server-side direction is
+    /// that identity comes from accounts, so this is the shape being
+    /// retired as issuers stop emitting the handle claim.
+    Auth0(Option<FloxhubToken>),
+    /// Decodable JWT without the handle claim — identity resolved lazily
+    /// via /me and cached process-wide. No `Option`: "logged-in mode with
+    /// no token" remains `Auth0(None)`.
+    Bare(BareToken),
+    /// Opaque token (`flox_`-prefixed, or any string that doesn't decode
+    /// as a JWT) — identity is resolved lazily and cached process-wide.
+    /// No `Option`, as for `Bare`.
+    AccessToken(AccessToken),
+    /// Kerberos authentication — may or may not have a ticket/principal.
+    Kerberos(Option<KerberosMaterial>),
+}
+
+impl Credential {
+    /// Return the user's handle, when it is known locally: JWT claims, a
+    /// Kerberos principal, or a token whose identity was already resolved
+    /// and cached. Never touches the network.
+    pub fn handle(&self) -> Option<String> {
+        match self {
+            Credential::Auth0(Some(token)) => Some(token.handle().to_string()),
+            Credential::Auth0(None) => None,
+            Credential::Bare(token) => token.handle(),
+            Credential::AccessToken(token) => token.handle(),
+            Credential::Kerberos(Some(material)) => Some(material.principal.clone()),
+            Credential::Kerberos(None) => None,
+        }
+    }
+
+    /// Return the pseudonymous subject identifier for telemetry attribution,
+    /// if one is available locally or in the process-wide identity cache.
+    ///
+    /// Auth0 tokens carry the OIDC `sub` claim ([`FloxhubToken::sub`]) —
+    /// opaque and stable across the user's lifetime, so it remains valid
+    /// attribution even when the token has expired. PATs and SATs read the
+    /// `/me.user_id` value after identity resolution has populated the cache.
+    /// Kerberos has no pseudonymous equivalent today (the principal is
+    /// directly identifying), so kerberos-mode invocations return `None`.
+    ///
+    /// [`FloxhubToken::sub`]: crate::auth::token::FloxhubToken::sub
+    pub fn user_subject(&self) -> Option<String> {
+        match self {
+            Credential::Auth0(Some(token)) => token.sub().map(str::to_owned),
+            Credential::Auth0(None) => None,
+            Credential::Bare(token) => token.sub().map(str::to_owned),
+            Credential::AccessToken(token) => {
+                crate::auth::identity::cached_identity(token.secret())
+                    .and_then(|identity| identity.sub)
+            },
+            Credential::Kerberos(_) => None,
+        }
+    }
+
+    /// Return the raw token secret, if this credential carries one.
+    ///
+    /// Kerberos does not use bearer tokens, so it has no secret.
+    pub fn token_secret(&self) -> Option<&str> {
+        match self {
+            Credential::Auth0(Some(token)) => Some(token.secret()),
+            Credential::Auth0(None) => None,
+            Credential::Bare(token) => Some(token.secret()),
+            Credential::AccessToken(token) => Some(token.secret()),
+            Credential::Kerberos(_) => None,
+        }
+    }
+
+    /// Create an [`Credential`] from a stored token, routing by what the
+    /// credential's claims answer locally:
+    ///
+    /// - `flox_`-prefixed token: [`Credential::AccessToken`] — opaque by
+    ///   fiat, never decoded.
+    /// - Auth0-shaped JWT (handle claim and expiry): [`Credential::Auth0`].
+    /// - Any other decodable JWT: [`Credential::Bare`].
+    /// - Anything else: [`Credential::AccessToken`] — an issuer may mint
+    ///   opaque access tokens.
+    /// - No token: `Auth0(None)` (not logged in).
+    ///
+    /// Routing is total: no local check can reject a token, and the
+    /// server's 401 is the authority on validity.
+    pub fn new_from_token(token: Option<&str>) -> Self {
+        let Some(token) = token else {
+            return Credential::Auth0(None);
+        };
+        if token.starts_with(ACCESS_TOKEN_PREFIX) {
+            return Credential::AccessToken(AccessToken::new(token.to_string()));
+        }
+        match FloxhubToken::new(token.to_string()) {
+            Ok(parsed) => Credential::Auth0(Some(parsed)),
+            Err(_) => match BareToken::new(token.to_string()) {
+                Ok(parsed) => Credential::Bare(parsed),
+                Err(_) => Credential::AccessToken(AccessToken::new(token.to_string())),
+            },
+        }
+    }
+
+    /// Create a Kerberos [`Credential`]: resolves the principal and embeds
+    /// a SPNEGO token generator; returns `Kerberos(None)` (with a warning
+    /// log) if the ticket cannot be resolved. FloxHub tokens are not used.
+    pub fn new_kerberos() -> Self {
+        crate::auth::kerberos::kerberos_credential()
+    }
+
+    /// Which kind of credential this is, without its material.
+    ///
+    /// The opaque arms read the token's prefix, which is the only thing about
+    /// an opaque token that is ever parsed — it names the kind and nothing
+    /// else. Authentication still treats them uniformly.
+    pub fn kind(&self) -> CredentialKind {
+        match self {
+            Credential::Auth0(Some(_)) => CredentialKind::Auth0,
+            Credential::Auth0(None) => CredentialKind::NotLoggedIn,
+            Credential::Bare(_) => CredentialKind::Bare,
+            Credential::AccessToken(token) => {
+                if token.secret().starts_with(PERSONAL_ACCESS_TOKEN_PREFIX) {
+                    CredentialKind::PersonalAccessToken
+                } else if token.secret().starts_with(SERVICE_ACCOUNT_TOKEN_PREFIX) {
+                    CredentialKind::ServiceAccountToken
+                } else {
+                    CredentialKind::OpaqueToken
+                }
+            },
+            Credential::Kerberos(_) => CredentialKind::Kerberos,
+        }
+    }
+
+    /// The non-secret facts worth recording about this credential.
+    ///
+    /// Derived per variant, because what a credential answers locally differs
+    /// by kind: an Auth0 JWT carries expiry and subject in its claims, a bare
+    /// JWT carries them only when the issuer emitted them, an opaque token
+    /// carries neither until `/me` has resolved it, and Kerberos is not
+    /// login-gated at all.
+    pub fn cached_facts(&self) -> CachedFacts {
+        CachedFacts {
+            logged_in: self.token_secret().is_some(),
+            kind: self.kind(),
+            requires_login: matches!(self, Credential::Auth0(_) | Credential::Bare(_)),
+            expires_at: match self {
+                Credential::Auth0(Some(token)) => Some(token.expires_at()),
+                Credential::Bare(token) => token.expires_at(),
+                // An opaque token's expiry is whatever `/me` reported, so it
+                // is known exactly when its identity is. This never reaches
+                // `is_unauthenticated`, which `requires_login` already
+                // answers `false` for — the server remains the authority on
+                // an opaque token's validity.
+                Credential::AccessToken(token) => token.expires_at(),
+                Credential::Auth0(None) | Credential::Kerberos(_) => None,
+            },
+            subject: self.user_subject(),
+            handle: self.handle(),
+            fingerprint: self.token_secret().map(credential_fingerprint),
+        }
+    }
+
+    /// Adopt a recorded identity as this credential's, sparing the `/me`
+    /// round trip that would otherwise resolve it.
+    ///
+    /// Only the credentials whose identity costs a request have anything to
+    /// gain: an Auth0 JWT reads its handle from its own claims and Kerberos
+    /// from its principal, so both ignore the record. And only when the
+    /// record describes *this* credential — the fingerprint is checked
+    /// against the secret in hand, so a record left by another account, or by
+    /// another `flox` writing the keyring behind our back, is ignored rather
+    /// than believed.
+    pub fn seed_from(&self, recorded: &CachedFacts) {
+        if !matches!(self, Credential::Bare(_) | Credential::AccessToken(_)) {
+            return;
+        }
+        let (Some(secret), Some(handle)) = (self.token_secret(), recorded.handle.clone()) else {
+            return;
+        };
+        if recorded.fingerprint.as_deref() != Some(&credential_fingerprint(secret)) {
+            return;
+        }
+        crate::auth::identity::cache_identity(secret, &crate::auth::UserIdentity {
+            handle,
+            expires_at: recorded.expires_at,
+            sub: recorded.subject.clone(),
+        });
+    }
+}
+
+impl std::fmt::Debug for Credential {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Credential::Auth0(Some(_)) => f.debug_tuple("Auth0").field(&"<token>").finish(),
+            Credential::Auth0(None) => f.write_str("Auth0(None)"),
+            Credential::Bare(token) => f.debug_tuple("Bare").field(&token).finish(),
+            Credential::AccessToken(token) => f.debug_tuple("AccessToken").field(&token).finish(),
+            Credential::Kerberos(Some(material)) => f
+                .debug_struct("Kerberos")
+                .field("principal", &material.principal)
+                .finish_non_exhaustive(),
+            Credential::Kerberos(None) => f.write_str("Kerberos(None)"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::*;
+    use crate::auth::identity::test_helpers::test_identity;
+    use crate::auth::token::FloxhubToken;
+    use crate::auth::token::test_helpers::{
+        FAKE_EXPIRED_TOKEN_WITH_SUB,
+        FAKE_TOKEN,
+        FAKE_TOKEN_NO_HANDLE,
+        FAKE_TOKEN_WITH_SUB,
+        test_bare_token,
+    };
+
+    #[test]
+    fn user_subject_returns_sub_for_auth0_token() {
+        let token = FloxhubToken::from_str(FAKE_TOKEN_WITH_SUB).expect("token parses");
+        assert_eq!(
+            Credential::Auth0(Some(token)).user_subject().as_deref(),
+            Some("github|424242")
+        );
+    }
+
+    /// Expiry gates authentication, not identity — an expired token's `sub`
+    /// is still the correct attribution.
+    #[test]
+    fn user_subject_returns_sub_for_expired_auth0_token() {
+        let token = FloxhubToken::from_str(FAKE_EXPIRED_TOKEN_WITH_SUB).expect("token parses");
+        assert!(token.is_expired(), "test premise: token is expired");
+        assert_eq!(
+            Credential::Auth0(Some(token)).user_subject().as_deref(),
+            Some("github|424242")
+        );
+    }
+
+    #[test]
+    fn user_subject_is_none_without_sub_token_or_auth0() {
+        let token = FloxhubToken::from_str(FAKE_TOKEN).expect("token parses");
+        assert_eq!(Credential::Auth0(Some(token)).user_subject(), None);
+        assert_eq!(Credential::Auth0(None).user_subject(), None);
+        assert_eq!(Credential::Kerberos(None).user_subject(), None);
+    }
+
+    #[test]
+    fn is_unauthenticated_covers_missing_and_expired_auth0_tokens() {
+        let valid = FloxhubToken::from_str(FAKE_TOKEN).expect("token parses");
+        let expired = FloxhubToken::from_str(FAKE_EXPIRED_TOKEN_WITH_SUB).expect("token parses");
+        assert!(expired.is_expired(), "test premise: token is expired");
+
+        assert!(Credential::Auth0(None).cached_facts().is_unauthenticated());
+        assert!(
+            Credential::Auth0(Some(expired))
+                .cached_facts()
+                .is_unauthenticated()
+        );
+        assert!(
+            !Credential::Auth0(Some(valid))
+                .cached_facts()
+                .is_unauthenticated()
+        );
+        assert!(!pat_unresolved().cached_facts().is_unauthenticated());
+        assert!(
+            !Credential::Kerberos(None)
+                .cached_facts()
+                .is_unauthenticated()
+        );
+    }
+
+    fn pat_unresolved() -> Credential {
+        Credential::AccessToken(AccessToken::new("flox_pat_secret".to_string()))
+    }
+
+    #[test]
+    fn pat_handle_is_unknown_until_resolved() {
+        let auth = pat_unresolved();
+        assert_eq!(auth.handle(), None);
+    }
+
+    #[test]
+    fn pat_handle_reads_the_cached_identity() {
+        let token = AccessToken::new("flox_pat_context-handle-test".to_string());
+        crate::auth::identity::cache_identity(token.secret(), &test_identity("testuser"));
+        let auth = Credential::AccessToken(token);
+
+        assert_eq!(auth.handle(), Some("testuser".to_string()));
+    }
+
+    #[test]
+    fn pat_subject_reads_the_cached_identity() {
+        let token = AccessToken::new("flox_pat_context-subject-test".to_string());
+        crate::auth::identity::cache_identity(token.secret(), &crate::auth::UserIdentity {
+            handle: "testuser".to_string(),
+            sub: Some("auth0|123".to_string()),
+            expires_at: None,
+        });
+        let auth = Credential::AccessToken(token);
+
+        assert_eq!(auth.user_subject().as_deref(), Some("auth0|123"));
+    }
+
+    #[test]
+    fn pat_debug_redacts_the_secret() {
+        let auth = pat_unresolved();
+        assert!(!format!("{auth:?}").contains("flox_pat_secret"));
+    }
+
+    /// The record's whole purpose for an opaque token: the handle `/me`
+    /// returned last time, adopted without a request.
+    #[test]
+    fn seed_from_adopts_a_handle_recorded_for_this_credential() {
+        let secret = "flox_pat_seed-adopts";
+        let auth = Credential::new_from_token(Some(secret));
+        assert_eq!(auth.handle(), None, "unresolved to begin with");
+
+        auth.seed_from(&CachedFacts {
+            handle: Some("seeded-user".to_string()),
+            subject: Some("auth0|seeded".to_string()),
+            fingerprint: Some(credential_fingerprint(secret)),
+            ..CachedFacts::default()
+        });
+
+        assert_eq!(auth.handle(), Some("seeded-user".to_string()));
+        assert_eq!(auth.user_subject(), Some("auth0|seeded".to_string()));
+    }
+
+    /// The fingerprint is what makes a recorded handle safe to believe: a
+    /// record left by another account must not name this credential's user.
+    #[test]
+    fn seed_from_ignores_a_record_for_another_credential() {
+        let auth = Credential::new_from_token(Some("flox_pat_seed-wrong-fingerprint"));
+
+        auth.seed_from(&CachedFacts {
+            handle: Some("someone-else".to_string()),
+            fingerprint: Some(credential_fingerprint("a-different-secret")),
+            ..CachedFacts::default()
+        });
+
+        assert_eq!(auth.handle(), None);
+    }
+
+    /// A record with no fingerprint cannot be attributed to any credential,
+    /// so it is never adopted.
+    #[test]
+    fn seed_from_ignores_a_record_without_a_fingerprint() {
+        let auth = Credential::new_from_token(Some("flox_pat_seed-no-fingerprint"));
+
+        auth.seed_from(&CachedFacts {
+            handle: Some("someone-else".to_string()),
+            fingerprint: None,
+            ..CachedFacts::default()
+        });
+
+        assert_eq!(auth.handle(), None);
+    }
+
+    /// A JWT answers its own handle from its claims, so a record — even a
+    /// correctly fingerprinted one — has nothing to add and must not
+    /// override it.
+    #[test]
+    fn seed_from_leaves_a_jwt_answering_from_its_claims() {
+        let auth = Credential::new_from_token(Some(FAKE_TOKEN));
+        let secret = auth.token_secret().expect("a JWT carries a secret");
+
+        auth.seed_from(&CachedFacts {
+            handle: Some("not-this-one".to_string()),
+            fingerprint: Some(credential_fingerprint(secret)),
+            ..CachedFacts::default()
+        });
+
+        assert_eq!(auth.handle(), Some("test".to_string()));
+    }
+
+    /// The facts a credential records are what a later invocation reads back,
+    /// so an opaque token contributes everything `/me` resolved for it.
+    #[test]
+    fn cached_facts_of_a_resolved_opaque_token() {
+        let secret = "flox_pat_cached-facts-test";
+        let auth = Credential::new_from_token(Some(secret));
+        crate::auth::identity::cache_identity(secret, &crate::auth::UserIdentity {
+            handle: "factsuser".to_string(),
+            sub: Some("auth0|facts".to_string()),
+            expires_at: None,
+        });
+
+        assert_eq!(auth.cached_facts(), CachedFacts {
+            logged_in: true,
+            kind: CredentialKind::PersonalAccessToken,
+            // Opaque: only the server can judge it, so no local gate.
+            requires_login: false,
+            expires_at: None,
+            subject: Some("auth0|facts".to_string()),
+            handle: Some("factsuser".to_string()),
+            fingerprint: Some(credential_fingerprint(secret)),
+        });
+    }
+
+    #[test]
+    fn jwt_handle_derives_from_claims() {
+        let auth = Credential::Auth0(Some(FAKE_TOKEN.parse().unwrap()));
+        assert_eq!(auth.handle(), Some("test".to_string()));
+    }
+
+    #[test]
+    fn new_from_token_routes_flox_prefix_to_access_token() {
+        // Any flox_-prefixed token is an opaque access token, including
+        // personal and service account tokens.
+        for secret in ["flox_pat_abc123", "flox_sat_abc123"] {
+            let auth = Credential::new_from_token(Some(secret));
+            let Credential::AccessToken(token) = auth else {
+                panic!("expected AccessToken, got {auth:?}");
+            };
+            assert_eq!(token.secret(), secret);
+        }
+    }
+
+    #[test]
+    fn new_from_token_routes_jwt_to_auth0() {
+        let auth = Credential::new_from_token(Some(FAKE_TOKEN));
+        let Credential::Auth0(Some(token)) = auth else {
+            panic!("expected Auth0, got {auth:?}");
+        };
+        assert_eq!(token.secret(), FAKE_TOKEN);
+    }
+
+    #[test]
+    fn new_from_token_without_token_is_not_logged_in() {
+        let auth = Credential::new_from_token(None);
+        assert!(matches!(auth, Credential::Auth0(None)));
+    }
+
+    #[test]
+    fn new_from_token_routes_claimless_jwt_to_bare() {
+        let auth = Credential::new_from_token(Some(FAKE_TOKEN_NO_HANDLE));
+        let Credential::Bare(token) = auth else {
+            panic!("expected Bare, got {auth:?}");
+        };
+        assert_eq!(token.secret(), FAKE_TOKEN_NO_HANDLE);
+    }
+
+    #[test]
+    fn new_from_token_carries_a_non_jwt_opaquely() {
+        // No local check can reject a token — an issuer may mint opaque
+        // access tokens, so a non-decodable string is a credential whose
+        // validity only the server can judge.
+        let auth = Credential::new_from_token(Some("not-a-jwt"));
+        let Credential::AccessToken(token) = auth else {
+            panic!("expected AccessToken, got {auth:?}");
+        };
+        assert_eq!(token.secret(), "not-a-jwt");
+    }
+
+    #[test]
+    fn bare_token_subject_and_cached_handle() {
+        // A bare token contributes its sub for telemetry, and its handle
+        // comes from the /me-filled cache, like an opaque token's.
+        let token = test_bare_token("context-bare-handle-test");
+        let auth = Credential::Bare(token.clone());
+        assert_eq!(
+            auth.user_subject().as_deref(),
+            Some("context-bare-handle-test")
+        );
+        assert_eq!(auth.handle(), None);
+
+        crate::auth::identity::cache_identity(token.secret(), &test_identity("dexter"));
+        assert_eq!(Credential::Bare(token).handle(), Some("dexter".to_string()));
+    }
+}

--- a/cli/floxhub-client/src/auth/identity.rs
+++ b/cli/floxhub-client/src/auth/identity.rs
@@ -4,14 +4,13 @@
 //! resolved through the FloxHub client (the accounts service's
 //! `GET /api/v1/accounts/me`, exposed publicly at
 //! `/accounts/api/v1/accounts/me`) at the point of use and cached process-wide,
-//! keyed by token secret — a token's identity never changes. This module
+//! keyed by token secret — successful lookups are reused until explicitly refreshed. This module
 //! defines the data contract and the cache only — it carries no transport.
 
 use std::collections::HashMap;
 use std::sync::{LazyLock, Mutex};
 
 use chrono::{DateTime, Utc};
-use thiserror::Error;
 
 /// Placeholder handle shown when a credential could not be verified (e.g.
 /// FloxHub was unreachable). The server is the authority for authn/authz,
@@ -44,22 +43,9 @@ impl UserIdentity {
     }
 }
 
-/// Why an identity could not be resolved.
-#[derive(Debug, Clone, Error)]
-pub enum IdentityError {
-    /// The server rejected the credential (invalid, expired, or revoked).
-    #[error("token is invalid, expired, or revoked")]
-    Unauthorized,
-    /// Resolution failed for another reason (e.g. the server was
-    /// unreachable); the credential may still authenticate requests.
-    #[error("{0}")]
-    Other(String),
-}
-
 /// Process-wide cache of identities resolved for opaque tokens, keyed by
-/// token secret. A token's identity never changes, so a successful
-/// resolution is cached for the process. Failures are not cached — a later
-/// call retries.
+/// token secret. Auth status can refresh entries to detect renamed handles.
+/// Failures are not cached, so a later call retries.
 static RESOLVED_IDENTITIES: LazyLock<Mutex<HashMap<String, UserIdentity>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 

--- a/cli/floxhub-client/src/auth/kerberos/credential.rs
+++ b/cli/floxhub-client/src/auth/kerberos/credential.rs
@@ -10,7 +10,8 @@ use tracing::debug;
 use url::Url;
 
 use super::KerberosMaterial;
-use crate::auth::auth_context::{AuthContext, AuthHeaderError};
+use crate::auth::AuthHeaderError;
+use crate::auth::credential::Credential;
 
 /// Errors from Kerberos credential acquisition.
 #[derive(Debug, Clone, thiserror::Error)]
@@ -25,18 +26,18 @@ enum AuthError {
 /// closure — it is `Clone` (Arc-wrapped) so each SPNEGO context gets a
 /// cheap handle to the same underlying credential.
 ///
-/// Returns `AuthContext::Kerberos(Some)` with a SPNEGO token generator on
-/// success, or `AuthContext::Kerberos(None)` if the principal cannot be
+/// Returns `Credential::Kerberos(Some)` with a SPNEGO token generator on
+/// success, or `Credential::Kerberos(None)` if the principal cannot be
 /// resolved.
-pub(crate) fn kerberos_credential() -> AuthContext {
+pub(crate) fn kerberos_credential() -> Credential {
     match acquire_credential() {
-        Ok((principal, cred)) => AuthContext::Kerberos(Some(KerberosMaterial {
+        Ok((principal, cred)) => Credential::Kerberos(Some(KerberosMaterial {
             principal,
             generate_token: Arc::new(move |url: &Url| generate_spnego_token(&cred, url)),
         })),
         Err(e) => {
             tracing::warn!(error = %e, "Kerberos principal resolution failed");
-            AuthContext::Kerberos(None)
+            Credential::Kerberos(None)
         },
     }
 }

--- a/cli/floxhub-client/src/auth/kerberos/mod.rs
+++ b/cli/floxhub-client/src/auth/kerberos/mod.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use url::Url;
 
-use crate::auth::auth_context::AuthHeaderError;
+use crate::auth::AuthHeaderError;
 
 /// A function that generates a SPNEGO token for a given URL.
 pub type TokenGenerator = Arc<dyn Fn(&Url) -> Result<String, AuthHeaderError> + Send + Sync>;

--- a/cli/floxhub-client/src/auth/mod.rs
+++ b/cli/floxhub-client/src/auth/mod.rs
@@ -6,30 +6,22 @@
 //! [`AuthContext::new_from_token`] (routing by the token's form) or
 //! [`AuthContext::new_kerberos`].
 //!
-//! This module carries no transport: the identity behind an opaque token is
-//! resolved at the point of use through `FloxhubClient::resolve_identity`
-//! and surfaced uniformly via `Flox::get_identity`.
-//!
-//! One file per type:
-//! - [`auth_context`]: [`AuthContext`] and its failure types
-//! - [`discovery`]: per-deployment login discovery
-//!   ([`discover_login_config`])
-//! - [`identity`]: [`UserIdentity`] and its resolution errors
-//! - [`token`]: one type per credential capability — [`FloxhubToken`]
-//!   (Auth0-shaped JWT, identity local), [`BareToken`] (JWT without the
-//!   handle claim, identity via /me), [`AccessToken`] (opaque, everything
-//!   via /me)
-//! - [`kerberos`]: [`KerberosMaterial`] and SPNEGO token generation
+//! Credential loading and cached identity resolution are handled by
+//! [`AuthContext`]. Callers request a handle or identity directly.
+//! Storage adapters use the separate [storage] integration API.
 
 mod auth_context;
+mod credential;
 mod discovery;
 pub(crate) mod identity;
 mod kerberos;
+pub mod storage;
 mod token;
 
-pub use auth_context::{AuthContext, AuthFailure, AuthHeaderError};
+pub use auth_context::AuthContext;
+pub use credential::{AuthFailure, AuthHeaderError, Credential, CredentialKind};
 pub use discovery::{DiscoveredLoginConfig, LoginDiscoveryError, discover_login_config};
-pub use identity::{IdentityError, UNKNOWN_HANDLE, UserIdentity};
+pub use identity::{UNKNOWN_HANDLE, UserIdentity};
 pub use kerberos::{KerberosMaterial, TokenGenerator};
 pub use token::{AccessToken, BareToken, FloxhubToken, InvalidTokenError};
 

--- a/cli/floxhub-client/src/auth/storage.rs
+++ b/cli/floxhub-client/src/auth/storage.rs
@@ -1,0 +1,127 @@
+//! Integration between credential storage and runtime authentication.
+//!
+//! Ordinary callers use [AuthContext] accessors. Storage adapters explicitly
+//! import [AuthContextStorageExt] to wire deferred loading and persistence.
+//! Recorded facts are advisory until checked against the loaded credential.
+
+use chrono::{DateTime, Utc};
+
+use super::{AuthContext, CredentialKind};
+
+/// Storage-only hooks for [AuthContext].
+///
+/// These methods require an explicit trait import; they are not part of the
+/// ordinary authentication interface.
+///
+/// ```
+/// use floxhub_client::AuthContext;
+/// use floxhub_client::auth::storage::{AuthContextStorageExt, CachedFacts};
+///
+/// let context = AuthContext::deferred(CachedFacts::default(), AuthContext::default)
+///     .with_identity_recorder(|_facts| {});
+/// context.seed_from(&CachedFacts::default());
+/// assert_eq!(context.cached_facts(), CachedFacts::default());
+/// assert_eq!(context.handle(), None);
+/// ```
+///
+/// Without the trait, neither construction nor instance hooks are available:
+///
+/// ```compile_fail,E0599
+/// use floxhub_client::AuthContext;
+/// use floxhub_client::auth::storage::CachedFacts;
+///
+/// let _ = AuthContext::deferred(CachedFacts::default(), AuthContext::default);
+/// ```
+///
+/// ```compile_fail,E0599
+/// use floxhub_client::AuthContext;
+///
+/// let _ = AuthContext::default().with_identity_recorder(|_| {});
+/// ```
+///
+/// ```compile_fail,E0599
+/// use floxhub_client::AuthContext;
+///
+/// let _ = AuthContext::default().cached_facts();
+/// ```
+///
+/// ```compile_fail,E0599
+/// use floxhub_client::AuthContext;
+/// use floxhub_client::auth::storage::CachedFacts;
+///
+/// AuthContext::default().seed_from(&CachedFacts::default());
+/// ```
+pub trait AuthContextStorageExt: Sized {
+    /// Retain startup facts while deferring the credential-store read.
+    fn deferred(
+        recorded: CachedFacts,
+        resolve: impl Fn() -> AuthContext + Send + Sync + 'static,
+    ) -> Self;
+
+    /// Install the persistent cache writer used after successful identity lookups.
+    fn with_identity_recorder(self, record: impl Fn(&CachedFacts) + Send + Sync + 'static) -> Self;
+
+    /// Non-secret snapshot for persistence, without loading the credential.
+    /// Ordinary callers should use accessors such as [AuthContext::handle].
+    fn cached_facts(&self) -> CachedFacts;
+
+    /// Seed an already-loaded credential from a fingerprint-checked record.
+    /// Deferred credentials check their record when first loaded.
+    fn seed_from(&self, recorded: &CachedFacts);
+}
+
+/// The non-secret facts about a credential, in the form an earlier invocation
+/// can record and a later one read back without paying to load the credential
+/// again.
+///
+/// Exposed by [`AuthContextStorageExt::cached_facts`] without loading a deferred
+/// credential. Recorded facts are advisory until checked against that credential.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CachedFacts {
+    /// A bearer credential is stored. Says nothing about whether the server
+    /// will accept it; no local check can.
+    pub logged_in: bool,
+    /// Which kind of credential this is. Telemetry stamps it on every event,
+    /// and reading the credential to learn it would defeat the deferral.
+    pub kind: CredentialKind,
+    /// Whether a FloxHub login gates this credential at all. False for an
+    /// opaque token, whose validity only the server knows, and for Kerberos,
+    /// which authenticates from the ccache and needs no FloxHub login.
+    pub requires_login: bool,
+    /// Local expiry, for the credentials that carry one.
+    pub expires_at: Option<DateTime<Utc>>,
+    /// The pseudonymous subject telemetry is attributed to.
+    pub subject: Option<String>,
+    /// The user's handle, when it is known — from a JWT's claims, a Kerberos
+    /// principal, or a `/me` resolution that has already happened.
+    pub handle: Option<String>,
+    /// Which credential these facts describe, as [`credential_fingerprint`].
+    ///
+    /// The facts are keyed by FloxHub instance, not by credential — the whole
+    /// point is to answer before the credential has been loaded — so this is
+    /// how a caller that *does* hold the secret checks that the record is
+    /// about the credential in its hand. See [`AuthContextStorageExt::seed_from`].
+    pub fingerprint: Option<String>,
+}
+
+/// A stable, non-reversible name for a credential.
+///
+/// Recorded beside the facts so a caller holding the secret can tell whether
+/// they describe it. blake3 over a high-entropy bearer token is not
+/// invertible, and the record is written `0600` regardless.
+pub fn credential_fingerprint(secret: &str) -> String {
+    blake3::hash(secret.as_bytes()).to_hex().to_string()
+}
+
+impl CachedFacts {
+    /// Whether the recorded credential needs a FloxHub login.
+    ///
+    /// `requires_login` is what keeps this honest for the credentials that
+    /// carry no bearer secret: Kerberos records `logged_in: false`, and
+    /// without the gate that would read as "not logged in" for a mode where
+    /// logging in is not a thing.
+    pub fn is_unauthenticated(&self) -> bool {
+        self.requires_login
+            && (!self.logged_in || self.expires_at.is_some_and(|expiry| expiry <= Utc::now()))
+    }
+}

--- a/cli/floxhub-client/src/auth/token/access_token.rs
+++ b/cli/floxhub-client/src/auth/token/access_token.rs
@@ -8,13 +8,19 @@ use crate::auth::identity;
 /// them.
 pub(crate) const ACCESS_TOKEN_PREFIX: &str = "flox_";
 
+/// Prefix of a personal access token.
+pub(crate) const PERSONAL_ACCESS_TOKEN_PREFIX: &str = "flox_pat_";
+
+/// Prefix of a service account token.
+pub(crate) const SERVICE_ACCOUNT_TOKEN_PREFIX: &str = "flox_sat_";
+
 /// An opaque access token (`flox_…`) authenticating a caller with FloxHub,
 /// including `flox_pat_` personal access tokens and `flox_sat_` service
 /// account tokens.
 ///
 /// The CLI cannot decode identity from an opaque token; it is resolved via
 /// the accounts service's `GET /api/v1/accounts/me` (publicly
-/// `/accounts/api/v1/accounts/me`; `FloxhubClient::resolve_identity`) and
+/// `/accounts/api/v1/accounts/me`; [`crate::AuthContext::identity`]) and
 /// cached process-wide, keyed by the secret. Until resolution succeeds,
 /// [`Self::handle`] returns `None` — the server's 401 is the authoritative
 /// backstop.
@@ -40,6 +46,13 @@ impl AccessToken {
     /// network.
     pub fn handle(&self) -> Option<String> {
         identity::cached_identity(&self.token).map(|identity| identity.handle)
+    }
+
+    /// The expiry `/me` reported for this token; `None` until resolution has
+    /// succeeded, and for a token that never expires. Nothing is knowable
+    /// locally — an opaque token has no claims to read.
+    pub fn expires_at(&self) -> Option<chrono::DateTime<chrono::Utc>> {
+        identity::cached_identity(&self.token).and_then(|identity| identity.expires_at)
     }
 }
 

--- a/cli/floxhub-client/src/auth/token/bare_token.rs
+++ b/cli/floxhub-client/src/auth/token/bare_token.rs
@@ -60,7 +60,7 @@ impl BareToken {
     /// Return the resolved handle; `None` until `/me` resolution has
     /// succeeded. Reads the process-wide cache — never blocks, never
     /// touches the network. For the resolved answer use
-    /// `Flox::get_identity`.
+    /// [`crate::AuthContext::handle`].
     pub fn handle(&self) -> Option<String> {
         identity::cached_identity(&self.token).map(|identity| identity.handle)
     }

--- a/cli/floxhub-client/src/auth/token/mod.rs
+++ b/cli/floxhub-client/src/auth/token/mod.rs
@@ -15,8 +15,12 @@ mod access_token;
 mod bare_token;
 mod floxhub_token;
 
-pub(crate) use access_token::ACCESS_TOKEN_PREFIX;
 pub use access_token::AccessToken;
+pub(crate) use access_token::{
+    ACCESS_TOKEN_PREFIX,
+    PERSONAL_ACCESS_TOKEN_PREFIX,
+    SERVICE_ACCOUNT_TOKEN_PREFIX,
+};
 pub use bare_token::BareToken;
 pub use floxhub_token::FloxhubToken;
 use thiserror::Error;

--- a/cli/floxhub-client/src/client.rs
+++ b/cli/floxhub-client/src/client.rs
@@ -29,8 +29,8 @@ use tracing::{debug, instrument};
 use url::Url;
 
 use crate::MapApiErrorExt;
-use crate::accounts::{AccountsApiClient, MeError};
-use crate::auth::{AuthContext, IdentityError, UserIdentity, identity};
+use crate::accounts::AccountsApiClient;
+use crate::auth::AuthContext;
 use crate::config::FloxhubClientConfig;
 use crate::error::{ByCommandError, FloxhubClientError, ResolveError, SearchError, VersionsError};
 use crate::mock::MockGuard;
@@ -881,39 +881,6 @@ where
 }
 
 // ---------------------------------------------------------------------------
-// Opaque-credential identity resolution
-// ---------------------------------------------------------------------------
-
-impl FloxhubClient {
-    /// Resolve the identity behind a bearer credential whose claims don't
-    /// carry it — a personal access token, or an interactive-login token
-    /// without the handle claim — from `GET /api/v1/accounts/me`. A
-    /// successful resolution is cached for the process, keyed by the
-    /// secret; failures are returned but not cached, so a later call
-    /// retries.
-    ///
-    /// This is the only auth operation that needs a client; every other
-    /// credential kind derives its identity locally. Callers holding a
-    /// [`Flox`] should use its uniform `Flox::get_identity` instead.
-    pub async fn resolve_identity(&self, secret: &str) -> Result<UserIdentity, IdentityError> {
-        if let Some(identity) = identity::cached_identity(secret) {
-            return Ok(identity);
-        }
-        let identity = self
-            .accounts()
-            .me(secret)
-            .await
-            .map_err(|err| match err {
-                MeError::Unauthorized => IdentityError::Unauthorized,
-                other => IdentityError::Other(other.to_string()),
-            })
-            .inspect_err(|err| debug!(%err, "could not resolve identity"))?;
-        identity::cache_identity(secret, &identity);
-        Ok(identity)
-    }
-}
-
-// ---------------------------------------------------------------------------
 // Shared HTTP client construction helpers (pub(crate) for factory module)
 // ---------------------------------------------------------------------------
 
@@ -939,6 +906,8 @@ pub(crate) fn build_pre_request_hook(
             }
         }
 
+        // The one place the secret is unavoidable, and the point the deferred
+        // read is paid for: a request is going out that needs to carry it.
         if let Some(result) = credential.authorization_header(request.url()) {
             match result {
                 Ok(value) => {
@@ -946,6 +915,8 @@ pub(crate) fn build_pre_request_hook(
                         request
                             .headers_mut()
                             .insert(reqwest::header::AUTHORIZATION, header_value);
+                    } else {
+                        tracing::warn!("Could not encode authorization header");
                     }
                 },
                 Err(e) => {
@@ -1063,73 +1034,6 @@ pub mod tests {
     use super::*;
     use crate::config::UnauthenticatedResolveHook;
     const SENTRY_TRACE_HEADER: &str = "sentry-trace";
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn resolve_identity_fetches_and_caches_via_me() {
-        let server = MockServer::start();
-        let mock = server.mock(|when, then| {
-            when.method(httpmock::Method::GET)
-                .path("/accounts/api/v1/accounts/me")
-                .header("authorization", "bearer flox_pat_client-cache-test");
-            then.status(200).json_body(json!({
-                "user_id": "pat|test",
-                "handle": "testuser",
-                "expires_at": null,
-            }));
-        });
-
-        let client = FloxhubClient::new(client_config(&server.base_url())).unwrap();
-        let identity = client
-            .resolve_identity("flox_pat_client-cache-test")
-            .await
-            .unwrap();
-        assert_eq!(identity.handle, "testuser");
-        // A second resolve reads the cache instead of the server.
-        client
-            .resolve_identity("flox_pat_client-cache-test")
-            .await
-            .unwrap();
-        mock.assert_calls(1);
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn resolve_identity_maps_401_to_unauthorized() {
-        let server = MockServer::start();
-        server.mock(|when, then| {
-            when.method(httpmock::Method::GET)
-                .path("/accounts/api/v1/accounts/me");
-            then.status(401)
-                .json_body(json!({"detail": "unauthorized"}));
-        });
-
-        let client = FloxhubClient::new(client_config(&server.base_url())).unwrap();
-        assert!(matches!(
-            client.resolve_identity("flox_pat_client-401-test").await,
-            Err(IdentityError::Unauthorized)
-        ));
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn resolve_identity_does_not_cache_failures() {
-        let server = MockServer::start();
-        let mock = server.mock(|when, then| {
-            when.method(httpmock::Method::GET)
-                .path("/accounts/api/v1/accounts/me");
-            then.status(500);
-        });
-
-        let client = FloxhubClient::new(client_config(&server.base_url())).unwrap();
-        assert!(matches!(
-            client.resolve_identity("flox_pat_client-500-test").await,
-            Err(IdentityError::Other(_))
-        ));
-        // The failure is not cached: a second resolve retries the server.
-        assert!(matches!(
-            client.resolve_identity("flox_pat_client-500-test").await,
-            Err(IdentityError::Other(_))
-        ));
-        mock.assert_calls(2);
-    }
 
     #[tokio::test]
     async fn resolve_response_with_new_message_type() {

--- a/cli/floxhub-client/src/config.rs
+++ b/cli/floxhub-client/src/config.rs
@@ -48,6 +48,9 @@ pub struct FloxhubClientConfig {
     pub extra_headers: BTreeMap<String, String>,
     /// Mock mode for testing.
     pub mock_mode: FloxhubMockMode,
+    /// The credential for outgoing requests, resolved on first request rather
+    /// than at construction — a client is built for every invocation, but most
+    /// invocations send nothing.
     pub auth_context: AuthContext,
     pub user_agent: Option<String>,
     /// Stability pin applied to every outgoing `PackageGroup` in

--- a/cli/floxhub-client/src/factory.rs
+++ b/cli/floxhub-client/src/factory.rs
@@ -404,7 +404,7 @@ pub mod tests {
     /// Build a bearer credential for tests. A personal access token is just a
     /// string, so no JWT construction is needed to test header handling.
     fn make_test_auth(secret: &str) -> AuthContext {
-        AuthContext::AccessToken(AccessToken::new(secret.to_string()))
+        AuthContext::from_access_token(AccessToken::new(secret.to_string()))
     }
 
     #[test]

--- a/cli/floxhub-client/src/lib.rs
+++ b/cli/floxhub-client/src/lib.rs
@@ -56,7 +56,25 @@ pub const FLOX_RESOLVE_STABILITY_VAR: &str = "_FLOX_RESOLVE_STABILITY";
 // Re-export the authentication types so consumers can keep depending only
 // on floxhub-client.
 pub use accounts::{AccountsApiClient, MeError};
-pub use auth::*;
+#[cfg(any(test, feature = "tests"))]
+pub use auth::test_helpers;
+pub use auth::{
+    AccessToken,
+    AuthContext,
+    AuthFailure,
+    AuthHeaderError,
+    BareToken,
+    CredentialKind,
+    DiscoveredLoginConfig,
+    FloxhubToken,
+    InvalidTokenError,
+    KerberosMaterial,
+    LoginDiscoveryError,
+    TokenGenerator,
+    UNKNOWN_HANDLE,
+    UserIdentity,
+    discover_login_config,
+};
 pub use catalog_api_v1::{
     Client as ApiClient,
     Error as ApiError,

--- a/cli/tests/auth.bats
+++ b/cli/tests/auth.bats
@@ -153,3 +153,48 @@ EXPIRED_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJodHRwczovL2Zsb3guZGV2L2hh
   run "$FLOX_BIN" auth status
   assert_failure
 }
+
+# bats test_tags=auth,auth:cache
+@test "plaintext login caches identity without claiming a keyring credential" {
+  echo "$DUMMY_TOKEN" > "$PROJECT_DIR/token"
+  run "$FLOX_BIN" auth login --token-file "$PROJECT_DIR/token" --insecure-storage
+  assert_success
+
+  run jq -c '[.storage, .handle, .logged_in]' "$FLOX_CACHE_DIR"/auth-state-*.json
+  assert_success
+  assert_output '["plaintext","test",true]'
+
+  # Removing the plaintext token must not leave its identity posing as
+  # a credential in the (suite-wide disabled) keyring on the next invocation.
+  run "$FLOX_BIN" config --delete floxhub_token
+  assert_success
+  # The delete command resolved auth before removing the token. Start a new
+  # invocation to check that auth resolution replaces the stale cache record.
+  run "$FLOX_BIN" config
+  assert_success
+
+  run jq -c '[.storage, .handle, .logged_in]' "$FLOX_CACHE_DIR"/auth-state-*.json
+  assert_success
+  assert_output '["keyring",null,false]'
+}
+
+# bats test_tags=auth,auth:cache
+@test "the auth record is written to the cache dir and dropped at logout" {
+  # With no env token and no plain-text token, the keyring is the only place a
+  # credential could be, so this traverses the deferred path — the one the
+  # record exists to serve, and the one the suite's `FLOX_FLOXHUB_TOKEN`
+  # otherwise short-circuits. The keyring is disabled suite-wide, which reads
+  # as "nothing stored", so what is under test is not the record's contents
+  # but that it lands where a later invocation looks for it and is removed
+  # once the credential it describes is gone.
+  run "$FLOX_BIN" config
+  assert_success
+
+  run ls "$FLOX_CACHE_DIR"/auth-state-*.json
+  assert_success
+
+  run "$FLOX_BIN" auth logout
+  assert_success
+  run ls "$FLOX_CACHE_DIR"/auth-state-*.json
+  assert_failure
+}


### PR DESCRIPTION
- **perf(auth): cache identity and defer credential loading**

  Current auth code has two performance issues:

  - We have to hit /me to get sub and handle for opaque tokens and
    handle for bare JWTs
  - Keyring access is slow (and prompts frequently)

  Add a cache file containing non-secret data. This first commit adds
  caching and reworks our auth code. A second commit will use the
  re-worked auth helpers in callers.

  The cache can get stale, but not in common cases:

  - /me would return a different result
  - The user manually modifies the cache or keyring

  When a token is set via environment variable, we read from cache
  (based on token hash) but never write to it.

  Auth code is split into two categories:

  - A credential_store module in the CLI, which manages disk caching,
    token storage, and migration
  - floxhub_client::AuthContext, which is stored on the Flox struct
    and passed throughout the codebase for authentication.

  In order to achieve laziness, credential_store has to set up
  callbacks in AuthContext to cache information when it's fetched.
  Ideally we'd split the Flox struct and only pass auth when we
  actually need it, in which case we wouldn't need the callbacks or
  the extension trait, but I think for now this solution is good
  enough. AuthContext currently communicates with /me, which also
  would make more sense in the CLI layer.

  AuthContext::handle continues returning an Option and is only used
  in some error handlers. I currently don't think they need to hit
  /me just to improve hints. In most cases we should have the handle
  cached already accurate.

- **refactor(auth): migrate callers to AuthContext accessors**

  Replace credential enum constructors and pattern matching with
  AuthContext constructors, credential kinds, and token accessors.
  Route identity lookups through AuthContext instead of the removed
  Flox helper, and update existing test callers to the new API.

  This completes the caller migration for the preceding auth and
  storage changes.


I benchmarked this and it has the expected performance improvements compared to 1.16.0 on macOS
```
version                   -0.2 ms (  -2%, baseline as it doesn't use auth)
config                   -13.7 ms ( -43%)
envs                     -10.8 ms ( -37%)
init                     -12.5 ms ( -33%)
activate                 -15.5 ms ( -24%)
```