### PR TITLE
refactor(catalog-lock): own the direct-input type in the build lock

### DIFF
--- a/cli/flox/src/commands/publish.rs
+++ b/cli/flox/src/commands/publish.rs
@@ -34,7 +34,7 @@ use floxhub_client::{
     PackageSystem,
 };
 use indoc::formatdoc;
-use nef_lock_catalog::{CatalogRef, NixFlakeref, scan_package};
+use nef_lock_catalog::{CatalogRef, NixFlakeref, NotAGitSourceError, scan_package};
 use tracing::{debug, info_span, instrument, warn};
 
 use super::{DirEnvironmentSelect, dir_environment_select};
@@ -122,24 +122,34 @@ async fn dedup_short_circuit(client: &impl CatalogClientTrait, query: CheckBuild
 }
 
 /// The locked-input subset a publish submits, projected from the lock its
-/// build consumes, with a stale committed lock translated into an
-/// actionable error. Only the committed lock can be stale: an ephemeral
-/// lock is resolved from the same expressions the references were scanned
-/// from.
+/// build consumes and converted to the wire form the catalog accepts, with
+/// a stale committed lock — or one pinning a source the catalog cannot
+/// accept back — translated into an actionable error. Only the committed
+/// lock can be either: an ephemeral lock is resolved by the catalog itself
+/// from the same expressions the references were scanned from.
 fn subset_for_publish(
     lock: &BuildLockGuard,
     references: &BTreeSet<CatalogRef>,
 ) -> Result<BTreeMap<String, LockedInputEntry>> {
-    lock.build_lock().subset_direct(references).map_err(|err| {
+    let with_update_catalogs_hint = |err: anyhow::Error| {
         if lock.is_existing() {
             anyhow!(formatdoc! {"
                 {err}
                 Run '{update_catalogs}' to update '.flox/catalog.lock', then commit the file and retry 'flox publish'.",
-                update_catalogs = UPDATE_CATALOGS_COMMAND})
+            update_catalogs = UPDATE_CATALOGS_COMMAND})
         } else {
-            anyhow::Error::from(err)
+            err
         }
-    })
+    };
+    let subset = lock
+        .build_lock()
+        .subset_direct(references)
+        .map_err(|err| with_update_catalogs_hint(err.into()))?;
+    subset
+        .iter()
+        .map(|(key, input)| Ok((key.clone(), LockedInputEntry::try_from(input)?)))
+        .collect::<Result<_, NotAGitSourceError>>()
+        .map_err(|err| with_update_catalogs_hint(err.into()))
 }
 
 #[derive(Bpaf, Clone)]
@@ -557,6 +567,48 @@ mod tests {
         assert!(
             message.contains("myorg.hello"),
             "the uncovered reference must be named, got: {message}"
+        );
+    }
+
+    /// A committed lock pinning a source the catalog cannot accept back
+    /// (here a `path` flakeref) fails a publish naming the entry and the
+    /// recovery command.
+    #[test]
+    fn non_git_source_in_committed_lock_names_update_catalogs() {
+        let expressions_dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            expressions_dir.path().join("hello.nix"),
+            "{ catalogs }: catalogs.myorg.hello",
+        )
+        .unwrap();
+        let references = scan_package(expressions_dir.path(), "hello.nix").unwrap();
+
+        let build_lock: nef_lock_catalog::BuildLock = serde_json::from_value(serde_json::json!({
+            "version": 1,
+            "direct_catalog_inputs": {
+                "myorg/hello": {
+                    "attr_path": ["hello"],
+                    "build_type": "nef",
+                    "catalog": "myorg",
+                    "locked_inputs_hash": "sha256-test",
+                    "source": { "type": "path", "path": "/src/hello", "dir": ".flox" },
+                }
+            },
+            "catalogs": {}
+        }))
+        .unwrap();
+        let lock = build_lock_guard_from_parts("/project/.flox/catalog.lock", build_lock, true);
+
+        let err = subset_for_publish(&lock, &references)
+            .expect_err("a path source has no wire form to publish");
+        let message = format!("{err:#}");
+        assert!(
+            message.contains("myorg/hello"),
+            "the entry must be named, got: {message}"
+        );
+        assert!(
+            message.contains(UPDATE_CATALOGS_COMMAND),
+            "the hint must name the recovery command, got: {message}"
         );
     }
 

--- a/cli/nef-lock-catalog/src/lib.rs
+++ b/cli/nef-lock-catalog/src/lib.rs
@@ -33,7 +33,8 @@ pub use lock::build_lock::{
     subset_direct_inputs,
     write_lock,
 };
-pub use lock::flakeref::NixFlakeref;
+pub use lock::direct_input::{DirectInput, NotAGitSourceError};
+pub use lock::flakeref::{NixFlakeref, RawNixFlakerefAttrs};
 pub use lock::lookup::{LockError, lock_references};
 pub use lock::render::render_unresolvable;
 pub use lock::transform::build_lock_from_locked_inputs;

