### PR TITLE
feat(build): add '--override-input' to 'flox build' and 'flox develop'

### DIFF
--- a/cli/flox-rust-sdk/src/providers/build.rs
+++ b/cli/flox-rust-sdk/src/providers/build.rs
@@ -4394,7 +4394,13 @@ mod nef_tests {
 
     use floxhub_client::LockedInputEntry;
     use indoc::{formatdoc, indoc};
-    use nef_lock_catalog::{build_lock_from_locked_inputs, write_lock};
+    use nef_lock_catalog::{
+        NixFlakeref,
+        build_lock_from_locked_inputs,
+        lock_flakeref,
+        read_lock,
+        write_lock,
+    };
     use pretty_assertions::assert_eq;
 
     use super::*;
@@ -4501,6 +4507,86 @@ mod nef_tests {
             lock_bytes,
             "the build must not rewrite the lock it is handed"
         );
+    }
+
+    /// An overridden input is fetched from the override's source, not the
+    /// one the lock pinned: the lock pins `hello` at its committed git
+    /// revision, the override locks a `path:` flakeref of the same working
+    /// tree after an uncommitted edit, and the build output carries the
+    /// edit. The NEF needs no knowledge of overrides; it fetches whatever
+    /// source a package leaf carries.
+    #[test]
+    fn nef_build_fetches_an_overridden_input_from_its_override() {
+        let pname = "foo";
+
+        let (flox, tempdir) = flox_instance();
+        let manifest = formatdoc! {r#"
+            version = 1
+        "#};
+        let mut env = new_path_environment(&flox, &manifest);
+        let env_path = env.parent_path().unwrap();
+
+        let (expressions_dir, expressions_ref) = prepare_nix_expressions_dir_in(&tempdir, &[
+            (&[pname], indoc! {r#"
+                {catalogs, runCommand}: runCommand "foo" {} ''
+                    cat ${catalogs.myorg.hello} >> $out
+                ''
+                "#}),
+            (&["hello"], indoc! {r#"
+                {runCommand}: runCommand "hello" {} ''
+                    echo -n "Hello from the catalog" > $out
+                ''
+                "#}),
+        ]);
+        let repo =
+            GitCommandProvider::init_with(test_git_options(), &expressions_dir, false).unwrap();
+        repo.add(&[&expressions_dir]).unwrap();
+        repo.commit("add nef catalog fixtures").unwrap();
+
+        let lockfile = tempdir.path().join("catalog.lock");
+        write_catalog_lock(&lockfile, &repo, &expressions_dir);
+
+        // An uncommitted edit: the locked git revision still says "from
+        // the catalog"; only a fetch of the working tree sees this.
+        fs::write(
+            expressions_dir
+                .join("pkgs")
+                .join("hello")
+                .join("default.nix"),
+            indoc! {r#"
+                {runCommand}: runCommand "hello" {} ''
+                    echo -n "Hello from the override" > $out
+                ''
+            "#},
+        )
+        .unwrap();
+
+        // The fixture keeps its `pkgs/` at the source root, so the
+        // project's expression directory is `.` rather than `.flox`.
+        let flakeref =
+            NixFlakeref::try_from(format!("path:{}", expressions_dir.display()).as_str()).unwrap();
+        let mut lock = read_lock(&lockfile).unwrap();
+        lock.override_input(
+            &"catalogs.myorg.hello".parse().unwrap(),
+            lock_flakeref(&flakeref, ".").unwrap(),
+        )
+        .unwrap();
+        let overridden_lockfile = tempdir.path().join("catalog-overridden.lock");
+        write_lock(&lock, &overridden_lockfile).unwrap();
+
+        assert_build_status_with_nix_expr(
+            &flox,
+            &mut env,
+            &expressions_ref,
+            pname,
+            Some(&overridden_lockfile),
+            None,
+            true,
+        );
+
+        let result_path = env_path.join(format!("result-{pname}"));
+        let content = fs::read_to_string(result_path).unwrap();
+        assert_eq!(content, "Hello from the override");
     }
 
     #[test]

--- a/cli/flox/doc/flox-build.md
+++ b/cli/flox/doc/flox-build.md
@@ -16,6 +16,7 @@ flox-build - Build packages with Flox
 flox [<general-options>] build
      [-d=<path>]
      [--stability <stability>]
+     [--override-input <reference>=<flakeref>]...
      [<package>]...
 ```
 
@@ -107,6 +108,18 @@ found, and is only ever rewritten by `flox build update-catalogs`.
 Without a committed lock, `flox build` resolves the references of the
 packages being built fresh on every invocation ("lockless" builds);
 nothing is written into the project tree.
+
+To build against an unpublished revision of a catalog input, such as a
+local checkout being iterated on, pass
+`--override-input <reference>=<flakeref>`.
+The input's source is replaced for that invocation only, as
+`nix build --override-input` replaces a flake input;
+the committed lock is left unchanged.
+`<reference>` names the input as the expression does, e.g.
+`catalogs.myorg.hello`, and `<flakeref>` is any Nix flake reference.
+A directory is fetched as a `path:` flakeref, so it should be the directory
+holding the input's `.flox`, and uncommitted changes in it are included;
+to fetch only git-tracked files, give a `git+file://` flakeref instead.
 Catalog references resolve to the latest published versions and are
 independent of `--stability`, which selects only the nixpkgs base
 package set.
@@ -128,6 +141,14 @@ package set.
     stability is used by default.
     An explicit `--stability` value overrides both of these defaults.
     Cannot be used with manifest builds.
+
+`--override-input <reference>=<flakeref>`
+:   Fetch the catalog input `<reference>`, as the expression names it
+    (e.g. `catalogs.myorg.hello`), from `<flakeref>` for this invocation
+    instead of its locked source.
+    A directory means a `path:` flakeref.
+    May be given more than once.
+    `.flox/catalog.lock` is not modified.
 
 
 ```{.include}

--- a/cli/flox/src/commands/build.rs
+++ b/cli/flox/src/commands/build.rs
@@ -39,7 +39,7 @@ use tracing::{debug, instrument, trace};
 use url::Url;
 
 use super::{DirEnvironmentSelect, dir_environment_select, needs_project_files_error};
-use crate::utils::catalog_lock::BuildLockGuard;
+use crate::utils::catalog_lock::{BuildLockGuard, InputOverride};
 use crate::utils::events::duration_to_ms;
 use crate::utils::message;
 use crate::{environment_subcommand_metric, subcommand_metric};
@@ -84,6 +84,38 @@ impl SystemOverride {
     pub fn into_inner(self) -> Option<String> {
         self.system
     }
+}
+
+// Reusable input-override option for commands that evaluate Nix expression
+// builds against the project catalog lock. Not a doc comment: bpaf renders
+// one on an external group as a header in `--help`.
+#[derive(Debug, Default, Bpaf, Clone)]
+pub struct InputOverrides {
+    /// Fetch catalog input <REFERENCE>, as the expression names it (e.g. 'catalogs.myorg.hello'), from <FLAKEREF> for this invocation instead of its locked source.
+    /// A directory is fetched as a 'path:' flakeref. '.flox/catalog.lock' is not modified.
+    #[bpaf(long("override-input"), argument("REFERENCE=FLAKEREF"), many)]
+    overrides: Vec<InputOverride>,
+}
+
+impl InputOverrides {
+    pub fn into_inner(self) -> Vec<InputOverride> {
+        self.overrides
+    }
+}
+
+/// Say what is being overridden, so a surprising build result is
+/// explainable from the terminal.
+pub(crate) fn announce_input_overrides(overrides: &[InputOverride]) {
+    if overrides.is_empty() {
+        return;
+    }
+    let listed = overrides
+        .iter()
+        .map(|input_override| format!("  {input_override}"))
+        .join("\n");
+    message::info(formatdoc! {"
+        Overriding catalog inputs:
+        {listed}"});
 }
 
 #[derive(Bpaf, Clone)]
@@ -147,6 +179,9 @@ enum SubcommandOrBuildTargets {
         #[bpaf(external(system_override))]
         system_override: SystemOverride,
 
+        #[bpaf(external(input_overrides))]
+        input_overrides: InputOverrides,
+
         /// The package to build.
         /// Corresponds to entries in the 'build' table in the environment's manifest.toml.
         /// If not specified, all packages are built.
@@ -205,6 +240,7 @@ impl Build {
                 targets,
                 base_catalog_url_select,
                 system_override,
+                input_overrides,
             } => {
                 let env = self
                     .environment
@@ -217,6 +253,7 @@ impl Build {
                     targets,
                     base_catalog_url_select,
                     system_override.into_inner(),
+                    input_overrides.into_inner(),
                 )
                 .await
             },
@@ -273,6 +310,7 @@ impl Build {
         packages: Vec<String>,
         nixpkgs_url_select: Option<BaseCatalogUrlSelect>,
         system_override: Option<String>,
+        input_overrides: Vec<InputOverride>,
     ) -> Result<()> {
         match &env {
             ConcreteEnvironment::Path(_) => (),
@@ -358,6 +396,12 @@ impl Build {
         } else {
             expression_rel_paths(&packages_to_build)
         };
+        if lock_rel_paths.is_empty() && !input_overrides.is_empty() {
+            bail!(
+                "'--override-input' applies to Nix expression builds, and none of the packages being built is one."
+            );
+        }
+        announce_input_overrides(&input_overrides);
         let catalog_lock = match &*lock_rel_paths {
             [] => None,
             lock_rel_paths => Some(
@@ -365,6 +409,7 @@ impl Build {
                     &flox.floxhub_client,
                     env.dot_flox_path(),
                     lock_rel_paths,
+                    &input_overrides,
                 )
                 .await?,
             ),

--- a/cli/flox/src/commands/develop.rs
+++ b/cli/flox/src/commands/develop.rs
@@ -26,9 +26,12 @@ use tracing::debug;
 
 use super::build::{
     BaseCatalogUrlSelect,
+    InputOverrides,
+    announce_input_overrides,
     base_catalog_url_select,
     base_nixpkgs_url_from_url_select,
     check_git_tracking_for_expression_builds,
+    input_overrides,
     packages_to_build,
     prefetch_expression_build_flake_ref,
     prefetch_flake_ref,
@@ -74,6 +77,9 @@ pub struct Develop {
     #[bpaf(external(base_catalog_url_select), optional)]
     base_catalog_url_select: Option<BaseCatalogUrlSelect>,
 
+    #[bpaf(external(input_overrides))]
+    input_overrides: InputOverrides,
+
     /// Shell command string to run in the development shell instead of entering it interactively
     #[bpaf(
         long("command"),
@@ -105,9 +111,11 @@ impl Develop {
         let Develop {
             environment,
             base_catalog_url_select,
+            input_overrides,
             shell_command,
             package,
         } = opts;
+        let input_overrides = input_overrides.into_inner();
 
         let mut env = environment.detect_concrete_environment(&mut flox, "Develop packages of")?;
         Self::refuse_managed_environment(&env)?;
@@ -151,11 +159,14 @@ impl Develop {
                 unreachable!("manifest builds are refused before the eval")
             },
         };
-        let catalog_lock =
-            BuildLockGuard::new_existing_or_ephemeral(&flox.floxhub_client, env.dot_flox_path(), [
-                &rel_file_path,
-            ])
-            .await?;
+        announce_input_overrides(&input_overrides);
+        let catalog_lock = BuildLockGuard::new_existing_or_ephemeral(
+            &flox.floxhub_client,
+            env.dot_flox_path(),
+            [&rel_file_path],
+            &input_overrides,
+        )
+        .await?;
 
         let base_nixpkgs_url =
             base_nixpkgs_url_from_url_select(&flox, base_catalog_url_select, Some(&lockfile))

--- a/cli/flox/src/commands/publish.rs
+++ b/cli/flox/src/commands/publish.rs
@@ -395,6 +395,7 @@ impl Publish {
                     &flox.floxhub_client,
                     path_env.dot_flox_path(),
                     &lock_rel_paths,
+                    &[],
                 )
                 .await?,
             ),

--- a/cli/flox/src/utils/catalog_lock.rs
+++ b/cli/flox/src/utils/catalog_lock.rs
@@ -5,23 +5,90 @@
 //! the ownership of an ephemeral lock's file. Without a committed
 //! `.flox/catalog.lock` the project builds locklessly: the CLI resolves a
 //! fresh lock into a temp file that lives exactly as long as the build, and
-//! nothing is ever written into the project tree.
+//! nothing is ever written into the project tree. Input overrides work the
+//! same way: whichever lock the invocation starts from, the copy with the
+//! overrides applied is ephemeral and the committed file is left as found.
 
+use std::fmt::Display;
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use flox_rust_sdk::providers::build::nix_expression_dir_in;
 use floxhub_client::CatalogClientTrait;
 use nef_lock_catalog::{
     BuildLock,
     CATALOG_LOCKFILE_NAME,
+    CatalogRef,
+    NixFlakeref,
     catalog_lockfile_path,
+    lock_flakeref,
     read_lock,
     resolve_lock,
     scan_references,
     write_lock,
 };
 use tracing::debug;
+
+/// A `--override-input <REFERENCE>=<FLAKEREF>` value: fetch the catalog
+/// input `reference` from `flakeref` for this invocation instead of the
+/// source the lock pins.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InputOverride {
+    /// The input as the expressions name it, e.g. `catalogs.myorg.hello`.
+    pub reference: CatalogRef,
+    /// A flakeref nix can lock. A bare path becomes a `path:` flakeref of
+    /// its canonical form: that is what a directory that is not a flake
+    /// needs, and nix refuses a `path:` input whose path passes through a
+    /// symlink (`/tmp` on macOS is one) or is relative.
+    pub flakeref: String,
+}
+
+impl FromStr for InputOverride {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        let Some((reference, flakeref)) = s.split_once('=') else {
+            bail!("'{s}' is not of the form '<REFERENCE>=<FLAKEREF>'.");
+        };
+        if flakeref.is_empty() {
+            bail!("'{s}' names no flakeref after '='.");
+        }
+        let reference = reference.parse().with_context(|| {
+            format!("'{reference}' is not a catalog reference like 'catalogs.<catalog>.<package>'.")
+        })?;
+        let flakeref = match has_url_scheme(flakeref) {
+            true => flakeref.to_string(),
+            false => {
+                let path = Path::new(flakeref)
+                    .canonicalize()
+                    .with_context(|| format!("'{flakeref}' does not exist."))?;
+                format!("path:{}", path.display())
+            },
+        };
+        Ok(InputOverride {
+            reference,
+            flakeref,
+        })
+    }
+}
+
+impl Display for InputOverride {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "'{}' from '{}'", self.reference, self.flakeref)
+    }
+}
+
+/// Whether `value` starts with a URL scheme (`git+file:`, `github:`, …)
+/// rather than being a bare path.
+fn has_url_scheme(value: &str) -> bool {
+    let Some((scheme, _)) = value.split_once(':') else {
+        return false;
+    };
+    let mut chars = scheme.chars();
+    chars.next().is_some_and(|c| c.is_ascii_alphabetic())
+        && chars.all(|c| c.is_ascii_alphanumeric() || "+.-".contains(c))
+}
 
 /// The lock a build consumes, created before the package builder is
 /// invoked and handed to it as `CATALOG_LOCKFILE`. Owns an ephemeral lock's
@@ -41,33 +108,51 @@ impl BuildLockGuard {
     /// references of the expressions named by `rel_file_paths` (relative to
     /// the project's expression directory), written to a randomly named
     /// temp file that is removed when the returned value is dropped.
+    ///
+    /// With `overrides`, the lock the invocation starts from — committed or
+    /// freshly resolved — has each override's flakeref locked and put in
+    /// place of the pinned source, and is always written to an ephemeral
+    /// file; the committed lock is never rewritten.
     pub async fn new_existing_or_ephemeral(
         client: &impl CatalogClientTrait,
         dot_flox_path: impl AsRef<Path>,
         rel_file_paths: impl IntoIterator<Item = impl AsRef<Path>>,
+        overrides: &[InputOverride],
     ) -> Result<BuildLockGuard> {
         let dot_flox_path = dot_flox_path.as_ref();
         let committed = catalog_lockfile_path(dot_flox_path);
-        if committed.exists() {
+        let dot_flox_dir_name = dot_flox_path
+            .file_name()
+            .expect("the .flox path has a final component");
+        let mut lock = if committed.exists() {
             let lock = read_lock(&committed)?;
-            // The path handed to make is *relative to the project
-            // directory* make is started in (`--directory`), composed of
-            // two constant components — so a project path containing
-            // whitespace (or any other character make's word-splitting
-            // positions would mangle) never reaches the makefile.
-            let dot_flox_dir_name = dot_flox_path
-                .file_name()
-                .expect("the .flox path has a final component");
-            debug!(path = %committed.display(), "build consumes the committed catalog lock");
-            return Ok(BuildLockGuard {
-                path: Path::new(dot_flox_dir_name).join(CATALOG_LOCKFILE_NAME),
-                lock,
-                _ephemeral: None,
-            });
-        }
+            if overrides.is_empty() {
+                // The path handed to make is *relative to the project
+                // directory* make is started in (`--directory`), composed
+                // of two constant components — so a project path containing
+                // whitespace (or any other character make's word-splitting
+                // positions would mangle) never reaches the makefile.
+                debug!(path = %committed.display(), "build consumes the committed catalog lock");
+                return Ok(BuildLockGuard {
+                    path: Path::new(dot_flox_dir_name).join(CATALOG_LOCKFILE_NAME),
+                    lock,
+                    _ephemeral: None,
+                });
+            }
+            debug!(path = %committed.display(), "build starts from the committed catalog lock");
+            lock
+        } else {
+            let references = scan_references(nix_expression_dir_in(dot_flox_path), rel_file_paths)?;
+            resolve_lock(client, references).await?
+        };
 
-        let references = scan_references(nix_expression_dir_in(dot_flox_path), rel_file_paths)?;
-        let lock = resolve_lock(client, references).await?;
+        for input_override in overrides {
+            let flakeref = NixFlakeref::try_from(input_override.flakeref.as_str())
+                .with_context(|| format!("Could not parse the flakeref of {input_override}."))?;
+            let source = lock_flakeref(&flakeref, &dot_flox_dir_name.to_string_lossy())
+                .with_context(|| format!("Could not lock {input_override}."))?;
+            lock.override_input(&input_override.reference, source)?;
+        }
         // The system temp dir, not flox's own temp dir: flox's derives from
         // `$HOME`, which the user may have placed at a path containing
         // whitespace, and the ephemeral path reaches make's word-splitting
@@ -82,7 +167,11 @@ impl BuildLockGuard {
             .context("Could not create a temporary file for the catalog lock.")?
             .into_temp_path();
         write_lock(&lock, &temp_path)?;
-        debug!(path = %temp_path.display(), "build consumes a fresh ephemeral catalog lock");
+        debug!(
+            path = %temp_path.display(),
+            overrides = overrides.len(),
+            "build consumes an ephemeral catalog lock"
+        );
         Ok(BuildLockGuard {
             path: temp_path.to_path_buf(),
             lock,
@@ -163,9 +252,123 @@ mod tests {
       }
     }
   },
-  "catalogs": {}
+  "catalogs": {
+    "myorg": {
+      "type": "floxhub",
+      "packages": {
+        "type": "package_set",
+        "entries": {
+          "hello": {
+            "type": "package",
+            "build_type": "nef",
+            "source": {
+              "dir": ".",
+              "ref": "refs/heads/main",
+              "rev": "0000000000000000000000000000000000000000",
+              "type": "git",
+              "url": "https://example.com/repo"
+            }
+          }
+        }
+      }
+    }
+  }
 }
 "#;
+
+    /// A bare value is a `path:` flakeref of the canonical path; a URL is
+    /// taken as given.
+    #[test]
+    fn input_override_parses_reference_and_flakeref() {
+        let dir = tempdir().unwrap();
+        let parsed: InputOverride = format!("catalogs.myorg.hello={}", dir.path().display())
+            .parse()
+            .unwrap();
+        assert_eq!(parsed, InputOverride {
+            reference: "catalogs.myorg.hello".parse().unwrap(),
+            flakeref: format!("path:{}", dir.path().canonicalize().unwrap().display()),
+        });
+
+        let parsed: InputOverride = "catalogs.myorg.hello=git+file:///src/hello?dir=sub"
+            .parse()
+            .unwrap();
+        assert_eq!(parsed.flakeref, "git+file:///src/hello?dir=sub");
+
+        let missing = dir.path().join("missing");
+        for invalid in [
+            "catalogs.myorg.hello".to_string(),
+            "catalogs.myorg.hello=".to_string(),
+            format!("myorg={}", dir.path().display()),
+            format!("catalogs.myorg.hello={}", missing.display()),
+        ] {
+            assert!(
+                invalid.parse::<InputOverride>().is_err(),
+                "'{invalid}' must not parse"
+            );
+        }
+    }
+
+    /// A committed lock with an override is never rewritten: the build
+    /// consumes an ephemeral copy pinning the override's locked source, and
+    /// the committed file stays byte-identical.
+    #[tokio::test]
+    async fn committed_lock_with_an_override_is_consumed_from_an_ephemeral_copy() {
+        let (_project, dot_flox, _pkgs_dir) =
+            project_with_expression("{ catalogs }: catalogs.myorg.hello");
+        std::fs::write(catalog_lockfile_path(&dot_flox), COMMITTED_LOCK).unwrap();
+        let override_dir = tempdir().unwrap();
+        let override_path = override_dir.path().canonicalize().unwrap();
+        let input_override: InputOverride =
+            format!("catalogs.myorg.hello={}", override_dir.path().display())
+                .parse()
+                .unwrap();
+
+        let lock =
+            BuildLockGuard::new_existing_or_ephemeral(&new_noop(), &dot_flox, ["hello.nix"], &[
+                input_override,
+            ])
+            .await
+            .unwrap();
+
+        assert!(!lock.is_existing());
+        assert_eq!(
+            std::fs::read_to_string(catalog_lockfile_path(&dot_flox)).unwrap(),
+            COMMITTED_LOCK,
+            "the committed lock must not be rewritten"
+        );
+        let ephemeral: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(lock.path()).unwrap()).unwrap();
+        let source = &ephemeral["catalogs"]["myorg"]["packages"]["entries"]["hello"]["source"];
+        assert_eq!(source["type"], "path");
+        assert_eq!(source["path"], override_path.display().to_string());
+        assert_eq!(source["dir"], ".flox");
+    }
+
+    /// An override of a reference the lock does not pin fails by name.
+    #[tokio::test]
+    async fn override_of_an_unpinned_reference_fails_by_name() {
+        let (_project, dot_flox, _pkgs_dir) =
+            project_with_expression("{ catalogs }: catalogs.myorg.hello");
+        std::fs::write(catalog_lockfile_path(&dot_flox), COMMITTED_LOCK).unwrap();
+        let override_dir = tempdir().unwrap();
+        let input_override: InputOverride =
+            format!("catalogs.myorg.missing={}", override_dir.path().display())
+                .parse()
+                .unwrap();
+
+        let err =
+            BuildLockGuard::new_existing_or_ephemeral(&new_noop(), &dot_flox, ["hello.nix"], &[
+                input_override,
+            ])
+            .await
+            .expect_err("the lock does not pin the reference");
+
+        let message = format!("{err:#}");
+        assert!(
+            message.contains("catalogs.myorg.missing") && message.contains("catalogs.myorg.hello"),
+            "the unpinned reference and the pinned ones must be named, got: {message}"
+        );
+    }
 
     fn project_with_expression(expression: &str) -> (tempfile::TempDir, PathBuf, PathBuf) {
         let project = tempdir().unwrap();
@@ -184,9 +387,10 @@ mod tests {
     async fn no_references_resolve_without_a_catalog_request() {
         let (_project, dot_flox, _pkgs_dir) =
             project_with_expression("{ runCommand }: runCommand \"hello\" { } \"\"");
-        let lock = BuildLockGuard::new_existing_or_ephemeral(&new_noop(), &dot_flox, ["hello.nix"])
-            .await
-            .unwrap();
+        let lock =
+            BuildLockGuard::new_existing_or_ephemeral(&new_noop(), &dot_flox, ["hello.nix"], &[])
+                .await
+                .unwrap();
 
         assert!(!lock.is_existing());
         assert!(
@@ -208,9 +412,10 @@ mod tests {
         let (_project, dot_flox, pkgs_dir) =
             project_with_expression("{ catalogs }: catalogs.myorg.hello");
         std::fs::write(catalog_lockfile_path(&dot_flox), COMMITTED_LOCK).unwrap();
-        let lock = BuildLockGuard::new_existing_or_ephemeral(&new_noop(), &dot_flox, ["hello.nix"])
-            .await
-            .unwrap();
+        let lock =
+            BuildLockGuard::new_existing_or_ephemeral(&new_noop(), &dot_flox, ["hello.nix"], &[])
+                .await
+                .unwrap();
 
         assert!(lock.is_existing());
         assert_eq!(lock.path(), Path::new(".flox").join(CATALOG_LOCKFILE_NAME));
@@ -235,9 +440,10 @@ mod tests {
         let (_project, dot_flox, pkgs_dir) =
             project_with_expression("{ catalogs }: catalogs.myorg.world");
         std::fs::write(catalog_lockfile_path(&dot_flox), COMMITTED_LOCK).unwrap();
-        let lock = BuildLockGuard::new_existing_or_ephemeral(&new_noop(), &dot_flox, ["hello.nix"])
-            .await
-            .unwrap();
+        let lock =
+            BuildLockGuard::new_existing_or_ephemeral(&new_noop(), &dot_flox, ["hello.nix"], &[])
+                .await
+                .unwrap();
         assert!(lock.is_existing());
 
         let references = scan_package(&pkgs_dir, "hello.nix").unwrap();

--- a/cli/nef-lock-catalog/src/lib.rs
+++ b/cli/nef-lock-catalog/src/lib.rs
@@ -27,6 +27,7 @@ impl Display for CatalogId {
 pub use lock::build_lock::{
     BuildLock,
     LockfileError,
+    OverrideInputError,
     StaleLockError,
     read_lock,
     render_lock,

--- a/cli/nef-lock-catalog/src/lib.rs
+++ b/cli/nef-lock-catalog/src/lib.rs
@@ -33,7 +33,7 @@ pub use lock::build_lock::{
     subset_direct_inputs,
     write_lock,
 };
-pub use lock::flakeref::NixFlakeref;
+pub use lock::flakeref::{NixFlakeref, RawNixFlakerefAttrs, lock_flakeref};
 pub use lock::lookup::{LockError, lock_references};
 pub use lock::render::render_unresolvable;
 pub use lock::transform::build_lock_from_locked_inputs;

--- a/cli/nef-lock-catalog/src/lock/build_lock.rs
+++ b/cli/nef-lock-catalog/src/lock/build_lock.rs
@@ -7,7 +7,9 @@ use floxhub_client::LockedInputEntry;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, instrument};
 
+use super::flakeref::RawNixFlakerefAttrs;
 use super::tree::PackageTreeNode;
+use crate::scan::AttrPath;
 use crate::{CatalogId, CatalogRef};
 
 /// Locked source information for a catalog: a package attribute hierarchy with
@@ -82,7 +84,71 @@ pub enum LockfileError {
     },
 }
 
+/// Why [BuildLock::override_input] could not replace a source.
+#[derive(Debug, thiserror::Error)]
+pub enum OverrideInputError {
+    #[error(
+        "The catalog lock does not pin '{reference}'.\nIt pins: {}",
+        .pinned.iter().map(ToString::to_string).collect::<Vec<_>>().join(", ")
+    )]
+    NotPinned {
+        reference: CatalogRef,
+        /// Every reference the lock does pin, in lock order.
+        pinned: Vec<CatalogRef>,
+    },
+
+    #[error("'{0}' names more than one input; an override replaces exactly one.")]
+    Wildcard(CatalogRef),
+}
+
 impl BuildLock {
+    /// Replace the source the lock pins for `reference` with `source`: the
+    /// lock's side of `nix build --override-input`. The replacement goes
+    /// into the `catalogs` tree, which is what the NEF fetches from;
+    /// `direct_catalog_inputs` stays as the catalog resolved it, since it
+    /// records what a publish submits and a publish never overrides.
+    pub fn override_input(
+        &mut self,
+        reference: &CatalogRef,
+        source: RawNixFlakerefAttrs,
+    ) -> Result<(), OverrideInputError> {
+        if reference.path().is_wildcard() {
+            return Err(OverrideInputError::Wildcard(reference.clone()));
+        }
+        // A reference names `<root>.<catalog>.<path...>`; its invariant
+        // guarantees the catalog component is present.
+        let names = reference.path().attribute_names();
+        let (catalog, path) = (names[1], &names[2..]);
+        let leaf = self
+            .catalogs
+            .get_mut(&CatalogId(catalog.to_string()))
+            .and_then(|CatalogLock::FloxHub { packages }| packages.package_mut(path));
+        let Some(PackageTreeNode::Package { source: pinned, .. }) = leaf else {
+            return Err(OverrideInputError::NotPinned {
+                reference: reference.clone(),
+                pinned: self.pinned_references(),
+            });
+        };
+        *pinned = source;
+        Ok(())
+    }
+
+    /// Every reference the lock pins, as the scanner would name it.
+    fn pinned_references(&self) -> Vec<CatalogRef> {
+        self.catalogs
+            .iter()
+            .flat_map(|(catalog, CatalogLock::FloxHub { packages })| {
+                packages.package_paths().into_iter().map(|path| {
+                    let root = AttrPath::root("catalogs").append_attribute(catalog.to_string());
+                    path.into_iter()
+                        .fold(root, AttrPath::append_attribute)
+                        .try_into()
+                        .expect("a pinned package lies beneath its catalog")
+                })
+            })
+            .collect()
+    }
+
     /// The direct-input entries covering exactly `references`; see
     /// [subset_direct_inputs].
     pub fn subset_direct(
@@ -311,6 +377,83 @@ mod tests {
             references(&["catalogs.myorg.missing", "catalogs.other.gone"])
                 .into_iter()
                 .collect::<Vec<_>>()
+        );
+    }
+
+    fn tree_source(lock: &BuildLock, catalog: &str, attr_path: &[&str]) -> serde_json::Value {
+        let value = serde_json::to_value(lock).unwrap();
+        let mut node = &value["catalogs"][catalog]["packages"];
+        for attribute in attr_path {
+            node = &node["entries"][*attribute];
+        }
+        node["source"].clone()
+    }
+
+    /// An override replaces the source in the `catalogs` tree the NEF
+    /// fetches from and nothing else: other inputs, and the direct entry a
+    /// publish would submit, stay as resolved.
+    #[test]
+    fn override_input_replaces_the_pinned_source_in_the_catalogs_tree() {
+        let mut lock = lock_with(&["myorg/hello", "myorg/world"]);
+        let source = serde_json::json!({ "type": "path", "path": "/src/hello", "dir": ".flox" });
+
+        lock.override_input(
+            &CatalogRef::new_unchecked("catalogs.myorg.hello"),
+            RawNixFlakerefAttrs::new_unchecked(source.clone()),
+        )
+        .expect("the lock pins the reference");
+
+        assert_eq!(tree_source(&lock, "myorg", &["hello"]), source);
+        assert_eq!(
+            tree_source(&lock, "myorg", &["world"])["type"],
+            serde_json::json!("git")
+        );
+        assert_eq!(
+            lock.direct_catalog_inputs["myorg/hello"],
+            entry("myorg", &["hello"])
+        );
+    }
+
+    #[test]
+    fn override_input_of_an_unpinned_reference_names_what_is_pinned() {
+        let mut lock = lock_with(&["myorg/hello", "myorg/toolkit.extras", "other/tool"]);
+        let source = RawNixFlakerefAttrs::new_unchecked(serde_json::json!({ "type": "path" }));
+
+        let err = lock
+            .override_input(&CatalogRef::new_unchecked("catalogs.myorg.missing"), source)
+            .expect_err("the lock does not pin the reference");
+
+        let OverrideInputError::NotPinned { reference, pinned } = err else {
+            panic!("expected NotPinned, got {err:?}");
+        };
+        assert_eq!(
+            reference,
+            CatalogRef::new_unchecked("catalogs.myorg.missing")
+        );
+        assert_eq!(
+            pinned,
+            references(&[
+                "catalogs.myorg.hello",
+                "catalogs.myorg.toolkit.extras",
+                "catalogs.other.tool",
+            ])
+            .into_iter()
+            .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn override_input_refuses_a_wildcard() {
+        let mut lock = lock_with(&["myorg/hello"]);
+        let source = RawNixFlakerefAttrs::new_unchecked(serde_json::json!({ "type": "path" }));
+
+        let err = lock
+            .override_input(&CatalogRef::new_unchecked("catalogs.myorg.*"), source)
+            .expect_err("a wildcard names more than one input");
+
+        assert!(
+            matches!(err, OverrideInputError::Wildcard(_)),
+            "got {err:?}"
         );
     }
 

--- a/cli/nef-lock-catalog/src/lock/flakeref.rs
+++ b/cli/nef-lock-catalog/src/lock/flakeref.rs
@@ -7,6 +7,7 @@ use serde_json::{Value, json};
 use url::Url;
 
 use crate::nix;
+use crate::nix::nix_base_command;
 
 #[derive(Debug, Clone)]
 pub struct NixFlakeref {
@@ -142,4 +143,82 @@ impl From<floxhub_client::LockedGitSource> for RawNixFlakerefAttrs {
     fn from(value: floxhub_client::LockedGitSource) -> Self {
         Self::new_unchecked(serde_json::to_value(value).expect("deserialized from json body"))
     }
+}
+
+/// Lock `flakeref` as the source of a NEF project, for a source the catalog
+/// did not resolve — one the user names on the command line.
+///
+/// The locked attribute set is what `nix flake prefetch` reports, which the
+/// NEF fetches as it does a catalog-resolved source, with `dir` pointing at
+/// the project's `nef_base_dir` (`.flox`) beneath any `dir` the flakeref
+/// itself names: that is where the NEF looks for the `pkgs/` holding the
+/// package expressions, as it is for every source the catalog pins.
+pub fn lock_flakeref(flakeref: &NixFlakeref, nef_base_dir: &str) -> Result<RawNixFlakerefAttrs> {
+    let NixPrefetchResult { mut locked } = nix_prefetch_url(flakeref.as_url())?;
+    let attrs = locked
+        .as_object_mut()
+        .context("'locked' attribute should be a map")?;
+    let dir = match attrs.get("dir").and_then(Value::as_str) {
+        Some(prefix) => format!("{prefix}/{nef_base_dir}"),
+        None => nef_base_dir.to_string(),
+    };
+    attrs.insert("dir".to_string(), dir.into());
+    Ok(RawNixFlakerefAttrs::new_unchecked(locked))
+}
+
+/// The part of `nix flake prefetch --json` output a lock needs: the locked
+/// source attributes. The output also carries the tree's `hash`,
+/// `original` and `storePath`, which are not.
+#[derive(Debug, Clone, Deserialize)]
+struct NixPrefetchResult {
+    locked: Value,
+}
+
+/// Lock a flakeref url using `nix flake prefetch`.
+/// This resolves urls, downloads the source and returns
+/// a locked source type as well as source information,
+/// such as hash and storePath.
+///
+/// Example:
+///
+/// ```shell
+/// $ nix flake prefetch git+ssh://git@github.com/flox/flox --json
+/// {
+///   "hash": "sha256-LdMMBff1PCXQQl3I5Dvg5U2s4l+7l9lemAncUCjJUY8=",
+///   "locked": {
+///     "lastModified": 1770220825,
+///     "ref": "refs/heads/main",
+///     "rev": "a6250c34313d184c5c5be7ad824ad0bbc7610e38",
+///     "revCount": 4546,
+///     "type": "git",
+///     "url": "ssh://git@github.com/flox/flox"
+///   },
+///   "original": {
+///     "type": "git",
+///     "url": "ssh://git@github.com/flox/flox"
+///   },
+///   "storePath": "/nix/store/pihgq0g5vnrzlx2g5lzdn7dh7aqfbl7g-source"
+/// }
+/// ```
+fn nix_prefetch_url(url: &Url) -> Result<NixPrefetchResult> {
+    let mut command = nix_base_command();
+    command
+        .arg("flake")
+        .arg("prefetch")
+        .arg("--refresh")
+        .arg("--json")
+        .arg(url.as_str());
+
+    let output = command
+        .output()
+        .with_context(|| format!("failed to run '{command:?}')"))?;
+
+    if !output.status.success() {
+        Err(anyhow::anyhow!(
+            String::from_utf8_lossy(&output.stderr).into_owned()
+        ))
+        .with_context(|| format!("failed to lock {url}"))?;
+    }
+
+    serde_json::from_slice(&output.stdout).context("could not parse nix prefetch")
 }

--- a/cli/nef-lock-catalog/src/lock/tree.rs
+++ b/cli/nef-lock-catalog/src/lock/tree.rs
@@ -27,6 +27,43 @@ pub enum PackageTreeNode {
     },
 }
 
+impl PackageTreeNode {
+    /// The package leaf at `attr_path`, if there is one; a package set
+    /// there, or a path leading through a package, is `None`.
+    pub(crate) fn package_mut(&mut self, attr_path: &[&str]) -> Option<&mut PackageTreeNode> {
+        let mut node = self;
+        for attribute in attr_path {
+            let PackageTreeNode::PackageSet { entries } = node else {
+                return None;
+            };
+            node = entries.get_mut(*attribute)?;
+        }
+        match node {
+            PackageTreeNode::Package { .. } => Some(node),
+            PackageTreeNode::PackageSet { .. } => None,
+        }
+    }
+
+    /// The attr path of every package leaf beneath this node, in key order.
+    pub(crate) fn package_paths(&self) -> Vec<Vec<String>> {
+        fn walk(node: &PackageTreeNode, prefix: &[String], paths: &mut Vec<Vec<String>>) {
+            match node {
+                PackageTreeNode::Package { .. } => paths.push(prefix.to_vec()),
+                PackageTreeNode::PackageSet { entries } => {
+                    for (name, child) in entries {
+                        let mut path = prefix.to_vec();
+                        path.push(name.clone());
+                        walk(child, &path, paths);
+                    }
+                },
+            }
+        }
+        let mut paths = Vec::new();
+        walk(self, &[], &mut paths);
+        paths
+    }
+}
+
 /// Builds a package tree from locked source items
 pub struct PackageTreeBuilder {
     root: PackageTreeNode,


### PR DESCRIPTION
## Proposed Changes

A `nix build --override-input` equivalent for Nix expression builds that reference the Flox Catalog: `flox build` and `flox develop` accept `--override-input <REFERENCE>=<FLAKEREF>`, repeatable, to fetch a catalog input from a different source, such as a local checkout, for a single invocation. The committed `.flox/catalog.lock` is never rewritten.

Supersedes #4692, #4693 and #4694 in light of review feedback: one PR as a commit sequence, no change to `direct_catalog_inputs`, no publish refusal (publish never takes the flag), no bats, and the source locking reused from the first NEF iteration rather than reinvented.

Commits, in order:

1. **Restore locking a flakeref with `nix flake prefetch`** (`lock_flakeref`, from the code dropped in 872c8c5b6). The locked attribute set is what the NEF fetches, with `dir` pointing at the project's `.flox` beneath any `dir` the flakeref names, as every catalog-pinned source has it.
2. **`BuildLock::override_input(reference, source)`**, keyed by a `CatalogRef` in the dotted form the expressions and the scanner use (`catalogs.myorg.hello`). It replaces the source in the `catalogs` tree, which is what the NEF fetches from; `direct_catalog_inputs` stays as resolved. An unpinned reference fails naming every reference the lock pins; a wildcard is refused.
3. **The flag.** The guard that hands the package builder its lock applies overrides to whichever lock the invocation starts from, committed or freshly resolved, and always writes an ephemeral file. A bare path becomes a `path:` flakeref of its canonical form: that is what a non-flake directory needs, and nix refuses a `path:` input through a symlink (`/tmp` on macOS is one). Overrides are announced once per invocation; `flox build` refuses them when no expression build is among the targets.
4. **Test and docs.** The SDK's NEF build test gains a sibling that overrides a git-pinned input with a `path:` flakeref of the same tree after an uncommitted edit and finds the edit in the output. `flox-build(1)` documents the flag.

Note for running the SDK NEF tests locally with hardware-key commit signing configured: the fixture repos commit with the developer's global git config, so they need `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false`. This predates the PR.

## Release Notes

`flox build` and `flox develop` accept `--override-input <REFERENCE>=<FLAKEREF>` to fetch a catalog input from a different source, such as a local checkout, for a single invocation. This is the equivalent of `nix build --override-input` for Nix expression builds that reference the Flox Catalog. `.flox/catalog.lock` is not modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NZPQecwsEp1Tq6RZMXwRwg
