### PR TITLE
feat(build): add '--override-input' to 'flox build' and 'flox develop'

### DIFF
--- a/cli/flox/doc/flox-build.md
+++ b/cli/flox/doc/flox-build.md
@@ -16,6 +16,7 @@ flox-build - Build packages with Flox
 flox [<general-options>] build
      [-d=<path>]
      [--stability <stability>]
+     [--override-input <key>=<flakeref>]...
      [<package>]...
 ```
 
@@ -107,6 +108,18 @@ found, and is only ever rewritten by `flox build update-catalogs`.
 Without a committed lock, `flox build` resolves the references of the
 packages being built fresh on every invocation ("lockless" builds);
 nothing is written into the project tree.
+
+To build against an unpublished revision of a catalog input, for example a
+local checkout being iterated on, pass `--override-input <key>=<flakeref>`.
+The input's source is replaced for that invocation only, in the same way
+`nix build --override-input` replaces a flake input;
+the committed lock is left unchanged, and a build with overridden inputs
+cannot be published.
+`<key>` is the input's `<catalog>/<package>` key as it appears in
+`.flox/catalog.lock`, and `<flakeref>` is any Nix flake reference.
+A directory is fetched as a `path:` flakeref, so it should be the directory
+holding the input's `.flox`, and uncommitted changes in it are included;
+to fetch only git-tracked files, give a `git+file://` flakeref instead.
 Catalog references resolve to the latest published versions and are
 independent of `--stability`, which selects only the nixpkgs base
 package set.
@@ -128,6 +141,15 @@ package set.
     stability is used by default.
     An explicit `--stability` value overrides both of these defaults.
     Cannot be used with manifest builds.