--- a/cli/nef-lock-catalog/src/lock/build_lock.rs
+++ b/cli/nef-lock-catalog/src/lock/build_lock.rs
@@ -3,10 +3,10 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use flox_core::{Version, WriteError, write_atomically};
-use floxhub_client::LockedInputEntry;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, instrument};
 
+use super::direct_input::DirectInput;
 use super::tree::PackageTreeNode;
 use crate::{CatalogId, CatalogRef};
 
@@ -32,14 +32,7 @@ pub struct BuildLock {
     pub(crate) _version: Version<1>,
     /// The direct (first-order) catalog inputs, keyed by the server's
     /// canonical `<catalog>/<attr-path>` form.
-    ///
-    /// Note: `LockedInputEntry` is generated from the catalog OpenAPI spec.
-    /// Serializing it verbatim into this on-disk lock couples the persisted
-    /// format to the generated schema, so regenerating the client can change
-    /// the lock format. A later increment should insulate this with a
-    /// hand-owned domain type (cf. the `BaseCatalogInfo` newtype and `From`
-    /// impls in `floxhub-client`).
-    pub(crate) direct_catalog_inputs: BTreeMap<String, LockedInputEntry>,
+    pub(crate) direct_catalog_inputs: BTreeMap<String, DirectInput>,
     pub(crate) catalogs: BTreeMap<CatalogId, CatalogLock>,
 }
 
