### PR TITLE
docs(config): clarify omitted default values in config listing

### DIFF
--- a/cli/flox/doc/flox-config.md
+++ b/cli/flox/doc/flox-config.md
@@ -21,8 +21,12 @@ flox [<general-options>] config
 
 # DESCRIPTION
 
-Without any flags or when `-l` is passed, `flox config` shows all options with
-their computed value.
+Without any flags or when `-l` is passed, `flox config` shows the merged
+configuration as TOML. Some defaults are added while reading the configuration
+and appear in the output. Other defaults are applied only when a command uses
+the configuration and are omitted until explicitly configured. For example,
+`auto_activate` is omitted when unset even though auto-activation behaves as if
+it were set to `prompt`.
 
 Config values are read from the following sources in order of descending priority:
 
@@ -53,7 +57,8 @@ flox config --set 'trusted_environments."owner/name"' trust
 ## Config Options
 
 `-l`, `--list`
-:   List the current values of all options.
+:   List the merged configuration. Options whose defaults are applied only when
+    used are omitted until explicitly configured.
 
 `-r`, `--reset`
 :   Reset all options to their default values without confirmation.

--- a/cli/flox/doc/flox-config.md
+++ b/cli/flox/doc/flox-config.md
@@ -21,12 +21,14 @@ flox [<general-options>] config
 
 # DESCRIPTION
 
-Without any flags or when `-l` is passed, `flox config` shows the merged
-configuration as TOML. Some defaults are added while reading the configuration
-and appear in the output. Other defaults are applied only when a command uses
-the configuration and are omitted until explicitly configured. For example,
-`auto_activate` is omitted when unset even though auto-activation behaves as if
-it were set to `prompt`.
+Without any flags or when `-l` is passed, `flox config` shows the parsed
+configuration as TOML, combining the sources listed below.
+The output includes defaults populated when loading the configuration, such as
+`cache_dir` and `disable_metrics`.
+Optional settings that are unset are omitted, even if they have a default
+behavior elsewhere in Flox.
+For example, `auto_activate` is omitted unless set in a configuration file or
+with `FLOX_AUTO_ACTIVATE`, but auto-activation still uses `prompt` when it is unset.
 
 Config values are read from the following sources in order of descending priority:
 
@@ -57,8 +59,7 @@ flox config --set 'trusted_environments."owner/name"' trust
 ## Config Options
 
 `-l`, `--list`
-:   List the merged configuration. Options whose defaults are applied only when
-    used are omitted until explicitly configured.
+:   List the parsed configuration as TOML, omitting unset optional settings.
 
 `-r`, `--reset`
 :   Reset all options to their default values without confirmation.

--- a/cli/flox/doc/flox-config.md
+++ b/cli/flox/doc/flox-config.md
@@ -21,14 +21,9 @@ flox [<general-options>] config
 
 # DESCRIPTION
 
-Without any flags or when `-l` is passed, `flox config` shows the parsed
-configuration as TOML, combining the sources listed below.
-The output includes defaults populated when loading the configuration, such as
-`cache_dir` and `disable_metrics`.
-Optional settings that are unset are omitted, even if they have a default
-behavior elsewhere in Flox.
-For example, `auto_activate` is omitted unless set in a configuration file or
-with `FLOX_AUTO_ACTIVATE`, but auto-activation still uses `prompt` when it is unset.
+Without any flags or when `-l` is passed, `flox config` lists explicitly set values
+and some built-in defaults, but omits unset optional settings even when they have
+default behavior.
 
 Config values are read from the following sources in order of descending priority:
 

--- a/cli/flox/doc/flox-config.md
+++ b/cli/flox/doc/flox-config.md
@@ -22,8 +22,7 @@ flox [<general-options>] config
 # DESCRIPTION
 
 Without any flags or when `-l` is passed, `flox config` lists explicitly set values
-and some built-in defaults, but omits unset optional settings even when they have
-default behavior.
+and some built-in defaults.
 
 Config values are read from the following sources in order of descending priority:
 
@@ -54,7 +53,7 @@ flox config --set 'trusted_environments."owner/name"' trust
 ## Config Options
 
 `-l`, `--list`
-:   List the parsed configuration as TOML, omitting unset optional settings.
+:   List explicitly set values and some built-in defaults.
 
 `-r`, `--reset`
 :   Reset all options to their default values without confirmation.


### PR DESCRIPTION
## Proposed Changes

The config manual promises all computed values, but the command prints the parsed configuration as TOML and omits unset optional settings. Document that rule, distinguish defaults populated during configuration loading from runtime fallbacks, and clarify the `--list` description.

The wording follows the implementation:

- [The list handler](https://github.com/flox/flox/blob/9cec04c58e504ed8c0fa58cca00dafef4bae1e0f/cli/flox/src/commands/general.rs) calls `config.get_verbatim(&[])`; [`write::get`](https://github.com/flox/flox/blob/9cec04c58e504ed8c0fa58cca00dafef4bae1e0f/cli/flox-config/src/write.rs) serializes `Config` with `toml_edit::ser::to_document` and returns the whole document.
- [The loader](https://github.com/flox/flox/blob/9cec04c58e504ed8c0fa58cca00dafef4bae1e0f/cli/flox-config/src/load.rs) supplies directory defaults. [`FloxConfig`](https://github.com/flox/flox/blob/9cec04c58e504ed8c0fa58cca00dafef4bae1e0f/cli/flox-config/src/config.rs) also supplies deserialization defaults, including `disable_metrics = false`. These values are present in the parsed config and appear in its output.
- `auto_activate` is an `Option<AutoActivate>`, so its unset value is omitted from TOML. The [hook](https://github.com/flox/flox/blob/9cec04c58e504ed8c0fa58cca00dafef4bae1e0f/cli/flox/src/commands/hook_env.rs#L875) separately calls `unwrap_or_default()`, which selects `AutoActivate::Prompt`. The listing does not compute this fallback.

Fixes #4659. Resolves [CLI-212](https://linear.app/floxdotdev/issue/CLI-212).

The proposed behavior change is tracked separately in [CLI-220](https://linear.app/floxdotdev/issue/CLI-220), including another documentation update.

Validation: traced the listing, loading, serialization, and fallback code; `git diff --check` passes. No builds or tests run.

## Release Notes

Clarify why `flox config -l` omits unset optional configuration values, including `auto_activate`.
