### PR TITLE
feat(catalog-lock): apply per-invocation input overrides to the build lock

### DIFF
--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -4394,7 +4394,13 @@ mod nef_tests {
 
     use floxhub_client::LockedInputEntry;
     use indoc::{formatdoc, indoc};
-    use nef_lock_catalog::{build_lock_from_locked_inputs, write_lock};
+    use nef_lock_catalog::{
+        InputOverride,
+        RawNixFlakerefAttrs,
+        build_lock_from_locked_inputs,
+        read_lock,
+        write_lock,
+    };
     use pretty_assertions::assert_eq;
 
     use super::*;
@@ -4501,6 +4507,85 @@ mod nef_tests {
             lock_bytes,
             "the build must not rewrite the lock it is handed"
         );
+    }
+
+    /// An overridden input is fetched from the override's source, not the
+    /// one the lock pinned: the lock pins `hello` at its committed git
+    /// revision, the override points a `path` source at the same working
+    /// tree after an uncommitted edit, and the build output carries the
+    /// edit. The NEF needs no knowledge of overrides; it fetches whatever
+    /// flakeref the package leaf carries.
+    #[test]
+    fn nef_build_fetches_an_overridden_input_from_its_override() {
+        let pname = "foo";
+
+        let (flox, tempdir) = flox_instance();
+        let manifest = formatdoc! {r#"
+            version = 1
+        "#};
+        let mut env = new_path_environment(&flox, &manifest);
+        let env_path = env.parent_path().unwrap();
+
+        let (expressions_dir, expressions_ref) = prepare_nix_expressions_dir_in(&tempdir, &[
+            (&[pname], indoc! {r#"
+                {catalogs, runCommand}: runCommand "foo" {} ''
+                    cat ${catalogs.myorg.hello} >> $out
+                ''
+                "#}),
+            (&["hello"], indoc! {r#"
+                {runCommand}: runCommand "hello" {} ''
+                    echo -n "Hello from the catalog" > $out
+                ''
+                "#}),
+        ]);
+        let repo =
+            GitCommandProvider::init_with(test_git_options(), &expressions_dir, false).unwrap();
+        repo.add(&[&expressions_dir]).unwrap();
+        repo.commit("add nef catalog fixtures").unwrap();
+
+        let lockfile = tempdir.path().join("catalog.lock");
+        write_catalog_lock(&lockfile, &repo, &expressions_dir);
+
+        // An uncommitted edit: the locked git revision still says "from
+        // the catalog"; only a fetch of the working tree sees this.
+        fs::write(
+            expressions_dir
+                .join("pkgs")
+                .join("hello")
+                .join("default.nix"),
+            indoc! {r#"
+                {runCommand}: runCommand "hello" {} ''
+                    echo -n "Hello from the override" > $out
+                ''
+            "#},
+        )
+        .unwrap();
+
+        let mut lock = read_lock(&lockfile).unwrap();
+        lock.override_inputs([InputOverride {
+            key: "myorg/hello".parse().unwrap(),
+            source: RawNixFlakerefAttrs::new_unchecked(serde_json::json!({
+                "type": "path",
+                "path": expressions_dir,
+            })),
+        }])
+        .unwrap();
+        let overridden_lockfile = tempdir.path().join("catalog-overridden.lock");
+        write_lock(&lock, &overridden_lockfile).unwrap();
+
+        assert_build_status_with_nix_expr(
+            &flox,
+            &mut env,
+            &expressions_ref,
+            pname,
+            Some(&overridden_lockfile),
+            None,
+            true,
+        );
+
+        let result_path = env_path.join(format!("result-{pname}"));
+        let content = fs::read_to_string(result_path).unwrap();
+        assert_eq!(content, "Hello from the override");
     }
 
     #[test]

--- a/cli/flox/src/commands/build.rs
+++ b/cli/flox/src/commands/build.rs
@@ -365,6 +365,7 @@ impl Build {
                     &flox.floxhub_client,
                     env.dot_flox_path(),
                     lock_rel_paths,
+                    vec![],
                 )
                 .await?,
             ),

--- a/cli/flox/src/commands/develop.rs
+++ b/cli/flox/src/commands/develop.rs
@@ -151,11 +151,13 @@ impl Develop {
                 unreachable!("manifest builds are refused before the eval")
             },
         };
-        let catalog_lock =
-            BuildLockGuard::new_existing_or_ephemeral(&flox.floxhub_client, env.dot_flox_path(), [
-                &rel_file_path,
-            ])
-            .await?;
+        let catalog_lock = BuildLockGuard::new_existing_or_ephemeral(
+            &flox.floxhub_client,
+            env.dot_flox_path(),
+            [&rel_file_path],
+            vec![],
+        )
+        .await?;
 
         let base_nixpkgs_url =
             base_nixpkgs_url_from_url_select(&flox, base_catalog_url_select, Some(&lockfile))

--- a/cli/flox/src/commands/publish.rs
+++ b/cli/flox/src/commands/publish.rs
@@ -127,10 +127,25 @@ async fn dedup_short_circuit(client: &impl CatalogClientTrait, query: CheckBuild
 /// accept back — translated into an actionable error. Only the committed
 /// lock can be either: an ephemeral lock is resolved by the catalog itself
 /// from the same expressions the references were scanned from.
+///
+/// A lock with input overrides is refused outright: its sources are not
+/// what the catalog resolved, so nothing built against it can be
+/// published.
 fn subset_for_publish(
     lock: &BuildLockGuard,
     references: &BTreeSet<CatalogRef>,
 ) -> Result<BTreeMap<String, LockedInputEntry>> {
+    if !lock.overrides().is_empty() {
+        let overridden = lock
+            .overrides()
+            .iter()
+            .map(|input_override| format!("'{}'", input_override.key))
+            .collect::<Vec<_>>()
+            .join(", ");
+        bail!(formatdoc! {"
+            Cannot publish a build whose catalog inputs are overridden: {overridden}.
+            Retry 'flox publish' without input overrides."});
+    }
     let with_update_catalogs_hint = |err: anyhow::Error| {
         if lock.is_existing() {
             anyhow!(formatdoc! {"
@@ -405,6 +420,7 @@ impl Publish {
                     &flox.floxhub_client,
                     path_env.dot_flox_path(),
                     &lock_rel_paths,
+                    vec![],
                 )
                 .await?,
             ),
@@ -536,6 +552,7 @@ mod tests {
     use flox_manifest::test_helpers::with_latest_schema;
     use flox_rust_sdk::providers::build::test_helpers::prepare_empty_expressions_ref;
     use indoc::indoc;
+    use nef_lock_catalog::{InputOverride, RawNixFlakerefAttrs};
 
     use super::*;
     use crate::utils::catalog_lock::test_helpers::build_lock_guard_from_parts;
@@ -567,6 +584,40 @@ mod tests {
         assert!(
             message.contains("myorg.hello"),
             "the uncovered reference must be named, got: {message}"
+        );
+    }
+
+    /// A lock with input overrides cannot be published, whatever it
+    /// covers; the refusal names the overridden inputs.
+    #[test]
+    fn overridden_lock_is_refused_naming_the_overrides() {
+        let expressions_dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            expressions_dir.path().join("hello.nix"),
+            "{ catalogs }: catalogs.myorg.hello",
+        )
+        .unwrap();
+        let references = scan_package(expressions_dir.path(), "hello.nix").unwrap();
+
+        let lock = build_lock_guard_from_parts(
+            "/tmp/flox-catalog.lock.ephemeral",
+            nef_lock_catalog::BuildLock::default(),
+            false,
+        )
+        .with_overrides(vec![InputOverride {
+            key: "myorg/hello".parse().unwrap(),
+            source: RawNixFlakerefAttrs::new_unchecked(serde_json::json!({
+                "type": "path",
+                "path": "/src/hello",
+            })),
+        }]);
+
+        let err = subset_for_publish(&lock, &references)
+            .expect_err("an overridden lock cannot be published");
+        let message = format!("{err:#}");
+        assert!(
+            message.contains("'myorg/hello'"),
+            "the overridden input must be named, got: {message}"
         );
     }
 

--- a/cli/flox/src/utils/catalog_lock.rs
+++ b/cli/flox/src/utils/catalog_lock.rs
@@ -5,7 +5,9 @@
 //! the ownership of an ephemeral lock's file. Without a committed
 //! `.flox/catalog.lock` the project builds locklessly: the CLI resolves a
 //! fresh lock into a temp file that lives exactly as long as the build, and
-//! nothing is ever written into the project tree.
+//! nothing is ever written into the project tree. Input overrides are
+//! applied the same way: whichever lock the invocation starts from, the
+//! overridden copy is ephemeral and the committed file is left as found.
 
 use std::path::{Path, PathBuf};
 
@@ -15,6 +17,7 @@ use floxhub_client::CatalogClientTrait;
 use nef_lock_catalog::{
     BuildLock,
     CATALOG_LOCKFILE_NAME,
+    InputOverride,
     catalog_lockfile_path,
     read_lock,
     resolve_lock,
@@ -33,6 +36,8 @@ pub struct BuildLockGuard {
     /// Keeps an ephemeral lock's temp file alive for as long as this value;
     /// `None` when the lock is the committed file.
     _ephemeral: Option<tempfile::TempPath>,
+    /// The input overrides applied to the lock, in the order given.
+    overrides: Vec<InputOverride>,
 }
 
 impl BuildLockGuard {
@@ -41,33 +46,52 @@ impl BuildLockGuard {
     /// references of the expressions named by `rel_file_paths` (relative to
     /// the project's expression directory), written to a randomly named
     /// temp file that is removed when the returned value is dropped.
+    ///
+    /// With `overrides`, the lock the invocation starts from — committed or
+    /// freshly resolved — has them applied and is always written to an
+    /// ephemeral file; the committed lock is never rewritten. An override
+    /// naming an input the lock does not pin fails before anything is
+    /// written.
     pub async fn new_existing_or_ephemeral(
         client: &impl CatalogClientTrait,
         dot_flox_path: impl AsRef<Path>,
         rel_file_paths: impl IntoIterator<Item = impl AsRef<Path>>,
+        overrides: Vec<InputOverride>,
     ) -> Result<BuildLockGuard> {
         let dot_flox_path = dot_flox_path.as_ref();
         let committed = catalog_lockfile_path(dot_flox_path);
-        if committed.exists() {
+        let lock = if committed.exists() {
             let lock = read_lock(&committed)?;
-            // The path handed to make is *relative to the project
-            // directory* make is started in (`--directory`), composed of
-            // two constant components — so a project path containing
-            // whitespace (or any other character make's word-splitting
-            // positions would mangle) never reaches the makefile.
-            let dot_flox_dir_name = dot_flox_path
-                .file_name()
-                .expect("the .flox path has a final component");
-            debug!(path = %committed.display(), "build consumes the committed catalog lock");
-            return Ok(BuildLockGuard {
-                path: Path::new(dot_flox_dir_name).join(CATALOG_LOCKFILE_NAME),
-                lock,
-                _ephemeral: None,
-            });
-        }
+            if overrides.is_empty() {
+                // The path handed to make is *relative to the project
+                // directory* make is started in (`--directory`), composed
+                // of two constant components — so a project path containing
+                // whitespace (or any other character make's word-splitting
+                // positions would mangle) never reaches the makefile.
+                let dot_flox_dir_name = dot_flox_path
+                    .file_name()
+                    .expect("the .flox path has a final component");
+                debug!(path = %committed.display(), "build consumes the committed catalog lock");
+                return Ok(BuildLockGuard {
+                    path: Path::new(dot_flox_dir_name).join(CATALOG_LOCKFILE_NAME),
+                    lock,
+                    _ephemeral: None,
+                    overrides,
+                });
+            }
+            debug!(path = %committed.display(), "build starts from the committed catalog lock");
+            lock
+        } else {
+            let references = scan_references(nix_expression_dir_in(dot_flox_path), rel_file_paths)?;
+            resolve_lock(client, references).await?
+        };
+        Self::ephemeral(lock, overrides)
+    }
 
-        let references = scan_references(nix_expression_dir_in(dot_flox_path), rel_file_paths)?;
-        let lock = resolve_lock(client, references).await?;
+    /// `lock` with `overrides` applied, written to a temp file that is
+    /// removed when the returned value is dropped.
+    fn ephemeral(mut lock: BuildLock, overrides: Vec<InputOverride>) -> Result<BuildLockGuard> {
+        lock.override_inputs(overrides.iter().cloned())?;
         // The system temp dir, not flox's own temp dir: flox's derives from
         // `$HOME`, which the user may have placed at a path containing
         // whitespace, and the ephemeral path reaches make's word-splitting
@@ -82,11 +106,16 @@ impl BuildLockGuard {
             .context("Could not create a temporary file for the catalog lock.")?
             .into_temp_path();
         write_lock(&lock, &temp_path)?;
-        debug!(path = %temp_path.display(), "build consumes a fresh ephemeral catalog lock");
+        debug!(
+            path = %temp_path.display(),
+            overrides = overrides.len(),
+            "build consumes an ephemeral catalog lock"
+        );
         Ok(BuildLockGuard {
             path: temp_path.to_path_buf(),
             lock,
             _ephemeral: Some(temp_path),
+            overrides,
         })
     }
 
@@ -106,6 +135,13 @@ impl BuildLockGuard {
     /// ephemeral lock, e.g. to select stale-lock messaging.
     pub fn is_existing(&self) -> bool {
         self._ephemeral.is_none()
+    }
+
+    /// The input overrides applied to this lock, in the order given. A
+    /// lock with any is never fit to publish: its sources are not what
+    /// the catalog resolved.
+    pub fn overrides(&self) -> &[InputOverride] {
+        &self.overrides
     }
 }
 
@@ -132,6 +168,16 @@ pub mod test_helpers {
                         .into_temp_path(),
                 ),
             },
+            overrides: Vec::new(),
+        }
+    }
+
+    impl BuildLockGuard {
+        /// This guard with `overrides` recorded, for tests of consumers
+        /// that refuse an overridden lock.
+        pub fn with_overrides(mut self, overrides: Vec<InputOverride>) -> Self {
+            self.overrides = overrides;
+            self
         }
     }
 }
@@ -139,7 +185,7 @@ pub mod test_helpers {
 #[cfg(test)]
 mod tests {
     use floxhub_client::client::test_helpers::new_noop;
-    use nef_lock_catalog::scan_package;
+    use nef_lock_catalog::{RawNixFlakerefAttrs, scan_package};
     use tempfile::tempdir;
 
     use super::*;
@@ -163,9 +209,38 @@ mod tests {
       }
     }
   },
-  "catalogs": {}
+  "catalogs": {
+    "myorg": {
+      "type": "floxhub",
+      "packages": {
+        "type": "package_set",
+        "entries": {
+          "hello": {
+            "type": "package",
+            "build_type": "nef",
+            "source": {
+              "dir": ".",
+              "ref": "refs/heads/main",
+              "rev": "0000000000000000000000000000000000000000",
+              "type": "git",
+              "url": "https://example.com/repo"
+            }
+          }
+        }
+      }
+    }
+  }
 }
 "#;
+
+    fn path_override(key: &str, path: &str) -> InputOverride {
+        InputOverride {
+            key: key.parse().unwrap(),
+            source: RawNixFlakerefAttrs::new_unchecked(
+                serde_json::json!({ "type": "path", "path": path }),
+            ),
+        }
+    }
 
     fn project_with_expression(expression: &str) -> (tempfile::TempDir, PathBuf, PathBuf) {
         let project = tempdir().unwrap();
@@ -184,9 +259,14 @@ mod tests {
     async fn no_references_resolve_without_a_catalog_request() {
         let (_project, dot_flox, _pkgs_dir) =
             project_with_expression("{ runCommand }: runCommand \"hello\" { } \"\"");
-        let lock = BuildLockGuard::new_existing_or_ephemeral(&new_noop(), &dot_flox, ["hello.nix"])
-            .await
-            .unwrap();
+        let lock = BuildLockGuard::new_existing_or_ephemeral(
+            &new_noop(),
+            &dot_flox,
+            ["hello.nix"],
+            vec![],
+        )
+        .await
+        .unwrap();
 
         assert!(!lock.is_existing());
         assert!(
@@ -208,9 +288,14 @@ mod tests {
         let (_project, dot_flox, pkgs_dir) =
             project_with_expression("{ catalogs }: catalogs.myorg.hello");
         std::fs::write(catalog_lockfile_path(&dot_flox), COMMITTED_LOCK).unwrap();
-        let lock = BuildLockGuard::new_existing_or_ephemeral(&new_noop(), &dot_flox, ["hello.nix"])
-            .await
-            .unwrap();
+        let lock = BuildLockGuard::new_existing_or_ephemeral(
+            &new_noop(),
+            &dot_flox,
+            ["hello.nix"],
+            vec![],
+        )
+        .await
+        .unwrap();
 
         assert!(lock.is_existing());
         assert_eq!(lock.path(), Path::new(".flox").join(CATALOG_LOCKFILE_NAME));
@@ -235,9 +320,14 @@ mod tests {
         let (_project, dot_flox, pkgs_dir) =
             project_with_expression("{ catalogs }: catalogs.myorg.world");
         std::fs::write(catalog_lockfile_path(&dot_flox), COMMITTED_LOCK).unwrap();
-        let lock = BuildLockGuard::new_existing_or_ephemeral(&new_noop(), &dot_flox, ["hello.nix"])
-            .await
-            .unwrap();
+        let lock = BuildLockGuard::new_existing_or_ephemeral(
+            &new_noop(),
+            &dot_flox,
+            ["hello.nix"],
+            vec![],
+        )
+        .await
+        .unwrap();
         assert!(lock.is_existing());
 
         let references = scan_package(&pkgs_dir, "hello.nix").unwrap();
@@ -248,6 +338,60 @@ mod tests {
         assert!(
             err.to_string().contains("myorg.world"),
             "the uncovered reference must be named, got: {err}"
+        );
+    }
+
+    /// A committed lock with overrides is never rewritten: the build
+    /// consumes an ephemeral copy carrying the overridden source, and the
+    /// committed file stays byte-identical.
+    #[tokio::test]
+    async fn committed_lock_with_overrides_is_consumed_from_an_ephemeral_copy() {
+        let (_project, dot_flox, _pkgs_dir) =
+            project_with_expression("{ catalogs }: catalogs.myorg.hello");
+        std::fs::write(catalog_lockfile_path(&dot_flox), COMMITTED_LOCK).unwrap();
+
+        let lock =
+            BuildLockGuard::new_existing_or_ephemeral(&new_noop(), &dot_flox, ["hello.nix"], vec![
+                path_override("myorg/hello", "/src/hello"),
+            ])
+            .await
+            .unwrap();
+
+        assert!(!lock.is_existing());
+        assert_ne!(lock.path(), Path::new(".flox").join(CATALOG_LOCKFILE_NAME));
+        assert_eq!(lock.overrides().len(), 1);
+        assert_eq!(
+            std::fs::read_to_string(catalog_lockfile_path(&dot_flox)).unwrap(),
+            COMMITTED_LOCK,
+            "the committed lock must not be rewritten"
+        );
+        let ephemeral: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(lock.path()).unwrap()).unwrap();
+        assert_eq!(
+            ephemeral["catalogs"]["myorg"]["packages"]["entries"]["hello"]["source"],
+            serde_json::json!({ "type": "path", "path": "/src/hello", "dir": "." })
+        );
+    }
+
+    /// An override naming an input the lock does not pin fails by name
+    /// before any lock is written.
+    #[tokio::test]
+    async fn override_of_an_unknown_input_fails_by_name() {
+        let (_project, dot_flox, _pkgs_dir) =
+            project_with_expression("{ catalogs }: catalogs.myorg.hello");
+        std::fs::write(catalog_lockfile_path(&dot_flox), COMMITTED_LOCK).unwrap();
+
+        let err =
+            BuildLockGuard::new_existing_or_ephemeral(&new_noop(), &dot_flox, ["hello.nix"], vec![
+                path_override("myorg/missing", "/src/missing"),
+            ])
+            .await
+            .expect_err("an unknown input cannot be overridden");
+
+        let message = format!("{err:#}");
+        assert!(
+            message.contains("myorg/missing") && message.contains("myorg/hello"),
+            "the unknown key and the available inputs must be named, got: {message}"
         );
     }
 }

--- a/cli/nef-lock-catalog/src/lib.rs
+++ b/cli/nef-lock-catalog/src/lib.rs
@@ -36,6 +36,7 @@ pub use lock::build_lock::{
 pub use lock::direct_input::{DirectInput, NotAGitSourceError};
 pub use lock::flakeref::{NixFlakeref, RawNixFlakerefAttrs};
 pub use lock::lookup::{LockError, lock_references};
+pub use lock::r#override::{InputKey, InputKeyError, InputOverride, OverrideError};
 pub use lock::render::render_unresolvable;
 pub use lock::transform::build_lock_from_locked_inputs;
 pub use project::{

--- a/cli/nef-lock-catalog/src/lock/flakeref.rs
+++ b/cli/nef-lock-catalog/src/lock/flakeref.rs
@@ -141,6 +141,19 @@ impl RawNixFlakerefAttrs {
     pub fn as_value(&self) -> &Value {
         &self.0
     }
+
+    /// This source, carrying `other`'s `dir` when it has none of its own.
+    /// `dir` names the subdirectory holding the package expressions, a
+    /// property of the project rather than of where it is fetched from, so
+    /// a replacement source that does not say otherwise keeps it.
+    pub fn inheriting_dir_from(mut self, other: &Self) -> Self {
+        if let (Value::Object(attrs), Some(dir)) = (&mut self.0, other.0.get("dir"))
+            && !attrs.contains_key("dir")
+        {
+            attrs.insert("dir".to_string(), dir.clone());
+        }
+        self
+    }
 }
 
 impl From<floxhub_client::LockedGitSource> for RawNixFlakerefAttrs {

--- a/cli/nef-lock-catalog/src/lock/mod.rs
+++ b/cli/nef-lock-catalog/src/lock/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod build_lock;
 pub(crate) mod direct_input;
 pub(crate) mod flakeref;
 pub(crate) mod lookup;
+pub(crate) mod r#override;
 pub(crate) mod render;
 pub(crate) mod transform;
 pub(crate) mod tree;

--- a/cli/nef-lock-catalog/src/lock/override.rs
+++ b/cli/nef-lock-catalog/src/lock/override.rs
@@ -1,0 +1,314 @@
+//! Per-invocation replacement of locked input sources.
+//!
+//! The lock equivalent of `nix build --override-input`: after a lock is
+//! read or resolved and before it is handed to the NEF, the source of a
+//! named input is swapped for one the user supplied — typically a local
+//! checkout — without touching the committed `.flox/catalog.lock`. The NEF
+//! fetches whatever flakeref attribute set a package leaf carries, so no
+//! change is needed downstream; the catalog, however, only ever accepts
+//! locked git sources back, so a lock with overrides must never be
+//! published.
+
+use std::fmt::Display;
+use std::str::FromStr;
+
+use super::build_lock::{BuildLock, CatalogLock};
+use super::flakeref::RawNixFlakerefAttrs;
+use super::tree::PackageTreeNode;
+use crate::CatalogId;
+
+/// Names a locked input by the lock's canonical `<catalog>/<attr-path>`
+/// key, the form `direct_catalog_inputs` is keyed by (e.g.
+/// `myorg/python3Packages.boolex`). Any package in the lock can be named,
+/// including a transitive one that has no direct entry.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct InputKey {
+    catalog: String,
+    attr_path: Vec<String>,
+}
+
+impl InputKey {
+    pub fn catalog(&self) -> &str {
+        &self.catalog
+    }
+
+    pub fn attr_path(&self) -> &[String] {
+        &self.attr_path
+    }
+}
+
+impl FromStr for InputKey {
+    type Err = InputKeyError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let Some((catalog, attr_path)) = s.split_once('/') else {
+            return Err(InputKeyError(s.to_string()));
+        };
+        if catalog.is_empty() || attr_path.is_empty() {
+            return Err(InputKeyError(s.to_string()));
+        }
+        let attr_path: Vec<String> = attr_path.split('.').map(str::to_string).collect();
+        if attr_path.iter().any(String::is_empty) {
+            return Err(InputKeyError(s.to_string()));
+        }
+        Ok(InputKey {
+            catalog: catalog.to_string(),
+            attr_path,
+        })
+    }
+}
+
+impl Display for InputKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}/{}", self.catalog, self.attr_path.join("."))
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error(
+    "'{0}' is not a catalog input key; expected the form '<catalog>/<package>' as found in '.flox/catalog.lock'."
+)]
+pub struct InputKeyError(String);
+
+/// The replacement of one locked input's source.
+#[derive(Debug, Clone, PartialEq)]
+pub struct InputOverride {
+    pub key: InputKey,
+    /// The replacement flakeref attribute set. A missing `dir` inherits the
+    /// locked source's, since the NEF locates the package expressions
+    /// beneath it.
+    pub source: RawNixFlakerefAttrs,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum OverrideError {
+    #[error(
+        "The catalog lock has no input '{key}'.\nInputs in the lock: {}",
+        .available.join(", ")
+    )]
+    UnknownInput {
+        key: InputKey,
+        available: Vec<String>,
+    },
+}
+
+impl BuildLock {
+    /// Replace the source of each named input, in the `catalogs` tree the
+    /// NEF fetches from and in `direct_catalog_inputs` when the input has
+    /// a direct entry. Every override must name an input the lock
+    /// contains; the first that does not fails the whole call, listing the
+    /// inputs the lock does have.
+    ///
+    /// A direct entry's `locked_inputs_hash` is left as found: it names
+    /// the recorded build the *original* source pinned, and nothing
+    /// consumes it from a lock that carries overrides — a publish refuses
+    /// such a lock before reading it.
+    pub fn override_inputs(
+        &mut self,
+        overrides: impl IntoIterator<Item = InputOverride>,
+    ) -> Result<(), OverrideError> {
+        for InputOverride { key, source } in overrides {
+            let leaf = self
+                .catalogs
+                .get_mut(&CatalogId(key.catalog.clone()))
+                .and_then(|CatalogLock::FloxHub { packages }| {
+                    packages.get_package_mut(&key.attr_path)
+                });
+            let Some(PackageTreeNode::Package { source: locked, .. }) = leaf else {
+                return Err(OverrideError::UnknownInput {
+                    key,
+                    available: self.input_keys().iter().map(ToString::to_string).collect(),
+                });
+            };
+            let source = source.inheriting_dir_from(locked);
+            *locked = source.clone();
+
+            if let Some(direct) = self
+                .direct_catalog_inputs
+                .values_mut()
+                .find(|direct| direct.catalog == key.catalog && direct.attr_path == key.attr_path)
+            {
+                direct.source = source;
+            }
+        }
+        Ok(())
+    }
+
+    /// The key of every package the lock pins, direct or transitive, in
+    /// catalog then attr-path order.
+    pub fn input_keys(&self) -> Vec<InputKey> {
+        self.catalogs
+            .iter()
+            .flat_map(|(catalog, CatalogLock::FloxHub { packages })| {
+                packages
+                    .package_paths()
+                    .into_iter()
+                    .map(|attr_path| InputKey {
+                        catalog: catalog.to_string(),
+                        attr_path,
+                    })
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use floxhub_client::{BuildType, LockedGitSource, LockedInputEntry};
+    use serde_json::{Value, json};
+
+    use super::*;
+    use crate::lock::transform::build_lock_from_locked_inputs;
+
+    fn git_entry(catalog: &str, attr_path: &[&str]) -> LockedInputEntry {
+        LockedInputEntry {
+            attr_path: attr_path.iter().map(|s| s.to_string()).collect(),
+            build_type: BuildType::Nef,
+            catalog: catalog.to_string(),
+            inputs: Some(vec![]),
+            locked_inputs_hash: "sha256-test".to_string(),
+            source: LockedGitSource {
+                dir: ".flox".to_string(),
+                ref_: "refs/heads/main".to_string(),
+                rev: "abc".to_string(),
+                type_: "git".to_string(),
+                url: "https://example.com/repo".to_string(),
+            },
+        }
+    }
+
+    /// A lock pinning `locked` (canonical keys), of which `direct` have a
+    /// direct entry; the rest are transitive.
+    fn lock_with(locked: &[&str], direct: &[&str]) -> BuildLock {
+        let locked: HashMap<String, LockedInputEntry> = locked
+            .iter()
+            .map(|key| {
+                let (catalog, rest) = key.split_once('/').unwrap();
+                let attr_path: Vec<&str> = rest.split('.').collect();
+                ((*key).to_string(), git_entry(catalog, &attr_path))
+            })
+            .collect();
+        let direct: Vec<String> = direct.iter().map(|key| (*key).to_string()).collect();
+        build_lock_from_locked_inputs(locked, direct.iter()).unwrap()
+    }
+
+    fn tree_source(lock: &BuildLock, catalog: &str, attr_path: &[&str]) -> Value {
+        let value = serde_json::to_value(lock).unwrap();
+        let mut node = &value["catalogs"][catalog]["packages"];
+        for attr in attr_path {
+            node = &node["entries"][*attr];
+        }
+        node["source"].clone()
+    }
+
+    fn override_of(key: &str, source: Value) -> InputOverride {
+        InputOverride {
+            key: key.parse().unwrap(),
+            source: RawNixFlakerefAttrs::new_unchecked(source),
+        }
+    }
+
+    #[test]
+    fn key_parses_and_renders_canonically() {
+        let key: InputKey = "myorg/python3Packages.boolex".parse().unwrap();
+        assert_eq!(key, InputKey {
+            catalog: "myorg".to_string(),
+            attr_path: vec!["python3Packages".to_string(), "boolex".to_string()],
+        });
+        assert_eq!(key.to_string(), "myorg/python3Packages.boolex");
+
+        for invalid in ["hello", "/hello", "myorg/", "myorg/a..b", ""] {
+            assert!(
+                invalid.parse::<InputKey>().is_err(),
+                "'{invalid}' must not parse"
+            );
+        }
+    }
+
+    /// An override rewrites both copies of the source: the tree leaf the
+    /// NEF fetches from and the direct entry a publish would submit.
+    #[test]
+    fn override_rewrites_tree_leaf_and_direct_entry() {
+        let mut lock = lock_with(&["myorg/hello", "myorg/world"], &["myorg/hello"]);
+        let replacement = json!({ "type": "path", "path": "/src/hello", "dir": "." });
+
+        lock.override_inputs([override_of("myorg/hello", replacement.clone())])
+            .unwrap();
+
+        assert_eq!(tree_source(&lock, "myorg", &["hello"]), replacement);
+        assert_eq!(
+            lock.direct_catalog_inputs["myorg/hello"].source.as_value(),
+            &replacement
+        );
+        // Untouched inputs keep their locked source.
+        assert_eq!(
+            tree_source(&lock, "myorg", &["world"])["type"],
+            json!("git")
+        );
+    }
+
+    #[test]
+    fn override_inherits_dir_when_the_replacement_has_none() {
+        let mut lock = lock_with(&["myorg/hello"], &["myorg/hello"]);
+
+        lock.override_inputs([override_of(
+            "myorg/hello",
+            json!({ "type": "git", "url": "file:///src/repo" }),
+        )])
+        .unwrap();
+
+        assert_eq!(
+            tree_source(&lock, "myorg", &["hello"]),
+            json!({ "type": "git", "url": "file:///src/repo", "dir": ".flox" })
+        );
+    }
+
+    /// A transitive input has a tree leaf but no direct entry; it can be
+    /// overridden all the same, and the direct map is left alone.
+    #[test]
+    fn override_of_a_transitive_input_rewrites_only_the_tree() {
+        let mut lock = lock_with(&["myorg/hello", "myorg/python3Packages.boolex"], &[
+            "myorg/hello",
+        ]);
+        let replacement = json!({ "type": "path", "path": "/src/boolex", "dir": "." });
+
+        lock.override_inputs([override_of(
+            "myorg/python3Packages.boolex",
+            replacement.clone(),
+        )])
+        .unwrap();
+
+        assert_eq!(
+            tree_source(&lock, "myorg", &["python3Packages", "boolex"]),
+            replacement
+        );
+        assert_eq!(lock.direct_catalog_inputs.keys().collect::<Vec<_>>(), vec![
+            "myorg/hello"
+        ]);
+    }
+
+    #[test]
+    fn unknown_input_fails_naming_the_inputs_the_lock_has() {
+        let mut lock = lock_with(
+            &["myorg/hello", "myorg/python3Packages.boolex", "other/tool"],
+            &["myorg/hello"],
+        );
+
+        let err = lock
+            .override_inputs([override_of(
+                "myorg/missing",
+                json!({ "type": "path", "path": "/x" }),
+            )])
+            .expect_err("an input the lock does not pin cannot be overridden");
+
+        let OverrideError::UnknownInput { key, available } = err;
+        assert_eq!(key.to_string(), "myorg/missing");
+        assert_eq!(available, vec![
+            "myorg/hello",
+            "myorg/python3Packages.boolex",
+            "other/tool"
+        ]);
+    }
+}

--- a/cli/nef-lock-catalog/src/lock/tree.rs
+++ b/cli/nef-lock-catalog/src/lock/tree.rs
@@ -27,6 +27,44 @@ pub enum PackageTreeNode {
     },
 }
 
+impl PackageTreeNode {
+    /// The package leaf at `attr_path`, if there is one. A package set at
+    /// that path, or a path leading through a package, is `None`.
+    pub fn get_package_mut(&mut self, attr_path: &[String]) -> Option<&mut PackageTreeNode> {
+        let mut node = self;
+        for attr in attr_path {
+            let PackageTreeNode::PackageSet { entries } = node else {
+                return None;
+            };
+            node = entries.get_mut(attr)?;
+        }
+        match node {
+            PackageTreeNode::Package { .. } => Some(node),
+            PackageTreeNode::PackageSet { .. } => None,
+        }
+    }
+
+    /// The attr path of every package leaf beneath this node, depth-first
+    /// in key order.
+    pub fn package_paths(&self) -> Vec<Vec<String>> {
+        fn walk(node: &PackageTreeNode, prefix: &[String], out: &mut Vec<Vec<String>>) {
+            match node {
+                PackageTreeNode::Package { .. } => out.push(prefix.to_vec()),
+                PackageTreeNode::PackageSet { entries } => {
+                    for (name, child) in entries {
+                        let mut path = prefix.to_vec();
+                        path.push(name.clone());
+                        walk(child, &path, out);
+                    }
+                },
+            }
+        }
+        let mut out = Vec::new();
+        walk(self, &[], &mut out);
+        out
+    }
+}
+
 /// Builds a package tree from locked source items
 pub struct PackageTreeBuilder {
     root: PackageTreeNode,


### PR DESCRIPTION
## Proposed Changes

Stacked on #4692. Second of three PRs adding a `nix build --override-input` equivalent for NEF catalog inputs: this is the lock-level step, applied after a lock is read or resolved and before it is handed to the NEF. The CLI flag that supplies overrides follows in the third PR.

- **`BuildLock::override_inputs`** (new `lock/override.rs`) takes overrides keyed by the lock's canonical `<catalog>/<attr-path>` form (`InputKey`, parsed and rendered with validation) and rewrites the source in both places the lock carries it: the `catalogs` tree leaf the NEF fetches from and the direct entry a publish would submit. Any package in the lock can be named, including a transitive one with no direct entry. An unknown key fails naming the inputs the lock does have.
- **`dir` inheritance.** A replacement without `dir` takes the locked source's, since `dir` locates the package expressions and belongs to the project rather than to where it is fetched from. A plain `path:/abs/checkout` override therefore still finds `.flox/pkgs`.
- **`PackageTreeNode`** gains `get_package_mut` and `package_paths`; it previously supported only insertion.
- **`BuildLockGuard`** takes the overrides. With any present it applies them and always writes an ephemeral lock, starting from the committed `.flox/catalog.lock` when one exists; the committed file is never rewritten. Call sites pass none for now.
- **`flox publish`** refuses a lock with overrides, naming the overridden inputs: its sources are not what the catalog resolved.

The NEF and the package builder need no change. A new SDK test builds through the real NEF with a `path` override of a git-pinned input after an uncommitted edit, and the output carries the edit.

Note for local runs: the SDK NEF tests create fixture git repos with `git commit`, which inherits the developer's global signing config. With hardware-key signing configured they need `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false`; this predates this PR.

## Release Notes

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NZPQecwsEp1Tq6RZMXwRwg