@@ -88,12 +81,12 @@ impl BuildLock {
     pub fn subset_direct(
         &self,
         references: &BTreeSet<CatalogRef>,
-    ) -> Result<BTreeMap<String, LockedInputEntry>, StaleLockError> {
+    ) -> Result<BTreeMap<String, DirectInput>, StaleLockError> {
         subset_direct_inputs(&self.direct_catalog_inputs, references)
     }
 
     /// The direct (first-order) catalog inputs the lock pins.
-    pub fn direct_catalog_inputs(&self) -> &BTreeMap<String, LockedInputEntry> {
+    pub fn direct_catalog_inputs(&self) -> &BTreeMap<String, DirectInput> {
         &self.direct_catalog_inputs
     }
 }
@@ -115,9 +108,9 @@ impl BuildLock {
 /// verbatim and never reconstructed. A wildcard reference selects every
 /// entry under its prefix.
 pub fn subset_direct_inputs(
-    direct_catalog_inputs: &BTreeMap<String, LockedInputEntry>,
+    direct_catalog_inputs: &BTreeMap<String, DirectInput>,
     references: &BTreeSet<CatalogRef>,
-) -> Result<BTreeMap<String, LockedInputEntry>, StaleLockError> {
+) -> Result<BTreeMap<String, DirectInput>, StaleLockError> {
     let mut subset = BTreeMap::new();
     let mut missing = Vec::new();
     for reference in references {
@@ -127,7 +120,7 @@ pub fn subset_direct_inputs(
         let (catalog, path) = (names[1], &names[2..]);
         let wildcard = reference.path().is_wildcard();
 
-        let mut matched: Vec<(&String, &LockedInputEntry)> = direct_catalog_inputs
+        let mut matched: Vec<(&String, &DirectInput)> = direct_catalog_inputs
             .iter()
             .filter(|(_, entry)| {
                 entry.catalog == catalog && {
@@ -311,6 +304,39 @@ mod tests {
             references(&["catalogs.myorg.missing", "catalogs.other.gone"])
                 .into_iter()
                 .collect::<Vec<_>>()
+        );
+    }
+
+    /// A lock whose direct entry pins a source the NEF can fetch but the
+    /// catalog never issues — here a `path` flakeref — reads and subsets
+    /// like any other: the lock does not require its sources to be git.
+    #[test]
+    fn lock_with_a_non_git_source_reads_and_subsets() {
+        let rendered = serde_json::json!({
+            "version": 1,
+            "direct_catalog_inputs": {
+                "myorg/hello": {
+                    "attr_path": ["hello"],
+                    "build_type": "nef",
+                    "catalog": "myorg",
+                    "locked_inputs_hash": "sha256-test",
+                    "source": { "type": "path", "path": "/src/hello", "dir": ".flox" },
+                }
+            },
+            "catalogs": {}
+        });
+
+        let read: BuildLock = serde_json::from_value(rendered).expect("a path source parses");
+        let subset = read
+            .subset_direct(&references(&["catalogs.myorg.hello"]))
+            .expect("references are covered");
+
+        assert_eq!(subset.keys().collect::<Vec<_>>(), vec![
+            &"myorg/hello".to_string()
+        ]);
+        assert_eq!(
+            subset["myorg/hello"].source.as_value(),
+            &serde_json::json!({ "type": "path", "path": "/src/hello", "dir": ".flox" })
         );
     }
 

--- a/cli/nef-lock-catalog/src/lock/direct_input.rs
+++ b/cli/nef-lock-catalog/src/lock/direct_input.rs
@@ -1,0 +1,158 @@
+//! The direct (first-order) catalog inputs a build lock pins, as persisted
+//! on disk.
+
+use floxhub_client::{BuildType, LockedGitSource, LockedInputEntry};
+use serde::{Deserialize, Serialize};
+
+use super::flakeref::RawNixFlakerefAttrs;
+
+/// A direct catalog input of a build lock: one entry of
+/// `direct_catalog_inputs`, keyed by the server's canonical
+/// `<catalog>/<attr-path>` form.
+///
+/// This is the lock's own type rather than the generated wire
+/// [LockedInputEntry] so that the on-disk format is owned here, not by the
+/// catalog OpenAPI spec, and so that `source` can hold any flakeref
+/// attribute set the NEF can fetch — the wire type admits only a locked git
+/// source. The field set and serialization mirror the wire type exactly, so
+/// a lock written from a lookup response reads back unchanged.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DirectInput {
+    pub attr_path: Vec<String>,
+    pub build_type: BuildType,
+    pub catalog: String,
+    /// Direct inputs of this input by key, as the server reported them;
+    /// `None` when the server did not state them. Carried through so a
+    /// publish can hand the server back exactly what it was given.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub inputs: Option<Vec<String>>,
+    pub locked_inputs_hash: String,
+    /// The locked source, stored verbatim. See [RawNixFlakerefAttrs] for
+    /// the invariant it carries.
+    pub source: RawNixFlakerefAttrs,
+}
+
+impl DirectInput {
+    /// The entry's canonical `<catalog>/<attr-path>` key, for messages.
+    pub fn key(&self) -> String {
+        format!("{}/{}", self.catalog, self.attr_path.join("."))
+    }
+}
+
+/// A direct input whose source is not a locked git source, which is the
+/// only source the catalog accepts back in a publish.
+#[derive(Debug, thiserror::Error)]
+#[error("The catalog lock entry for '{key}' is not a locked git source")]
+pub struct NotAGitSourceError {
+    /// The entry's canonical `<catalog>/<attr-path>` key.
+    pub key: String,
+    #[source]
+    source: serde_json::Error,
+}
+
+impl From<LockedInputEntry> for DirectInput {
+    fn from(entry: LockedInputEntry) -> Self {
+        let LockedInputEntry {
+            attr_path,
+            build_type,
+            catalog,
+            inputs,
+            locked_inputs_hash,
+            source,
+        } = entry;
+        DirectInput {
+            attr_path,
+            build_type,
+            catalog,
+            inputs,
+            locked_inputs_hash,
+            source: source.into(),
+        }
+    }
+}
+
+/// The wire form of a direct input, for a publish. Fails when the source is
+/// not a locked git source (every git field present and `type == "git"` is
+/// what the wire type requires).
+impl TryFrom<&DirectInput> for LockedInputEntry {
+    type Error = NotAGitSourceError;
+
+    fn try_from(input: &DirectInput) -> Result<Self, Self::Error> {
+        let source: LockedGitSource = serde_json::from_value(input.source.as_value().clone())
+            .map_err(|source| NotAGitSourceError {
+                key: input.key(),
+                source,
+            })?;
+        Ok(LockedInputEntry {
+            attr_path: input.attr_path.clone(),
+            build_type: input.build_type,
+            catalog: input.catalog.clone(),
+            inputs: input.inputs.clone(),
+            locked_inputs_hash: input.locked_inputs_hash.clone(),
+            source,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    fn wire_entry() -> LockedInputEntry {
+        LockedInputEntry {
+            attr_path: vec!["python3Packages".to_string(), "boolex".to_string()],
+            build_type: BuildType::Nef,
+            catalog: "myorg".to_string(),
+            inputs: Some(vec!["myorg/dep".to_string()]),
+            locked_inputs_hash: "sha256-test".to_string(),
+            source: LockedGitSource {
+                dir: ".flox".to_string(),
+                ref_: "refs/heads/main".to_string(),
+                rev: "abc".to_string(),
+                type_: "git".to_string(),
+                url: "https://example.com/repo".to_string(),
+            },
+        }
+    }
+
+    /// The lock's type serializes exactly as the wire type does, so the
+    /// on-disk format is unchanged by owning it here.
+    #[test]
+    fn serializes_identically_to_the_wire_entry() {
+        let wire = wire_entry();
+        let input = DirectInput::from(wire.clone());
+        assert_eq!(
+            serde_json::to_value(&input).unwrap(),
+            serde_json::to_value(&wire).unwrap()
+        );
+    }
+
+    #[test]
+    fn git_source_round_trips_to_the_wire_entry() {
+        let wire = wire_entry();
+        let input = DirectInput::from(wire.clone());
+        assert_eq!(LockedInputEntry::try_from(&input).unwrap(), wire);
+        assert_eq!(input.key(), "myorg/python3Packages.boolex");
+    }
+
+    /// A source the NEF can fetch but the catalog cannot accept back — here
+    /// a `path` flakeref — reads into the lock, and is refused by name only
+    /// when converted for the wire.
+    #[test]
+    fn non_git_source_reads_but_does_not_convert_for_the_wire() {
+        let input: DirectInput = serde_json::from_value(json!({
+            "attr_path": ["hello"],
+            "build_type": "nef",
+            "catalog": "myorg",
+            "locked_inputs_hash": "sha256-test",
+            "source": { "type": "path", "path": "/src/hello", "dir": ".flox" },
+        }))
+        .unwrap();
+        assert_eq!(input.inputs, None);
+
+        let err = LockedInputEntry::try_from(&input).expect_err("a path source has no wire form");
+        assert_eq!(err.key, "myorg/hello");
+    }
+}

--- a/cli/nef-lock-catalog/src/lock/flakeref.rs
+++ b/cli/nef-lock-catalog/src/lock/flakeref.rs
@@ -136,6 +136,11 @@ impl RawNixFlakerefAttrs {
     pub fn new_unchecked(value: Value) -> Self {
         Self(value)
     }
+
+    /// The flakeref attribute set as JSON.
+    pub fn as_value(&self) -> &Value {
+        &self.0
+    }
 }
 
 impl From<floxhub_client::LockedGitSource> for RawNixFlakerefAttrs {

--- a/cli/nef-lock-catalog/src/lock/mod.rs
+++ b/cli/nef-lock-catalog/src/lock/mod.rs
@@ -7,6 +7,7 @@
 //! builds into this module in ECO-93.
 
 pub(crate) mod build_lock;
+pub(crate) mod direct_input;
 pub(crate) mod flakeref;
 pub(crate) mod lookup;
 pub(crate) mod render;

--- a/cli/nef-lock-catalog/src/lock/transform.rs
+++ b/cli/nef-lock-catalog/src/lock/transform.rs
@@ -10,6 +10,7 @@ use tracing::instrument;
 
 use crate::CatalogId;
 use crate::lock::build_lock::{BuildLock, CatalogLock};
+use crate::lock::direct_input::DirectInput;
 use crate::lock::tree::PackageTreeBuilder;
 
 /// Build a hierarchical [BuildLock] from the flat locked-input map (the merged
@@ -33,9 +34,9 @@ pub fn build_lock_from_locked_inputs<'d>(
             let entry = locked.get(key).cloned().with_context(|| {
                 format!("Direct dependency '{key}' does not appear to be locked")
             })?;
-            Ok((key.clone(), entry))
+            Ok((key.clone(), DirectInput::from(entry)))
         })
-        .collect::<Result<BTreeMap<String, LockedInputEntry>>>()?;
+        .collect::<Result<BTreeMap<String, DirectInput>>>()?;
 
     for entry in locked.into_values() {
         let LockedInputEntry {


### PR DESCRIPTION
## Proposed Changes

`direct_catalog_inputs` in `.flox/catalog.lock` was typed with the generated wire `LockedInputEntry`, which coupled the on-disk lock format to the catalog OpenAPI spec (the standing TODO on `BuildLock`) and restricted every direct input's `source` to a locked git source. That is the only source the catalog issues, but not the only source the NEF can fetch: the `catalogs` tree already stores sources as a verbatim flakeref attribute set.

This PR introduces `DirectInput`, a hand-owned type with the same fields and serialization as the wire entry (including `inputs`), whose `source` is the same verbatim `RawNixFlakerefAttrs` the tree uses.

- A lock written from a lookup response reads back unchanged; a test asserts the serialization is identical to the wire entry.
- The wire type is now produced only where it is needed: `flox publish` converts the subset it submits via `TryFrom<&DirectInput> for LockedInputEntry`, and refuses a committed lock whose source is not a locked git source, naming the entry and pointing at `flox build update-catalogs` in the same shape as the stale-lock error.
- `subset_direct` and `direct_catalog_inputs()` return `DirectInput`.

No behaviour change for locks the catalog produced. This is groundwork for per-invocation catalog input overrides (a `flox build --override-input` equivalent of `nix build --override-input`), which will place non-git sources in an ephemeral lock; that lands in follow-up PRs.

Verified: `nef-lock-catalog` unit tests, `flox` publish and catalog-lock tests, and the SDK test that runs a real NEF build against a supplied lock.

## Release Notes

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NZPQecwsEp1Tq6RZMXwRwg
