### PR TITLE
Revert "chore: temporarily skip schema check"

### DIFF
--- a/cli/flox-manifest/src/parsed/common.rs
+++ b/cli/flox-manifest/src/parsed/common.rs
@@ -731,7 +731,6 @@ mod tests {
     /// cycle a newly added schema is legitimately ahead of it. The invariant
     /// only has to hold at release time, so it is asserted only in release CI.
     #[test]
-    #[ignore = "schema 1.17.0 merged to main before the 1.16.0 release was merged, and CI merges main back into the release branch"]
     fn cli_version_is_at_least_latest_schema_version() {
         if std::env::var("FLOX_RUNNING_RELEASE").as_deref() != Ok("true") {
             return;


### PR DESCRIPTION
This reverts commit e85392328f92a6e54549c01763e9c2f0f83675cf.

That commit was required for the release branch to merge into main, but in general we want this test enabled.