+
+`--override-input <key>=<flakeref>`
+:   Fetch the catalog input `<key>` from `<flakeref>` for this invocation
+    instead of its locked source.
+    `<key>` is the input's `<catalog>/<package>` key in `.flox/catalog.lock`;
+    `<flakeref>` is a Nix flake reference, where a directory means a `path:`
+    flakeref.
+    May be given more than once.
+    `.flox/catalog.lock` is not modified.
 
 
 ```{.include}

--- a/cli/flox/src/commands/build.rs
+++ b/cli/flox/src/commands/build.rs
@@ -2,6 +2,7 @@ use std::env;
 use std::os::unix::process::ExitStatusExt;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
+use std::str::FromStr;
 use std::time::Instant;
 
 // `::` selects the extern `nix` crate rather than the
@@ -33,13 +34,19 @@ use flox_rust_sdk::utils::{CommandExt, FLOX_INTERPRETER};
 use floxhub_client::{BaseCatalogUrl, CatalogClientTrait};
 use indoc::formatdoc;
 use itertools::Itertools;
-use nef_lock_catalog::{NixFlakeref, catalog_lockfile_path, lock_project_catalog};
+use nef_lock_catalog::{
+    InputKey,
+    InputOverride,
+    NixFlakeref,
+    catalog_lockfile_path,
+    lock_project_catalog,
+};
 use thiserror::Error;
 use tracing::{debug, instrument, trace};
 use url::Url;
 
 use super::{DirEnvironmentSelect, dir_environment_select, needs_project_files_error};
-use crate::utils::catalog_lock::BuildLockGuard;
+use crate::utils::catalog_lock::{BuildLockGuard, ResolvedOverride};
 use crate::utils::events::duration_to_ms;
 use crate::utils::message;
 use crate::{environment_subcommand_metric, subcommand_metric};
@@ -83,6 +90,79 @@ pub struct SystemOverride {
 impl SystemOverride {
     pub fn into_inner(self) -> Option<String> {
         self.system
+    }
+}
+
+/// One `--override-input KEY=FLAKEREF` value, split at the CLI boundary.
+#[derive(Debug, Clone, PartialEq)]
+pub struct InputOverrideArg {
+    key: InputKey,
+    flakeref: String,
+}
+
+impl FromStr for InputOverrideArg {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        let Some((key, flakeref)) = s.split_once('=') else {
+            bail!("'{s}' is not of the form '<KEY>=<FLAKEREF>'.");
+        };
+        if flakeref.is_empty() {
+            bail!("'{s}' names no flakeref after '='.");
+        }
+        Ok(InputOverrideArg {
+            key: key.parse()?,
+            flakeref: flakeref.to_string(),
+        })
+    }
+}
+
+// Reusable input-override option for commands that evaluate Nix
+// expression builds against the project catalog lock. Not a doc comment:
+// bpaf renders one on an external group as a header in `--help`.
+#[derive(Debug, Default, Bpaf, Clone)]
+pub struct InputOverrides {
+    /// Fetch catalog input <KEY> from <FLAKEREF> for this invocation instead of its locked source.
+    /// <KEY> is the input's '<catalog>/<package>' key in '.flox/catalog.lock'.
+    /// A directory is fetched as a 'path:' flakeref; '.flox/catalog.lock' is not modified.
+    #[bpaf(long("override-input"), argument("KEY=FLAKEREF"), many)]
+    overrides: Vec<InputOverrideArg>,
+}
+
+impl InputOverrides {
+    pub fn is_empty(&self) -> bool {
+        self.overrides.is_empty()
+    }
+
+    /// Parse every override's flakeref through nix and say what is being
+    /// overridden, so a surprising build result is explainable from the
+    /// terminal.
+    pub fn resolve(self) -> Result<Vec<InputOverride>> {
+        if self.overrides.is_empty() {
+            return Ok(Vec::new());
+        }
+        let resolved = self
+            .overrides
+            .into_iter()
+            .map(|arg| ResolvedOverride::new(arg.key, &arg.flakeref))
+            .collect::<Result<Vec<_>>>()?;
+        let listed = resolved
+            .iter()
+            .map(|input_override| {
+                format!(
+                    "  '{}' from '{}'",
+                    input_override.key(),
+                    input_override.url()
+                )
+            })
+            .join("\n");
+        message::info(formatdoc! {"
+            Overriding catalog inputs for this invocation; '.flox/catalog.lock' is left unchanged.
+            {listed}"});
+        Ok(resolved
+            .into_iter()
+            .map(ResolvedOverride::into_override)
+            .collect())
     }
 }
 
@@ -147,6 +227,9 @@ enum SubcommandOrBuildTargets {
         #[bpaf(external(system_override))]
         system_override: SystemOverride,
 
+        #[bpaf(external(input_overrides))]
+        input_overrides: InputOverrides,
+
         /// The package to build.
         /// Corresponds to entries in the 'build' table in the environment's manifest.toml.
         /// If not specified, all packages are built.
@@ -205,6 +288,7 @@ impl Build {
                 targets,
                 base_catalog_url_select,
                 system_override,
+                input_overrides,
             } => {
                 let env = self
                     .environment
@@ -217,6 +301,7 @@ impl Build {
                     targets,
                     base_catalog_url_select,
                     system_override.into_inner(),
+                    input_overrides,
                 )
                 .await
             },
@@ -273,6 +358,7 @@ impl Build {
         packages: Vec<String>,
         nixpkgs_url_select: Option<BaseCatalogUrlSelect>,
         system_override: Option<String>,
+        input_overrides: InputOverrides,
     ) -> Result<()> {
         match &env {
             ConcreteEnvironment::Path(_) => (),
@@ -358,6 +444,11 @@ impl Build {
         } else {
             expression_rel_paths(&packages_to_build)
         };
+        if lock_rel_paths.is_empty() && !input_overrides.is_empty() {
+            bail!(
+                "'--override-input' applies to Nix expression builds, and none of the packages being built is one."
+            );
+        }
         let catalog_lock = match &*lock_rel_paths {
             [] => None,
             lock_rel_paths => Some(
@@ -365,7 +456,7 @@ impl Build {
                     &flox.floxhub_client,
                     env.dot_flox_path(),
                     lock_rel_paths,
-                    vec![],
+                    input_overrides.resolve()?,
                 )
                 .await?,
             ),

--- a/cli/flox/src/commands/develop.rs
+++ b/cli/flox/src/commands/develop.rs
@@ -26,9 +26,11 @@ use tracing::debug;
 
 use super::build::{
     BaseCatalogUrlSelect,
+    InputOverrides,
     base_catalog_url_select,
     base_nixpkgs_url_from_url_select,
     check_git_tracking_for_expression_builds,
+    input_overrides,
     packages_to_build,
     prefetch_expression_build_flake_ref,
     prefetch_flake_ref,
@@ -74,6 +76,9 @@ pub struct Develop {
     #[bpaf(external(base_catalog_url_select), optional)]
     base_catalog_url_select: Option<BaseCatalogUrlSelect>,
 
+    #[bpaf(external(input_overrides))]
+    input_overrides: InputOverrides,
+
     /// Shell command string to run in the development shell instead of entering it interactively
     #[bpaf(
         long("command"),
@@ -105,6 +110,7 @@ impl Develop {
         let Develop {
             environment,
             base_catalog_url_select,
+            input_overrides,
             shell_command,
             package,
         } = opts;
@@ -155,7 +161,7 @@ impl Develop {
             &flox.floxhub_client,
             env.dot_flox_path(),
             [&rel_file_path],
-            vec![],
+            input_overrides.resolve()?,
         )
         .await?;
 

--- a/cli/flox/src/utils/catalog_lock.rs
+++ b/cli/flox/src/utils/catalog_lock.rs
@@ -17,7 +17,10 @@ use floxhub_client::CatalogClientTrait;
 use nef_lock_catalog::{
     BuildLock,
     CATALOG_LOCKFILE_NAME,
+    InputKey,
     InputOverride,
+    NixFlakeref,
+    RawNixFlakerefAttrs,
     catalog_lockfile_path,
     read_lock,
     resolve_lock,
@@ -25,6 +28,83 @@ use nef_lock_catalog::{
     write_lock,
 };
 use tracing::debug;
+use url::Url;
+
+/// An input override as given on the command line, with its flakeref
+/// parsed by nix so that what reaches the lock is exactly the attribute
+/// set the NEF will fetch.
+#[derive(Debug, Clone)]
+pub struct ResolvedOverride {
+    key: InputKey,
+    flakeref: NixFlakeref,
+}
+
+impl ResolvedOverride {
+    /// Parse `flakeref` for the input `key`. A bare or `path:` path is
+    /// canonicalized against the working directory first: nix refuses a
+    /// relative path in `fetchTree`, and one through a symlink (`/tmp` on
+    /// macOS), and the eval that fetches runs from the project directory,
+    /// not the user's.
+    pub fn new(key: InputKey, flakeref: &str) -> Result<Self> {
+        let cwd = std::env::current_dir().context("Could not determine the working directory.")?;
+        let canonical = canonicalize_flakeref_path(flakeref, &cwd)?;
+        let flakeref = NixFlakeref::try_from(canonical.as_str())
+            .with_context(|| format!("'{flakeref}' is not a flakeref usable for input '{key}'."))?;
+        Ok(ResolvedOverride { key, flakeref })
+    }
+
+    pub fn key(&self) -> &InputKey {
+        &self.key
+    }
+
+    /// The flakeref as nix renders it, for messages.
+    pub fn url(&self) -> &Url {
+        self.flakeref.as_url()
+    }
+
+    pub fn into_override(self) -> InputOverride {
+        InputOverride {
+            key: self.key,
+            source: RawNixFlakerefAttrs::new_unchecked(self.flakeref.as_parsed().clone()),
+        }
+    }
+}
+
+/// Whether `value` starts with a URL scheme (`git+file:`, `github:`, …),
+/// as opposed to a bare path.
+fn has_url_scheme(value: &str) -> bool {
+    let Some((scheme, _)) = value.split_once(':') else {
+        return false;
+    };
+    let mut chars = scheme.chars();
+    chars.next().is_some_and(|c| c.is_ascii_alphabetic())
+        && chars.all(|c| c.is_ascii_alphanumeric() || "+.-".contains(c))
+}
+
+/// `value` with a bare or `path:` path canonicalized — resolved against
+/// `cwd`, symlinks and `..` resolved — which fails if the path does not
+/// exist. Any other flakeref is returned as given.
+fn canonicalize_flakeref_path(value: &str, cwd: &Path) -> Result<String> {
+    let (prefix, rest) = match value.strip_prefix("path:") {
+        Some(rest) => ("path:", rest),
+        None if has_url_scheme(value) => return Ok(value.to_string()),
+        None => ("", value),
+    };
+    let (path, query) = rest
+        .split_once('?')
+        .map_or((rest, None), |(path, query)| (path, Some(query)));
+    if path.is_empty() {
+        return Ok(value.to_string());
+    }
+    let canonical = cwd
+        .join(path)
+        .canonicalize()
+        .with_context(|| format!("'{path}' does not exist."))?;
+    Ok(match query {
+        Some(query) => format!("{prefix}{}?{query}", canonical.display()),
+        None => format!("{prefix}{}", canonical.display()),
+    })
+}
 
 /// The lock a build consumes, created before the package builder is
 /// invoked and handed to it as `CATALOG_LOCKFILE`. Owns an ephemeral lock's
@@ -249,6 +329,50 @@ mod tests {
         std::fs::create_dir_all(&pkgs_dir).unwrap();
         std::fs::write(pkgs_dir.join("hello.nix"), expression).unwrap();
         (project, dot_flox, pkgs_dir)
+    }
+
+    /// Bare and `path:` values are canonicalized: relative to the working
+    /// directory, `..` and symlinks resolved. Other flakerefs pass through.
+    #[test]
+    fn canonicalize_flakeref_path_resolves_bare_and_path_values_only() {
+        let root = tempdir().unwrap();
+        let root_path = root.path().canonicalize().unwrap();
+        let cwd = root_path.join("project");
+        std::fs::create_dir_all(&cwd).unwrap();
+        std::fs::create_dir_all(root_path.join("desco")).unwrap();
+        std::os::unix::fs::symlink(root_path.join("desco"), root_path.join("link")).unwrap();
+        let desco = root_path.join("desco").display().to_string();
+        let link = root_path.join("link").display().to_string();
+
+        let cases = [
+            ("../desco", desco.clone()),
+            ("../link", desco.clone()),
+            (link.as_str(), desco.clone()),
+            ("path:../desco", format!("path:{desco}")),
+            ("path:../desco?dir=.flox", format!("path:{desco}?dir=.flox")),
+            (
+                "git+file:///abs/desco?dir=.flox",
+                "git+file:///abs/desco?dir=.flox".to_string(),
+            ),
+            (
+                "github:org/repo/branch",
+                "github:org/repo/branch".to_string(),
+            ),
+            ("path:", "path:".to_string()),
+        ];
+        for (given, expected) in cases {
+            assert_eq!(
+                canonicalize_flakeref_path(given, &cwd).unwrap(),
+                expected,
+                "for '{given}'"
+            );
+        }
+
+        let err = canonicalize_flakeref_path("../missing", &cwd).unwrap_err();
+        assert!(
+            err.to_string().contains("'../missing' does not exist"),
+            "got: {err}"
+        );
     }
 
     /// A project whose expressions make no catalog references resolves an

--- a/cli/tests/build.bats
+++ b/cli/tests/build.bats
@@ -1,0 +1,188 @@
+#! /usr/bin/env bats
+# -*- mode: bats; -*-
+# ============================================================================ #
+#
+# Test `flox build` of Nix expression packages that reference catalog inputs.
+#
+# ---------------------------------------------------------------------------- #
+
+load test_support.bash
+
+# bats file_tags=build
+
+# ---------------------------------------------------------------------------- #
+
+setup_file() {
+  common_file_setup
+}
+
+# ---------------------------------------------------------------------------- #
+
+# Helpers for project based tests.
+
+project_setup() {
+  export PROJECT_DIR="${BATS_TEST_TMPDIR?}/project-${BATS_TEST_NUMBER?}"
+  export PROJECT_NAME="${PROJECT_DIR##*/}"
+
+  rm -rf "$PROJECT_DIR"
+  mkdir -p "$PROJECT_DIR"
+  pushd "$PROJECT_DIR" >/dev/null || return
+  "$FLOX_BIN" init -d "$PROJECT_DIR"
+  git_init "$PROJECT_DIR"
+}
+
+project_teardown() {
+  popd >/dev/null || return
+  rm -rf "${PROJECT_DIR?}"
+  unset PROJECT_DIR
+  unset PROJECT_NAME
+}
+
+# Expression builds require their expressions to be git tracked.
+git_init() {
+  local dir="${1?}"
+  git -C "$dir" init -q
+  git -C "$dir" config user.name "test"
+  git -C "$dir" config user.email "test@email.address"
+  git -C "$dir" config commit.gpgsign false
+}
+
+# Add and commit the project's Nix expression package `foo`, whose output
+# is the content of the catalog input `catalogs.myorg.hello`.
+project_package_setup() {
+  local pkg_dir="$PROJECT_DIR/.flox/pkgs/foo"
+  mkdir -p "$pkg_dir"
+  cat >"$pkg_dir/default.nix" <<'EOF'
+{catalogs, runCommand}:
+runCommand "foo" {} "cat ${catalogs.myorg.hello} > $out"
+EOF
+  git -C "$PROJECT_DIR" add -A
+  git -C "$PROJECT_DIR" commit -q -m "add foo"
+}
+
+# A git repository standing in for the published source of `myorg/hello`:
+# a project whose `.flox/pkgs/hello` produces a file containing `$2`.
+input_repo_setup() {
+  local dir="${1?}"
+  local text="${2?}"
+  mkdir -p "$dir/.flox/pkgs/hello"
+  input_repo_write_hello "$dir" "$text"
+  git_init "$dir"
+  git -C "$dir" add -A
+  git -C "$dir" commit -q -m "add hello"
+}
+
+input_repo_write_hello() {
+  local dir="${1?}"
+  local text="${2?}"
+  cat >"$dir/.flox/pkgs/hello/default.nix" <<EOF
+{runCommand}:
+runCommand "hello" {} "echo -n '$text' > \$out"
+EOF
+}
+
+# Commit a catalog lock pinning `myorg/hello` to the input repository `$1`
+# at its HEAD: the lock `flox build update-catalogs` would write had
+# `myorg/hello` been published from that repository, so the build resolves
+# the reference with no catalog request.
+commit_catalog_lock() {
+  local repo="${1?}"
+  local rev ref source
+  rev="$(git -C "$repo" rev-parse HEAD)"
+  ref="$(git -C "$repo" symbolic-ref HEAD)"
+  source="{\"dir\": \".flox\", \"ref\": \"$ref\", \"rev\": \"$rev\", \"type\": \"git\", \"url\": \"file://$repo\"}"
+  cat >"$PROJECT_DIR/.flox/catalog.lock" <<EOF
+{
+  "version": 1,
+  "direct_catalog_inputs": {
+    "myorg/hello": {
+      "attr_path": ["hello"],
+      "build_type": "nef",
+      "catalog": "myorg",
+      "inputs": [],
+      "locked_inputs_hash": "sha256-test",
+      "source": $source
+    }
+  },
+  "catalogs": {
+    "myorg": {
+      "type": "floxhub",
+      "packages": {
+        "type": "package_set",
+        "entries": {
+          "hello": {
+            "type": "package",
+            "build_type": "nef",
+            "source": $source
+          }
+        }
+      }
+    }
+  }
+}
+EOF
+  git -C "$PROJECT_DIR" add -A
+  git -C "$PROJECT_DIR" commit -q -m "lock catalog inputs"
+}
+
+# ---------------------------------------------------------------------------- #
+
+setup() {
+  common_test_setup
+  home_setup test # Isolate $HOME for each test.
+  user_dotfiles_setup
+  setup_isolated_flox
+  # With no `--stability` and no `toplevel` group, resolving the nixpkgs
+  # base URL calls the base-catalog-info endpoint.
+  export _FLOX_USE_CATALOG_MOCK="$UNIT_TEST_GENERATED/get_base_catalog_nixpkgs_url.yaml"
+  project_setup
+  project_package_setup
+  export INPUT_REPO="$BATS_TEST_TMPDIR/hello"
+  input_repo_setup "$INPUT_REPO" "from the catalog"
+  commit_catalog_lock "$INPUT_REPO"
+}
+
+teardown() {
+  project_teardown
+  common_test_teardown
+}
+
+# ---------------------------------------------------------------------------- #
+
+# bats test_tags=build:override-input
+@test "build: '--override-input' fetches the input from the override and leaves the committed lock unchanged" {
+  cp "$PROJECT_DIR/.flox/catalog.lock" "$BATS_TEST_TMPDIR/catalog.lock.committed"
+
+  # An uncommitted edit: the locked revision still says "from the catalog".
+  input_repo_write_hello "$INPUT_REPO" "from the override"
+
+  run "$FLOX_BIN" build -d "$PROJECT_DIR" foo
+  assert_success
+  run cat "$PROJECT_DIR/result-foo"
+  assert_output "from the catalog"
+
+  run "$FLOX_BIN" build -d "$PROJECT_DIR" --override-input "myorg/hello=$INPUT_REPO" foo
+  assert_success
+  assert_output --partial "Overriding catalog inputs for this invocation"
+  assert_output --partial "'myorg/hello' from 'path:$(cd "$INPUT_REPO" && pwd -P)'"
+  run cat "$PROJECT_DIR/result-foo"
+  assert_output "from the override"
+
+  run diff "$PROJECT_DIR/.flox/catalog.lock" "$BATS_TEST_TMPDIR/catalog.lock.committed"
+  assert_success
+}
+
+# bats test_tags=build:override-input
+@test "build: '--override-input' naming an input the lock does not pin fails listing the lock's inputs" {
+  run "$FLOX_BIN" build -d "$PROJECT_DIR" --override-input "myorg/missing=$INPUT_REPO" foo
+  assert_failure
+  assert_output --partial "The catalog lock has no input 'myorg/missing'"
+  assert_output --partial "Inputs in the lock: myorg/hello"
+}
+
+# bats test_tags=build:override-input
+@test "build: '--override-input' rejects a value that is not '<KEY>=<FLAKEREF>'" {
+  run "$FLOX_BIN" build -d "$PROJECT_DIR" --override-input "myorg/hello" foo
+  assert_failure
+  assert_output --partial "<KEY>=<FLAKEREF>"
+}


### PR DESCRIPTION
## Proposed Changes

Stacked on #4693 (which stacks on #4692). Third and last PR of the series: the user-facing flag.

`flox build` and `flox develop` gain `--override-input <KEY>=<FLAKEREF>`, repeatable. It fetches the catalog input `<KEY>` (its `<catalog>/<package>` key in `.flox/catalog.lock`) from `<FLAKEREF>` for that invocation only, so a project can build against a local checkout of an input without publishing it. The committed lock is left unchanged, and a build with overridden inputs cannot be published (refused in #4693).

- The value is split at the CLI boundary into an `InputKey` and a flakeref string; nix parses the flakeref (`builtins.parseFlakeRef` via the existing `NixFlakeref`), and the parsed attribute set is what reaches the lock.
- A bare or `path:` path is canonicalized against the working directory first. `fetchTree` refuses a relative path, and one through a symlink (`/tmp` on macOS), and the eval that fetches runs from the project directory rather than the user's. A directory therefore means a `path:` flakeref, as with nix's own flag; `git+file://` fetches only tracked files. A missing `dir` inherits the locked source's (#4693), so pointing at the directory holding the input's `.flox` just works.
- The overrides are announced once per invocation, and `flox build` refuses them when no Nix expression build is among the targets.
- `flox-build(1)` documents the flag and the semantics; `flox develop` has no man page yet.
- New `cli/tests/build.bats` exercises the flag end to end against a fixture repository standing in for a published input, with a committed lock pinning it at a revision. The overridden build carries an uncommitted edit the locked revision does not, and the committed lock stays byte-identical. Two more tests cover an unknown key (lists the lock's inputs) and a malformed value.

Not included: telemetry for the flag. A `has_input_overrides` field on the `cli.build` event would follow the `adding-metrics-events` procedure if wanted.

## Release Notes

`flox build` and `flox develop` accept `--override-input <KEY>=<FLAKEREF>` to fetch a catalog input from a different source, such as a local checkout, for a single invocation. This is the equivalent of `nix build --override-input` for Nix expression builds that reference the Flox Catalog. `.flox/catalog.lock` is not modified, and a build with overridden inputs cannot be published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NZPQecwsEp1Tq6RZMXwRwg
